### PR TITLE
Performance / UI: Virtualized list rendering for buffer + minimap

### DIFF
--- a/bench/lib/BenchEditorSurface.re
+++ b/bench/lib/BenchEditorSurface.re
@@ -7,30 +7,103 @@ open Revery.UI;
 let rootNode = (new node)();
 
 /* Create a state with some editor size */
-let simpleState = Reducer.reduce(State.create(), Actions.SetEditorSize(Types.EditorSize.create(~pixelWidth=1600, ~pixelHeight=1200, ())));
-let simpleState = Reducer.reduce(simpleState, Actions.SetEditorFont(Types.EditorFont.create(~fontFile="dummy", ~fontSize=14, ~measuredWidth=14, ~measuredHeight=14, ())));
+let simpleState =
+  Reducer.reduce(
+    State.create(),
+    Actions.SetEditorSize(
+      Types.EditorSize.create(~pixelWidth=1600, ~pixelHeight=1200, ()),
+    ),
+  );
+let simpleState =
+  Reducer.reduce(
+    simpleState,
+    Actions.SetEditorFont(
+      Types.EditorFont.create(
+        ~fontFile="dummy",
+        ~fontSize=14,
+        ~measuredWidth=14,
+        ~measuredHeight=14,
+        (),
+      ),
+    ),
+  );
 
-let thousandLines = Array.make(1000, "This is a buffer with a thousand lines!") |> Array.to_list;
+let thousandLines =
+  Array.make(1000, "This is a buffer with a thousand lines!") |> Array.to_list;
 
-let thousandLineState = Reducer.reduce(simpleState, Actions.BufferUpdate(Types.BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=thousandLines, ())));
+let thousandLineState =
+  Reducer.reduce(
+    simpleState,
+    Actions.BufferUpdate(
+      Types.BufferUpdate.create(
+        ~startLine=0,
+        ~endLine=1,
+        ~lines=thousandLines,
+        (),
+      ),
+    ),
+  );
 
-let hundredThousandLines = Array.make(100000, "This is a buffer with a hundred thousand lines!") |> Array.to_list;
-let hundredThousandLineState = Reducer.reduce(simpleState, Actions.BufferUpdate(Types.BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=hundredThousandLines, ())));
+let hundredThousandLines =
+  Array.make(100000, "This is a buffer with a hundred thousand lines!")
+  |> Array.to_list;
+let hundredThousandLineState =
+  Reducer.reduce(
+    simpleState,
+    Actions.BufferUpdate(
+      Types.BufferUpdate.create(
+        ~startLine=0,
+        ~endLine=1,
+        ~lines=hundredThousandLines,
+        (),
+      ),
+    ),
+  );
 
 let editorSurfaceMinimalState = () => {
-    let _ = React.RenderedElement.render(rootNode, <EditorSurface state={simpleState} />);
+  let _ =
+    React.RenderedElement.render(
+      rootNode,
+      <EditorSurface state=simpleState />,
+    );
+  ();
 };
 
 let editorSurfaceThousandLineState = () => {
-    let _ = React.RenderedElement.render(rootNode, <EditorSurface state={thousandLineState} />);
+  let _ =
+    React.RenderedElement.render(
+      rootNode,
+      <EditorSurface state=thousandLineState />,
+    );
+  ();
 };
 
 let editorSurfaceHundredThousandLineState = () => {
-    let _ = React.RenderedElement.render(rootNode, <EditorSurface state={hundredThousandLineState} />);
+  let _ =
+    React.RenderedElement.render(
+      rootNode,
+      <EditorSurface state=hundredThousandLineState />,
+    );
+  ();
 };
 
 let options = Reperf.Options.create(~iterations=10, ());
 
-bench(~name="EditorSurface: Minimal state", ~options, ~f=editorSurfaceMinimalState, ());
-bench(~name="EditorSurface: 1000 Lines state", ~options, ~f=editorSurfaceThousandLineState, ());
-bench(~name="EditorSurface: 100000 Lines state", ~options, ~f=editorSurfaceHundredThousandLineState, ());
+bench(
+  ~name="EditorSurface: Minimal state",
+  ~options,
+  ~f=editorSurfaceMinimalState,
+  (),
+);
+bench(
+  ~name="EditorSurface: 1000 Lines state",
+  ~options,
+  ~f=editorSurfaceThousandLineState,
+  (),
+);
+bench(
+  ~name="EditorSurface: 100000 Lines state",
+  ~options,
+  ~f=editorSurfaceHundredThousandLineState,
+  (),
+);

