### PR TITLE
Editor: Initial smooth scroll implementation

### DIFF
--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -20,4 +20,5 @@ type t =
   | WildmenuShow(Wildmenu.t)
   | WildmenuHide(Wildmenu.t)
   | WildmenuSelected(int)
+  | EditorScroll(int)
   | Noop;

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -80,7 +80,10 @@ let reduce: (State.t, Actions.t) => State.t =
           level,
         },
       }
-    | EditorScroll(scrollY) => {...s, editor: Editor.scroll(s.editor, scrollY) }
+    | EditorScroll(scrollY) => {
+        ...s,
+        editor: Editor.scroll(s.editor, scrollY),
+      }
     | WildmenuShow(wildmenu) => {...s, wildmenu}
     | WildmenuHide(wildmenu) => {...s, wildmenu}
     | WildmenuSelected(selected) => {

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -80,6 +80,7 @@ let reduce: (State.t, Actions.t) => State.t =
           level,
         },
       }
+    | EditorScroll(scrollY) => {...s, editor: Editor.scroll(s.editor, scrollY) }
     | WildmenuShow(wildmenu) => {...s, wildmenu}
     | WildmenuHide(wildmenu) => {...s, wildmenu}
     | WildmenuSelected(selected) => {

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -28,6 +28,7 @@ type t = {
   configuration: Configuration.t,
   theme: Theme.t,
   size: EditorSize.t,
+  editor: Editor.t,
 };
 
 let create: unit => t =
@@ -62,4 +63,5 @@ let create: unit => t =
     tabs: [Tab.create(0, "[No Name]")],
     theme: Theme.create(),
     size: EditorSize.create(~pixelWidth=0, ~pixelHeight=0, ()),
+    editor: Editor.create(~scrollY=0, ()),
   };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -29,23 +29,20 @@ module EditorSize = {
 };
 
 module Editor = {
-    type t = {
-        id: int,
-        scrollY: int,
-    };
+  type t = {
+    id: int,
+    scrollY: int,
+  };
 
-    let create = (~scrollY=0, ()) => {
-        let ret: t = {
-            id: 0,
-            scrollY: scrollY,
-        };
-        ret;
-    };
+  let create = (~scrollY=0, ()) => {
+    let ret: t = {id: 0, scrollY};
+    ret;
+  };
 
-    let scroll = (view: t, scrollDeltaY) => {
-       ...view,
-        scrollY: view.scrollY + scrollDeltaY,
-    };
+  let scroll = (view: t, scrollDeltaY) => {
+    ...view,
+    scrollY: view.scrollY + scrollDeltaY,
+  };
 };
 
 module Mode = {

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -28,6 +28,26 @@ module EditorSize = {
   };
 };
 
+module Editor = {
+    type t = {
+        id: int,
+        scrollY: int,
+    };
+
+    let create = (~scrollY=0, ()) => {
+        let ret: t = {
+            id: 0,
+            scrollY: scrollY,
+        };
+        ret;
+    };
+
+    let scroll = (view: t, scrollDeltaY) => {
+       ...view,
+        scrollY: view.scrollY + scrollDeltaY,
+    };
+};
+
 module Mode = {
   type t =
     | Insert

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -64,13 +64,7 @@ let tokensToElement =
     <Text style text={token.text} />;
   };
 
