### PR TITLE
Fix a "[[ not found" build error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "scripts": {
-    "bootstrap": "sh ./scripts/bootstrap.sh"
+    "bootstrap": "bash ./scripts/bootstrap.sh"
   },
   "dependencies": {
     "ocaml": "~4.7.0",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -53,7 +53,7 @@ if [ ! -d "$config_path" ]; then
   check_command_succeded "creating parent directory: $config_path"
 fi
 # create the output file, if it exists remove it first so it is recreated
-if [[ -e $OUTPUT ]]; then
+if [[ -e "$OUTPUT" ]]; then
   rm -f "$OUTPUT"
   check_command_succeded "removing old setup $OUTPUT"
 fi


### PR DESCRIPTION
[[ ]] syntax is in bash, not sh, so we should be more explicit in using bash in the script.

This most likely works on other distros because of a link to bash from sh, but failed when I tried on Ubuntu.