--- a/bench/lib/BenchEditorSurface.re
+++ b/bench/lib/BenchEditorSurface.re
@@ -14,6 +14,9 @@ let thousandLines = Array.make(1000, "This is a buffer with a thousand lines!") 
 
 let thousandLineState = Reducer.reduce(simpleState, Actions.BufferUpdate(Types.BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=thousandLines, ())));
 
+let hundredThousandLines = Array.make(100000, "This is a buffer with a hundred thousand lines!") |> Array.to_list;
+let hundredThousandLineState = Reducer.reduce(simpleState, Actions.BufferUpdate(Types.BufferUpdate.create(~startLine=0, ~endLine=1, ~lines=hundredThousandLines, ())));
+
 let editorSurfaceMinimalState = () => {
     let _ = React.RenderedElement.render(rootNode, <EditorSurface state={simpleState} />);
 };
@@ -22,7 +25,12 @@ let editorSurfaceThousandLineState = () => {
     let _ = React.RenderedElement.render(rootNode, <EditorSurface state={thousandLineState} />);
 };
 
-let options = Reperf.Options.create(~iterations=100, ());
+let editorSurfaceHundredThousandLineState = () => {
+    let _ = React.RenderedElement.render(rootNode, <EditorSurface state={hundredThousandLineState} />);
+};
+
+let options = Reperf.Options.create(~iterations=10, ());
 
 bench(~name="EditorSurface: Minimal state", ~options, ~f=editorSurfaceMinimalState, ());
-bench(~name="EditorSurface: Thousand Lines state", ~options, ~f=editorSurfaceThousandLineState, ());
+bench(~name="EditorSurface: 1000 Lines state", ~options, ~f=editorSurfaceThousandLineState, ());
+bench(~name="EditorSurface: 100000 Lines state", ~options, ~f=editorSurfaceHundredThousandLineState, ());

--- a/bench/lib/BenchEditorSurface.re
+++ b/bench/lib/BenchEditorSurface.re
@@ -8,6 +8,7 @@ let rootNode = (new node)();
 
 /* Create a state with some editor size */
 let simpleState = Reducer.reduce(State.create(), Actions.SetEditorSize(Types.EditorSize.create(~pixelWidth=1600, ~pixelHeight=1200, ())));
+let simpleState = Reducer.reduce(simpleState, Actions.SetEditorFont(Types.EditorFont.create(~fontFile="dummy", ~fontSize=14, ~measuredWidth=14, ~measuredHeight=14, ())));
 
 let thousandLines = Array.make(1000, "This is a buffer with a thousand lines!") |> Array.to_list;
 

--- a/bench/lib/BenchFramework.re
+++ b/bench/lib/BenchFramework.re
@@ -1,4 +1,3 @@
 include Reperf.Make({
-  let config =
-    Reperf.Config.create(~snapshotDir="bench/__snapshots__", ());
+  let config = Reperf.Config.create(~snapshotDir="bench/__snapshots__", ());
 });

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -136,25 +136,25 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let fontWidth = state.editorFont.measuredWidth;
 
     let cursorLine = state.cursorPosition.line;
-    let cursorWidth =	    
-      switch (state.mode) {	
-      | Insert => 2	
-      | _ => fontWidth	
-      };	
+    let cursorWidth =
+      switch (state.mode) {
+      | Insert => 2
+      | _ => fontWidth
+      };
 
-     let cursorStyle =	
-      Style.[	
-        position(`Absolute),	
-        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line)),	
-        left(	
-          lineNumberWidth	
-          + fontWidth	
-          * Index.toZeroBasedInt(state.cursorPosition.character),	
-        ),	
-        height(fontHeight),	
-        width(cursorWidth),	
-        opacity(0.8),	
-        backgroundColor(Colors.white),	
+    let cursorStyle =
+      Style.[
+        position(`Absolute),
+        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line)),
+        left(
+          lineNumberWidth
+          + fontWidth
+          * Index.toZeroBasedInt(state.cursorPosition.character),
+        ),
+        height(fontHeight),
+        width(cursorWidth),
+        opacity(0.8),
+        backgroundColor(Colors.white),
       ];
 
     let render = (b: BufferViewLine.t) =>
@@ -236,7 +236,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
             height={state.size.pixelHeight}
             rowHeight={state.editorFont.measuredHeight}
           />
-          <View style={cursorStyle} />
+          <View style=cursorStyle />
         </View>
         <View style=minimapViewStyle>
           <Minimap

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -5,6 +5,7 @@
  * the view of the buffer in the window.
  */
 
