### PR TITLE
Theming / Textmate: Add getTokenColor to theme

### DIFF
--- a/src/editor/Core/Theme.re
+++ b/src/editor/Core/Theme.re
@@ -6,36 +6,71 @@
 
 open Revery;
 
+module EditorColors {
+
+    type t = {
+      background: Color.t,
+      foreground: Color.t,
+      editorBackground: Color.t,
+      editorForeground: Color.t,
+      editorLineNumberBackground: Color.t,
+      editorLineNumberForeground: Color.t,
+      editorActiveLineNumberForeground: Color.t,
+      scrollbarSliderBackground: Color.t,
+      scrollbarSliderActiveBackground: Color.t,
+      editorMenuBackground: Color.t,
+      editorMenuForeground: Color.t,
+      editorMenuItemSelected: Color.t,
+      tabActiveForeground: Color.t,
+    };
+
+    let default: t = {
+      background: Color.hex("#212733"),
+      foreground: Color.hex("#ECEFF4"),
+      editorBackground: Color.hex("#2F3440"),
+      editorForeground: Color.hex("#DCDCDC"),
+      editorLineNumberBackground: Color.hex("#2F3440"),
+      editorLineNumberForeground: Color.hex("#495162"),
+      editorActiveLineNumberForeground: Color.hex("#737984"),
+      scrollbarSliderBackground: Color.rgba(0., 0., 0., 0.2),
+      scrollbarSliderActiveBackground: Color.hex("#2F3440"),
+      editorMenuBackground: Color.hex("#2F3440"),
+      editorMenuForeground: Color.hex("#FFFFFF"),
+      editorMenuItemSelected: Color.hex("#495162"),
+      tabActiveForeground: Color.hex("#DCDCDC"),
+    };
+}
+
+module TokenColor {
+
+    type fontStyle =
+    | Normal
+    | Bold
+    | Italic;
+
+    type settings = {
+        foreground: option(Color.t),
+        fontStyle: option(fontStyle),
+    };
+
+    type t = {
+        name: string,
+        scope: list(string),
+        settings,
+    };
+}
+
 type t = {
-  background: Color.t,
-  foreground: Color.t,
-  editorBackground: Color.t,
-  editorForeground: Color.t,
-  editorLineNumberBackground: Color.t,
-  editorLineNumberForeground: Color.t,
-  editorActiveLineNumberForeground: Color.t,
-  scrollbarSliderBackground: Color.t,
-  scrollbarSliderActiveBackground: Color.t,
-  editorMenuBackground: Color.t,
-  editorMenuForeground: Color.t,
-  editorMenuItemSelected: Color.t,
-  tabActiveForeground: Color.t,
+    colors: EditorColors.t,
+    tokenColors: list(TokenColor.t),
 };
 
-let default: t = {
-  background: Color.hex("#212733"),
-  foreground: Color.hex("#ECEFF4"),
-  editorBackground: Color.hex("#2F3440"),
-  editorForeground: Color.hex("#DCDCDC"),
-  editorLineNumberBackground: Color.hex("#2F3440"),
-  editorLineNumberForeground: Color.hex("#495162"),
-  editorActiveLineNumberForeground: Color.hex("#737984"),
-  scrollbarSliderBackground: Color.rgba(0., 0., 0., 0.2),
-  scrollbarSliderActiveBackground: Color.hex("#2F3440"),
-  editorMenuBackground: Color.hex("#2F3440"),
-  editorMenuForeground: Color.hex("#FFFFFF"),
-  editorMenuItemSelected: Color.hex("#495162"),
-  tabActiveForeground: Color.hex("#DCDCDC"),
-};
+let getTokenColor = (_theme: t, _scopes: list(string)) => {
+    Colors.red
+}
 
-let create: unit => t = () => default;
+
+let create: unit => t = () => {
+    colors: EditorColors.default,
+    tokenColors: [],
+};

