### PR TITLE
Initial VimL Interop

### DIFF
--- a/assets/viml/dune
+++ b/assets/viml/dune
@@ -1,0 +1,4 @@
+(install
+    (section bin)
+    (package Oni2)
+    (files init.vim))

--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -1,0 +1,53 @@
+" init.vim
+" Entry point for Oni interop
+" Sets defaults for Oni2, and wires up some RPC for autocmds
+
+if exists("g:loaded_oni_interop_plugin")
+    finish
+endif
+
+set hidden
+set nocursorline
+set nobackup
+set nowritebackup
+set noswapfile
+
+syntax off
+
+let g:loaded_oni_interop_plugin = 1
+
+function OniNotify(args)
+    call rpcnotify(1, "oni_plugin_notify", a:args)
+endfunction
+
+function OniNotifyEvent(eventName)
+    let context = OniGetContext()
+    call OniNotify(["event", a:eventName, context])
+endfunction
+
+augroup OniEventListeners
+    autocmd!
+    autocmd! BufWritePre * :call OniNotifyEvent("BufWritePre")
+    autocmd! BufWritePost * :call OniNotifyEvent("BufWritePost")
+    autocmd! BufEnter * :call OniNotifyEvent("BufEnter")
+    autocmd! BufRead * :call OniNotifyEvent("BufRead")
+    autocmd! BufWinEnter * :call OniNotifyEvent("BufWinEnter")
+    autocmd! BufDelete * :call OniNotifyEvent("BufDelete")
+    autocmd! BufUnload * :call OniNotifyEvent("BufUnload")
+    autocmd! BufWipeout * :call OniNotifyEvent("BufWipeout")
+    autocmd! CursorMoved * :call OniNotifyEvent("CursorMoved")
+    autocmd! CursorMovedI * :call OniNotifyEvent("CursorMovedI")
+augroup END
+
+function OniGetContext()
+let context = {}
+let context.bufferNumber = bufnr("%")
+let context.line = line(".")
+let context.column = col(".")
+
+if exists("b:last_change_tick")
+    let context.version = b:last_change_tick
+endif
+
+return context
+endfunction

--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -20,34 +20,31 @@ function OniNotify(args)
     call rpcnotify(1, "oni_plugin_notify", a:args)
 endfunction
 
-function OniNotifyEvent(eventName)
+function OniNotifyAutocmd(eventName)
     let context = OniGetContext()
-    call OniNotify(["event", a:eventName, context])
+    call OniNotify(["autocmd", a:eventName, context])
 endfunction
 
 augroup OniEventListeners
     autocmd!
-    autocmd! BufWritePre * :call OniNotifyEvent("BufWritePre")
-    autocmd! BufWritePost * :call OniNotifyEvent("BufWritePost")
-    autocmd! BufEnter * :call OniNotifyEvent("BufEnter")
-    autocmd! BufRead * :call OniNotifyEvent("BufRead")
-    autocmd! BufWinEnter * :call OniNotifyEvent("BufWinEnter")
-    autocmd! BufDelete * :call OniNotifyEvent("BufDelete")
-    autocmd! BufUnload * :call OniNotifyEvent("BufUnload")
-    autocmd! BufWipeout * :call OniNotifyEvent("BufWipeout")
-    autocmd! CursorMoved * :call OniNotifyEvent("CursorMoved")
-    autocmd! CursorMovedI * :call OniNotifyEvent("CursorMovedI")
+    autocmd! BufWritePre * :call OniNotifyAutocmd("BufWritePre")
+    autocmd! BufWritePost * :call OniNotifyAutocmd("BufWritePost")
+    autocmd! BufEnter * :call OniNotifyAutocmd("BufEnter")
+    autocmd! BufRead * :call OniNotifyAutocmd("BufRead")
+    autocmd! BufWinEnter * :call OniNotifyAutocmd("BufWinEnter")
+    autocmd! BufDelete * :call OniNotifyAutocmd("BufDelete")
+    autocmd! BufUnload * :call OniNotifyAutocmd("BufUnload")
+    autocmd! BufWipeout * :call OniNotifyAutocmd("BufWipeout")
+    autocmd! CursorMoved * :call OniNotifyAutocmd("CursorMoved")
+    autocmd! CursorMovedI * :call OniNotifyAutocmd("CursorMovedI")
 augroup END
 
 function OniGetContext()
-let context = {}
-let context.bufferNumber = bufnr("%")
-let context.line = line(".")
-let context.column = col(".")
+let bufferNumber = bufnr("%")
+let line = line(".")
+let column = col(".")
 
