### PR TITLE
View: Handle zz, zb, zt in our view layer

### DIFF
--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -71,6 +71,6 @@ function OniGetBufferContext(bufnum)
     endif
 endfunction
 
-nnoremap <silent> zz :<C-u>call OniCommand("oni.editorView.scrollToCursor")<CR>
-nnoremap <silent> zb :<C-u>call OniCommand("oni.editorView.scrollToCursorBottom")<CR>
-nnoremap <silent> zt :<C-u>call OniCommand("oni.editorView.scrollToCursorTop")<CR>
+nnoremap <silent> zz :<C-u>call OniCommand('oni.editorView.scrollToCursor')<CR>
+nnoremap <silent> zb :<C-u>call OniCommand('oni.editorView.scrollToCursorBottom')<CR>
+nnoremap <silent> zt :<C-u>call OniCommand('oni.editorView.scrollToCursorTop')<CR>

--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -25,6 +25,10 @@ function OniNotifyAutocmd(eventName)
     call OniNotify(["autocmd", a:eventName, context])
 endfunction
 
+function OniCommand(commandName)
+    call OniNotify(["command", a:commandName])
+endfunction
+
 augroup OniEventListeners
     autocmd!
     autocmd! BufWritePre * :call OniNotifyAutocmd("BufWritePre")
@@ -49,7 +53,6 @@ function OniGetContext()
     return context
 endfunction
 
-
 function OniGetBufferContext(bufnum)
     let l:context = {}
     let l:bufpath = bufname(a:bufnum)
@@ -67,3 +70,7 @@ function OniGetBufferContext(bufnum)
         return
     endif
 endfunction
+
+nnoremap <silent> zz :<C-u>call OniCommand("oni.editorView.scrollToCursor")<CR>
+nnoremap <silent> zb :<C-u>call OniCommand("oni.editorView.scrollToCursorBottom")<CR>
+nnoremap <silent> zt :<C-u>call OniCommand("oni.editorView.scrollToCursorTop")<CR>

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -22,4 +22,7 @@ type t =
   | WildmenuHide(Wildmenu.t)
   | WildmenuSelected(int)
   | EditorScroll(int)
+  | EditorScrollToCursorCentered
+  | EditorScrollToCursorTop
+  | EditorScrollToCursorBottom
   | Noop;

--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -41,8 +41,8 @@ let getTotalSizeInPixels = (view: t, lineHeight: int) => {
 };
 
 let getCursorPixelLine = (view: t, lineHeight: int) => {
-    Index.toZeroBasedInt(view.cursorPosition.line) * lineHeight;
-}
+  Index.toZeroBasedInt(view.cursorPosition.line) * lineHeight;
+};
 
 let getScrollbarMetrics = (view: t, scrollBarHeight: int, lineHeight: int) => {
   let totalViewSizeInPixels =
@@ -62,8 +62,8 @@ let scrollTo = (view: t, newScrollY, measuredFontHeight) => {
   let newScrollY = max(0, newScrollY);
   let availableScroll = max(view.viewLines - 1, 0) * measuredFontHeight;
   let newScrollY = min(newScrollY, availableScroll);
-  {...view, scrollY: newScrollY };
-}
+  {...view, scrollY: newScrollY};
+};
 
 let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
   let newScrollY = view.scrollY + scrollDeltaY;
@@ -72,22 +72,27 @@ let scroll = (view: t, scrollDeltaY, measuredFontHeight) => {
 
 /* Scroll so that the cursor is at the TOP of the view */
 let scrollToCursorTop = (view: t, lineHeight) => {
-    let scrollPosition = getCursorPixelLine(view, lineHeight);
-    scrollTo(view, scrollPosition, lineHeight);
+  let scrollPosition = getCursorPixelLine(view, lineHeight);
+  scrollTo(view, scrollPosition, lineHeight);
 };
 
 /* Scroll so that the cursor is at the BOTTOM of the view */
 let scrollToCursorBottom = (view: t, lineHeight) => {
-    let cursorPixelPosition = getCursorPixelLine(view, lineHeight);
-    let scrollPosition =  cursorPixelPosition - (view.size.pixelHeight - lineHeight * 1);
-    scrollTo(view, scrollPosition, lineHeight);
+  let cursorPixelPosition = getCursorPixelLine(view, lineHeight);
+  let scrollPosition =
+    cursorPixelPosition - (view.size.pixelHeight - lineHeight * 1);
+  scrollTo(view, scrollPosition, lineHeight);
 };
 
 let scrollToCursor = (view: t, lineHeight) => {
-    let scrollPosition = 
-        getCursorPixelLine(view, lineHeight) - view.size.pixelHeight / 2 + lineHeight / 2;
-        
-    scrollTo(view, scrollPosition, lineHeight);
+  let scrollPosition =
+    getCursorPixelLine(view, lineHeight)
+    - view.size.pixelHeight
+    / 2
+    + lineHeight
+    / 2;
+
+  scrollTo(view, scrollPosition, lineHeight);
 };
 
 let snapToCursorPosition = (view: t, lineHeight: int) => {
@@ -95,9 +100,9 @@ let snapToCursorPosition = (view: t, lineHeight: int) => {
   let scrollY = view.scrollY;
 
   if (cursorPixelPosition < scrollY) {
-      scrollToCursorTop(view, lineHeight);
+    scrollToCursorTop(view, lineHeight);
   } else if (cursorPixelPosition > scrollY + view.size.pixelHeight - lineHeight) {
-      scrollToCursorBottom(view, lineHeight);
+    scrollToCursorBottom(view, lineHeight);
   } else {
     view;
   };
@@ -119,11 +124,11 @@ let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
   | EditorScroll(scrollY) =>
     scroll(view, scrollY, fontMetrics.measuredHeight)
   | EditorScrollToCursorTop =>
-    scrollToCursorTop(view, fontMetrics.measuredHeight);
+    scrollToCursorTop(view, fontMetrics.measuredHeight)
   | EditorScrollToCursorBottom =>
-    scrollToCursorBottom(view, fontMetrics.measuredHeight);
+    scrollToCursorBottom(view, fontMetrics.measuredHeight)
   | EditorScrollToCursorCentered =>
-    scrollToCursor(view, fontMetrics.measuredHeight);
+    scrollToCursor(view, fontMetrics.measuredHeight)
   | _ => view
   };
 };

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -41,6 +41,7 @@ module BufferEnterNotification = {
 
 type t =
   | Redraw
+  | OniCommand(string)
   | ModeChanged(string)
   | BufferLines(BufferLinesNotification.t)
   | BufferEnter(BufferEnterNotification.t)
@@ -232,6 +233,14 @@ let parse = (t: string, msg: Msgpck.t) => {
         ]),
       ) =>
       let result = parseAutoCommand(autocmd, args);