--- a/src/editor/Core/Theme.re
+++ b/src/editor/Core/Theme.re
@@ -66,9 +66,8 @@ type t = {
 };
 
 let getTokenColor = (_theme: t, _scopes: list(string)) => {
-    Colors.red
+    Colors.white
 }
-
 
 let create: unit => t = () => {
     colors: EditorColors.default,

--- a/src/editor/Core/Theme.re
+++ b/src/editor/Core/Theme.re
@@ -6,70 +6,65 @@
 
 open Revery;
 
-module EditorColors {
+module EditorColors = {
+  type t = {
+    background: Color.t,
+    foreground: Color.t,
+    editorBackground: Color.t,
+    editorForeground: Color.t,
+    editorLineNumberBackground: Color.t,
+    editorLineNumberForeground: Color.t,
+    editorActiveLineNumberForeground: Color.t,
+    scrollbarSliderBackground: Color.t,
+    scrollbarSliderActiveBackground: Color.t,
+    editorMenuBackground: Color.t,
+    editorMenuForeground: Color.t,
+    editorMenuItemSelected: Color.t,
+    tabActiveForeground: Color.t,
+  };
 
-    type t = {
-      background: Color.t,
-      foreground: Color.t,
-      editorBackground: Color.t,
-      editorForeground: Color.t,
-      editorLineNumberBackground: Color.t,
-      editorLineNumberForeground: Color.t,
-      editorActiveLineNumberForeground: Color.t,
-      scrollbarSliderBackground: Color.t,
-      scrollbarSliderActiveBackground: Color.t,
-      editorMenuBackground: Color.t,
-      editorMenuForeground: Color.t,
-      editorMenuItemSelected: Color.t,
-      tabActiveForeground: Color.t,
-    };
+  let default: t = {
+    background: Color.hex("#212733"),
+    foreground: Color.hex("#ECEFF4"),
+    editorBackground: Color.hex("#2F3440"),
+    editorForeground: Color.hex("#DCDCDC"),
+    editorLineNumberBackground: Color.hex("#2F3440"),
+    editorLineNumberForeground: Color.hex("#495162"),
+    editorActiveLineNumberForeground: Color.hex("#737984"),
+    scrollbarSliderBackground: Color.rgba(0., 0., 0., 0.2),
+    scrollbarSliderActiveBackground: Color.hex("#2F3440"),
+    editorMenuBackground: Color.hex("#2F3440"),
+    editorMenuForeground: Color.hex("#FFFFFF"),
+    editorMenuItemSelected: Color.hex("#495162"),
+    tabActiveForeground: Color.hex("#DCDCDC"),
+  };
+};
 
-    let default: t = {
-      background: Color.hex("#212733"),
-      foreground: Color.hex("#ECEFF4"),
-      editorBackground: Color.hex("#2F3440"),
-      editorForeground: Color.hex("#DCDCDC"),
-      editorLineNumberBackground: Color.hex("#2F3440"),
-      editorLineNumberForeground: Color.hex("#495162"),
-      editorActiveLineNumberForeground: Color.hex("#737984"),
-      scrollbarSliderBackground: Color.rgba(0., 0., 0., 0.2),
-      scrollbarSliderActiveBackground: Color.hex("#2F3440"),
-      editorMenuBackground: Color.hex("#2F3440"),
-      editorMenuForeground: Color.hex("#FFFFFF"),
-      editorMenuItemSelected: Color.hex("#495162"),
-      tabActiveForeground: Color.hex("#DCDCDC"),
-    };
-}
-
-module TokenColor {
-
-    type fontStyle =
+module TokenColor = {
+  type fontStyle =
     | Normal
     | Bold
     | Italic;
 
-    type settings = {
-        foreground: option(Color.t),
-        fontStyle: option(fontStyle),
-    };
+  type settings = {
+    foreground: option(Color.t),
+    fontStyle: option(fontStyle),
+  };
 
-    type t = {
-        name: string,
-        scope: list(string),
-        settings,
-    };
-}
+  type t = {
+    name: string,
+    scope: list(string),
+    settings,
+  };
+};
 
 type t = {
-    colors: EditorColors.t,
-    tokenColors: list(TokenColor.t),
+  colors: EditorColors.t,
+  tokenColors: list(TokenColor.t),
 };
 
 let getTokenColor = (_theme: t, _scopes: list(string)) => {
-    Colors.white
-}
-
-let create: unit => t = () => {
-    colors: EditorColors.default,
-    tokenColors: [],
+  Colors.white;
 };
+
+let create: unit => t = () => {colors: EditorColors.default, tokenColors: []};

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -39,8 +39,8 @@ let _moveToNextMatchingToken = (f, str, startIdx) => {
 let _moveToNextWhitespace = _moveToNextMatchingToken(_isWhitespace);
 let _moveToNextNonWhitespace = _moveToNextMatchingToken(_isNonWhitespace);
 
-let tokenize: string => list(t) =
-  s => {
+let tokenize: (string, Theme.t) => list(t) =
+  (s, theme) => {
     let idx = ref(0);
     let length = String.length(s);
     let tokens: ref(list(t)) = ref([]);
@@ -57,7 +57,7 @@ let tokenize: string => list(t) =
           text: tokenText,
           startPosition: ZeroBasedIndex(startToken),
           endPosition: ZeroBasedIndex(endToken),
-          color: Colors.white,
+          color: Theme.getTokenColor(theme, []),
         };
 
         tokens := List.append([token], tokens^);

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -2,12 +2,15 @@
  * Tokenizer.re
  */
 
+open Revery;
+
 open Types;
 
 type t = {
   text: string,
   startPosition: Index.t,
   endPosition: Index.t,
+  color: Color.t,
 };
 
 let _isWhitespace = c => {
@@ -54,6 +57,7 @@ let tokenize: string => list(t) =
           text: tokenText,
           startPosition: ZeroBasedIndex(startToken),
           endPosition: ZeroBasedIndex(endToken),
+          color: Colors.white,
         };
 
         tokens := List.append([token], tokens^);

--- a/src/editor/UI/CommandlineView.re
+++ b/src/editor/UI/CommandlineView.re
@@ -40,7 +40,7 @@ let createElement =
           style=Style.[
             width(400),
             overflow(`Hidden),
-            backgroundColor(theme.editorBackground),
+            backgroundColor(theme.colors.editorBackground),
             flexDirection(`Row),
             alignItems(`Center),
             marginBottom(20),

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -41,8 +41,8 @@ let tokensToElement =
   let isActiveLine = lineNumber == cursorLine;
   let lineNumberTextColor =
     isActiveLine
-      ? theme.editorActiveLineNumberForeground
-      : theme.editorLineNumberForeground;
+      ? theme.colors.editorActiveLineNumberForeground
+      : theme.colors.editorLineNumberForeground;
   let lineNumberAlignment = isActiveLine ? `FlexStart : `Center;
 
   let f = (token: Tokenizer.t) => {
@@ -70,7 +70,7 @@ let tokensToElement =
       height(fontLineHeight),
       left(0),
       width(lineNumberWidth),
-      backgroundColor(theme.editorLineNumberBackground),
+      backgroundColor(theme.colors.editorLineNumberBackground),
       justifyContent(`Center),
       alignItems(lineNumberAlignment),
     ];
@@ -169,7 +169,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
 
     let getTokensForLine = i => {
       let line = lines[i];
-      Tokenizer.tokenize(line);
+      Tokenizer.tokenize(line, state.theme);
     };
 
     let render = i => {
@@ -188,8 +188,8 @@ let createElement = (~state: State.t, ~children as _, ()) =>
 
     let style =
       Style.[
-        backgroundColor(theme.background),
-        color(theme.foreground),
+        backgroundColor(theme.colors.background),
+        color(theme.colors.foreground),
         flexGrow(1),
       ];
 
@@ -240,7 +240,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         top(0),
         left(bufferPixelWidth + minimapPixelWidth),
         width(Constants.default.scrollBarThickness),
-        backgroundColor(theme.scrollbarSliderBackground),
+        backgroundColor(theme.colors.scrollbarSliderBackground),
         bottom(0),
       ];
 

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -54,7 +54,7 @@ let tokensToElement =
         fontFamily("FiraCode-Regular.ttf"),
         fontSize(14),
         lineHeight(1.0),
-        color(Revery.Colors.white),
+        color(token.color),
         textWrap(Revery.TextWrapping.NoWrap),
       ];
 

--- a/src/editor/UI/EditorVerticalScrollbar.re
+++ b/src/editor/UI/EditorVerticalScrollbar.re
@@ -30,7 +30,7 @@ let createElement =
         left(0),
         width(totalWidth),
         height(scrollMetrics.thumbSize),
-        backgroundColor(state.theme.scrollbarSliderActiveBackground),
+        backgroundColor(state.theme.colors.scrollbarSliderActiveBackground),
       ];
 
     let cursorPixelY =
@@ -55,7 +55,7 @@ let createElement =
         left(0),
         width(totalWidth),
         height(cursorSize),
-        backgroundColor(state.theme.foreground),
+        backgroundColor(state.theme.colors.foreground),
       ];
 
     (

--- a/src/editor/UI/EditorView.re
+++ b/src/editor/UI/EditorView.re
@@ -44,7 +44,8 @@ let createElement = (~state: Oni_Core.State.t, ~children as _, ()) =>
     let theme = state.theme;
 
     let tabs = toUiTabs(state.tabs);
-    let style = editorViewStyle(theme.colors.background, theme.colors.foreground);
+    let style =
+      editorViewStyle(theme.colors.background, theme.colors.foreground);
 
     (hooks, <View style> <Tabs theme tabs /> <EditorSurface state /> </View>);
   });

