### PR TITLE
[WIP] Initial status bar state

### DIFF
--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -1,0 +1,12 @@
+/*
+ * Actions.re
+ *
+ * Encapsulates actions that can impact the editor state
+ */
+
+open State;
+
+type t =
+| ChangeMode(Mode.t)
+| Noop
+;

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -7,6 +7,5 @@
 open State;
 
 type t =
-| ChangeMode(Mode.t)
-| Noop
-;
+  | ChangeMode(Mode.t)
+  | Noop;

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -4,7 +4,10 @@
  * Top-level module for Oni_Core. This module is intended for core editing primitives.
  */
 
+module Actions = Actions;
 module Buffer = Buffer;
+module Reducer = Reducer;
+module State = State;
 module TokenizedBuffer = TokenizedBuffer;
 module TokenizedBufferView = TokenizedBufferView;
 module Tokenizer = Tokenizer;

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -6,14 +6,12 @@
 
 open Actions;
 
-let reduce: (State.t, Actions.t) => State.t = (s, a) => {
+let reduce: (State.t, Actions.t) => State.t =
+  (s, a) => {
     switch (a) {
-    | ChangeMode(m) => { 
-        let ret: State.t = {
-            mode: m,
-        };
-        ret;
-    }
+    | ChangeMode(m) =>
+      let ret: State.t = {mode: m};
+      ret;
     | Noop => s
     };
-};
+  };

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -1,0 +1,19 @@
+/*
+ * Reducer.re
+ *
+ * Manage state transitions based on Actions
+ */
+
+open Actions;
+
+let reduce: (State.t, Actions.t) => State.t = (s, a) => {
+    switch (a) {
+    | ChangeMode(m) => { 
+        let ret: State.t = {
+            mode: m,
+        };
+        ret;
+    }
+    | Noop => s
+    };
+};

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -1,0 +1,28 @@
+/*
+ * State.re
+ *
+ * Top-level state of the editor
+ */
+
+module Mode {
+    type t =
+    | Insert
+    | Normal
+    | Other;
+
+    let show = (v) => switch(v) {
+    | Insert => "insert"
+    | Normal => "normal"
+    | Other => "unknwon"
+    };
+    
+}
+
+type t = {
+    mode: Mode.t,
+};
+
+
+let create: unit => t = () => {
+    mode: Insert,
+};

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -4,25 +4,20 @@
  * Top-level state of the editor
  */
 
-module Mode {
-    type t =
+module Mode = {
+  type t =
     | Insert
     | Normal
     | Other;
 
-    let show = (v) => switch(v) {
+  let show = v =>
+    switch (v) {
     | Insert => "insert"
     | Normal => "normal"
     | Other => "unknwon"
     };
-    
-}
-
-type t = {
-    mode: Mode.t,
 };
 
+type t = {mode: Mode.t};
 
-let create: unit => t = () => {
-    mode: Insert,
-};
+let create: unit => t = () => {mode: Insert};

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -49,13 +49,12 @@ let make = () =>
     let textElements = _viewLinesToElements(bufferView.viewLines);
 
     let style =
-      Style.
-        [
-          backgroundColor(theme.background),
-          color(theme.foreground),
-          flexGrow(1),
-        ];
-        /* flexShrink(1), */
+      Style.[
+        backgroundColor(theme.background),
+        color(theme.foreground),
+        flexGrow(1),
+      ];
+    /* flexShrink(1), */
 
     <View style> ...textElements </View>;
   });

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -4,9 +4,14 @@
  * Root editor component - contains all UI elements
  */
 
+open Revery.Core;
 open Revery.UI;
 
+open Oni_Core;
+
 let component = React.component("Root");
+
+let statusBarHeight = 25;
 
 let rootStyle = (background, foreground) =>
   Style.[
@@ -21,12 +26,31 @@ let rootStyle = (background, foreground) =>
     alignItems(`Center),
   ];
 
-let make = () =>
+let surfaceStyle = Style.[
+    position(`Absolute),
+    top(0),
+    left(0),
+    right(0),
+    bottom(statusBarHeight),
+];
+
+let statusBarStyle = Style.[
+    backgroundColor(Color.hex("#21252b")),
+    position(`Absolute),
+    left(0),
+    right(0),
+    bottom(0),
+    height(statusBarHeight),
+    justifyContent(`Center),
+    alignItems(`Center),
+];
+
+let make = (state: State.t) =>
   component((_slots: React.Hooks.empty) => {
     let theme = Theme.get();
     let style = rootStyle(theme.background, theme.foreground);
 
-    <View style> <Editor /> </View>;
+    <View style> <View style=surfaceStyle><Editor /></View> <View style=statusBarStyle><StatusBar mode={state.mode} /> </View></View>;
   });
 
-let createElement = (~children as _, ()) => React.element(make());
+let createElement = (~state, ~children as _, ()) => React.element(make(state));

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -26,15 +26,17 @@ let rootStyle = (background, foreground) =>
     alignItems(`Center),
   ];
 
