### PR TITLE
Run unit tests without an init.vim.

### DIFF
--- a/test/editor/Neovim/Helpers.re
+++ b/test/editor/Neovim/Helpers.re
@@ -37,7 +37,7 @@ let uiAttach = (api: NeovimApi.t) => {
 
 let withNeovimApi = f => {
   let {neovimPath, _}: Setup.t = Setup.init();
-  let nvim = NeovimProcess.start(~neovimPath, ~args=[|"--embed"|]);
+  let nvim = NeovimProcess.start(~neovimPath, ~args=[|"-u", "NORC", "--embed"|]);
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,


### PR DESCRIPTION
This can cause issues if a developer has a custom config that conflicts.