+      [result];
+    | (
+        "oni_plugin_notify",
+        M.List([
+          M.List([M.String("command"), M.String(commandName)]),
+        ]),
+      ) =>
+      let result = OniCommand(commandName);
       [result];
     | ("redraw", M.List(msgs)) => parseRedraw(msgs)
     | _ => [Ignored]

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -169,26 +169,30 @@ let init = app => {
     Event.subscribe(
       neovimProtocol.onNotification,
       n => {
-        let msg =
+        open Core.Actions;
+        let msg = 
           switch (n) {
-          | ModeChanged("normal") => Core.Actions.ChangeMode(Normal)
-          | ModeChanged("insert") => Core.Actions.ChangeMode(Insert)
+          | OniCommand("oni.editorView.scrollToCursor") => EditorScrollToCursorCentered
+          | OniCommand("oni.editorView.scrollToCursorTop") => EditorScrollToCursorTop
+          | OniCommand("oni.editorView.scrollToCursorBottom") => EditorScrollToCursorBottom
+          | ModeChanged("normal") => ChangeMode(Normal)
+          | ModeChanged("insert") => ChangeMode(Insert)
           | ModeChanged("cmdline_normal") =>
-            Core.Actions.ChangeMode(Commandline)
-          | TablineUpdate(tabs) => Core.Actions.TablineUpdate(tabs)
-          | ModeChanged(_) => Core.Actions.ChangeMode(Other)
+            ChangeMode(Commandline)
+          | TablineUpdate(tabs) => TablineUpdate(tabs)
+          | ModeChanged(_) => ChangeMode(Other)
           | CursorMoved(c) =>
-            Core.Actions.CursorMove(
+            CursorMove(
               Core.Types.BufferPosition.create(c.cursorLine, c.cursorColumn),
             )
           | BufferEnter(b) =>
             neovimProtocol.bufAttach(b.bufferId);
-            Core.Actions.BufferEnter({
+            BufferEnter({
               bufferId: b.bufferId,
               buffers: NeovimBuffer.getBufferList(nvimApi),
             });
           | BufferLines(bc) =>
-            Core.Actions.BufferUpdate(
+            BufferUpdate(
               Core.Types.BufferUpdate.create(
                 ~id=bc.id,
                 ~startLine=bc.firstLine,
@@ -198,15 +202,14 @@ let init = app => {
                 (),
               ),
             )
-          | WildmenuShow(w) => Core.Actions.WildmenuShow(w)
-          | WildmenuHide(w) => Core.Actions.WildmenuHide(w)
-          | WildmenuSelected(s) => Core.Actions.WildmenuSelected(s)
-          | CommandlineUpdate(u) => Core.Actions.CommandlineUpdate(u)
-          | CommandlineShow(c) => Core.Actions.CommandlineShow(c)
-          | CommandlineHide(c) => Core.Actions.CommandlineHide(c)
+          | WildmenuShow(w) => WildmenuShow(w)
+          | WildmenuHide(w) => WildmenuHide(w)
+          | WildmenuSelected(s) => WildmenuSelected(s)
+          | CommandlineUpdate(u) => CommandlineUpdate(u)
+          | CommandlineShow(c) => CommandlineShow(c)
+          | CommandlineHide(c) => CommandlineHide(c)
           | _ => Noop
           };
-
 
         App.dispatch(app, msg);
 


### PR DESCRIPTION
This adds support for `zz`, `zb`, and `zt` in our view layer. It hooks up basic interop so that we can call 'oni' commands from the Viml world, and wire them through to our state management infrastructure.