-  let lineStyle =
-    Style.[
-      position(`Absolute),
-      top(0),
-      left(0),
-      right(0),
-    ];
+  let lineStyle = Style.[position(`Absolute), top(0), left(0), right(0)];
 
   let lineNumberStyle =
     Style.[
@@ -158,7 +152,11 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let cursorStyle =
       Style.[
         position(`Absolute),
-        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line) - state.editor.scrollY),
+        top(
+          fontHeight
+          * Index.toZeroBasedInt(state.cursorPosition.line)
+          - state.editor.scrollY,
+        ),
         left(
           lineNumberWidth
           + fontWidth

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -30,7 +30,7 @@ let tokensToElement =
       fontWidth: int,
       fontHeight: int,
       lineNumber: int,
-      virtualLineNumber: int,
+      _virtualLineNumber: int,
       lineNumberWidth: int,
       theme: Theme.t,
       cursorLine: int,
@@ -65,7 +65,7 @@ let tokensToElement =
   let lineStyle =
     Style.[
       position(`Absolute),
-      top(fontHeight * virtualLineNumber),
+      top(0),
       left(0),
       right(0),
     ];

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -15,6 +15,8 @@ open Oni_Core.TokenizedBufferView;
 
 open Types;
 
+let empty = React.listToElement([]);
+
 /* Set up some styles */
 let textHeaderStyle =
   Style.[fontFamily("FiraCode-Regular.ttf"), fontSize(14)];
@@ -156,7 +158,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let cursorStyle =
       Style.[
         position(`Absolute),
-        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line)),
+        top(fontHeight * Index.toZeroBasedInt(state.cursorPosition.line) - state.editor.scrollY),
         left(
           lineNumberWidth
           + fontWidth
@@ -212,6 +214,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         left(0),
         width(bufferPixelWidth),
         bottom(0),
+        overflow(LayoutTypes.Hidden),
       ];
 
     let minimapPixelWidth =
@@ -219,6 +222,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let minimapViewStyle =
       Style.[
         position(`Absolute),
+        overflow(LayoutTypes.Hidden),
         top(0),
         left(bufferPixelWidth),
         width(minimapPixelWidth),
@@ -245,6 +249,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
             width=bufferPixelWidth
             height={state.size.pixelHeight}
             rowHeight={state.editorFont.measuredHeight}
+            scrollY={state.editor.scrollY}
           />
           <View style=cursorStyle />
         </View>

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -14,6 +14,7 @@ let additionalRowsToRender = 1;
 
 let createElement =
     (
+      ~scrollY=0,
       ~height as height_,
       ~width as width_,
       ~rowHeight: int,
@@ -23,8 +24,7 @@ let createElement =
       (),
     ) =>
   component(hooks => {
-    let (v, setV, hooks) = React.Hooks.state(0, hooks);
-    let scrollY = v;
+    /* let (v, setV, hooks) = React.Hooks.state(0, hooks); */
     let rowsToRender = rowHeight > 0 ? height_ / rowHeight : 0;
     let startRowOffset = rowHeight > 0 ? scrollY / rowHeight : 0;
     let pixelOffset = scrollY mod rowHeight;
@@ -57,7 +57,6 @@ let createElement =
     let style =
       Style.[
         position(`Absolute),
-        overflow(LayoutTypes.Hidden),
         top(0),
         left(0),
         width(width_),
@@ -65,7 +64,7 @@ let createElement =
       ];
 
     let scroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
-        setV(max(v - (int_of_float(wheelEvent.deltaY) * 25), 0));
+        GlobalContext.current().editorScroll(~deltaY=int_of_float(wheelEvent.deltaY) * 25, ());
     };
 
     (hooks, <View style onMouseWheel={scroll}> ...items^ </View>);

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -4,7 +4,6 @@
  * Virtualized list helper
  */
 
-/* open Oni_Core; */
 open Revery.UI;
 
 type renderFunction('a) = 'a => React.syntheticElement;

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -37,16 +37,17 @@ let createElement =
 
     while (i^ < rowsToRender + additionalRowsToRender && i^ < len) {
       let rowOffset = (i^ - startRowOffset) * rowHeight;
-      let rowContainerStyle = Style.[
-        position(`Absolute),
-            top(rowOffset - pixelOffset),
-            left(0),
-            right(0),
-            height(rowHeight),
-      ];
+      let rowContainerStyle =
+        Style.[
+          position(`Absolute),
+          top(rowOffset - pixelOffset),
+          left(0),
+          right(0),
+          height(rowHeight),
+        ];
 
       let item = data[i^];
-      let v = <View style={rowContainerStyle}>{render(item)}</View>;
+      let v = <View style=rowContainerStyle> {render(item)} </View>;
 
       items := List.append([v], items^);
       i := i^ + 1;
@@ -64,8 +65,11 @@ let createElement =
       ];
 
     let scroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
-        GlobalContext.current().editorScroll(~deltaY=int_of_float(wheelEvent.deltaY) * 25, ());
+      GlobalContext.current().editorScroll(
+        ~deltaY=int_of_float(wheelEvent.deltaY) * 25,
+        (),
+      );
     };
 
-    (hooks, <View style onMouseWheel={scroll}> ...items^ </View>);
+    (hooks, <View style onMouseWheel=scroll> ...items^ </View>);
   });

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -66,7 +66,6 @@ let createElement =
       ];
 
     let scroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
-        print_endline ("delta: " ++ string_of_float(wheelEvent.deltaY));
         setV(max(v - (int_of_float(wheelEvent.deltaY) * 25), 0));
     };
 

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -11,6 +11,8 @@ type renderFunction('a) = 'a => React.syntheticElement;
 
 let component = React.component("FlatList");
 
+let additionalRowsToRender = 1;
+
 let createElement =
     (
       ~height as height_,
@@ -22,22 +24,32 @@ let createElement =
       (),
     ) =>
   component(hooks => {
+    let (v, setV, hooks) = React.Hooks.state(0, hooks);
+    let scrollY = v;
     let rowsToRender = rowHeight > 0 ? height_ / rowHeight : 0;
+    let startRowOffset = rowHeight > 0 ? scrollY / rowHeight : 0;
+    let pixelOffset = scrollY mod rowHeight;
 
-    let i = ref(0);
+    let i = ref(max(startRowOffset - additionalRowsToRender, 0));
 
     let items: ref(list(React.syntheticElement)) = ref([]);
 
     let len = Array.length(data);
 
-    while (i^ < rowsToRender && i^ < len) {
-      /* print_endline ("rendering row: " ++ string_of_int(i^)); */
+    while (i^ < rowsToRender + additionalRowsToRender && i^ < len) {
+      let rowOffset = (i^ - startRowOffset) * rowHeight;
+      let rowContainerStyle = Style.[
+        position(`Absolute),
+            top(rowOffset - pixelOffset),
+            left(0),
+            right(0),
+            height(rowHeight),
+      ];
 
       let item = data[i^];
-      let v = render(item);
+      let v = <View style={rowContainerStyle}>{render(item)}</View>;
 
       items := List.append([v], items^);
-
       i := i^ + 1;
     };
 
@@ -46,11 +58,17 @@ let createElement =
     let style =
       Style.[
         position(`Absolute),
+        overflow(LayoutTypes.Hidden),
         top(0),
         left(0),
         width(width_),
         height(height_),
       ];
 
-    (hooks, <View style> ...items^ </View>);
+    let scroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
+        print_endline ("delta: " ++ string_of_float(wheelEvent.deltaY));
+        setV(max(v - (int_of_float(wheelEvent.deltaY) * 25), 0));
+    };
+
+    (hooks, <View style onMouseWheel={scroll}> ...items^ </View>);
   });

--- a/src/editor/UI/GlobalContext.re
+++ b/src/editor/UI/GlobalContext.re
@@ -8,17 +8,17 @@
  * Hopefully, once there is a context API, this can be wholly replaced with it!
  */
 
-type notifySizeChanged= (~width: int, ~height: int, unit) => unit;
+type notifySizeChanged = (~width: int, ~height: int, unit) => unit;
 type editorScroll = (~deltaY: int, unit) => unit;
 
 type t = {
-    notifySizeChanged,
-    editorScroll,
+  notifySizeChanged,
+  editorScroll,
 };
 
 let default = {
-    notifySizeChanged: (~width as _, ~height as _, ()) => (),
-    editorScroll: (~deltaY as _, ()) => (),
+  notifySizeChanged: (~width as _, ~height as _, ()) => (),
+  editorScroll: (~deltaY as _, ()) => (),
 };
 
 let _current: ref(t) = ref(default);

--- a/src/editor/UI/GlobalContext.re
+++ b/src/editor/UI/GlobalContext.re
@@ -8,11 +8,18 @@
  * Hopefully, once there is a context API, this can be wholly replaced with it!
  */
 
-type notifySizeChangedFunction = (~width: int, ~height: int, unit) => unit;
+type notifySizeChanged= (~width: int, ~height: int, unit) => unit;
+type editorScroll = (~deltaY: int, unit) => unit;
 
-type t = {notifySizeChanged: notifySizeChangedFunction};
+type t = {
+    notifySizeChanged,
+    editorScroll,
+};
 
-let default = {notifySizeChanged: (~width as _, ~height as _, ()) => ()};
+let default = {
+    notifySizeChanged: (~width as _, ~height as _, ()) => (),
+    editorScroll: (~deltaY as _, ()) => (),
+};
 
 let _current: ref(t) = ref(default);
 

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -12,7 +12,7 @@ open Oni_Core.TokenizedBufferView;
 open Types;
 
 let tokensToElement =
-    (virtualLineNumber: int, tokens: list(Tokenizer.t), theme: Theme.t) => {
+    (tokens: list(Tokenizer.t), theme: Theme.t) => {
   let f = (token: Tokenizer.t) => {
     let tokenWidth =
       Index.toZeroBasedInt(token.endPosition)
@@ -37,11 +37,7 @@ let tokensToElement =
     Style.[
       position(`Absolute),
       top(
-        (
-          Constants.default.minimapCharacterHeight
-          + Constants.default.minimapLineSpacing
-        )
-        * virtualLineNumber,
+            0
       ),
     ];
 
@@ -52,7 +48,6 @@ let tokensToElement =
 
 let renderLine = (theme, b: BufferViewLine.t) => {
   tokensToElement(
-    Index.toZeroBasedInt(b.virtualLineNumber),
     b.tokens,
     theme,
   );

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -11,15 +11,9 @@ open Oni_Core.TokenizedBufferView;
 
 open Types;
 
-let lineStyle = Style.[
-    position(`Absolute),
-    top(
-        0
-    )
-];
+let lineStyle = Style.[position(`Absolute), top(0)];
 
-let tokensToElement =
-    (tokens: list(Tokenizer.t), theme: Theme.t) => {
+let tokensToElement = (tokens: list(Tokenizer.t), theme: Theme.t) => {
   let f = (token: Tokenizer.t) => {
     let tokenWidth =
       Index.toZeroBasedInt(token.endPosition)
@@ -46,21 +40,13 @@ let tokensToElement =
 };
 
 let renderLine = (theme, b: BufferViewLine.t) => {
-  tokensToElement(
-    b.tokens,
-    theme,
-  );
+  tokensToElement(b.tokens, theme);
 };
 
 let component = React.component("Minimap");
 
-let absoluteStyle = Style.[
-    position(`Absolute),
-    top(0),
-    bottom(0),
-    left(0),
-    right(0),
-];
+let absoluteStyle =
+  Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
 let createElement =
     (
@@ -72,7 +58,6 @@ let createElement =
       (),
     ) =>
   component(hooks => {
-
     let rowHeight =
       Constants.default.minimapCharacterHeight
       + Constants.default.minimapLineSpacing;
@@ -80,7 +65,7 @@ let createElement =
 
     (
       hooks,
-      <View style={absoluteStyle}>
+      <View style=absoluteStyle>
         <FlatList
           width
           height

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -11,6 +11,13 @@ open Oni_Core.TokenizedBufferView;
 
 open Types;
 
+let lineStyle = Style.[
+    position(`Absolute),
+    top(
+        0
+    )
+];
+
 let tokensToElement =
     (tokens: list(Tokenizer.t), theme: Theme.t) => {
   let f = (token: Tokenizer.t) => {
@@ -33,14 +40,6 @@ let tokensToElement =
     <View style />;
   };
 
-  let lineStyle =
-    Style.[
-      position(`Absolute),
-      top(
-            0
-      ),
-    ];
-
   let tokens = List.map(f, tokens);
 
   <View style=lineStyle> ...tokens </View>;
@@ -55,6 +54,14 @@ let renderLine = (theme, b: BufferViewLine.t) => {
 
 let component = React.component("Minimap");
 
+let absoluteStyle = Style.[
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+];
+
 let createElement =
     (
       ~state: State.t,
@@ -65,8 +72,6 @@ let createElement =
       (),
     ) =>
   component(hooks => {
-    let style =
-      Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
     let rowHeight =
       Constants.default.minimapCharacterHeight
@@ -75,7 +80,7 @@ let createElement =
 
     (
       hooks,
-      <View style>
+      <View style={absoluteStyle}>
         <FlatList
           width
           height

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -42,6 +42,7 @@ let init = app => {
             ),
           ),
         ),
+      editorScroll: (~deltaY, ()) => App.dispatch(app, Core.Actions.EditorScroll(deltaY)),
     });
     prerr_endline(
       "[DEBUG - STATE] Mode: "

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -42,7 +42,8 @@ let init = app => {
             ),
           ),
         ),
-      editorScroll: (~deltaY, ()) => App.dispatch(app, Core.Actions.EditorScroll(deltaY)),
+      editorScroll: (~deltaY, ()) =>
+        App.dispatch(app, Core.Actions.EditorScroll(deltaY)),
     });
     prerr_endline(
       "[DEBUG - STATE] Mode: "


### PR DESCRIPTION
An initial implementation of smooth-scrolling (allowing our `FlatList` to have pixel offsets):

![smooth-scroll](https://user-images.githubusercontent.com/13532591/53107993-16716580-34eb-11e9-9315-113cc392c45e.gif)

Still a few things to work out:
- [x] Fix cursor rendering

And then some things to track in next steps:
- Need to synchronize minimap (will do this in a separate issue)
- Set up the right scrollbar to be 'scrollable'