+open Revery.Core;
 open Revery.UI;
 
 open CamomileLibraryDefault.Camomile;
@@ -135,6 +136,26 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let fontWidth = state.editorFont.measuredWidth;
 
     let cursorLine = state.cursorPosition.line;
+    let cursorWidth =	    
+      switch (state.mode) {	
+      | Insert => 2	
+      | _ => fontWidth	
+      };	
+
+     let cursorStyle =	
+      Style.[	
+        position(`Absolute),	
+        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line)),	
+        left(	
+          lineNumberWidth	
+          + fontWidth	
+          * Index.toZeroBasedInt(state.cursorPosition.character),	
+        ),	
+        height(fontHeight),	
+        width(cursorWidth),	
+        opacity(0.8),	
+        backgroundColor(Colors.white),	
+      ];
 
     let render = (b: BufferViewLine.t) =>
       tokensToElement(
@@ -215,6 +236,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
             height={state.size.pixelHeight}
             rowHeight={state.editorFont.measuredHeight}
           />
+          <View style={cursorStyle} />
         </View>
         <View style=minimapViewStyle>
           <Minimap

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -5,7 +5,7 @@
  * the view of the buffer in the window.
  */
 
-open Revery.Core;
+/* open Revery.Core; */
 open Revery.UI;
 
 open CamomileLibraryDefault.Camomile;
@@ -156,41 +156,56 @@ let createElement = (~state: State.t, ~children as _, ()) =>
       |> TokenizedBuffer.ofBuffer
       |> TokenizedBufferView.ofTokenizedBuffer;
 
-    let textElements =
-      viewLinesToElements(
-        state.editorFont.measuredWidth,
-        state.editorFont.measuredHeight,
-        lineNumberWidth,
-        bufferView,
-        state.theme,
-        state.cursorPosition.line,
-      );
+    /* let textElements = */
+    /*   viewLinesToElements( */
+    /*     state.editorFont.measuredWidth, */
+    /*     state.editorFont.measuredHeight, */
+    /*     lineNumberWidth, */
+    /*     bufferView, */
+    /*     state.theme, */
+    /*     state.cursorPosition.line, */
+    /*   ); */
 
     let fontHeight = state.editorFont.measuredHeight;
     let fontWidth = state.editorFont.measuredWidth;
 
-    let cursorWidth =
-      switch (state.mode) {
-      | Insert => 2
-      | _ => fontWidth
-      };
+    let render = (fontWidth, fontHeight, lineNumberWidth, theme, cursorLine, b: BufferViewLine.t) => {
+        tokensToElement(
+          fontWidth,
+          fontHeight,
+          Index.toZeroBasedInt(b.lineNumber),
+          Index.toZeroBasedInt(b.virtualLineNumber),
+          lineNumberWidth,
+          b.tokens,
+          theme,
+          Index.toZeroBasedInt(cursorLine),
+        );
+    };
+    
+    let r = render(fontWidth, fontHeight, lineNumberWidth, theme, state.cursorPosition.line);
 
-    let cursorStyle =
-      Style.[
-        position(`Absolute),
-        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line)),
-        left(
-          lineNumberWidth
-          + fontWidth
-          * Index.toZeroBasedInt(state.cursorPosition.character),
-        ),
-        height(fontHeight),
-        width(cursorWidth),
-        opacity(0.8),
-        backgroundColor(Colors.white),
-      ];
+    /* let cursorWidth = */
+    /*   switch (state.mode) { */
+    /*   | Insert => 2 */
+    /*   | _ => fontWidth */
+    /*   }; */
 