--- a/src/editor/UI/EditorView.re
+++ b/src/editor/UI/EditorView.re
@@ -44,7 +44,7 @@ let createElement = (~state: Oni_Core.State.t, ~children as _, ()) =>
     let theme = state.theme;
 
     let tabs = toUiTabs(state.tabs);
-    let style = editorViewStyle(theme.background, theme.foreground);
+    let style = editorViewStyle(theme.colors.background, theme.colors.foreground);
 
     (hooks, <View style> <Tabs theme tabs /> <EditorSurface state /> </View>);
   });

--- a/src/editor/UI/MenuItem.re
+++ b/src/editor/UI/MenuItem.re
@@ -10,7 +10,7 @@ let textStyles = (~theme: Theme.t) =>
   Style.[
     fontFamily("FiraCode-Regular.ttf"),
     fontSize(menuItemFontSize),
-    color(theme.editorMenuForeground),
+    color(theme.colors.editorMenuForeground),
   ];
 
 let containerStyles = (~selected, ~theme: Theme.t) =>
@@ -18,7 +18,7 @@ let containerStyles = (~selected, ~theme: Theme.t) =>
     padding(10),
     flexDirection(`Row),
     backgroundColor(
-      selected ? theme.editorMenuItemSelected : Colors.transparentWhite,
+      selected ? theme.colors.editorMenuItemSelected : Colors.transparentWhite,
     ),
   ];
 

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -12,7 +12,7 @@ open Types;
 
 let lineStyle = Style.[position(`Absolute), top(0)];
 
