### PR TITLE
Bugfix - Scroll: You can scroll past the current view

### DIFF
--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -14,6 +14,7 @@ type t =
   | CursorMove(BufferPosition.t)
   | SetEditorFont(EditorFont.t)
   | SetEditorSize(EditorSize.t)
+  | RecalculateEditorView
   | CommandlineShow(Commandline.t)
   | CommandlineHide(Commandline.t)
   | CommandlineUpdate((int, int))

--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -17,7 +17,6 @@ let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
   let newScrollY = max(0, newScrollY);
 
   let availableScroll = max(view.viewLines - 1, 0) * measuredFontHeight;
-  print_endline ("AVAILABLE SCROLL: " ++ string_of_int(availableScroll));
   let newScrollY = min(newScrollY, availableScroll);
 
   {
@@ -27,7 +26,6 @@ let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
 }
 
 let recalculate = (view: t, buffer: Buffer.t) => {
-    print_endline(" LINES: " ++ string_of_int(Array.length(buffer.lines)));
   {
     ...view,
     viewLines: Array.length(buffer.lines)

--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -1,0 +1,47 @@
+open Actions;
+open Types;
+
+type t = {
+id: int,
+scrollY: int,
+viewLines: int,
+};
+
+let create = (~scrollY=0, ()) => {
+let ret: t = {id: 0, scrollY, viewLines: 0,};
+ret;
+};
+
+let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
+  let newScrollY = view.scrollY + scrollDeltaY;
+  let newScrollY = max(0, newScrollY);
+
+  let availableScroll = max(view.viewLines - 1, 0) * measuredFontHeight;
+  print_endline ("AVAILABLE SCROLL: " ++ string_of_int(availableScroll));
+  let newScrollY = min(newScrollY, availableScroll);
+
+  {
+    ...view,
+    scrollY: newScrollY,
+  };
+}
+
+let recalculate = (view: t, buffer: Buffer.t) => {
+    print_endline(" LINES: " ++ string_of_int(Array.length(buffer.lines)));
+  {
+    ...view,
+    viewLines: Array.length(buffer.lines)
+  }
+};
+
+let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
+   switch (action) {
+    | RecalculateEditorView => { 
+        recalculate(view, buffer);
+    }
+    | EditorScroll(scrollY) => {
+        scroll(view, scrollY, fontMetrics.measuredHeight);
+      }
+    | _ => view;
+   } 
+};

--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -2,14 +2,14 @@ open Actions;
 open Types;
 
 type t = {
-id: int,
-scrollY: int,
-viewLines: int,
+  id: int,
+  scrollY: int,
+  viewLines: int,
 };
 
 let create = (~scrollY=0, ()) => {
-let ret: t = {id: 0, scrollY, viewLines: 0,};
-ret;
+  let ret: t = {id: 0, scrollY, viewLines: 0};
+  ret;
 };
 
 let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
@@ -19,27 +19,18 @@ let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
   let availableScroll = max(view.viewLines - 1, 0) * measuredFontHeight;
   let newScrollY = min(newScrollY, availableScroll);
 
-  {
-    ...view,
-    scrollY: newScrollY,
-  };
-}
+  {...view, scrollY: newScrollY};
+};
 
 let recalculate = (view: t, buffer: Buffer.t) => {
-  {
-    ...view,
-    viewLines: Array.length(buffer.lines)
-  }
+  {...view, viewLines: Array.length(buffer.lines)};
 };
 
 let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
-   switch (action) {
-    | RecalculateEditorView => { 
-        recalculate(view, buffer);
-    }
-    | EditorScroll(scrollY) => {
-        scroll(view, scrollY, fontMetrics.measuredHeight);
-      }
-    | _ => view;
-   } 
+  switch (action) {
+  | RecalculateEditorView => recalculate(view, buffer)
+  | EditorScroll(scrollY) =>
+    scroll(view, scrollY, fontMetrics.measuredHeight)
+  | _ => view
+  };
 };

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -52,6 +52,12 @@ let applyBufferUpdate =
 
 let reduce: (State.t, Actions.t) => State.t =
   (s, a) => {
+ 
+    let s = {
+       ...s,
+        editorView: EditorView.reduce(s.editorView, a, BufferMap.getBuffer(s.activeBufferId, s.buffers), s.editorFont),
+    };
+
     switch (a) {
     | ChangeMode(m) =>
       let ret: State.t = {...s, mode: m};
@@ -80,10 +86,6 @@ let reduce: (State.t, Actions.t) => State.t =
           level,
         },
       }
