### PR TITLE
Bugfix/changed tick

### DIFF
--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -59,20 +59,14 @@ endfunction
 
 function OniGetBufferContext(bufnum)
     let l:context = {}
-    let l:bufpath = bufname(a:bufnum)
+    let l:context.bufferNumber = a:bufnum
+    let l:context.bufferFullPath = expand("#".a:bufnum.":p")
+    let l:context.filetype = getbufvar(a:bufnum, "&filetype")
+    let l:context.buftype = getbufvar(a:bufnum, "&buftype")
+    let l:context.modified = getbufvar(a:bufnum, "&mod")
+    let l:context.hidden = getbufvar(a:bufnum, "&hidden")
 
-    if strlen(l:bufpath)
-        let l:context.bufferNumber = a:bufnum
-        let l:context.bufferFullPath = expand("#".a:bufnum.":p")
-        let l:context.filetype = getbufvar(a:bufnum, "&filetype")
-        let l:context.buftype = getbufvar(a:bufnum, "&buftype")
-        let l:context.modified = getbufvar(a:bufnum, "&mod")
-        let l:context.hidden = getbufvar(a:bufnum, "&hidden")
-
-        return l:context
-    elseif -1 < index(['nofile','acwrite'], getbufvar(a:bufnum, '&buftype')) " scratch buffer
-        return
-    endif
+    return l:context
 endfunction
 
 nnoremap <silent> zz :<C-u>call OniCommand('oni.editorView.scrollToCursor')<CR>

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -58,10 +58,22 @@ let applyUpdate = (lines: array(string), update: BufferUpdate.t) => {
 };
 
 let update = (buf: t, update: BufferUpdate.t) =>
-  if (update.version > buf.metadata.version) {
+  switch (update) {
+  /***
+     When a buffer is first attached it emits an update with
+     a startLine of 0 and endLine of -1 in this case we should
+     update the buffer's version but set the content of the buffer
+     rather than update it, which would result in duplication
+   */
+  | {startLine: 0, endLine: (-1), version, _} => {
+      metadata: {
+        ...buf.metadata,
+        version,
+      },
+      lines: Array.of_list(update.lines),
+    }
+  | {version, _} when version > buf.metadata.version =>
     let metadata = {...buf.metadata, version: update.version};
-
     {metadata, lines: applyUpdate(buf.lines, update)};
-  } else {
-    buf;
+  | _ => buf
   };

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -6,6 +6,7 @@
 
 open Types;
 
+[@deriving show]
 type t = {
   metadata: BufferMetadata.t,
   lines: array(string),
@@ -15,12 +16,6 @@ let ofLines = (lines: array(string)) => {
   metadata: BufferMetadata.create(),
   lines,
 };
-
-let show = (b: t) =>
-  "Buffer ["
-  ++ string_of_int(b.metadata.id)
-  ++ "]: "
-  ++ String.concat("\n", Array.to_list(b.lines));
 
 let ofMetadata = (metadata: BufferMetadata.t) => {metadata, lines: [||]};
 

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -62,7 +62,7 @@ let log = (m: t) =>
   Buffers.iter(
     (_, b) =>
       Buffer.show(b)
-      |> (++)("Buffer =======================: \n")
+      |> (++)("Buffer ======================: \n")
       |> print_endline,
     m,
   );

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -13,6 +13,7 @@ module Buffers =
   });
 
 let empty = Buffers.empty;
+[@deriving show]
 type t = Buffers.t(Buffer.t);
 
 type mapFunction = Buffer.t => Buffer.t;

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -67,4 +67,7 @@ let log = (m: t) =>
     m,
   );
 
-let getBuffer = (id, map) => Buffers.find(id, map);
+let getBuffer = (id, map) =>
+  try (Buffers.find(id, map)) {
+  | Not_found => Buffer.ofLines([||])
+  };

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -59,6 +59,12 @@ let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) => {
 };
 
 let log = (m: t) =>
-  Buffers.iter((_, b) => Buffer.show(b) |> print_endline, m);
+  Buffers.iter(
+    (_, b) =>
+      Buffer.show(b)
+      |> (++)("Buffer =======================: \n")
+      |> print_endline,
+    m,
+  );
 
 let getBuffer = (id, map) => Buffers.find(id, map);

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -6,15 +6,16 @@ open Types;
    with a type that satisfies the interface
    i.e. specifies a compare function and a type
  */
+
 module Buffers =
   Map.Make({
     type t = int;
     let compare = compare;
   });
 
