### PR TITLE
Feature/improve commandline cursor

### DIFF
--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -16,6 +16,7 @@ type t =
   | SetEditorSize(EditorSize.t)
   | CommandlineShow(Commandline.t)
   | CommandlineHide(Commandline.t)
+  | CommandlineUpdate((int, int))
   | WildmenuShow(Wildmenu.t)
   | WildmenuHide(Wildmenu.t)
   | WildmenuSelected(int)

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -61,6 +61,14 @@ let reduce: (State.t, Actions.t) => State.t =
     | SetEditorSize(size) => {...s, size}
     | CommandlineShow(commandline) => {...s, commandline}
     | CommandlineHide(commandline) => {...s, commandline}
+    | CommandlineUpdate((position, level)) => {
+        ...s,
+        commandline: {
+          ...s.commandline,
+          position,
+          level,
+        },
+      }
     | WildmenuShow(wildmenu) => {...s, wildmenu}
     | WildmenuHide(wildmenu) => {...s, wildmenu}
     | WildmenuSelected(selected) => {

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -45,6 +45,7 @@ type t =
   | CursorMoved(AutoCommandContext.t)
   | CommandlineShow(Commandline.t)
   | CommandlineHide(Commandline.t)
+  | CommandlineUpdate((int, int))
   | WildmenuShow(Wildmenu.t)
   | WildmenuHide(Wildmenu.t)
   | WildmenuSelected(int)
@@ -92,6 +93,12 @@ let showCommandline = args =>
       level,
       show: true,
     });
+  | _ => Ignored
+  };
+
+let updateCommandline = msgs =>
+  switch (msgs) {
+  | [M.Int(position), M.Int(level)] => CommandlineUpdate((position, level))
   | _ => Ignored
   };
 
@@ -143,6 +150,8 @@ let parseRedraw = (msgs: list(Msgpck.t)) => {
       showCommandline(msgs)
     | M.List([M.String("cmdline_hide"), M.List(msgs)]) =>
       hideCommandline(msgs)
+    | M.List([M.String("cmdline_pos"), M.List(msgs)]) =>
+      updateCommandline(msgs)
     | M.List([M.String("wildmenu_show"), M.List(msgs)]) =>
       showWildmenu(msgs)
     | M.List([M.String("wildmenu_select"), M.List([selected])]) =>

--- a/src/editor/UI/Commandline.re
+++ b/src/editor/UI/Commandline.re
@@ -4,7 +4,7 @@ open Oni_Core;
 
 let component = React.component("commandline");
 
-let cmdFontSize = 20;
+let cmdFontSize = 15;
 let cmdFontColor = Colors.white;
 
 let cmdTextStyles =
@@ -13,14 +13,13 @@ let cmdTextStyles =
     fontSize(cmdFontSize),
     color(cmdFontColor),
     textWrap(TextWrapping.WhitespaceWrap),
-    marginVertical(8),
   ];
 
 /*
    TODO: Flow text around a "cursor"
  */
 
