### PR TITLE
Performance: Add benchmarks for buffer update

### DIFF
--- a/bench/lib/BufferBench.re
+++ b/bench/lib/BufferBench.re
@@ -9,35 +9,97 @@ let setup = () => ();
 
 let emptyBuffer = Buffer.ofLines([||]);
 
-let hundredThousandLineBuffer = Buffer.ofLines(Array.make(100000, "This buffer is pretty big"));
-let smallBuffer = Buffer.ofLines(Array.make(100, "This buffer is a bit smaller"));
+let hundredThousandLineBuffer =
+  Buffer.ofLines(Array.make(100000, "This buffer is pretty big"));
+let smallBuffer =
+  Buffer.ofLines(Array.make(100, "This buffer is a bit smaller"));
 
-let hundredThousandLines = Array.make(100000, "Another big buffer update") |> Array.to_list;
+let hundredThousandLines =
+  Array.make(100000, "Another big buffer update") |> Array.to_list;
 
 let addLinesToEmptyBuffer = () => {
-    let _ = Types.BufferUpdate.create(~id=emptyBuffer.metadata.id, ~startLine=0, ~endLine=-1, ~lines=hundredThousandLines, ~version=1, ())
-        |>
-    Buffer.update(emptyBuffer);  
+  let _ =
+    Types.BufferUpdate.create(
+      ~id=emptyBuffer.metadata.id,
+      ~startLine=0,
+      ~endLine=-1,
+      ~lines=hundredThousandLines,
+      ~version=1,
+      (),
+    )
+    |> Buffer.update(emptyBuffer);
+  ();
 };
 
-let clearLargeBuffer = () => { 
-    let _ = Types.BufferUpdate.create(~id=hundredThousandLineBuffer.metadata.id, ~startLine=0, ~endLine=-1, ~lines=[], ~version=1, ())
-        |> Buffer.update(hundredThousandLineBuffer);
-}
+let clearLargeBuffer = () => {
+  let _ =
+    Types.BufferUpdate.create(
+      ~id=hundredThousandLineBuffer.metadata.id,
+      ~startLine=0,
+      ~endLine=-1,
+      ~lines=[],
+      ~version=1,
+      (),
+    )
+    |> Buffer.update(hundredThousandLineBuffer);
+  ();
+};
 
-let insertInMiddleOfSmallBuffer = () => { 
-    let _ = Types.BufferUpdate.create(~id=smallBuffer.metadata.id, ~startLine=50, ~endLine=51, ~lines=["this is a new line"], ~version=1, ())
-        |> Buffer.update(smallBuffer);
-}
+let insertInMiddleOfSmallBuffer = () => {
+  let _ =
+    Types.BufferUpdate.create(
+      ~id=smallBuffer.metadata.id,
+      ~startLine=50,
+      ~endLine=51,
+      ~lines=["this is a new line"],
+      ~version=1,
+      (),
+    )
+    |> Buffer.update(smallBuffer);
+  ();
+};
 
-let insertInMiddleOfLargeBuffer = () => { 
-    let _ = Types.BufferUpdate.create(~id=hundredThousandLineBuffer.metadata.id, ~startLine=5000, ~endLine=50001, ~lines=["this is a new line"], ~version=1, ())
-        |> Buffer.update(hundredThousandLineBuffer);
-}
+let insertInMiddleOfLargeBuffer = () => {
+  let _ =
+    Types.BufferUpdate.create(
+      ~id=hundredThousandLineBuffer.metadata.id,
+      ~startLine=5000,
+      ~endLine=50001,
+      ~lines=["this is a new line"],
+      ~version=1,
+      (),
+    )
+    |> Buffer.update(hundredThousandLineBuffer);
+  ();
+};
 
 let options = Reperf.Options.create(~iterations=1000, ());
 
-bench(~name="Buffer: Add lines to empty buffer", ~options, ~setup, ~f=addLinesToEmptyBuffer, ());
-bench(~name="Buffer: Insert line in middle of small buffer", ~options, ~setup, ~f=insertInMiddleOfSmallBuffer, ());
-bench(~name="Buffer: Insert line in middle of large buffer", ~options, ~setup, ~f=insertInMiddleOfLargeBuffer, ());
-bench(~name="Buffer: Clear large buffer", ~options, ~setup, ~f=clearLargeBuffer, ());
+bench(
+  ~name="Buffer: Add lines to empty buffer",
+  ~options,
+  ~setup,
+  ~f=addLinesToEmptyBuffer,
+  (),
+);
+bench(
+  ~name="Buffer: Insert line in middle of small buffer",
+  ~options,
+  ~setup,
+  ~f=insertInMiddleOfSmallBuffer,
+  (),
+);
+bench(
+  ~name="Buffer: Insert line in middle of large buffer",
+  ~options,
+  ~setup,
+  ~f=insertInMiddleOfLargeBuffer,
+  (),
+);
+bench(
+  ~name="Buffer: Clear large buffer",
+  ~options,
+  ~setup,
+  ~f=clearLargeBuffer,
+  (),
+);