-let tokensToElement = (tokens: list(Tokenizer.t), theme: Theme.t) => {
+let tokensToElement = (tokens: list(Tokenizer.t)) => {
   let f = (token: Tokenizer.t) => {
     let tokenWidth =
       Index.toZeroBasedInt(token.endPosition)
@@ -28,7 +28,7 @@ let tokensToElement = (tokens: list(Tokenizer.t), theme: Theme.t) => {
         ),
         height(Constants.default.minimapCharacterHeight),
         width(tokenWidth * Constants.default.minimapCharacterWidth),
-        backgroundColor(theme.editorForeground),
+        backgroundColor(token.color),
       ];
 
     <View style />;
@@ -39,8 +39,8 @@ let tokensToElement = (tokens: list(Tokenizer.t), theme: Theme.t) => {
   <View style=lineStyle> ...tokens </View>;
 };
 
-let renderLine = (theme, tokens) => {
-  tokensToElement(tokens, theme);
+let renderLine = (_theme, tokens) => {
+  tokensToElement(tokens);
 };
 
 let component = React.component("Minimap");

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -50,7 +50,7 @@ let statusBarStyle =
 let createElement = (~state: State.t, ~children as _, ()) =>
   component(hooks => {
     let theme = state.theme;
-    let style = rootStyle(theme.background, theme.foreground);
+    let style = rootStyle(theme.colors.background, theme.colors.foreground);
 
     (
       hooks,

--- a/src/editor/UI/Tab.re
+++ b/src/editor/UI/Tab.re
@@ -37,7 +37,7 @@ let createElement =
       Style.[
         overflow(`Hidden),
         paddingHorizontal(5),
-        backgroundColor(theme.editorBackground),
+        backgroundColor(theme.colors.editorBackground),
         opacity(opacityValue),
         height(tabHeight),
         width(maxWidth),
@@ -50,12 +50,12 @@ let createElement =
       Style.[
         fontFamily(fontName),
         fontSize(fontPixelSize),
-        color(theme.tabActiveForeground),
+        color(theme.colors.tabActiveForeground),
       ];
 
     let modifiedStyles =
       Style.[
-        color(theme.tabActiveForeground),
+        color(theme.colors.tabActiveForeground),
         marginHorizontal(5),
         fontSize(fontPixelSize),
         fontFamily("FontAwesome5FreeSolid.otf"),
@@ -89,7 +89,7 @@ let createElement =
           <Text
             text={||}
             style=Style.[
-              color(theme.tabActiveForeground),
+              color(theme.colors.tabActiveForeground),
               fontFamily("FontAwesome5FreeSolid.otf"),
               fontSize(15),
             ]

--- a/src/editor/UI/WildmenuView.re
+++ b/src/editor/UI/WildmenuView.re
@@ -10,7 +10,7 @@ let containerStyles = (theme: Theme.t) =>
   Style.[
     width(400),
     height(300),
-    backgroundColor(theme.editorMenuBackground),
+    backgroundColor(theme.colors.editorMenuBackground),
     paddingVertical(20),
     overflow(`Hidden),
     boxShadow(

--- a/test/editor/Core/TokenizerTests.re
+++ b/test/editor/Core/TokenizerTests.re
@@ -4,19 +4,21 @@ open TestFramework;
 
 open Helpers;
 
+let theme = Theme.create();
+
 describe("tokenize", ({test, _}) => {
   test("empty string", ({expect}) => {
-    let result = Tokenizer.tokenize("");
+    let result = Tokenizer.tokenize("", theme);
     expect.int(List.length(result)).toBe(0);
   });
 
   test("string with only whitespace", ({expect}) => {
-    let result = Tokenizer.tokenize("   \t");
+    let result = Tokenizer.tokenize("   \t", theme);
     expect.int(List.length(result)).toBe(0);
   });
 
   test("single word token", ({expect}) => {
-    let result = Tokenizer.tokenize("testWord");
+    let result = Tokenizer.tokenize("testWord", theme);
 
     let expectedTokens: list(Tokenizer.t) = [
       {
@@ -31,7 +33,7 @@ describe("tokenize", ({test, _}) => {
   });
 
   test("single word token, surrounded by whitespace", ({expect}) => {
-    let result = Tokenizer.tokenize("  testWord  ");
+    let result = Tokenizer.tokenize("  testWord  ", theme);
 
     let expectedTokens: list(Tokenizer.t) = [
       {
@@ -46,7 +48,7 @@ describe("tokenize", ({test, _}) => {
   });
 
   test("single letter token, no spaces", ({expect}) => {
-    let result = Tokenizer.tokenize("a");
+    let result = Tokenizer.tokenize("a", theme);
 
     let expectedTokens: list(Tokenizer.t) = [
       {
@@ -61,7 +63,7 @@ describe("tokenize", ({test, _}) => {
   });
 
   test("multiple tokens", ({expect}) => {
-    let result = Tokenizer.tokenize(" a btest ");
+    let result = Tokenizer.tokenize(" a btest ", theme);
 
     let expectedTokens: list(Tokenizer.t) = [
       {

--- a/test/editor/Core/TokenizerTests.re
+++ b/test/editor/Core/TokenizerTests.re
@@ -25,7 +25,7 @@ describe("tokenize", ({test, _}) => {
         text: "testWord",
         startPosition: ZeroBasedIndex(0),
         endPosition: ZeroBasedIndex(8),
-        color: Colors.red
+        color: Colors.red,
       },
     ];
 
@@ -40,7 +40,7 @@ describe("tokenize", ({test, _}) => {
         text: "testWord",
         startPosition: ZeroBasedIndex(2),
         endPosition: ZeroBasedIndex(10),
-        color: Colors.red
+        color: Colors.red,
       },
     ];
 
@@ -55,7 +55,7 @@ describe("tokenize", ({test, _}) => {
         text: "a",
         startPosition: ZeroBasedIndex(0),
         endPosition: ZeroBasedIndex(1),
-        color: Colors.red
+        color: Colors.red,
       },
     ];
 
@@ -70,13 +70,13 @@ describe("tokenize", ({test, _}) => {
         text: "a",
         startPosition: ZeroBasedIndex(1),
         endPosition: ZeroBasedIndex(2),
-        color: Colors.red
+        color: Colors.red,
       },
       {
         text: "btest",
         startPosition: ZeroBasedIndex(3),
         endPosition: ZeroBasedIndex(8),
-        color: Colors.red
+        color: Colors.red,
       },
     ];
 

--- a/test/editor/Core/TokenizerTests.re
+++ b/test/editor/Core/TokenizerTests.re
@@ -1,3 +1,4 @@
+open Revery;
 open Oni_Core;
 open TestFramework;
 
@@ -22,6 +23,7 @@ describe("tokenize", ({test, _}) => {
         text: "testWord",
         startPosition: ZeroBasedIndex(0),
         endPosition: ZeroBasedIndex(8),
+        color: Colors.red
       },
     ];
 
@@ -36,6 +38,7 @@ describe("tokenize", ({test, _}) => {
         text: "testWord",
         startPosition: ZeroBasedIndex(2),
         endPosition: ZeroBasedIndex(10),
+        color: Colors.red
       },
     ];
 
@@ -50,6 +53,7 @@ describe("tokenize", ({test, _}) => {
         text: "a",
         startPosition: ZeroBasedIndex(0),
         endPosition: ZeroBasedIndex(1),
+        color: Colors.red
       },
     ];
 
@@ -64,11 +68,13 @@ describe("tokenize", ({test, _}) => {
         text: "a",
         startPosition: ZeroBasedIndex(1),
         endPosition: ZeroBasedIndex(2),
+        color: Colors.red
       },
       {
         text: "btest",
         startPosition: ZeroBasedIndex(3),
         endPosition: ZeroBasedIndex(8),
+        color: Colors.red
       },
     ];
 


### PR DESCRIPTION
This enhances our `Theme` module to also include token colors with scopes, and a method `getTokenColor` to get color for a token given a set of scopes (currently hardcoded). This plumbs through to our `tokenize` method, which now will report the color based on what the theme says - still need to hook up scopes and theme colors for this to actually be useful.