### PR TITLE
Bugfix: Editor layout - gap on right side of scrollbar

### DIFF
--- a/src/editor/UI/EditorLayout.re
+++ b/src/editor/UI/EditorLayout.re
@@ -62,7 +62,14 @@ let getLayout =
   let minimapHeightInCharacters =
     pixelHeight / Constants.default.minimapCharacterHeight;
 
-  let leftOverWidth = pixelWidth - bufferWidthInPixels - minimapWidthInPixels - lineNumberWidthInPixels - Constants.default.scrollBarThickness - (Constants.default.minimapPadding * 2);
+  let leftOverWidth =
+    pixelWidth
+    - bufferWidthInPixels
+    - minimapWidthInPixels
+    - lineNumberWidthInPixels
+    - Constants.default.scrollBarThickness
+    - Constants.default.minimapPadding
+    * 2;
 
   {
     lineNumberWidthInPixels,

--- a/src/editor/UI/EditorLayout.re
+++ b/src/editor/UI/EditorLayout.re
@@ -62,10 +62,12 @@ let getLayout =
   let minimapHeightInCharacters =
     pixelHeight / Constants.default.minimapCharacterHeight;
 
+  let leftOverWidth = pixelWidth - bufferWidthInPixels - minimapWidthInPixels - lineNumberWidthInPixels - Constants.default.scrollBarThickness - (Constants.default.minimapPadding * 2);
+
   {
     lineNumberWidthInPixels,
     minimapWidthInPixels,
-    bufferWidthInPixels,
+    bufferWidthInPixels: bufferWidthInPixels + leftOverWidth,
     widthInCharacters,
     bufferHeightInCharacters,
     minimapHeightInCharacters,

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -52,12 +52,15 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let theme = state.theme;
     let style = rootStyle(theme.background, theme.foreground);
 
-    (hooks, <View style>
-      <View style=surfaceStyle> <Editor state /> </View>
-      <Overlay>
-        <Commandline theme command={state.commandline} />
-        <Wildmenu theme wildmenu={state.wildmenu} />
-      </Overlay>
-      <View style=statusBarStyle> <StatusBar mode={state.mode} /> </View>
-    </View>);
+    (
+      hooks,
+      <View style>
+        <View style=surfaceStyle> <Editor state /> </View>
+        <Overlay>
+          <Commandline theme command={state.commandline} />
+          <Wildmenu theme wildmenu={state.wildmenu} />
+        </Overlay>
+        <View style=statusBarStyle> <StatusBar mode={state.mode} /> </View>
+      </View>,
+    );
   });


### PR DESCRIPTION
__Issue:__ Depending on the window size, there is a small gap between the editor scrollbar and the edge of the screen.

__Defect:__ Because the buffer width is a multiple of the measured character width in pixels, sometimes there is a little bit of space leftover. That ends up on the right side of the window.

__Fix:__ Include this 'leftover' space in the main buffer area, between the text and the minimap, instead of on the window edge.