### PR TITLE
Quote paths to prevent issues with paths that contain spaces.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Set the path for the file we are going to generate
 config_path="$(pwd)/assets/configuration"
 OUTPUT="$config_path/setup.json"
@@ -15,16 +17,16 @@ esac
 check_command_succeded() {
   # $? variable is the return code of a command
   if [ $? -eq 0 ]; then
-    echo Command: $1 Succeded
+    echo "Command: $1 Succeded"
   else
-    echo Command: $1 Failed
+    echo "Command: $1 Failed"
     exit
   fi
 }
 
 # this is a utility to help adding more variables to the generated file
 append_line() {
-  echo $1 >> $OUTPUT
+  echo "$1" >> "$OUTPUT"
 }
 
 # Based on the operating system get the correct vendor path
@@ -38,25 +40,25 @@ case "${machine}" in
       NEOVIM_PATH="$(pwd)/vendor/neovim-0.3.3/nvim-osx64/bin/nvim";;
   *)
       NEOVIM_PATH="$(pwd)/vendor/neovim-0.3.3/nvim-win64/bin/nvim.exe"
-      NEOVIM_PATH="$(cygpath -m $NEOVIM_PATH)"
+      NEOVIM_PATH="$(cygpath -m "$NEOVIM_PATH")"
       NODE_PATH="$(pwd)/vendor/node-v10.15.1/win-x64/node.exe"
-      NODE_PATH="$(cygpath -m $NODE_PATH)";;
+      NODE_PATH="$(cygpath -m "$NODE_PATH")";;
 esac
 
 oni_bin_path="{neovim:\"$NEOVIM_PATH\",node:\"$NODE_PATH\"}"
 
 # create the current bin path as this might not exist yet
 if [ ! -d "$config_path" ]; then
-  mkdir -p $config_path
+  mkdir -p "$config_path"
   check_command_succeded "creating parent directory: $config_path"
 fi
 # create the output file, if it exists remove it first so it is recreated
 if [[ -e $OUTPUT ]]; then
-  rm -f $OUTPUT
+  rm -f "$OUTPUT"
   check_command_succeded "removing old setup $OUTPUT"
 fi
 
-touch $OUTPUT
+touch "$OUTPUT"
 check_command_succeded "creating new $OUTPUT"
 
-append_line $oni_bin_path
+append_line "$oni_bin_path"


### PR DESCRIPTION
To continue with my Windows issues due to spaces in paths, hit an issue with the `bootstrap` script.

```
touch: cannot touch 'Files/Documents/Git/oni2/assets/configuration/setup.json': No such file or directory
Command: creating new /cygdrive/f/User Files/Documents/Git/oni2/assets/configuration/setup.json Failed
```

I've quoted the variables now, as well as all the rest since I think its best practise in shell scripts anyways.