-let getStringParts = (index, str) => {
+let getStringParts = (index, str) =>
   switch (index) {
   | 0 => ("", str)
   | _ =>
@@ -28,15 +27,14 @@ let getStringParts = (index, str) => {
     let strEnd = Str.string_after(str, index);
     (strBeginning, strEnd);
   };
-};
 
 let createElement =
-    (~children as _, ~command: Types.Commandline.t, ~theme: Theme.t, ()) => {
+    (~children as _, ~command: Types.Commandline.t, ~theme: Theme.t, ()) =>
   component(hooks => {
     let (startStr, endStr) =
       getStringParts(command.position, command.content);
-    command.show
-      ? (
+    command.show ?
+      (
         hooks,
         <View
           style=Style.[
@@ -46,6 +44,7 @@ let createElement =
             flexDirection(`Row),
             alignItems(`Center),
             marginBottom(20),
+            paddingVertical(8),
             boxShadow(
               ~xOffset=-15.,
               ~yOffset=5.,
@@ -61,15 +60,12 @@ let createElement =
           <View
             style=Style.[
               width(2),
-              alignSelf(`FlexEnd),
               height(cmdFontSize),
               backgroundColor(cmdFontColor),
-              marginVertical(8),
             ]
           />
           <Text style=cmdTextStyles text=endStr />
         </View>,
-      )
-      : (hooks, React.listToElement([]));
+      ) :
+      (hooks, React.listToElement([]));
   });
-};

--- a/src/editor/UI/Commandline.re
+++ b/src/editor/UI/Commandline.re
@@ -13,37 +13,22 @@ let cmdTextStyles =
     marginLeft(10),
     fontSize(cmdFontSize),
     color(cmdFontColor),
+    lineHeight(1.5),
+    textWrap(TextWrapping.WhitespaceWrap),
+    overflow(LayoutTypes.Hidden),
+    paddingLeft(10),
   ];
 
 /*
    TODO: Flow text around a "cursor"
  */
-let isZeroIndex = num => num - 1 <= 0;
-
-let safeStrSub = (str, strStart, strEnd) =>
-  switch (String.sub(str, strStart, strEnd)) {
-  | v => v
-  | exception (Invalid_argument(_)) =>
-    print_endline(
-      "Error getting substring from "
-      ++ str
-      ++ " starting at "
-      ++ string_of_int(strStart)
-      ++ " ending at "
-      ++ string_of_int(strEnd),
-    );
-    "";
-  };
 
 let getStringParts = (index, str) => {
-  switch (String.length(str), index) {
-  | (0, _) => ("", "")
-  | (_, i) when isZeroIndex(i) => (str, "")
-  | (l, _) when isZeroIndex(l) => (str, "")
-  | (l, i) when l == i => (str, "")
-  | (len, idx) =>
-    let strBeginning = safeStrSub(str, 0, idx - 1);
-    let strEnd = safeStrSub(str, idx - 1, len - 1);
+  switch (index) {
+  | 0 => ("", str)
+  | _ =>
+    let strBeginning = Str.string_before(str, index);
+    let strEnd = Str.string_after(str, index);
     (strBeginning, strEnd);
   };
 };
@@ -59,7 +44,6 @@ let createElement =
         <View
           style=Style.[
             width(400),
-            height(40),
             backgroundColor(theme.editorBackground),
             flexDirection(`Row),
             alignItems(`Center),

--- a/src/editor/UI/Commandline.re
+++ b/src/editor/UI/Commandline.re
@@ -10,13 +10,11 @@ let cmdFontColor = Colors.white;
 let cmdTextStyles =
   Style.[
     fontFamily("FiraCode-Regular.ttf"),
-    marginLeft(10),
     fontSize(cmdFontSize),
     color(cmdFontColor),
-    lineHeight(1.5),
     textWrap(TextWrapping.WhitespaceWrap),
     overflow(LayoutTypes.Hidden),
-    paddingLeft(10),
+    marginVertical(8),
   ];
 
 /*
@@ -56,7 +54,10 @@ let createElement =
               ~color=Color.rgba(0., 0., 0., 0.2),
             ),
           ]>
-          <Text style=cmdTextStyles text={command.firstC ++ startStr} />
+          <Text
+            style=Style.[marginLeft(10), ...cmdTextStyles]
+            text={command.firstC ++ startStr}
+          />
           <View
             style=Style.[
               width(2),

--- a/src/editor/UI/Commandline.re
+++ b/src/editor/UI/Commandline.re
@@ -13,7 +13,6 @@ let cmdTextStyles =
     fontSize(cmdFontSize),
     color(cmdFontColor),
     textWrap(TextWrapping.WhitespaceWrap),
-    overflow(LayoutTypes.Hidden),
     marginVertical(8),
   ];
 
@@ -42,6 +41,7 @@ let createElement =
         <View
           style=Style.[
             width(400),
+            overflow(LayoutTypes.Hidden),
             backgroundColor(theme.editorBackground),
             flexDirection(`Row),
             alignItems(`Center),
@@ -61,8 +61,10 @@ let createElement =
           <View
             style=Style.[
               width(2),
+              alignSelf(`FlexEnd),
               height(cmdFontSize),
               backgroundColor(cmdFontColor),
+              marginVertical(8),
             ]
           />
           <Text style=cmdTextStyles text=endStr />

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -41,9 +41,8 @@ let tokensToElement =
 
   let isActiveLine = lineNumber == cursorLine;
   let lineNumberTextColor =
-    isActiveLine
-      ? theme.editorActiveLineNumberForeground
-      : theme.editorLineNumberForeground;
+    isActiveLine ?
+      theme.editorActiveLineNumberForeground : theme.editorLineNumberForeground;
   let lineNumberAlignment = isActiveLine ? `FlexStart : `Center;
 
   let f = (token: Tokenizer.t) => {
@@ -107,14 +106,16 @@ let tokensToElement =
     <View style=lineNumberStyle>
       <Text
         style=lineNumberTextStyle
-        text={string_of_int(
-          LineNumber.getLineNumber(
-            ~bufferLine=lineNumber + 1,
-            ~cursorLine=cursorLine + 1,
-            ~setting=Relative,
-            (),
-          ),
-        )}
+        text={
+          string_of_int(
+            LineNumber.getLineNumber(
+              ~bufferLine=lineNumber + 1,
+              ~cursorLine=cursorLine + 1,
+              ~setting=Relative,
+              (),
+            ),
+          )
+        }
       />
     </View>
     <View style=lineContentsStyle> ...tokens </View>
@@ -186,9 +187,8 @@ let createElement = (~state: State.t, ~children as _, ()) =>
       ];
 
     let onDimensionsChanged =
-        ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
+        ({width, height}: NodeEvents.DimensionsChangedEventParams.t) =>
       GlobalContext.current().notifySizeChanged(~width, ~height, ());
-    };
 
     let layout =
       EditorLayout.getLayout(

--- a/src/editor/UI/Wildmenu.re
+++ b/src/editor/UI/Wildmenu.re
@@ -5,8 +5,6 @@ open Oni_Core;
 
 let component = React.component("wildmenu");
 
-let menuFontSize = 20;
-
 let containerStyles = (theme: Theme.t) =>
   Style.[
     width(400),
@@ -24,20 +22,24 @@ let containerStyles = (theme: Theme.t) =>
   ];
 
 let createElement =
-    (~children as _, ~wildmenu: Types.Wildmenu.t, ~theme: Theme.t, ()) => {
+    (~children as _, ~wildmenu: Types.Wildmenu.t, ~theme: Theme.t, ()) =>
   component(hooks => {
     let element =
-      wildmenu.show
-        ? <ScrollView style={containerStyles(theme)}>
-            ...{List.mapi(
-              (index, item) => {
-                let selected = index == wildmenu.selected;
-                <MenuItem selected theme label=item />;
-              },
-              wildmenu.items,
-            )}
-          </ScrollView>
-        : React.listToElement([]);
+      wildmenu.show ?
+        <ScrollView style={containerStyles(theme)}>
+          ...{
+               List.mapi(
+                 (index, item) =>
+                   <MenuItem
+                     theme
+                     label=item
+                     selected={index == wildmenu.selected}
+                     style=Style.[fontSize(16)]
+                   />,
+                 wildmenu.items,
+               )
+             }
+        </ScrollView> :
+        React.listToElement([]);
     (hooks, element);
   });
-};

--- a/src/editor/UI/dune
+++ b/src/editor/UI/dune
@@ -2,6 +2,7 @@
     (name Oni_UI)
     (public_name Oni_UI)
     (libraries 
+        str
         bigarray
         zed
         reglfw

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -209,6 +209,7 @@ let init = app => {
           | WildmenuShow(w) => Core.Actions.WildmenuShow(w)
           | WildmenuHide(w) => Core.Actions.WildmenuHide(w)
           | WildmenuSelected(s) => Core.Actions.WildmenuSelected(s)
+          | CommandlineUpdate(u) => Core.Actions.CommandlineUpdate(u)
           | CommandlineShow(c) => Core.Actions.CommandlineShow(c)
           | CommandlineHide(c) => Core.Actions.CommandlineHide(c)
           | _ => Noop


### PR DESCRIPTION
This PR improves the logic allowing the cursor in the commandline to move using the arrow keys

![cmd-cursor](https://user-images.githubusercontent.com/22454918/52911864-b471ef80-32a1-11e9-8970-2c14d4392742.gif)

### Note
This has some drawbacks as it also adds line wrapping which the cursor cannot properly follow, because when a text element wraps it does so as a rectangle so if the content of the bottom wrapped section is smaller than the width the cursor pokes out.

Not sure if this should be fixed by revery if not we will have to consider a completely different cursor strategy :confounded: 