--- a/bench/lib/BufferBench.re
+++ b/bench/lib/BufferBench.re
@@ -1,0 +1,43 @@
+open Oni_Core;
+open BenchFramework;
+
+open Revery.UI;
+
+let rootNode = (new node)();
+
+let setup = () => ();
+
+let emptyBuffer = Buffer.ofLines([||]);
+
+let hundredThousandLineBuffer = Buffer.ofLines(Array.make(100000, "This buffer is pretty big"));
+let smallBuffer = Buffer.ofLines(Array.make(100, "This buffer is a bit smaller"));
+
+let hundredThousandLines = Array.make(100000, "Another big buffer update") |> Array.to_list;
+
+let addLinesToEmptyBuffer = () => {
+    let _ = Types.BufferUpdate.create(~id=emptyBuffer.metadata.id, ~startLine=0, ~endLine=-1, ~lines=hundredThousandLines, ~version=1, ())
+        |>
+    Buffer.update(emptyBuffer);  
+};
+
+let clearLargeBuffer = () => { 
+    let _ = Types.BufferUpdate.create(~id=hundredThousandLineBuffer.metadata.id, ~startLine=0, ~endLine=-1, ~lines=[], ~version=1, ())
+        |> Buffer.update(hundredThousandLineBuffer);
+}
+
+let insertInMiddleOfSmallBuffer = () => { 
+    let _ = Types.BufferUpdate.create(~id=smallBuffer.metadata.id, ~startLine=50, ~endLine=51, ~lines=["this is a new line"], ~version=1, ())
+        |> Buffer.update(smallBuffer);
+}
+
+let insertInMiddleOfLargeBuffer = () => { 
+    let _ = Types.BufferUpdate.create(~id=hundredThousandLineBuffer.metadata.id, ~startLine=5000, ~endLine=50001, ~lines=["this is a new line"], ~version=1, ())
+        |> Buffer.update(hundredThousandLineBuffer);
+}
+
+let options = Reperf.Options.create(~iterations=1000, ());
+
+bench(~name="Buffer: Add lines to empty buffer", ~options, ~setup, ~f=addLinesToEmptyBuffer, ());
+bench(~name="Buffer: Insert line in middle of small buffer", ~options, ~setup, ~f=insertInMiddleOfSmallBuffer, ());
+bench(~name="Buffer: Insert line in middle of large buffer", ~options, ~setup, ~f=insertInMiddleOfLargeBuffer, ());
+bench(~name="Buffer: Clear large buffer", ~options, ~setup, ~f=clearLargeBuffer, ());

--- a/src/editor/Neovim/Notification.re
+++ b/src/editor/Neovim/Notification.re
@@ -37,7 +37,7 @@ module BufferLinesNotification = {
   };
 };
 
-[@deriving show({ with_path: false })]
+[@deriving show({with_path: false})]
 type t =
   | Redraw
   | OniCommand(string)


### PR DESCRIPTION
This adds a set of benchmarks around buffer update:
```
+----------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                      |  TIME               |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|-------------------------------------------------+---------------------+------------+------------+---------------+------------+---------------|
|  Buffer: Add lines to empty buffer              |  1.22300958633      |  334       |  67        |  24359        |  1627      |  100002627    |
|-------------------------------------------------+---------------------+------------+------------+---------------+------------+---------------|
|  Buffer: Insert line in middle of small buffer  |  0.000998497009277  |  1         |  0         |  244029       |  25        |  25           |
|-------------------------------------------------+---------------------+------------+------------+---------------+------------+---------------|
|  Buffer: Insert line in middle of large buffer  |  0.546031951904     |  401       |  80        |  42349        |  3945      |  110005945    |
|-------------------------------------------------+---------------------+------------+------------+---------------+------------+---------------|
|  Buffer: Clear large buffer                     |  0.                 |  1         |  0         |  19029        |  25        |  25           |
```

This will be useful when we tackle things like #80 . The biggest concern I have at the moment is that the insert gets more expensive with large buffers.