### PR TITLE
Bugfix: Buffer lines disappear when adding line at end of file

### DIFF
--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -34,11 +34,10 @@ let slice = (~lines: array(string), ~start, ~length, ()) => {
 let applyUpdate = (lines: array(string), update: BufferUpdate.t) => {
   let updateLines = Array.of_list(update.lines);
   if (Array.length(lines) == 0) {
-    updateLines
-  }
-  else if (update.startLine >= Array.length(lines)) {
+    updateLines;
+  } else if (update.startLine >= Array.length(lines)) {
     let ret = Array.concat([lines, updateLines]);
-    ret
+    ret;
   } else {
     let prev = slice(~lines, ~start=0, ~length=update.startLine, ());
     let post =

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -21,6 +21,7 @@ let slice = (~lines: array(string), ~start, ~length, ()) => {
   if (start >= len) {
     [||];
   } else {
+    let start = max(start, 0);
     let len = min(start + length, len) - start;
     if (len <= 0) {
       [||];
@@ -30,9 +31,14 @@ let slice = (~lines: array(string), ~start, ~length, ()) => {
   };
 };
 
-let applyUpdate = (lines: array(string), update: BufferUpdate.t) =>
-  if (update.endLine <= update.startLine) {
-    Array.of_list(update.lines);
+let applyUpdate = (lines: array(string), update: BufferUpdate.t) => {
+  let updateLines = Array.of_list(update.lines);
+  if (Array.length(lines) == 0) {
+    updateLines
+  }
+  else if (update.startLine >= Array.length(lines)) {
+    let ret = Array.concat([lines, updateLines]);
+    ret
   } else {
     let prev = slice(~lines, ~start=0, ~length=update.startLine, ());
     let post =
@@ -47,6 +53,7 @@ let applyUpdate = (lines: array(string), update: BufferUpdate.t) =>
 
     Array.concat([prev, lines, post]);
   };
+};
 
 let update = (buf: t, update: BufferUpdate.t) => {
   let ret: t = {...buf, lines: applyUpdate(buf.lines, update)};

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -36,7 +36,7 @@ let create: unit => t =
       level: 0,
       show: false,
     },
-    buffer: Buffer.ofLines([|"testing"|]),
+    buffer: Buffer.ofLines([||]),
     cursorPosition: BufferPosition.createFromZeroBasedIndices(0, 0),
     editorFont:
       EditorFont.create(

--- a/test/editor/Core/BufferTests.re
+++ b/test/editor/Core/BufferTests.re
@@ -34,4 +34,13 @@ describe("update", ({test, _}) => {
     let updatedBuffer = Buffer.update(buffer, update);
     validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
   });
+
+  test("add new line after buffer", ({expect}) => {
+    let buffer = Buffer.ofLines([|"a", "b", "c"|]);
+    prerr_endline ("BEFORE");
+    let update = BufferUpdate.create(~startLine=3, ~endLine=3, ~lines=["d"], ());
+    let updatedBuffer = Buffer.update(buffer, update);
+    prerr_endline ("AFTER");
+    validateBuffer(expect, updatedBuffer, [|"a", "b", "c", "d"|]);
+  });
 });

--- a/test/editor/Core/BufferTests.re
+++ b/test/editor/Core/BufferTests.re
@@ -9,14 +9,16 @@ module Buffer = Oni_Core.Buffer;
 describe("update", ({test, _}) => {
   test("empty buffer w/ update", ({expect}) => {
     let buffer = Buffer.ofLines([||]);
-    let update = BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=["a"], ());
+    let update =
+      BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=["a"], ());
     let updatedBuffer = Buffer.update(buffer, update);
     validateBuffer(expect, updatedBuffer, [|"a"|]);
   });
 
   test("update single line", ({expect}) => {
     let buffer = Buffer.ofLines([|"a"|]);
-    let update = BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=["abc"], ());
+    let update =
+      BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=["abc"], ());
     let updatedBuffer = Buffer.update(buffer, update);
     validateBuffer(expect, updatedBuffer, [|"abc"|]);
   });
@@ -30,17 +32,24 @@ describe("update", ({test, _}) => {
 
   test("update single line", ({expect}) => {
     let buffer = Buffer.ofLines([|"a", "b", "c"|]);
-    let update = BufferUpdate.create(~startLine=1, ~endLine=2, ~lines=["d", "e", "f"], ());
+    let update =
+      BufferUpdate.create(
+        ~startLine=1,
+        ~endLine=2,
+        ~lines=["d", "e", "f"],
+        (),
+      );
     let updatedBuffer = Buffer.update(buffer, update);
     validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
   });
 
   test("add new line after buffer", ({expect}) => {
     let buffer = Buffer.ofLines([|"a", "b", "c"|]);
-    prerr_endline ("BEFORE");
-    let update = BufferUpdate.create(~startLine=3, ~endLine=3, ~lines=["d"], ());
+    prerr_endline("BEFORE");
+    let update =
+      BufferUpdate.create(~startLine=3, ~endLine=3, ~lines=["d"], ());
     let updatedBuffer = Buffer.update(buffer, update);
-    prerr_endline ("AFTER");
+    prerr_endline("AFTER");
     validateBuffer(expect, updatedBuffer, [|"a", "b", "c", "d"|]);
   });
 });

--- a/test/editor/Core/Helpers.re
+++ b/test/editor/Core/Helpers.re
@@ -39,11 +39,13 @@ let validateBuffer =
       actualBuffer: Buffer.t,
       expectedLines: array(string),
     ) => {
-  expect.int(Array.length(actualBuffer.lines)).toBe(Array.length(expectedLines));
+  expect.int(Array.length(actualBuffer.lines)).toBe(
+    Array.length(expectedLines),
+  );
 
   let validateLine = (actualLine, expectedLine) => {
     expect.string(actualLine).toEqual(expectedLine);
-  }
+  };
 
   let f = (actual, expected) => {
     validateLine(actual, expected);


### PR DESCRIPTION
__Issue:__ When adding a line at the end of a file (ie, `GO`), the buffer contents would disappear.

__Defect:__ Bug in our buffer update handling when the buffer update is past the extent of the buffer.

__Fix:__ Add test to exercise this case; fix buffer update logic.