### PR TITLE
Textmate - theme loading

### DIFF
--- a/src/editor/Core/ColorMap.re
+++ b/src/editor/Core/ColorMap.re
@@ -1,0 +1,22 @@
+/*
+ * ColorMap.re
+ *
+ * A mapping of int -> colors
+ */
+
+open Revery;
+
+[@deriving yojson({strict: false, exn: true})]
+type raw = list(string);
+
+type t = array(Color.t);
+
+let ofJson = (v: Yojson.Safe.json) => {
+    raw_of_yojson_exn(v)
+    |> List.map((c) => Color.hex(c))
+    |> Array.of_list
+};
+
+let get = (v: t, i) => {
+    v[i]
+};

--- a/src/editor/Core/ColorMap.re
+++ b/src/editor/Core/ColorMap.re
@@ -12,11 +12,9 @@ type raw = list(string);
 type t = array(Color.t);
 
 let ofJson = (v: Yojson.Safe.json) => {
-    raw_of_yojson_exn(v)
-    |> List.map((c) => Color.hex(c))
-    |> Array.of_list
+  raw_of_yojson_exn(v) |> List.map(c => Color.hex(c)) |> Array.of_list;
 };
 
 let get = (v: t, i) => {
-    v[i]
+  v[i];
 };

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -7,6 +7,7 @@
 module Actions = Actions;
 module Buffer = Buffer;
 module BufferMap = BufferMap;
+module ColorMap = ColorMap;
 module Commandline = Commandline;
 module Constants = Constants;
 module Editor = Editor;