-    let elements = [<View style=cursorStyle />, ...textElements];
+    /* let cursorStyle = */
+    /*   Style.[ */
+    /*     position(`Absolute), */
+    /*     top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line)), */
+    /*     left( */
+    /*       lineNumberWidth */
+    /*       + fontWidth */
+    /*       * Index.toZeroBasedInt(state.cursorPosition.character), */
+    /*     ), */
+    /*     height(fontHeight), */
+    /*     width(cursorWidth), */
+    /*     opacity(0.8), */
+    /*     backgroundColor(Colors.white), */
+    /*   ]; */
+
+    /* let elements = [<View style=cursorStyle />, ...textElements]; */
 
     let style =
       Style.[
@@ -251,7 +266,9 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     (
       hooks,
       <View style onDimensionsChanged>
-        <View style=bufferViewStyle> ...elements </View>
+        <View style=bufferViewStyle>
+            <FlatList render={r} data={bufferView.viewLines} width={bufferPixelWidth} height={state.size.pixelHeight} rowHeight={state.editorFont.measuredHeight} />
+        </View>
         <View style=minimapViewStyle>
           <Minimap state tokenizedBufferView=bufferView />
         </View>

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -270,7 +270,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
             <FlatList render={r} data={bufferView.viewLines} width={bufferPixelWidth} height={state.size.pixelHeight} rowHeight={state.editorFont.measuredHeight} />
         </View>
         <View style=minimapViewStyle>
-          <Minimap state tokenizedBufferView=bufferView />
+          <Minimap state width=layout.minimapWidthInPixels height=state.size.pixelHeight tokenizedBufferView=bufferView />
         </View>
         <View style=verticalScrollBarStyle />
       </View>,

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -1,0 +1,53 @@
+/*
+ * FlatList.re
+ *
+ * Virtualized list helper
+ */
+
+/* open Oni_Core; */
+open Revery.UI;
+
+type renderFunction('a) = ('a) => React.syntheticElement;
+
+let component = React.component("FlatList");
+
+let createElement = (
+    ~height as height_,
+    ~width as width_,
+    ~rowHeight: int,
+    ~render: renderFunction('a),
+    ~data: array('a),
+    (),
+) => component((hooks) => {
+   
+
+    let rowsToRender = rowHeight / height_;
+
+    let i = ref(0);
+
+    let items: ref(list(React.syntheticElement)) = ref([]);
+
+    while(i^ < rowsToRender) {
+
+        let item = data[i^];
+        let v = render(item);
+
+        items := List.append([v], items^);
+
+        i := i^ + 1;
+    }
+
+    items := List.rev(items^);
+
+    let style = Style.[
+        position(`Absolute),
+        top(0),
+        left(0),
+        width(width_),
+        height(height_),
+    ];
+
+    (hooks, <View style>
+        ...(items^)
+    </View>)
+});

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -17,17 +17,21 @@ let createElement = (
     ~rowHeight: int,
     ~render: renderFunction('a),
     ~data: array('a),
+    ~children as _,
     (),
 ) => component((hooks) => {
    
 
-    let rowsToRender = rowHeight / height_;
+    let rowsToRender = (rowHeight >  0) ? height_ / rowHeight : 0;
 
     let i = ref(0);
 
     let items: ref(list(React.syntheticElement)) = ref([]);
 
-    while(i^ < rowsToRender) {
+    let len = Array.length(data);
+
+    while(i^ < rowsToRender && i^ < len) {
+        /* print_endline ("rendering row: " ++ string_of_int(i^)); */
 
         let item = data[i^];
         let v = render(item);

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -7,22 +7,22 @@
 /* open Oni_Core; */
 open Revery.UI;
 
-type renderFunction('a) = ('a) => React.syntheticElement;
+type renderFunction('a) = 'a => React.syntheticElement;
 
 let component = React.component("FlatList");
 
-let createElement = (
-    ~height as height_,
-    ~width as width_,
-    ~rowHeight: int,
-    ~render: renderFunction('a),
-    ~data: array('a),
-    ~children as _,
-    (),
-) => component((hooks) => {
-   
-
-    let rowsToRender = (rowHeight >  0) ? height_ / rowHeight : 0;
+let createElement =
+    (
+      ~height as height_,
+      ~width as width_,
+      ~rowHeight: int,
+      ~render: renderFunction('a),
+      ~data: array('a),
+      ~children as _,
+      (),
+    ) =>
+  component(hooks => {
+    let rowsToRender = rowHeight > 0 ? height_ / rowHeight : 0;
 
     let i = ref(0);
 
@@ -30,28 +30,27 @@ let createElement = (
 
     let len = Array.length(data);
 
-    while(i^ < rowsToRender && i^ < len) {
-        /* print_endline ("rendering row: " ++ string_of_int(i^)); */
+    while (i^ < rowsToRender && i^ < len) {
+      /* print_endline ("rendering row: " ++ string_of_int(i^)); */
 
-        let item = data[i^];
-        let v = render(item);
+      let item = data[i^];
+      let v = render(item);
 
-        items := List.append([v], items^);
+      items := List.append([v], items^);
 
-        i := i^ + 1;
-    }
+      i := i^ + 1;
+    };
 
     items := List.rev(items^);
 
-    let style = Style.[
+    let style =
+      Style.[
         position(`Absolute),
         top(0),
         left(0),
         width(width_),
         height(height_),
-    ];
+      ];
 
-    (hooks, <View style>
-        ...(items^)
-    </View>)
-});
+    (hooks, <View style> ...items^ </View>);
+  });

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -50,14 +50,13 @@ let tokensToElement =
   <View style=lineStyle> ...tokens </View>;
 };
 