-if exists("b:last_change_tick")
-    let context.version = b:last_change_tick
-endif
+let context = [bufferNumber, line, column]
 
 return context
 endfunction

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -30,26 +30,23 @@ let slice = (~lines: array(string), ~start, ~length, ()) => {
   };
 };
 
-let applyUpdate = (lines: array(string), update: BufferUpdate.t) => {
+let applyUpdate = (lines: array(string), update: BufferUpdate.t) =>
+  if (update.endLine <= update.startLine) {
+    Array.of_list(update.lines);
+  } else {
+    let prev = slice(~lines, ~start=0, ~length=update.startLine, ());
+    let post =
+      slice(
+        ~lines,
+        ~start=update.endLine,
+        ~length=Array.length(lines) - update.endLine,
+        (),
+      );
 
-    if (update.endLine <= update.startLine) {
-        Array.of_list(update.lines)
-    } else {
+    let lines = Array.of_list(update.lines);
 
-  let prev = slice(~lines, ~start=0, ~length=update.startLine, ());
-  let post =
-    slice(
-      ~lines,
-      ~start=update.endLine,
-      ~length=Array.length(lines) - update.endLine,
-      (),
-    );
-
-  let lines = Array.of_list(update.lines);
-
-  Array.concat([prev, lines, post]);
-    }
-};
+    Array.concat([prev, lines, post]);
+  };
 
 let update = (buf: t, update: BufferUpdate.t) => {
   let ret: t = {...buf, lines: applyUpdate(buf.lines, update)};

--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -4,14 +4,14 @@
  * Simple console logger
  */
 
-open Types;
-
 let isDebugLoggingEnabled = switch(Sys.getenv_opt("ONI2_DEBUG")) {
 | Some(_) => true
 | _ => false
 }
 
 
-let info = (msg) => print_endline(msg);
+let info = (msg) => print_endline(["[INFO] " ++ msg);
 
-let error = (msg) => isDebugLoggingEnabled ? prerr_endline(msg) : ();
+let debug = (msg) => isDebugLoggingEnabled ? print_endline("[DEBUG] " ++ msg);
+
+let error = (msg) => prerr_endline("[ERROR] " ++ msg);

--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -4,14 +4,15 @@
  * Simple console logger
  */
 
-let isDebugLoggingEnabled = switch(Sys.getenv_opt("ONI2_DEBUG")) {
-| Some(_) => true
-| _ => false
-}
+let isDebugLoggingEnabled =
+  switch (Sys.getenv_opt("ONI2_DEBUG")) {
+  | Some(_) => true
+  | _ => false
+  };
 
+let info = msg => print_endline("[INFO] " ++ msg);
 
-let info = (msg) => print_endline("[INFO] " ++ msg);
+let debug = msg =>
+  isDebugLoggingEnabled ? print_endline("[DEBUG] " ++ msg) : ();
 
-let debug = (msg) => isDebugLoggingEnabled ? print_endline("[DEBUG] " ++ msg) : ();
-
-let error = (msg) => prerr_endline("[ERROR] " ++ msg);
+let error = msg => prerr_endline("[ERROR] " ++ msg);

--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -10,8 +10,8 @@ let isDebugLoggingEnabled = switch(Sys.getenv_opt("ONI2_DEBUG")) {
 }
 
 
-let info = (msg) => print_endline(["[INFO] " ++ msg);
+let info = (msg) => print_endline("[INFO] " ++ msg);
 
-let debug = (msg) => isDebugLoggingEnabled ? print_endline("[DEBUG] " ++ msg);
+let debug = (msg) => isDebugLoggingEnabled ? print_endline("[DEBUG] " ++ msg) : ();
 
 let error = (msg) => prerr_endline("[ERROR] " ++ msg);

--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -1,0 +1,17 @@
+/*
+ * Log.re
+ *
+ * Simple console logger
+ */
+
+open Types;
+
+let isDebugLoggingEnabled = switch(Sys.getenv_opt("ONI2_DEBUG")) {
+| Some(_) => true
+| _ => false
+}
+
+
+let info = (msg) => print_endline(msg);
+
+let error = (msg) => isDebugLoggingEnabled ? prerr_endline(msg) : ();

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -6,6 +6,7 @@
 
 module Actions = Actions;
 module Buffer = Buffer;
+module Log = Log;
 module Reducer = Reducer;
 module State = State;
 module TokenizedBuffer = TokenizedBuffer;

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -59,19 +59,23 @@ let parseRedraw = (msgs: list(Msgpck.t)) => {
 exception InvalidAutoCommandContext;
 
 let parseAutoCommand = (autocmd: string, args: list(Msgpck.t)) => {
-
-    let context = switch(args) {
-    | [M.Int(activeBufferId), M.Int(cursorLine), M.Int(cursorColumn)] => {
-       Types.AutoCommandContext.create(~activeBufferId, ~cursorLine, ~cursorColumn, ());
-    }
-    | _ => raise(InvalidAutoCommandContext);
+  let context =
+    switch (args) {
+    | [M.Int(activeBufferId), M.Int(cursorLine), M.Int(cursorColumn)] =>
+      Types.AutoCommandContext.create(
+        ~activeBufferId,
+        ~cursorLine,
+        ~cursorColumn,
+        (),
+      )
+    | _ => raise(InvalidAutoCommandContext)
     };
 
-    switch (autocmd) {
-    | "CursorMoved" => CursorMoved(context)
-    | "CursorMovedI" => CursorMoved(context)
-    | _ => Ignored
-    };
+  switch (autocmd) {
+  | "CursorMoved" => CursorMoved(context)
+  | "CursorMovedI" => CursorMoved(context)
+  | _ => Ignored
+  };
 };
 
 let parse = (t: string, msg: Msgpck.t) => {
@@ -97,10 +101,14 @@ let parse = (t: string, msg: Msgpck.t) => {
           ),
         ),
       ]
-    | ("oni_plugin_notify", M.List([M.List([M.String("autocmd"), M.String(autocmd), M.List(args)])])) => {
-        let result = parseAutoCommand(autocmd, args);
-        [result]
-    }
+    | (
+        "oni_plugin_notify",
+        M.List([
+          M.List([M.String("autocmd"), M.String(autocmd), M.List(args)]),
+        ]),
+      ) =>
+      let result = parseAutoCommand(autocmd, args);
+      [result];
     | ("redraw", M.List(msgs)) => parseRedraw(msgs)
     | _ => [Ignored]
     };

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -7,6 +7,8 @@
 /* open Oni_Core; */
 /* open Rench; */
 
+open Types;
+
 module BufferLinesNotification = {
   type t = {
     changedTick: int,
@@ -34,6 +36,7 @@ type t =
   | Redraw
   | ModeChanged(string)
   | BufferLines(BufferLinesNotification.t)
+  | CursorMoved(AutoCommandContext.t)
   | Ignored;
 
 module M = Msgpck;
@@ -51,6 +54,24 @@ let parseRedraw = (msgs: list(Msgpck.t)) => {
   };
 
   msgs |> List.map(p);
+};
+
+exception InvalidAutoCommandContext;
+
+let parseAutoCommand = (autocmd: string, args: list(Msgpck.t)) => {
+
+    let context = switch(args) {
+    | [M.Int(activeBufferId), M.Int(cursorLine), M.Int(cursorColumn)] => {
+       Types.AutoCommandContext.create(~activeBufferId, ~cursorLine, ~cursorColumn, ());
+    }
+    | _ => raise(InvalidAutoCommandContext);
+    };
+
+    switch (autocmd) {
+    | "CursorMoved" => CursorMoved(context)
+    | "CursorMovedI" => CursorMoved(context)
+    | _ => Ignored
+    };
 };
 
 let parse = (t: string, msg: Msgpck.t) => {
@@ -76,6 +97,10 @@ let parse = (t: string, msg: Msgpck.t) => {
           ),
         ),
       ]
+    | ("oni_plugin_notify", M.List([M.List([M.String("autocmd"), M.String(autocmd), M.List(args)])])) => {
+        let result = parseAutoCommand(autocmd, args);
+        [result]
+    }
     | ("redraw", M.List(msgs)) => parseRedraw(msgs)
     | _ => [Ignored]
     };
@@ -87,6 +112,7 @@ let show = (n: t) => {
   switch (n) {
   | Redraw => "redraw"
   | ModeChanged(s) => "mode changed: " ++ s
+  | CursorMoved(c) => "cursor moved: " ++ AutoCommandContext.show(c)
   | BufferLines(_) => "buffer lines"
   | _ => "unknown"
   };

--- a/src/editor/Neovim/Types.re
+++ b/src/editor/Neovim/Types.re
@@ -14,3 +14,21 @@ module EditorState = {
     cursorPosition: CursorPosition.t,
   };
 };
+
+module AutoCommandContext = {
+    type t = {
+        activeBufferId: int,
+        cursorLine: int,
+        cursorColumn: int,
+    };
+
+    let create = (~activeBufferId, ~cursorLine, ~cursorColumn, ()) => {
+        activeBufferId,
+        cursorLine,
+        cursorColumn,
+    };
+
+    let show = (v: t) => {
+        "activeBufferId: " ++ string_of_int(v.activeBufferId) ++ " line: "++ string_of_int(v.cursorLine) ++ " column: " ++ string_of_int(v.cursorColumn);
+    }
+};

--- a/src/editor/Neovim/Types.re
+++ b/src/editor/Neovim/Types.re
@@ -16,19 +16,24 @@ module EditorState = {
 };
 
 module AutoCommandContext = {
-    type t = {
-        activeBufferId: int,
-        cursorLine: int,
-        cursorColumn: int,
-    };
+  type t = {
+    activeBufferId: int,
+    cursorLine: int,
+    cursorColumn: int,
+  };
 
-    let create = (~activeBufferId, ~cursorLine, ~cursorColumn, ()) => {
-        activeBufferId,
-        cursorLine,
-        cursorColumn,
-    };
+  let create = (~activeBufferId, ~cursorLine, ~cursorColumn, ()) => {
+    activeBufferId,
+    cursorLine,
+    cursorColumn,
+  };
 
-    let show = (v: t) => {
-        "activeBufferId: " ++ string_of_int(v.activeBufferId) ++ " line: "++ string_of_int(v.cursorLine) ++ " column: " ++ string_of_int(v.cursorColumn);
-    }
+  let show = (v: t) => {
+    "activeBufferId: "
+    ++ string_of_int(v.activeBufferId)
+    ++ " line: "
+    ++ string_of_int(v.cursorLine)
+    ++ " column: "
+    ++ string_of_int(v.cursorColumn);
+  };
 };

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -52,7 +52,7 @@ let init = app => {
   UI.start(w, render);
 
   let initVimPath = Revery_Core.Environment.getExecutingDirectory() ++ "init.vim";
-  Log.debug("initVimPath: " ++ initVimPath);
+  Core.Log.debug("initVimPath: " ++ initVimPath);
 
   let nvim = NeovimProcess.start(~neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
   let msgpackTransport =

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -52,7 +52,7 @@ let init = app => {
   UI.start(w, render);
 
   let initVimPath = Revery_Core.Environment.getExecutingDirectory() ++ "init.vim";
-  prerr_endline ("initVimPath: " ++ initVimPath);
+  Log.debug("initVimPath: " ++ initVimPath);
 
   let nvim = NeovimProcess.start(~neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
   let msgpackTransport =

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -51,7 +51,10 @@ let init = app => {
 
   UI.start(w, render);
 
-  let nvim = NeovimProcess.start(~neovimPath, ~args=[|"--embed"|]);
+  let initVimPath = Revery_Core.Environment.getExecutingDirectory() ++ "init.vim";
+  prerr_endline ("initVimPath: " ++ initVimPath);
+
+  let nvim = NeovimProcess.start(~neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -51,10 +51,12 @@ let init = app => {
 
   UI.start(w, render);
 
-  let initVimPath = Revery_Core.Environment.getExecutingDirectory() ++ "init.vim";
+  let initVimPath =
+    Revery_Core.Environment.getExecutingDirectory() ++ "init.vim";
   Core.Log.debug("initVimPath: " ++ initVimPath);
 
-  let nvim = NeovimProcess.start(~neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
+  let nvim =
+    NeovimProcess.start(~neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,
@@ -157,7 +159,15 @@ let init = app => {
           | ModeChanged("normal") => Core.Actions.ChangeMode(Normal)
           | ModeChanged("insert") => Core.Actions.ChangeMode(Insert)
           | ModeChanged(_) => Core.Actions.ChangeMode(Other)
-          | BufferLines(bc) => Core.Actions.BufferUpdate(Core.Types.BufferUpdate.create(~startLine=bc.firstLine, ~endLine=bc.lastLine, ~lines=bc.lines, ()))
+          | BufferLines(bc) =>
+            Core.Actions.BufferUpdate(
+              Core.Types.BufferUpdate.create(
+                ~startLine=bc.firstLine,
+                ~endLine=bc.lastLine,
+                ~lines=bc.lines,
+                (),
+              ),
+            )
           | _ => Noop
           };
 


### PR DESCRIPTION
This change ports over Oni's core interop `init.vim` so that we can be aware of certain events / autocmds on the front-end.