--- a/src/editor/Core/TextmateClient.re
+++ b/src/editor/Core/TextmateClient.re
@@ -44,7 +44,7 @@ let defaultColorMap: onColorMap = _ => ();
 type t = {
   process: NodeProcess.t,
   rpc: Rpc.t,
-  onColorMap: onColorMap,
+  onColorMap,
 };
 
 let emptyJsonValue = `Assoc([]);
@@ -98,18 +98,16 @@ let preloadScope = (v: t, scopeName: string) => {
 let pump = (v: t) => Rpc.pump(v.rpc);
 
 let setTheme = (v: t, themePath: string) => {
-    Rpc.sendRequest(
-        v.rpc,
-        "textmate/setTheme",
-        `Assoc([
-            ("path", `String(themePath)),
-        ]),
-        (response, _) => {
-            switch (response)  {
-            | Ok(json) => v.onColorMap(ColorMap.ofJson(json));
-            | _ => prerr_endline ("Unable to load theme");
-            }
-        });
+  Rpc.sendRequest(
+    v.rpc,
+    "textmate/setTheme",
+    `Assoc([("path", `String(themePath))]),
+    (response, _) =>
+    switch (response) {
+    | Ok(json) => v.onColorMap(ColorMap.ofJson(json))
+    | _ => prerr_endline("Unable to load theme")
+    }
+  );
 };
 
 let tokenizeLineSync = (v: t, scopeName: string, line: string) => {

--- a/test/editor/Core/TextmateTokenizerTests.re
+++ b/test/editor/Core/TextmateTokenizerTests.re
@@ -1,8 +1,10 @@
 open Oni_Core;
 open TestFramework;
 
-let reasonSyntaxPath = (setup: Setup.t) => setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
-let testThemePath = (setup: Setup.t) => setup.bundledExtensionsPath ++ "/oni-test/theme1.json";
+let reasonSyntaxPath = (setup: Setup.t) =>
+  setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
+let testThemePath = (setup: Setup.t) =>
+  setup.bundledExtensionsPath ++ "/oni-test/theme1.json";
 
 describe("Textmate Service", ({test, _}) => {
   test("receive init message", ({expect}) =>
@@ -44,7 +46,8 @@ describe("Textmate Service", ({test, _}) => {
 
   let withTextmateClient = (~onColorMap, ~onScopeLoaded, initData, f) => {
     let setup = Setup.init();
-    let tmClient = TextmateClient.start(~onColorMap, ~onScopeLoaded, setup, initData);
+    let tmClient =
+      TextmateClient.start(~onColorMap, ~onScopeLoaded, setup, initData);
 
     f(tmClient);
 
@@ -59,7 +62,7 @@ describe("Textmate Service", ({test, _}) => {
   test("load grammar / scope", ({expect}) => {
     let setup = Setup.init();
 
-    let onColorMap = (_) => ();
+    let onColorMap = _ => ();
     let gotScopeLoadedMessage = ref(false);
 
     let onScopeLoaded = (s: string) =>
@@ -71,12 +74,7 @@ describe("Textmate Service", ({test, _}) => {
     withTextmateClient(
       ~onColorMap,
       ~onScopeLoaded,
-      [
-        {
-          scopeName: "source.reason",
-          path: reasonSyntaxPath(setup),
-        },
-      ],
+      [{scopeName: "source.reason", path: reasonSyntaxPath(setup)}],
       tmClient => {
         TextmateClient.preloadScope(tmClient, "source.reason");
 
@@ -107,21 +105,15 @@ describe("Textmate Service", ({test, _}) => {
 
     let colorMap: ref(option(ColorMap.t)) = ref(None);
 
-    let onColorMap = (c) => colorMap := Some(c);
+    let onColorMap = c => colorMap := Some(c);
 
-    let onScopeLoaded = (_) => ();
+    let onScopeLoaded = _ => ();
 
     withTextmateClient(
       ~onColorMap,
       ~onScopeLoaded,
-      [
-        {
-          scopeName: "source.reason",
-          path: reasonSyntaxPath(setup),
-        },
-      ],
+      [{scopeName: "source.reason", path: reasonSyntaxPath(setup)}],
       tmClient => {
-
         TextmateClient.setTheme(tmClient, testThemePath(setup));
 
         Oni_Core.Utility.waitForCondition(() => {
@@ -129,16 +121,16 @@ describe("Textmate Service", ({test, _}) => {
           switch (colorMap^) {
           | Some(_) => true
           | None => false
-          }
+          };
         });
 
         switch (colorMap^) {
-        | Some(c) => {
-            let firstColor = ColorMap.get(c, 0);
-            expect.float(firstColor.r).toBeCloseTo(1.0);
-        }
-        | None => expect.string("Failed").toEqual("get color map");
-        }
-      })
+        | Some(c) =>
+          let firstColor = ColorMap.get(c, 0);
+          expect.float(firstColor.r).toBeCloseTo(1.0);
+        | None => expect.string("Failed").toEqual("get color map")
+        };
+      },
+    );
   });
 });

--- a/test/editor/Core/TextmateTokenizerTests.re
+++ b/test/editor/Core/TextmateTokenizerTests.re
@@ -3,8 +3,8 @@ open TestFramework;
 
 let reasonSyntaxPath = (setup: Setup.t) =>
   setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
-let testThemePath = (setup: Setup.t) =>
-  setup.bundledExtensionsPath ++ "/oni-test/theme1.json";
+/* let testThemePath = (setup: Setup.t) => setup.bundledExtensionsPath ++ "/oni-test/theme1.json"; */
+let testThemePath = (setup: Setup.t) => setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
 
 describe("Textmate Service", ({test, _}) => {
   test("receive init message", ({expect}) =>
@@ -127,7 +127,14 @@ describe("Textmate Service", ({test, _}) => {
         switch (colorMap^) {
         | Some(c) =>
           let firstColor = ColorMap.get(c, 0);
-          expect.float(firstColor.r).toBeCloseTo(1.0);
+          expect.float(firstColor.r).toBeCloseTo(0.0);
+          expect.float(firstColor.g).toBeCloseTo(0.0);
+          expect.float(firstColor.b).toBeCloseTo(0.0);
+
+          let secondColor = ColorMap.get(c, 1);
+          expect.float(secondColor.r).toBeCloseTo(1.0);
+          expect.float(secondColor.g).toBeCloseTo(1.0);
+          expect.float(secondColor.b).toBeCloseTo(1.0);
         | None => expect.string("Failed").toEqual("get color map")
         };
       },

--- a/test/editor/Core/TextmateTokenizerTests.re
+++ b/test/editor/Core/TextmateTokenizerTests.re
@@ -4,7 +4,8 @@ open TestFramework;
 let reasonSyntaxPath = (setup: Setup.t) =>
   setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
 /* let testThemePath = (setup: Setup.t) => setup.bundledExtensionsPath ++ "/oni-test/theme1.json"; */
-let testThemePath = (setup: Setup.t) => setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
+let testThemePath = (setup: Setup.t) =>
+  setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
 
 describe("Textmate Service", ({test, _}) => {
   test("receive init message", ({expect}) =>


### PR DESCRIPTION
It turns out the textmate themes have a pretty complicated scope selector system (almost like CSS!). It also turns out that `vscode-textmate` can handling that matching, and return a minimal set of token information via `tokenizeLine2`. We'll leverage this instead of implementing that scope-matching ourselves for now.

This adds a `textmate/setTheme` request to the textmate service, which responds with a new colormap (when it sends colorized tokens, it just sends indices to the map to minimize traffic)