-let empty = Buffers.empty;
-[@deriving show]
 type t = Buffers.t(Buffer.t);
+
+let empty = Buffers.empty;
 
 type mapFunction = Buffer.t => Buffer.t;
 
@@ -41,7 +42,6 @@ let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) => {
         ),
       buffersMap,
     );
-
   List.fold_left(
     (m: t, metadata: BufferMetadata.t) =>
       Buffers.update(
@@ -57,5 +57,8 @@ let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) => {
     newBuffers,
   );
 };
+
+let log = (m: t) =>
+  Buffers.iter((_, b) => Buffer.show(b) |> print_endline, m);
 
 let getBuffer = (id, map) => Buffers.find(id, map);

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -67,7 +67,4 @@ let log = (m: t) =>
     m,
   );
 
-let getBuffer = (id, map) =>
-  try (Buffers.find(id, map)) {
-  | Not_found => Buffer.ofLines([||])
-  };
+let getBuffer = (id, map) => Buffers.find_opt(id, map);

--- a/src/editor/Core/EditorView.re
+++ b/src/editor/Core/EditorView.re
@@ -34,17 +34,14 @@ type viewport = {
   pixelHeight: int,
 };
 
-let getVisibleLines = (view: t, lineHeight: int) => {
+let getVisibleLines = (view: t, lineHeight: int) =>
   view.size.pixelWidth / lineHeight;
-};
 
-let getTotalSizeInPixels = (view: t, lineHeight: int) => {
+let getTotalSizeInPixels = (view: t, lineHeight: int) =>
   view.viewLines * lineHeight;
-};
 
-let getCursorPixelLine = (view: t, lineHeight: int) => {
+let getCursorPixelLine = (view: t, lineHeight: int) =>
   Index.toZeroBasedInt(view.cursorPosition.line) * lineHeight;
-};
 
 let getScrollbarMetrics = (view: t, scrollBarHeight: int, lineHeight: int) => {
   let totalViewSizeInPixels =
@@ -125,11 +122,13 @@ let snapToCursorPosition = (view: t, lineHeight: int) => {
   };
 };
 
-let recalculate = (view: t, buffer: Buffer.t) => {
-  {...view, viewLines: Array.length(buffer.lines)};
-};
+let recalculate = (view: t, buffer: option(Buffer.t)) =>
+  switch (buffer) {
+  | Some(b) => {...view, viewLines: Array.length(b.lines)}
+  | None => view
+  };
 
-let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
+let reduce = (view, action, buffer, fontMetrics: EditorFont.t) =>
   switch (action) {
   | CursorMove(b) =>
     snapToCursorPosition(
@@ -148,4 +147,3 @@ let reduce = (view, action, buffer, fontMetrics: EditorFont.t) => {
     scrollToCursor(view, fontMetrics.measuredHeight)
   | _ => view
   };
-};

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -51,8 +51,7 @@ let updateTabs = (bufId, modified, tabs) =>
     |> sortTabsById
   );
 
-let applyBufferUpdate =
-    (bufferUpdate: BufferUpdate.t, buffer: option(Buffer.t)) =>
+let applyBufferUpdate = (bufferUpdate, buffer) =>
   switch (buffer) {
   | None => None
   | Some(b) => Some(Buffer.update(b, bufferUpdate))

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -90,13 +90,10 @@ let reduce: (State.t, Actions.t) => State.t =
         buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
         tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
       }
-    | BufferUpdate(bu) =>
-      let r = {
+    | BufferUpdate(bu) => {
         ...s,
         buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
-      };
-      BufferMap.log(r.buffers);
-      r;
+      }
     | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
     | SetEditorFont(font) => {...s, editorFont: font}
     | CommandlineShow(commandline) => {...s, commandline}

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -13,7 +13,7 @@ let sortTabsById = tabs =>
 let truncateFilepath = path =>
   switch (path) {
   | Some(p) => Filename.basename(p)
-  | None => ""
+  | None => "[No Name]"
   };
 
 let showTablineTabs = (state: State.t, tabs) =>

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -91,10 +91,13 @@ let reduce: (State.t, Actions.t) => State.t =
         buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
         tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
       }
-    | BufferUpdate(bu) => {
+    | BufferUpdate(bu) =>
+      let r = {
         ...s,
         buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
-      }
+      };
+      BufferMap.log(r.buffers);
+      r;
     | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
     | SetEditorFont(font) => {...s, editorFont: font}
     | CommandlineShow(commandline) => {...s, commandline}

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -84,22 +84,12 @@ let reduce: (State.t, Actions.t) => State.t =
         ...s,
         tabs: showTablineBuffers(s, bd.buffers, bd.bufferId),
       }
