### PR TITLE
Scroll: Synchronize normal mode cursor position with scrollview

### DIFF
--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -26,11 +26,11 @@ type scrollbarMetrics = {
 };
 
 type viewport = {
-    pixelX: int,
-    pixelY: int,
-    pixelWidth: int,
-    pixelHeight: int,
-}
+  pixelX: int,
+  pixelY: int,
+  pixelWidth: int,
+  pixelHeight: int,
+};
 
 let getVisibleLines = (view: t, lineHeight: int) => {
   view.size.pixelWidth / lineHeight;
@@ -41,22 +41,20 @@ let getTotalSizeInPixels = (view: t, lineHeight: int) => {
 };
 
 let snapToCursorPosition = (view: t, lineHeight: int) => {
-    let cursorPixelPosition = Index.toZeroBasedInt(view.cursorPosition.line) * lineHeight;
-    let scrollY = view.scrollY;
+  let cursorPixelPosition =
+    Index.toZeroBasedInt(view.cursorPosition.line) * lineHeight;
+  let scrollY = view.scrollY;
 
-    if (cursorPixelPosition < scrollY) {
-        {
-            ...view,
-            scrollY: cursorPixelPosition,
-        }
-    } else if (cursorPixelPosition > (scrollY + view.size.pixelHeight - lineHeight)) {
-        {
-            ...view,
-            scrollY: cursorPixelPosition - (view.size.pixelHeight - lineHeight * 1),
-        };
-    } else {
-        view
-    }
+  if (cursorPixelPosition < scrollY) {
+    {...view, scrollY: cursorPixelPosition};
+  } else if (cursorPixelPosition > scrollY + view.size.pixelHeight - lineHeight) {
+    {
+      ...view,
+      scrollY: cursorPixelPosition - (view.size.pixelHeight - lineHeight * 1),
+    };
+  } else {
+    view;
+  };
 };
 
 let getScrollbarMetrics = (view: t, scrollBarHeight: int, lineHeight: int) => {
@@ -89,7 +87,11 @@ let recalculate = (view: t, buffer: Buffer.t) => {
 
 let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
   switch (action) {
-  | CursorMove(b) => snapToCursorPosition({...view, cursorPosition: b}, fontMetrics.measuredHeight)
+  | CursorMove(b) =>
+    snapToCursorPosition(
+      {...view, cursorPosition: b},
+      fontMetrics.measuredHeight,
+    )
   | SetEditorSize(size) => {...view, size}
   | RecalculateEditorView => recalculate(view, buffer)
   | EditorScroll(scrollY) =>

--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -6,6 +6,7 @@ type t = {
   scrollY: int,
   viewLines: int,
   size: EditorSize.t,
+  cursorPosition: BufferPosition.t,
 };
 
 let create = (~scrollY=0, ()) => {
@@ -14,6 +15,7 @@ let create = (~scrollY=0, ()) => {
     scrollY,
     viewLines: 0,
     size: EditorSize.create(~pixelWidth=0, ~pixelHeight=0, ()),
+    cursorPosition: BufferPosition.createFromZeroBasedIndices(0, 0),
   };
   ret;
 };
@@ -61,6 +63,7 @@ let recalculate = (view: t, buffer: Buffer.t) => {
 
 let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
   switch (action) {
+  | CursorMove(b) => {...view, cursorPosition: b}
   | SetEditorSize(size) => {...view, size}
   | RecalculateEditorView => recalculate(view, buffer)
   | EditorScroll(scrollY) =>

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -67,7 +67,6 @@ let reduce: (State.t, Actions.t) => State.t =
     | ChangeMode(m) =>
       let ret: State.t = {...s, mode: m};
       ret;
-    | CursorMove(b) => {...s, cursorPosition: b}
     | BufferEnter(bs) => {
         ...s,
         activeBufferId: bs.bufferId,

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -22,7 +22,6 @@ type t = {
   buffers: BufferMap.t,
   activeBufferId: int,
   editorFont: EditorFont.t,
-  cursorPosition: BufferPosition.t,
   commandline: Commandline.t,
   wildmenu: Wildmenu.t,
   configuration: Configuration.t,
@@ -50,7 +49,6 @@ let create: unit => t =
     },
     activeBufferId: 0,
     buffers: BufferMap.Buffers.add(0, Buffer.ofLines([||]), BufferMap.empty),
-    cursorPosition: BufferPosition.createFromZeroBasedIndices(0, 0),
     editorFont:
       EditorFont.create(
         ~fontFile="FiraCode-Regular.ttf",

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -134,7 +134,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let fontHeight = state.editorFont.measuredHeight;
     let fontWidth = state.editorFont.measuredWidth;
 
-    let cursorLine = state.cursorPosition.line;
+    let cursorLine = state.editorView.cursorPosition.line;
     let cursorWidth =
       switch (state.mode) {
       | Insert => 2
@@ -146,13 +146,13 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         position(`Absolute),
         top(
           fontHeight
-          * Index.toZeroBasedInt(state.cursorPosition.line)
+          * Index.toZeroBasedInt(state.editorView.cursorPosition.line)
           - state.editorView.scrollY,
         ),
         left(
           lineNumberWidth
           + fontWidth
-          * Index.toZeroBasedInt(state.cursorPosition.character),
+          * Index.toZeroBasedInt(state.editorView.cursorPosition.character),
         ),
         height(fontHeight),
         width(cursorWidth),

--- a/src/editor/UI/EditorVerticalScrollbar.re
+++ b/src/editor/UI/EditorVerticalScrollbar.re
@@ -39,7 +39,7 @@ let createElement =
       ];
 
     let cursorPixelY =
-      Index.toZeroBasedInt(state.cursorPosition.line)
+      Index.toZeroBasedInt(state.editorView.cursorPosition.line)
       * state.editorFont.measuredHeight
       |> float_of_int;
     let totalPixel =

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -32,7 +32,7 @@ let surfaceStyle =
     top(0),
     left(0),
     right(0),
-    bottom(statusBarHeight),
+    bottom(statusBarHeight + 20),
   ];
 
 let statusBarStyle =


### PR DESCRIPTION
This change updates our view so that when the cursor moves offscreen (ie, due to a normal mode command), we'll snap the view to the cursor. This is a first round of viewport / scroll sync fixes. Next up will be hooking up `zz`, `zb`, `zt`, etc.