-let surfaceStyle = Style.[
+let surfaceStyle =
+  Style.[
     position(`Absolute),
     top(0),
     left(0),
     right(0),
     bottom(statusBarHeight),
-];
+  ];
 
-let statusBarStyle = Style.[
+let statusBarStyle =
+  Style.[
     backgroundColor(Color.hex("#21252b")),
     position(`Absolute),
     left(0),
@@ -43,14 +45,18 @@ let statusBarStyle = Style.[
     height(statusBarHeight),
     justifyContent(`Center),
     alignItems(`Center),
-];
+  ];
 
 let make = (state: State.t) =>
   component((_slots: React.Hooks.empty) => {
     let theme = Theme.get();
     let style = rootStyle(theme.background, theme.foreground);
 
-    <View style> <View style=surfaceStyle><Editor /></View> <View style=statusBarStyle><StatusBar mode={state.mode} /> </View></View>;
+    <View style>
+      <View style=surfaceStyle> <Editor /> </View>
+      <View style=statusBarStyle> <StatusBar mode={state.mode} /> </View>
+    </View>;
   });
 
-let createElement = (~state, ~children as _, ()) => React.element(make(state));
+let createElement = (~state, ~children as _, ()) =>
+  React.element(make(state));

--- a/src/editor/UI/StatusBar.re
+++ b/src/editor/UI/StatusBar.re
@@ -1,0 +1,43 @@
+/*
+ * Tabs.re
+ *
+ * Container for <Tab /> components
+ */
+
+open Revery.Core;
+open Revery.UI;
+
+open Oni_Core;
+
+let noop = () => ();
+
+type tabInfo = {
+  title: string,
+  active: bool,
+  onClick: Tab.tabAction,
+  onClose: Tab.tabAction,
+};
+
+let component = React.component("StatusBar");
+
+let textStyle =
+  Style.[color(Color.hex("#9da5b4")), fontFamily("Inter-UI-Regular.ttf"), fontSize(14)];
+
+let toTab = (t: tabInfo) => {
+  <Tab
+    title={t.title}
+    active={t.active}
+    onClick={t.onClick}
+    onClose={t.onClose}
+  />;
+};
+
+let viewStyle = Style.[flexDirection(`Row), justifyContent(`Center), alignItems(`Center)];
+
+let make = (~mode: State.Mode.t, ()) =>
+  component((_slots: React.Hooks.empty) => {
+    <View style=viewStyle><Text style=textStyle text={State.Mode.show(mode)} /></View>
+  });
+
+let createElement = (~children as _, ~mode, ()) =>
+  React.element(make(~mode, ()));

--- a/src/editor/UI/StatusBar.re
+++ b/src/editor/UI/StatusBar.re
@@ -1,22 +1,13 @@
 /*
- * Tabs.re
+ * StatusBar.re
  *
- * Container for <Tab /> components
+ * Container for StatusBar
  */
 
 open Revery.Core;
 open Revery.UI;
 
 open Oni_Core;
-
-let noop = () => ();
-
-type tabInfo = {
-  title: string,
-  active: bool,
-  onClick: Tab.tabAction,
-  onClose: Tab.tabAction,
-};
 
 let component = React.component("StatusBar");
 
@@ -26,15 +17,6 @@ let textStyle =
     fontFamily("Inter-UI-Regular.ttf"),
     fontSize(14),
   ];
-
-let toTab = (t: tabInfo) => {
-  <Tab
-    title={t.title}
-    active={t.active}
-    onClick={t.onClick}
-    onClose={t.onClose}
-  />;
-};
 
 let viewStyle =
   Style.[

--- a/src/editor/UI/StatusBar.re
+++ b/src/editor/UI/StatusBar.re
@@ -21,7 +21,11 @@ type tabInfo = {
 let component = React.component("StatusBar");
 
 let textStyle =
-  Style.[color(Color.hex("#9da5b4")), fontFamily("Inter-UI-Regular.ttf"), fontSize(14)];
+  Style.[
+    color(Color.hex("#9da5b4")),
+    fontFamily("Inter-UI-Regular.ttf"),
+    fontSize(14),
+  ];
 
 let toTab = (t: tabInfo) => {
   <Tab
@@ -32,12 +36,19 @@ let toTab = (t: tabInfo) => {
   />;
 };
 
-let viewStyle = Style.[flexDirection(`Row), justifyContent(`Center), alignItems(`Center)];
+let viewStyle =
+  Style.[
+    flexDirection(`Row),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
 
 let make = (~mode: State.Mode.t, ()) =>
-  component((_slots: React.Hooks.empty) => {
-    <View style=viewStyle><Text style=textStyle text={State.Mode.show(mode)} /></View>
-  });
+  component((_slots: React.Hooks.empty) =>
+    <View style=viewStyle>
+      <Text style=textStyle text={State.Mode.show(mode)} />
+    </View>
+  );
 
 let createElement = (~children as _, ~mode, ()) =>
   React.element(make(~mode, ()));

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -37,8 +37,8 @@ let init = app => {
     };
 
   let render = () => {
-      let state: Core.State.t = App.getState(app);
-      prerr_endline ("[STATE] Mode: " ++ Core.State.Mode.show(state.mode));
+    let state: Core.State.t = App.getState(app);
+    prerr_endline("[STATE] Mode: " ++ Core.State.Mode.show(state.mode));
     <Root />;
   };
 
@@ -106,20 +106,23 @@ let init = app => {
     );
 
   let _ =
-    Event.subscribe(neovimProtocol.onNotification, n => {
-      let msg = switch (n) {
-      | ModeChanged("normal") => Core.Actions.ChangeMode(Normal)
-      | ModeChanged("insert") => Core.Actions.ChangeMode(Insert)
-      | ModeChanged(_) => Core.Actions.ChangeMode(Other)
-      | _ => Noop
-      };
+    Event.subscribe(
+      neovimProtocol.onNotification,
+      n => {
+        let msg =
+          switch (n) {
+          | ModeChanged("normal") => Core.Actions.ChangeMode(Normal)
+          | ModeChanged("insert") => Core.Actions.ChangeMode(Insert)
+          | ModeChanged(_) => Core.Actions.ChangeMode(Other)
+          | _ => Noop
+          };
 
-      App.dispatch(app, msg);
-      prerr_endline("Protocol Notification: " ++ Notification.show(n))
-    });
+        App.dispatch(app, msg);
+        prerr_endline("Protocol Notification: " ++ Notification.show(n));
+      },
+    );
   ();
 };
-
 
 /* Let's get this party started! */
 App.startWithState(Core.State.create(), Core.Reducer.reduce, init);

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -39,7 +39,7 @@ let init = app => {
   let render = () => {
     let state: Core.State.t = App.getState(app);
     prerr_endline("[STATE] Mode: " ++ Core.State.Mode.show(state.mode));
-    <Root />;
+    <Root state />;
   };
 
   UI.start(w, render);

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -13,6 +13,8 @@ open Rench;
 open Oni_UI;
 open Oni_Neovim;
 
+module Core = Oni_Core;
+
 exception NeovimNotFound;
 
 /* The 'main' function for our app */
@@ -35,6 +37,8 @@ let init = app => {
     };
 
   let render = () => {
+      let state: Core.State.t = App.getState(app);
+      prerr_endline ("[STATE] Mode: " ++ Core.State.Mode.show(state.mode));
     <Root />;
   };
 
@@ -102,11 +106,20 @@ let init = app => {
     );
 
   let _ =
-    Event.subscribe(neovimProtocol.onNotification, n =>
+    Event.subscribe(neovimProtocol.onNotification, n => {
+      let msg = switch (n) {
+      | ModeChanged("normal") => Core.Actions.ChangeMode(Normal)
+      | ModeChanged("insert") => Core.Actions.ChangeMode(Insert)
+      | ModeChanged(_) => Core.Actions.ChangeMode(Other)
+      | _ => Noop
+      };
+
+      App.dispatch(app, msg);
       prerr_endline("Protocol Notification: " ++ Notification.show(n))
-    );
+    });
   ();
 };
 
+
 /* Let's get this party started! */
-App.start(init);
+App.startWithState(Core.State.create(), Core.Reducer.reduce, init);


### PR DESCRIPTION
This starts connecting Neovim's state with Oni2's internal editor model. This picks up the `mode_changed` notification, converts it to Oni2's action, and updates the internal state + re-renders.

Next steps:
- Switch the current 'tab state' to  be from the App state, and not hardcoded in the Tab component
- Start keeping buffer state, so we can actually render a live buffer instead of 'Hello World'
- Track buffer cursor position