### PR TITLE
Performance: Initial benchmarking infra

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -11,3 +11,9 @@ steps:
     displayName: 'Build: esy build'
   - script: esy x OniUnitTestRunner
     displayName: 'Unit Tests: esy x OniUnitTestRunner'
+  - script: esy @bench install
+    displayName: "Bench: install"
+  - script: esy @bench build
+    displayName: "Bench: build"
+  - script: esy @bench x oni-bench
+    displayName: "Bench: run"

--- a/OniBench.opam
+++ b/OniBench.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "bryphe@outrunlabs.com"
+author: ["Bryan Phelps"]
+build: [
+
+]

--- a/bench.json
+++ b/bench.json
@@ -3,7 +3,7 @@
   "override": {
       "build": ["dune build --root . -j4"],
       "dependencies": {
-        "reperf": "*"
+        "reperf": "^1.2.0"
       },
       "install": [
           "esy-installer OniBench.install"

--- a/bench.json
+++ b/bench.json
@@ -1,0 +1,12 @@
+{
+  "source": "./package.json",
+  "override": {
+      "build": ["dune build --root . -j4"],
+      "dependencies": {
+        "reperf": "*"
+      },
+      "install": [
+          "esy-installer OniBench.install"
+      ]
+  }
+}

--- a/bench/exe/Bench.re
+++ b/bench/exe/Bench.re
@@ -1,0 +1,1 @@
+OniBench.BenchFramework.cli();

--- a/bench/exe/dune
+++ b/bench/exe/dune
@@ -1,0 +1,6 @@
+(executable
+    (name bench)
+    (public_name oni-bench)
+    (libraries OniBench.lib)
+    (package OniBench)
+)

--- a/bench/lib/BenchEditorSurface.re
+++ b/bench/lib/BenchEditorSurface.re
@@ -5,10 +5,23 @@ open BenchFramework;
 open Revery.UI;
 
 let rootNode = (new node)();
-let simpleState = State.create();
+
+/* Create a state with some editor size */
+let simpleState = Reducer.reduce(State.create(), Actions.SetEditorSize(Types.EditorSize.create(~pixelWidth=1600, ~pixelHeight=1200, ())));
+
+let thousandLines = Array.make(1000, "This is a buffer with a thousand lines!") |> Array.to_list;
+
+let thousandLineState = Reducer.reduce(simpleState, Actions.BufferUpdate(Types.BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=thousandLines, ())));
 
 let editorSurfaceMinimalState = () => {
     let _ = React.RenderedElement.render(rootNode, <EditorSurface state={simpleState} />);
 };
 
-bench(~name="EditorSurface: Minimal state", ~f=editorSurfaceMinimalState, ());
+let editorSurfaceThousandLineState = () => {
+    let _ = React.RenderedElement.render(rootNode, <EditorSurface state={thousandLineState} />);
+};
+
+let options = Reperf.Options.create(~iterations=100, ());
+
+bench(~name="EditorSurface: Minimal state", ~options, ~f=editorSurfaceMinimalState, ());
+bench(~name="EditorSurface: Thousand Lines state", ~options, ~f=editorSurfaceThousandLineState, ());

--- a/bench/lib/BenchEditorSurface.re
+++ b/bench/lib/BenchEditorSurface.re
@@ -1,0 +1,14 @@
+open Oni_Core;
+open Oni_UI;
+open BenchFramework;
+
+open Revery.UI;
+
+let rootNode = (new node)();
+let simpleState = State.create();
+
+let editorSurfaceMinimalState = () => {
+    let _ = React.RenderedElement.render(rootNode, <EditorSurface state={simpleState} />);
+};
+
+bench(~name="EditorSurface: Minimal state", ~f=editorSurfaceMinimalState, ());

--- a/bench/lib/BenchFramework.re
+++ b/bench/lib/BenchFramework.re
@@ -1,0 +1,4 @@
+include Reperf.Make({
+  let config =
+    Reperf.Config.create(~snapshotDir="bench/__snapshots__", ());
+});

--- a/bench/lib/dune
+++ b/bench/lib/dune
@@ -1,0 +1,6 @@
+(library
+    (name OniBench)
+    (public_name OniBench.lib)
+    (ocamlopt_flags -linkall)
+    (libraries Oni_Core Oni_Neovim Oni_UI reperf.lib)
+)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be",
     "rebez": "github:jchavarri/rebez#46cbc183",
-    "revery": "github:revery-ui/revery#ccac6fc"
+    "revery": "github:revery-ui/revery#ccac6fc",
+    "reperf": "link:../reperf"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be",
     "rebez": "github:jchavarri/rebez#46cbc183",
-    "revery": "github:revery-ui/revery#ccac6fc",
-    "reperf": "link:../reperf"
+    "revery": "github:revery-ui/revery#ccac6fc"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",
-    "@opam/merlin": "*"
+    "@opam/merlin": "*",
+    "reperf": "^1.2.0"
   }
 }

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -52,8 +52,8 @@ let create: unit => t =
       EditorFont.create(
         ~fontFile="FiraCode-Regular.ttf",
         ~fontSize=14,
-        ~measuredWidth=0,
-        ~measuredHeight=0,
+        ~measuredWidth=1,
+        ~measuredHeight=1,
         (),
       ),
     tabs: [Tab.create(0, "[No Name]")],

--- a/src/editor/UI/Oni_UI.re
+++ b/src/editor/UI/Oni_UI.re
@@ -5,4 +5,5 @@
  */
 
 module GlobalContext = GlobalContext;
+module EditorSurface = EditorSurface;
 module Root = Root;


### PR DESCRIPTION
This adds infrastructure for benchmarking using the [`reperf`](https://github.com/bryphe/reperf) library. I put some simple benchmarks for our `EditorSurface` component which is doing most of the heavy-lifting right now. Benchmarks can be run via:
- `esy @bench install`
- `esy @bench build`
- `esy @bench x oni-bench`

I put a simple benchmark for an empty buffer and a buffer with a thousand lines:
```
+---------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                            |  TIME           |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED   |  MAJOR ALLOC  |
|---------------------------------------+-----------------+------------+------------+---------------+-------------+---------------|
|  EditorSurface: Minimal state         |  0.             |  1         |  0         |  120431       |  25         |  25           |
|---------------------------------------+-----------------+------------+------------+---------------+-------------+---------------|
|  EditorSurface: Thousand Lines state  |  6.35164308548  |  2000      |  299       |  390647745    |  288861325  |  289261725    |
+---------------------------------------------------------------------------------------------------------------------------------+
```

There is a __lot__ of room for improvement here! Our current `EditorSurface` strategy is very wasteful - we're re-tokenizing _and_ rendering the _entire buffer_ every render, which is unnecessary. Will be fun to fix that and see these numbers improve!





