### PR TITLE
Remove builds in source from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
   "license": "MIT",
   "esy": {
     "build": "refmterr dune build --root . -j4",
-    "buildsInSource": "_build",
     "install": [
-        "esy-installer Oni2.install",
-        "esy-installer Oni_Core.install",
-        "esy-installer Oni_UI.install",
-        "esy-installer Oni_Neovim.install",
-        "esy-installer OniUnitTestRunner.install"
+      "esy-installer Oni2.install",
+      "esy-installer Oni_Core.install",
+      "esy-installer Oni_UI.install",
+      "esy-installer Oni_Neovim.install",
+      "esy-installer OniUnitTestRunner.install"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "esy": {
     "build": "refmterr dune build --root . -j4",
     "install": [
-      "esy-installer Oni2.install",
-      "esy-installer Oni_Core.install",
-      "esy-installer Oni_UI.install",
-      "esy-installer Oni_Neovim.install",
-      "esy-installer OniUnitTestRunner.install"
+        "esy-installer Oni2.install",
+        "esy-installer Oni_Core.install",
+        "esy-installer Oni_UI.install",
+        "esy-installer Oni_Neovim.install",
+        "esy-installer OniUnitTestRunner.install"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Remove builds in source (this can cause lsp clients like `reason-language-server` to fail