### PR TITLE
Bugfix: Buffer updates not handled correctly

### DIFF
--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -12,24 +12,21 @@ type t = {
 };
 
 let ofLines = (lines: array(string)) => {
-  let ret: t = {
-      metadata: BufferMetadata.create(),
-      lines
-  };
+  let ret: t = {metadata: BufferMetadata.create(), lines};
   ret;
 };
 
 let show = (b: t) => {
-    "Buffer [" ++ string_of_int(b.metadata.id) ++ "]: " ++ String.concat("\n", Array.to_list(b.lines));
-}
+  "Buffer ["
+  ++ string_of_int(b.metadata.id)
+  ++ "]: "
+  ++ String.concat("\n", Array.to_list(b.lines));
+};
 
 let ofMetadata = (metadata: BufferMetadata.t) => {
-    let ret: t = {
-        metadata,
-        lines: [||],
-    };
-    ret;
-}
+  let ret: t = {metadata, lines: [||]};
+  ret;
+};
 
 let slice = (~lines: array(string), ~start, ~length, ()) => {
   let len = Array.length(lines);

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -12,7 +12,7 @@ type t = {
 };
 
 let ofLines = (lines: array(string)) => {
-  metadata: BufferMetadata.create(), 
+  metadata: BufferMetadata.create(),
   lines,
 };
 
@@ -23,10 +23,7 @@ let show = (b: t) => {
   ++ String.concat("\n", Array.to_list(b.lines));
 };
 
-let ofMetadata = (metadata: BufferMetadata.t) => {
-  metadata, 
-  lines: [||],
-};
+let ofMetadata = (metadata: BufferMetadata.t) => {metadata, lines: [||]};
 
 let slice = (~lines: array(string), ~start, ~length, ()) => {
   let len = Array.length(lines);

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -12,8 +12,8 @@ type t = {
 };
 
 let ofLines = (lines: array(string)) => {
-  let ret: t = {metadata: BufferMetadata.create(), lines};
-  ret;
+  metadata: BufferMetadata.create(), 
+  lines,
 };
 
 let show = (b: t) => {
@@ -24,8 +24,8 @@ let show = (b: t) => {
 };
 
 let ofMetadata = (metadata: BufferMetadata.t) => {
-  let ret: t = {metadata, lines: [||]};
-  ret;
+  metadata, 
+  lines: [||],
 };
 
 let slice = (~lines: array(string), ~start, ~length, ()) => {

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -7,14 +7,25 @@
 open Types;
 
 type t = {
-  file: option(string),
+  metadata: BufferMetadata.t,
   lines: array(string),
 };
 
 let ofLines = (lines: array(string)) => {
-  let ret: t = {file: None, lines};
+  let ret: t = {
+      metadata: BufferMetadata.create(),
+      lines
+  };
   ret;
 };
+
+let ofMetadata = (metadata: BufferMetadata.t) => {
+    let ret: t = {
+        metadata,
+        lines: [||],
+    };
+    ret;
+}
 
 let slice = (~lines: array(string), ~start, ~length, ()) => {
   let len = Array.length(lines);

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -19,6 +19,10 @@ let ofLines = (lines: array(string)) => {
   ret;
 };
 
+let show = (b: t) => {
+    "Buffer [" ++ string_of_int(b.metadata.id) ++ "]: " ++ String.concat("\n", Array.to_list(b.lines));
+}
+
 let ofMetadata = (metadata: BufferMetadata.t) => {
     let ret: t = {
         metadata,

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -13,14 +13,29 @@ module Buffers =
   });
 
 let empty = Buffers.empty;
-type t = Buffers.t(buffer);
+type t = Buffers.t(Buffer.t);
 
-let update = (buffersMap, newBuffers) =>
+type mapFunction = Buffer.t => Buffer.t;
+
+let map = Buffers.map;
+let update = Buffers.update;
+
+let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) =>
   List.fold_left(
-    (m, buffer) => Buffers.add(buffer.id, buffer, m),
+    (m: t, metadata: BufferMetadata.t) => {
+        Buffers.update(metadata.id, (original) => {
+            switch (original) {
+            | None => Some(Buffer.ofMetadata(metadata))
+            | Some(v) => Some({
+                ...v,
+                metadata,
+            }: Buffer.t)
+            }
+        }, m);
+    },
     buffersMap,
     newBuffers,
   );
 
-let getActiveBuffer = (activeBufferId, map) =>
-  Buffers.find(activeBufferId, map);
+let getBuffer = (id, map) =>
+  Buffers.find(id, map);

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -22,20 +22,18 @@ let update = Buffers.update;
 
 let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) =>
   List.fold_left(
-    (m: t, metadata: BufferMetadata.t) => {
-        Buffers.update(metadata.id, (original) => {
-            switch (original) {
-            | None => Some(Buffer.ofMetadata(metadata))
-            | Some(v) => Some({
-                ...v,
-                metadata,
-            }: Buffer.t)
-            }
-        }, m);
-    },
+    (m: t, metadata: BufferMetadata.t) =>
+      Buffers.update(
+        metadata.id,
+        original =>
+          switch (original) {
+          | None => Some(Buffer.ofMetadata(metadata))
+          | Some(v) => Some({...v, metadata}: Buffer.t)
+          },
+        m,
+      ),
     buffersMap,
     newBuffers,
   );
 
-let getBuffer = (id, map) =>
-  Buffers.find(id, map);
+let getBuffer = (id, map) => Buffers.find(id, map);

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -45,14 +45,8 @@ let showTablineBuffers = (state: State.t, buffers: list(BufferMetadata.t)) => {
 let applyBufferUpdate =
     (bufferUpdate: BufferUpdate.t, buffer: option(Buffer.t)) => {
   switch (buffer) {
-  | None =>
-    print_endline("applyBufferUpdate: NO BUFFER FOUND!");
-    None;
-  | Some(b) =>
-    print_endline(
-      "applyBufferUpdate: Buffer update! " ++ string_of_int(bufferUpdate.id),
-    );
-    Some(Buffer.update(b, bufferUpdate));
+  | None => None
+  | Some(b) => Some(Buffer.update(b, bufferUpdate))
   };
 };
 

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -44,8 +44,14 @@ let showTablineBuffers = (state: State.t, buffers: list(BufferMetadata.t)) => {
 
 let applyBufferUpdate = (bufferUpdate: BufferUpdate.t, buffer: option(Buffer.t)) => {
     switch (buffer) {
-    | None => None
-    | Some(b) => Some(Buffer.update(b, bufferUpdate))
+    | None => {
+       print_endline ("applyBufferUpdate: NO BUFFER FOUND!"); 
+       None;
+    }
+    | Some(b) => {
+       print_endline ("applyBufferUpdate: Buffer update! " ++ string_of_int(bufferUpdate.id)); 
+        Some(Buffer.update(b, bufferUpdate))
+    }
     }
 };
 

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -8,7 +8,10 @@ open Actions;
 open Types;
 
 let truncateFilepath = path => {
-  Filename.basename(path);
+    switch (path) {
+    | Some(p) => Filename.basename(p);
+    | None => ""
+    }
 };
 
 let showTablineTabs = (state: State.t, tabs) => {
@@ -23,20 +26,27 @@ let showTablineTabs = (state: State.t, tabs) => {
   };
 };
 
-let showTablineBuffers = (state: State.t, buffers: list(buffer)) => {
+let showTablineBuffers = (state: State.t, buffers: list(BufferMetadata.t)) => {
   switch (state.configuration.tablineMode) {
   | Buffers =>
     List.map(
-      ({id, filepath, _}) =>
+      ({id, filePath, _}: BufferMetadata.t) =>
         State.Tab.{
           id,
-          title: filepath |> truncateFilepath,
+          title: filePath |> truncateFilepath,
           active: state.activeBufferId == id,
         },
       buffers,
     )
   | _ => state.tabs
   };
+};
+
+let applyBufferUpdate = (bufferUpdate: BufferUpdate.t, buffer: option(Buffer.t)) => {
+    switch (buffer) {
+    | None => None
+    | Some(b) => Some(Buffer.update(b, bufferUpdate))
+    }
 };
 
 let reduce: (State.t, Actions.t) => State.t =
@@ -49,12 +59,12 @@ let reduce: (State.t, Actions.t) => State.t =
     | BufferEnter(bs) => {
         ...s,
         activeBufferId: bs.bufferId,
-        buffers: BufferMap.update(s.buffers, bs.buffers),
+        buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
         tabs: showTablineBuffers(s, bs.buffers),
       }
     | BufferUpdate(bu) => {
         ...s,
-        activeBuffer: Buffer.update(s.activeBuffer, bu),
+        buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
       }
     | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
     | SetEditorFont(font) => {...s, editorFont: font}

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -8,10 +8,10 @@ open Actions;
 open Types;
 
 let truncateFilepath = path => {
-    switch (path) {
-    | Some(p) => Filename.basename(p);
-    | None => ""
-    }
+  switch (path) {
+  | Some(p) => Filename.basename(p)
+  | None => ""
+  };
 };
 
 let showTablineTabs = (state: State.t, tabs) => {
@@ -42,17 +42,18 @@ let showTablineBuffers = (state: State.t, buffers: list(BufferMetadata.t)) => {
   };
 };
 
-let applyBufferUpdate = (bufferUpdate: BufferUpdate.t, buffer: option(Buffer.t)) => {
-    switch (buffer) {
-    | None => {
-       print_endline ("applyBufferUpdate: NO BUFFER FOUND!"); 
-       None;
-    }
-    | Some(b) => {
-       print_endline ("applyBufferUpdate: Buffer update! " ++ string_of_int(bufferUpdate.id)); 
-        Some(Buffer.update(b, bufferUpdate))
-    }
-    }
+let applyBufferUpdate =
+    (bufferUpdate: BufferUpdate.t, buffer: option(Buffer.t)) => {
+  switch (buffer) {
+  | None =>
+    print_endline("applyBufferUpdate: NO BUFFER FOUND!");
+    None;
+  | Some(b) =>
+    print_endline(
+      "applyBufferUpdate: Buffer update! " ++ string_of_int(bufferUpdate.id),
+    );
+    Some(Buffer.update(b, bufferUpdate));
+  };
 };
 
 let reduce: (State.t, Actions.t) => State.t =

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -21,7 +21,6 @@ type t = {
   tabs: list(Tab.t),
   buffers: BufferMap.t,
   activeBufferId: int,
-  activeBuffer: Buffer.t,
   editorFont: EditorFont.t,
   cursorPosition: BufferPosition.t,
   commandline: Commandline.t,
@@ -53,17 +52,9 @@ let create: unit => t =
     buffers:
       BufferMap.Buffers.add(
         0,
-        {
-          filepath: "",
-          filetype: "",
-          buftype: Empty,
-          modified: false,
-          id: 0,
-          hidden: false,
-        },
+        Buffer.ofLines([||]),
         BufferMap.empty,
       ),
-    activeBuffer: Buffer.ofLines([||]),
     cursorPosition: BufferPosition.createFromZeroBasedIndices(0, 0),
     editorFont:
       EditorFont.create(

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -49,12 +49,7 @@ let create: unit => t =
       show: false,
     },
     activeBufferId: 0,
-    buffers:
-      BufferMap.Buffers.add(
-        0,
-        Buffer.ofLines([||]),
-        BufferMap.empty,
-      ),
+    buffers: BufferMap.Buffers.add(0, Buffer.ofLines([||]), BufferMap.empty),
     cursorPosition: BufferPosition.createFromZeroBasedIndices(0, 0),
     editorFont:
       EditorFont.create(

--- a/src/editor/Core/TokenizedBuffer.re
+++ b/src/editor/Core/TokenizedBuffer.re
@@ -7,7 +7,7 @@
  */
 
 type t = {
-  file: option(string),
+  metadata: Types.BufferMetadata.t,
   tokenizedLines: array(list(Tokenizer.t)),
 };
 
@@ -15,6 +15,6 @@ let ofBuffer = (buffer: Buffer.t) => {
   let f: string => list(Tokenizer.t) = Tokenizer.tokenize;
   let tokenizedLines = Array.map(f, buffer.lines);
 
-  let ret: t = {tokenizedLines, file: buffer.file};
+  let ret: t = {tokenizedLines, metadata: buffer.metadata};
   ret;
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -81,25 +81,25 @@ let getBufType = bt =>
   };
 
 module BufferMetadata = {
-
   type t = {
-  filePath: option(string),
-  fileType: option(string),
-  bufType: buftype,
-  modified: bool,
-  hidden: bool,
-  id: int,
-  }
+    filePath: option(string),
+    fileType: option(string),
+    bufType: buftype,
+    modified: bool,
+    hidden: bool,
+    id: int,
+  };
 
-  let create = (
-    ~filePath=None,
-    ~fileType=None,
-    ~bufType=Empty,
-    ~id=0,
-    ~hidden=false,
-    ~modified=false,
-    (),
-  ) => {
+  let create =
+      (
+        ~filePath=None,
+        ~fileType=None,
+        ~bufType=Empty,
+        ~id=0,
+        ~hidden=false,
+        ~modified=false,
+        (),
+      ) => {
     filePath,
     fileType,
     bufType,

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -80,30 +80,52 @@ let getBufType = bt =>
   | _ => Unknown
   };
 
-type buffer = {
-  filepath: string,
-  filetype: string,
-  buftype,
+module BufferMetadata = {
+
+  type t = {
+  filePath: option(string),
+  fileType: option(string),
+  bufType: buftype,
   modified: bool,
   hidden: bool,
   id: int,
+  }
+
+  let create = (
+    ~filePath=None,
+    ~fileType=None,
+    ~bufType=Empty,
+    ~id=0,
+    ~hidden=false,
+    ~modified=false,
+    (),
+  ) => {
+    filePath,
+    fileType,
+    bufType,
+    id,
+    hidden,
+    modified,
+  };
 };
 
 module BufferEnter = {
   type t = {
     bufferId: int,
-    buffers: list(buffer),
+    buffers: list(BufferMetadata.t),
   };
 };
 
 module BufferUpdate = {
   type t = {
+    id: int,
     startLine: int,
     endLine: int,
     lines: list(string),
   };
 
-  let create = (~startLine, ~endLine, ~lines, ()) => {
+  let create = (~id=0, ~startLine, ~endLine, ~lines, ()) => {
+    id,
     startLine,
     endLine,
     lines,

--- a/src/editor/Neovim/NeovimBuffer.re
+++ b/src/editor/Neovim/NeovimBuffer.re
@@ -13,11 +13,11 @@ let constructMetadataCalls = id => [
 
 let parseBufferContext = map =>
   List.fold_left(
-    (accum, item) =>
+    (accum: BufferMetadata.t, item) =>
       switch (item) {
       | (Msgpck.String("bufferFullPath"), Msgpck.String(value)) => {
           ...accum,
-          filepath: value,
+          filePath: Some(value),
         }
       | (Msgpck.String("bufferNumber"), Msgpck.Int(bufNum)) => {
           ...accum,
@@ -29,11 +29,11 @@ let parseBufferContext = map =>
         }
       | (Msgpck.String("buftype"), Msgpck.String(buftype)) => {
           ...accum,
-          buftype: getBufType(buftype),
+          bufType: getBufType(buftype),
         }
-      | (Msgpck.String("filetype"), Msgpck.String(filetype)) => {
+      | (Msgpck.String("filetype"), Msgpck.String(fileType)) => {
           ...accum,
-          filetype,
+          fileType: Some(fileType),
         }
       | (Msgpck.String("hidden"), Msgpck.Bool(hidden)) => {
           ...accum,
@@ -41,14 +41,7 @@ let parseBufferContext = map =>
         }
       | _ => accum
       },
-    {
-      filepath: "",
-      id: 0,
-      buftype: Empty,
-      filetype: "",
-      modified: false,
-      hidden: false,
-    },
+    BufferMetadata.create(),
     map,
   );
 
@@ -115,14 +108,15 @@ let getBufferList = (api: NeovimApi.t) => {
 
             let newBuffers =
               [
-                {
-                  id,
-                  modified: false,
-                  hidden: false,
-                  buftype: Empty,
-                  filetype: "",
-                  filepath: "[No Name]",
-                },
+                BufferMetadata.create(
+                    ~id,
+                    ~modified=false,
+                    ~hidden=false,
+                    ~bufType=Empty,
+                    ~fileType=None,
+                    ~filePath=Some("[No Name]"),
+                    (),
+                ),
                 ...bufs,
               ]
               |> List.rev;

--- a/src/editor/Neovim/NeovimBuffer.re
+++ b/src/editor/Neovim/NeovimBuffer.re
@@ -109,13 +109,13 @@ let getBufferList = (api: NeovimApi.t) => {
             let newBuffers =
               [
                 BufferMetadata.create(
-                    ~id,
-                    ~modified=false,
-                    ~hidden=false,
-                    ~bufType=Empty,
-                    ~fileType=None,
-                    ~filePath=Some("[No Name]"),
-                    (),
+                  ~id,
+                  ~modified=false,
+                  ~hidden=false,
+                  ~bufType=Empty,
+                  ~fileType=None,
+                  ~filePath=Some("[No Name]"),
+                  (),
                 ),
                 ...bufs,
               ]

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -207,7 +207,7 @@ let parse = (t: string, msg: Msgpck.t) => {
     | (
         "nvim_buf_lines_event",
         M.List([
-          M.Ext(_, id), 
+          M.Ext(_, id),
           M.Int(changedTick),
           M.Int(firstLine),
           M.Int(lastLine),

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -10,16 +10,18 @@
 open Types;
 
 module Core = Oni_Core;
+module Utility = Oni_Core.Utility;
 
 module BufferLinesNotification = {
   type t = {
+    id: int,
     changedTick: int,
     firstLine: int,
     lastLine: int,
     lines: list(string),
   };
 
-  let make = (changedTick, firstLine, lastLine, lineData) => {
+  let make = (id, changedTick, firstLine, lastLine, lineData) => {
     let f = s =>
       switch (s) {
       | Msgpck.String(v) => v
@@ -28,7 +30,7 @@ module BufferLinesNotification = {
 
     let lines = List.map(f, lineData);
 
-    let ret: t = {changedTick, firstLine, lastLine, lines};
+    let ret: t = {id, changedTick, firstLine, lastLine, lines};
     ret;
   };
 };
@@ -205,7 +207,7 @@ let parse = (t: string, msg: Msgpck.t) => {
     | (
         "nvim_buf_lines_event",
         M.List([
-          _,
+          M.Ext(_, id), 
           M.Int(changedTick),
           M.Int(firstLine),
           M.Int(lastLine),
@@ -215,6 +217,7 @@ let parse = (t: string, msg: Msgpck.t) => {
       ) => [
         BufferLines(
           BufferLinesNotification.make(
+            Utility.convertUTF8string(id),
             changedTick,
             firstLine,
             lastLine,

--- a/src/editor/UI/Commandline.re
+++ b/src/editor/UI/Commandline.re
@@ -33,8 +33,8 @@ let createElement =
   component(hooks => {
     let (startStr, endStr) =
       getStringParts(command.position, command.content);
-    command.show ?
-      (
+    command.show
+      ? (
         hooks,
         <View
           style=Style.[
@@ -66,6 +66,6 @@ let createElement =
           />
           <Text style=cmdTextStyles text=endStr />
         </View>,
-      ) :
-      (hooks, React.listToElement([]));
+      )
+      : (hooks, React.listToElement([]));
   });

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -130,6 +130,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
 
     let activeBuffer = Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
     let lineCount = Array.length(activeBuffer.lines);
+    print_endline ("EditorSurface::createElement - buffer id: " ++ Buffer.show(activeBuffer));
 
     let lineNumberWidth =
       LineNumber.getLineNumberPixelWidth(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -41,8 +41,9 @@ let tokensToElement =
 
   let isActiveLine = lineNumber == cursorLine;
   let lineNumberTextColor =
-    isActiveLine ?
-      theme.editorActiveLineNumberForeground : theme.editorLineNumberForeground;
+    isActiveLine
+      ? theme.editorActiveLineNumberForeground
+      : theme.editorLineNumberForeground;
   let lineNumberAlignment = isActiveLine ? `FlexStart : `Center;
 
   let f = (token: Tokenizer.t) => {
@@ -106,16 +107,14 @@ let tokensToElement =
     <View style=lineNumberStyle>
       <Text
         style=lineNumberTextStyle
-        text={
-          string_of_int(
-            LineNumber.getLineNumber(
-              ~bufferLine=lineNumber + 1,
-              ~cursorLine=cursorLine + 1,
-              ~setting=Relative,
-              (),
-            ),
-          )
-        }
+        text={string_of_int(
+          LineNumber.getLineNumber(
+            ~bufferLine=lineNumber + 1,
+            ~cursorLine=cursorLine + 1,
+            ~setting=Relative,
+            (),
+          ),
+        )}
       />
     </View>
     <View style=lineContentsStyle> ...tokens </View>
@@ -128,9 +127,13 @@ let createElement = (~state: State.t, ~children as _, ()) =>
   component(hooks => {
     let theme = state.theme;
 
-    let activeBuffer = Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
+    let activeBuffer =
+      Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
     let lineCount = Array.length(activeBuffer.lines);
-    print_endline ("EditorSurface::createElement - buffer id: " ++ Buffer.show(activeBuffer));
+    print_endline(
+      "EditorSurface::createElement - buffer id: "
+      ++ Buffer.show(activeBuffer),
+    );
 
     let lineNumberWidth =
       LineNumber.getLineNumberPixelWidth(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -130,10 +130,6 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let activeBuffer =
       Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
     let lineCount = Array.length(activeBuffer.lines);
-    print_endline(
-      "EditorSurface::createElement - buffer id: "
-      ++ Buffer.show(activeBuffer),
-    );
 
     let lineNumberWidth =
       LineNumber.getLineNumberPixelWidth(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -128,7 +128,8 @@ let createElement = (~state: State.t, ~children as _, ()) =>
   component(hooks => {
     let theme = state.theme;
 
-    let lineCount = Array.length(state.activeBuffer.lines);
+    let activeBuffer = Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
+    let lineCount = Array.length(activeBuffer.lines);
 
     let lineNumberWidth =
       LineNumber.getLineNumberPixelWidth(
@@ -138,7 +139,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
       );
 
     let bufferView =
-      state.activeBuffer
+      activeBuffer
       |> TokenizedBuffer.ofBuffer
       |> TokenizedBufferView.ofTokenizedBuffer;
 

--- a/src/editor/UI/Wildmenu.re
+++ b/src/editor/UI/Wildmenu.re
@@ -25,21 +25,19 @@ let createElement =
     (~children as _, ~wildmenu: Types.Wildmenu.t, ~theme: Theme.t, ()) =>
   component(hooks => {
     let element =
-      wildmenu.show ?
-        <ScrollView style={containerStyles(theme)}>
-          ...{
-               List.mapi(
-                 (index, item) =>
-                   <MenuItem
-                     theme
-                     label=item
-                     selected={index == wildmenu.selected}
-                     style=Style.[fontSize(16)]
-                   />,
-                 wildmenu.items,
-               )
-             }
-        </ScrollView> :
-        React.listToElement([]);
+      wildmenu.show
+        ? <ScrollView style={containerStyles(theme)}>
+            ...{List.mapi(
+              (index, item) =>
+                <MenuItem
+                  theme
+                  label=item
+                  selected={index == wildmenu.selected}
+                  style=Style.[fontSize(16)]
+                />,
+              wildmenu.items,
+            )}
+          </ScrollView>
+        : React.listToElement([]);
     (hooks, element);
   });

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -200,6 +200,7 @@ let init = app => {
           | BufferLines(bc) =>
             Core.Actions.BufferUpdate(
               Core.Types.BufferUpdate.create(
+                ~id=bc.id,
                 ~startLine=bc.firstLine,
                 ~endLine=bc.lastLine,
                 ~lines=bc.lines,

--- a/test/editor/Core/BufferMapTests.re
+++ b/test/editor/Core/BufferMapTests.re
@@ -4,31 +4,37 @@ open TestFramework;
 
 open Oni_Core.Types;
 module BufferMap = Oni_Core.BufferMap;
+module Buffer = Oni_Core.Buffer;
+
+let getOrFail = (v: option(string)) => switch(v) {
+| Some(v) => v
+| None => "failed - no buffer was specified"
+};
 
 describe("Buffer List Tests", ({test, _}) => {
   test(
     "Bufferlist should take a list of buffers and add them to the map",
     ({expect}) => {
     let bufferlist = BufferMap.empty;
-    let testBuffers: list(buffer) = [
+    let testBuffers: list(BufferMetadata.t) = [
       {
-        filepath: "/test.re",
+        filePath: Some("/test.re"),
         id: 0,
         modified: false,
         hidden: false,
-        buftype: Empty,
-        filetype: "",
+        bufType: Empty,
+        fileType: None,
       },
       {
-        filepath: "/test2.re",
+        filePath: Some("/test2.re"),
         id: 1,
         modified: false,
         hidden: false,
-        buftype: Empty,
-        filetype: "",
+        bufType: Empty,
+        fileType: None,
       },
     ];
-    let added = BufferMap.update(bufferlist, testBuffers);
+    let added = BufferMap.updateMetadata(bufferlist, testBuffers);
     expect.int(BufferMap.Buffers.cardinal(added)).toBe(2);
   });
 
@@ -40,27 +46,27 @@ describe("Buffer List Tests", ({test, _}) => {
    */
   test("Bufferlist should override duplicate buffer Ids", ({expect}) => {
     let bufferlist = BufferMap.empty;
-    let testBuffers: list(buffer) = [
+    let testBuffers: list(BufferMetadata.t) = [
       {
-        filepath: "/test.re",
+        filePath: Some("/test.re"),
         id: 1,
         modified: false,
         hidden: false,
-        buftype: Empty,
-        filetype: "",
+        bufType: Empty,
+        fileType: None,
       },
       {
-        filepath: "/test2.re",
+        filePath: Some("/test2.re"),
         id: 0,
         modified: false,
         hidden: false,
-        buftype: Empty,
-        filetype: "",
+        bufType: Empty,
+        fileType: None,
       },
     ];
-    let added = BufferMap.update(bufferlist, testBuffers);
+    let added = BufferMap.updateMetadata(bufferlist, testBuffers);
 
-    expect.string(BufferMap.Buffers.find(0, added).filepath).toMatch(
+    expect.string(BufferMap.Buffers.find(0, added).metadata.filePath |> getOrFail).toMatch(
       "/test2.re",
     );
   });
@@ -70,17 +76,17 @@ describe("Buffer List Tests", ({test, _}) => {
     let updated =
       BufferMap.Buffers.add(
         4,
-        {
-          filepath: "/myfile.js",
+        Buffer.ofMetadata({
+          filePath: Some("/myfile.js"),
           id: 4,
           modified: false,
           hidden: false,
-          buftype: Empty,
-          filetype: "",
-        },
+          bufType: Empty,
+          fileType: None,
+        }),
         bufferlist,
       );
-    let activeBuffer = BufferMap.getActiveBuffer(4, updated);
-    expect.string(activeBuffer.filepath).toMatch("/myfile.js");
+    let activeBuffer = BufferMap.getBuffer(4, updated);
+    expect.string(activeBuffer.metadata.filePath |> getOrFail).toMatch("/myfile.js");
   });
 });


### PR DESCRIPTION
__Issue:__ There were several strange quirks with buffer updates, like when switching buffers, having the previous buffer appended.

__Defect:__ We weren't using the `id` passed with the buffer line event to target the appropriate buffer.

__Fix:__
- Parse the `id` property and update the `BufferUpdate.t` type to include this
- Refactor the `buffer` type to `BufferMetadata.t` and consolidate with `Buffer.t`, so they can be updated in a unified way in the reducer
- Remove `activeBuffer` and use `activeBufferId` + `BufferMap.getBuffer` to derive the active buffer
- Update reducer to update metadata logic
- Update reducer to handle buffer update with the `BufferMap.update` method
- Update view logic to pick up new active buffer