-  let renderLine = (theme, b: BufferViewLine.t) => {
-    tokensToElement(
-      Index.toZeroBasedInt(b.virtualLineNumber),
-      b.tokens,
-      theme,
-    );
-  };
-
+let renderLine = (theme, b: BufferViewLine.t) => {
+  tokensToElement(
+    Index.toZeroBasedInt(b.virtualLineNumber),
+    b.tokens,
+    theme,
+  );
+};
 
 let component = React.component("Minimap");
 
@@ -74,10 +73,21 @@ let createElement =
     let style =
       Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
-    let rowHeight = Constants.default.minimapCharacterHeight + Constants.default.minimapLineSpacing;
-    let render =  renderLine(state.theme);
+    let rowHeight =
+      Constants.default.minimapCharacterHeight
+      + Constants.default.minimapLineSpacing;
+    let render = renderLine(state.theme);
 
-    (hooks, <View style>
-        <FlatList width height rowHeight render data={tokenizedBufferView.viewLines} />
-     </View>);
+    (
+      hooks,
+      <View style>
+        <FlatList
+          width
+          height
+          rowHeight
+          render
+          data={tokenizedBufferView.viewLines}
+        />
+      </View>,
+    );
   });

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -50,8 +50,7 @@ let tokensToElement =
   <View style=lineStyle> ...tokens </View>;
 };
 
-let viewLinesToElements = (bufferView: TokenizedBufferView.t, theme) => {
-  let f = (b: BufferViewLine.t) => {
+  let renderLine = (theme, b: BufferViewLine.t) => {
     tokensToElement(
       Index.toZeroBasedInt(b.virtualLineNumber),
       b.tokens,
@@ -59,14 +58,14 @@ let viewLinesToElements = (bufferView: TokenizedBufferView.t, theme) => {
     );
   };
 
-  Array.map(f, bufferView.viewLines) |> Array.to_list;
-};
 
 let component = React.component("Minimap");
 
 let createElement =
     (
       ~state: State.t,
+      ~width: int,
+      ~height: int,
       ~tokenizedBufferView: TokenizedBufferView.t,
       ~children as _,
       (),
@@ -75,7 +74,10 @@ let createElement =
     let style =
       Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
-    let elements = viewLinesToElements(tokenizedBufferView, state.theme);
+    let rowHeight = Constants.default.minimapCharacterHeight + Constants.default.minimapLineSpacing;
+    let render =  renderLine(state.theme);
 
-    (hooks, <View style> ...elements </View>);
+    (hooks, <View style>
+        <FlatList width height rowHeight render data={tokenizedBufferView.viewLines} />
+     </View>);
   });


### PR DESCRIPTION
As mentioned in #60 , Onivim2 currently always renders the entire buffer - which is horrible for performance!

This change brings in a virtualized list (like the `FlatList` in the React-Native world), so that we only render lines that are in the current view. 

This is the first major performance bottleneck we saw - previous measurements were:
```
+---------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                            |  TIME           |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED   |  MAJOR ALLOC  |
|---------------------------------------+-----------------+------------+------------+---------------+-------------+---------------|
|  EditorSurface: Minimal state         |  0.             |  1         |  0         |  120431       |  25         |  25           |
|---------------------------------------+-----------------+------------+------------+---------------+-------------+---------------|
|  EditorSurface: Thousand Lines state  |  6.35164308548  |  2000      |  299       |  390647745    |  288861325  |  289261725    |
+---------------------------------------------------------------------------------------------------------------------------------+
```

With the virtualization changes, they are now:
```
+--------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                        |  TIME               |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|-----------------------------------+---------------------+------------+------------+---------------+------------+---------------|
|  EditorSurface: Minimal state     |  0.000976085662842  |  1         |  0         |  150534       |  25        |  25           |
|-----------------------------------+---------------------+------------+------------+---------------+------------+---------------|
|  EditorSurface: 1000 Lines state  |  1.23529911041      |  533       |  98        |  102424684    |  64807062  |  65007262     |
+--------------------------------------------------------------------------------------------------------------------------------+
```

__~5x improvement in timing__ and __~3-4x improvement in GC allocs__. This also doesn't measure the actual draw calls (just the reconciliation), so there'd also be a perf benefit there.

What's neat about the OCaml infrastructure is that the GC behavior is deterministic - so we should be able to hook this up build-over-build to verify we don't regress performance!

We're still doing some wasteful things - like re-tokenizing the buffer on every render - addressing that should bring us within striking distance of our perf goals.