-    | BufferEnter(bs) =>
-      List.iter(
-        b =>
-          BufferMetadata.show(b)
-          |> (++)("Neovim Buffer:  ----> \n")
-          |> print_endline,
-        bs.buffers,
-      );
-      let r = {
+    | BufferEnter(bs) => {
         ...s,
         activeBufferId: bs.bufferId,
         buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
         tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
-      };
-      BufferMap.log(r.buffers);
-      r;
+      }
     | BufferUpdate(bu) => {
         ...s,
         buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -84,12 +84,22 @@ let reduce: (State.t, Actions.t) => State.t =
         ...s,
         tabs: showTablineBuffers(s, bd.buffers, bd.bufferId),
       }
-    | BufferEnter(bs) => {
+    | BufferEnter(bs) =>
+      List.iter(
+        b =>
+          BufferMetadata.show(b)
+          |> (++)("Neovim Buffer:  ----> \n")
+          |> print_endline,
+        bs.buffers,
+      );
+      let r = {
         ...s,
         activeBufferId: bs.bufferId,
         buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
         tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
-      }
+      };
+      BufferMap.log(r.buffers);
+      r;
     | BufferUpdate(bu) => {
         ...s,
         buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -1,4 +1,5 @@
 module Index = {
+  [@deriving show]
   type t =
     | ZeroBasedIndex(int)
     | OneBasedIndex(int);
@@ -29,19 +30,16 @@ module EditorSize = {
 };
 
 module Mode = {
+  /**
+     hide path for this printer as the value is shown
+     to the end user
+   */
+  [@deriving show({with_path: false})]
   type t =
     | Insert
     | Normal
     | Commandline
     | Other;
-
-  let show = v =>
-    switch (v) {
-    | Insert => "insert"
-    | Normal => "normal"
-    | Commandline => "commandline"
-    | Other => "unknown"
-    };
 };
 
 /**
@@ -84,6 +82,7 @@ module BufferPosition = {
   };
 };
 
+[@deriving show]
 type buftype =
   | Empty
   | Help
@@ -107,6 +106,7 @@ let getBufType = bt =>
   };
 
 module BufferMetadata = {
+  [@deriving show]
   type t = {
     filePath: option(string),
     fileType: option(string),

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -146,6 +146,7 @@ module BufferNotification = {
 };
 
 module BufferUpdate = {
+  [@deriving show]
   type t = {
     id: int,
     startLine: int,

--- a/src/editor/Core/dune
+++ b/src/editor/Core/dune
@@ -13,4 +13,4 @@
         yojson
         ppx_deriving_yojson.runtime
     )
-    (preprocess (pps ppx_deriving_yojson)))
+    (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/src/editor/Core/dune
+++ b/src/editor/Core/dune
@@ -11,6 +11,7 @@
         Rench
         Revery
         yojson
+        ppx_deriving.runtime
         ppx_deriving_yojson.runtime
     )
     (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/src/editor/Neovim/NeovimBuffer.re
+++ b/src/editor/Neovim/NeovimBuffer.re
@@ -19,7 +19,7 @@ let parseBufferContext = map =>
       switch (item) {
       | (M.String("bufferFullPath"), M.String(value)) => {
           ...accum,
-          filePath: Some(value),
+          filePath: value == "" ? None : Some(value),
         }
       | (M.String("bufferNumber"), M.Int(bufNum)) => {...accum, id: bufNum}
       | (M.String("modified"), M.Int(modified)) => {

--- a/src/editor/Neovim/NeovimBuffer.re
+++ b/src/editor/Neovim/NeovimBuffer.re
@@ -4,6 +4,8 @@ open NeovimHelpers;
 
 module M = Msgpck;
 
+type partialBuffer = {id: int};
+
 let constructMetadataCalls = id => [
   M.List([
     M.String("nvim_call_function"),
@@ -46,23 +48,21 @@ let parseBufferContext = map =>
     we then use the IDs of the buffers to request more
     metadata about each buffer using "atomic calls"
    */
-let enrichBuffers = (api: NeovimApi.t, (atomicCalls, buffers)) => {
+let enrichBuffers = (api: NeovimApi.t, atomicCalls) => {
   let rsp =
     api.requestSync("nvim_call_atomic", M.List([M.List(atomicCalls)]))
     |> getAtomicCallsResponse;
 
   switch (rsp) {
   | (_, Some(items)) =>
-    Utility.safe_fold_left2(
-      (accum, buf, bufferContext) =>
+    List.fold_left(
+      (accum, bufferContext) =>
         switch (bufferContext) {
         | M.Map(context) => [parseBufferContext(context), ...accum]
-        | _ => [buf, ...accum]
+        | _ => accum
         },
       [],
-      buffers,
       items,
-      ~default=buffers,
     )
   | _ => []
   };
@@ -118,28 +118,6 @@ let getBufferList = (api: NeovimApi.t) =>
   api.requestSync("nvim_list_bufs", M.List([]))
   |> unwrapBufferList
   |> filterInvalidBuffers(api)
-  |> List.fold_left(
-       ((calls, bufs), (_, id)) => {
-         let newCalls =
-           constructMetadataCalls(id) |> List.append(calls) |> List.rev;
-
-         let newBuffers =
-           [
-             BufferMetadata.create(
-               ~id,
-               ~modified=false,
-               ~hidden=false,
-               ~bufType=Empty,
-               ~fileType=None,
-               ~filePath=Some("[No Name]"),
-               (),
-             ),
-             ...bufs,
-           ]
-           |> List.rev;
-
-         (newCalls, newBuffers);
-       },
-       ([], []),
-     )
+  |> List.map(((_, id)) => constructMetadataCalls(id))
+  |> List.flatten
   |> enrichBuffers(api);

--- a/src/editor/Neovim/NeovimBuffer.re
+++ b/src/editor/Neovim/NeovimBuffer.re
@@ -6,7 +6,7 @@ module M = Msgpck;
 
 type partialBuffer = {id: int};
 
-let constructMetadataCalls = id => [
+let constructMetadataCalls = ((_, id)) => [
   M.List([
     M.String("nvim_call_function"),
     M.List([M.String("OniGetBufferContext"), M.List([M.Int(id)])]),
@@ -118,6 +118,6 @@ let getBufferList = (api: NeovimApi.t) =>
   api.requestSync("nvim_list_bufs", M.List([]))
   |> unwrapBufferList
   |> filterInvalidBuffers(api)
-  |> List.map(((_, id)) => constructMetadataCalls(id))
+  |> List.map(constructMetadataCalls)
   |> List.flatten
   |> enrichBuffers(api);

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -202,7 +202,7 @@ let parseAutoCommand = (autocmd: string, args: list(Msgpck.t)) => {
   | "BufEnter" => BufferEnter(context)
   | "TextChanged" => TextChanged(context)
   | "TextChangedI" => TextChangedI(context)
-  // Unload is here as a remider that some actions might need to be dealt with here
+  // Unload is here as a reminder that some actions might need to be dealt with here
   | "BufUnload" => Ignored
   | "BufDelete" => BufferDelete(context)
   | "CursorMoved" => CursorMoved(context)

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -252,9 +252,7 @@ let parse = (t: string, msg: Msgpck.t) => {
       [result];
     | (
         "oni_plugin_notify",
-        M.List([
-          M.List([M.String("command"), M.String(commandName)]),
-        ]),
+        M.List([M.List([M.String("command"), M.String(commandName)])]),
       ) =>
       let result = OniCommand(commandName);
       [result];

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -40,9 +40,8 @@ let tokensToElement =
 
   let isActiveLine = lineNumber == cursorLine;
   let lineNumberTextColor =
-    isActiveLine
-      ? theme.editorActiveLineNumberForeground
-      : theme.editorLineNumberForeground;
+    isActiveLine ?
+      theme.editorActiveLineNumberForeground : theme.editorLineNumberForeground;
   let lineNumberAlignment = isActiveLine ? `FlexStart : `Center;
 
   let f = (token: Tokenizer.t) => {
@@ -100,14 +99,16 @@ let tokensToElement =
     <View style=lineNumberStyle>
       <Text
         style=lineNumberTextStyle
-        text={string_of_int(
-          LineNumber.getLineNumber(
-            ~bufferLine=lineNumber + 1,
-            ~cursorLine=cursorLine + 1,
-            ~setting=Relative,
-            (),
-          ),
-        )}
+        text={
+          string_of_int(
+            LineNumber.getLineNumber(
+              ~bufferLine=lineNumber + 1,
+              ~cursorLine=cursorLine + 1,
+              ~setting=Relative,
+              (),
+            ),
+          )
+        }
       />
     </View>
     <View style=lineContentsStyle> ...tokens </View>
@@ -122,7 +123,14 @@ let createElement = (~state: State.t, ~children as _, ()) =>
 
     let activeBuffer =
       Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
-    let lineCount = Array.length(activeBuffer.lines);
+
+    let lines =
+      switch (activeBuffer) {
+      | Some(buffer) => buffer.lines
+      | None => [||]
+      };
+
+    let lineCount = Array.length(lines);
 
     let lineNumberWidth =
       LineNumber.getLineNumberPixelWidth(
@@ -161,7 +169,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
       ];
 
     let getTokensForLine = i => {
-      let line = activeBuffer.lines[i];
+      let line = lines[i];
       Tokenizer.tokenize(line);
     };
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -17,9 +17,11 @@ module Core = Oni_Core;
 
 /**
    This allows a stack trace to be printed when exceptions occur
-   TODO: trigger this only if oni is in DEBUG mode
  */
-Printexc.record_backtrace(true) |> ignore;
+switch (Sys.getenv_opt("REVERY_DEBUG")) {
+| Some(_) => Printexc.record_backtrace(true) |> ignore
+| None => ()
+};
 
 /* The 'main' function for our app */
 let init = app => {

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -15,6 +15,12 @@ open Oni_Neovim;
 
 module Core = Oni_Core;
 
+/**
+   This allows a stack trace to be printed when exceptions occur
+   TODO: trigger this only if oni is in DEBUG mode
+ */
+Printexc.record_backtrace(true) |> ignore;
+
 /* The 'main' function for our app */
 let init = app => {
   let w =

--- a/test/editor/Core/BufferMapTests.re
+++ b/test/editor/Core/BufferMapTests.re
@@ -6,11 +6,17 @@ open Oni_Core.Types;
 module BufferMap = Oni_Core.BufferMap;
 module Buffer = Oni_Core.Buffer;
 
-let getOrFail = (v: option(string)) =>
+let getOrFail = (v: option(Buffer.t)) => {
+  let failedMsg = "failed - no buffer was specified";
   switch (v) {
-  | Some(v) => v
-  | None => "failed - no buffer was specified"
+  | Some(v) =>
+    switch (v.metadata.filePath) {
+    | Some(path) => path
+    | None => failedMsg
+    }
+  | None => failedMsg
   };
+};
 
 describe("Buffer List Tests", ({test, _}) => {
   test(
@@ -39,10 +45,7 @@ describe("Buffer List Tests", ({test, _}) => {
     ];
     let added = BufferMap.updateMetadata(bufferlist, testBuffers);
 
-    expect.string(
-      BufferMap.Buffers.find(0, added).metadata.filePath |> getOrFail,
-    ).
-      toMatch(
+    expect.string(BufferMap.getBuffer(0, added) |> getOrFail).toMatch(
       "/test2.re",
     );
   });
@@ -64,8 +67,7 @@ describe("Buffer List Tests", ({test, _}) => {
         bufferlist,
       );
     let activeBuffer = BufferMap.getBuffer(4, updated);
-    expect.string(activeBuffer.metadata.filePath |> getOrFail).toMatch(
-      "/myfile.js",
-    );
+    let path = getOrFail(activeBuffer);
+    expect.string(path).toMatch("/myfile.js");
   });
 });

--- a/test/editor/Core/BufferTests.re
+++ b/test/editor/Core/BufferTests.re
@@ -22,6 +22,20 @@ describe("Buffer", ({describe, _}) =>
       validateBuffer(expect, updatedBuffer, [|"a"|]);
     });
 
+    test("BufEnter update does not duplicate content", ({expect}) => {
+      let buffer = Buffer.ofLines([|"a", "d", "e", "f", "c"|]);
+      let update =
+        BufferUpdate.create(
+          ~startLine=0,
+          ~endLine=-1,
+          ~lines=["a", "d", "e", "f", "c"],
+          ~version=2,
+          (),
+        );
+      let updatedBuffer = Buffer.update(buffer, update);
+      validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
+    });
+
     test("update single line", ({expect}) => {
       let buffer = Buffer.ofLines([|"a"|]);
       let update =


### PR DESCRIPTION
Fix a bug where the `changedtick` of the buffer being edited is not correctly updated.

#### Steps to reproduce
1. Open a buffer with content
1. run `:e<CR>`
1. Content of the buffer is duplicated

On initial investigation it seems the update function is failing to verify that nothing has changed with the buffer, so instead it runs an update of its content