-    | EditorScroll(scrollY) => {
-        ...s,
-        editor: Editor.scroll(s.editor, scrollY),
-      }
     | WildmenuShow(wildmenu) => {...s, wildmenu}
     | WildmenuHide(wildmenu) => {...s, wildmenu}
     | WildmenuSelected(selected) => {
@@ -93,6 +95,6 @@ let reduce: (State.t, Actions.t) => State.t =
           selected,
         },
       }
-    | Noop => s
+    | _ => s
     };
   };

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -52,10 +52,15 @@ let applyBufferUpdate =
 
 let reduce: (State.t, Actions.t) => State.t =
   (s, a) => {
- 
     let s = {
-       ...s,
-        editorView: EditorView.reduce(s.editorView, a, BufferMap.getBuffer(s.activeBufferId, s.buffers), s.editorFont),
+      ...s,
+      editorView:
+        EditorView.reduce(
+          s.editorView,
+          a,
+          BufferMap.getBuffer(s.activeBufferId, s.buffers),
+          s.editorFont,
+        ),
     };
 
     switch (a) {

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -28,7 +28,7 @@ type t = {
   configuration: Configuration.t,
   theme: Theme.t,
   size: EditorSize.t,
-  editor: Editor.t,
+  editorView: EditorView.t,
 };
 
 let create: unit => t =
@@ -63,5 +63,5 @@ let create: unit => t =
     tabs: [Tab.create(0, "[No Name]")],
     theme: Theme.create(),
     size: EditorSize.create(~pixelWidth=0, ~pixelHeight=0, ()),
-    editor: Editor.create(~scrollY=0, ()),
+    editorView: EditorView.create(~scrollY=0, ()),
   };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -28,23 +28,6 @@ module EditorSize = {
   };
 };
 
-module Editor = {
-  type t = {
-    id: int,
-    scrollY: int,
-  };
-
-  let create = (~scrollY=0, ()) => {
-    let ret: t = {id: 0, scrollY};
-    ret;
-  };
-
-  let scroll = (view: t, scrollDeltaY) => {
-    ...view,
-    scrollY: view.scrollY + scrollDeltaY,
-  };
-};
-
 module Mode = {
   type t =
     | Insert

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -147,7 +147,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         top(
           fontHeight
           * Index.toZeroBasedInt(state.cursorPosition.line)
-          - state.editor.scrollY,
+          - state.editorView.scrollY,
         ),
         left(
           lineNumberWidth
@@ -246,7 +246,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
             width=bufferPixelWidth
             height={state.size.pixelHeight}
             rowHeight={state.editorFont.measuredHeight}
-            scrollY={state.editor.scrollY}
+            scrollY={state.editorView.scrollY}
           />
           <View style=cursorStyle />
         </View>

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -207,7 +207,17 @@ let init = app => {
           | _ => Noop
           };
 
+
         App.dispatch(app, msg);
+
+        /* TODO:
+         * Refactor this into a middleware concept, like Redux */
+        switch(msg) {
+        | Core.Actions.BufferUpdate(_)
+        | Core.Actions.BufferEnter(_) => App.dispatch(app, RecalculateEditorView)
+        | _ => ();
+        };
+
         prerr_endline("Protocol Notification: " ++ Notification.show(n));
       },
     );


### PR DESCRIPTION
Our current smooth-scroll implementation knows no boundaries... meaning, you can scroll past the buffer space:

![scroll-boundaries](https://user-images.githubusercontent.com/13532591/53184567-230cc100-35b2-11e9-9ab5-d0800584e5cc.gif)

This change expands our view to be array of the lines in the view, and not allow scrolling past.