### PR TITLE
Textmate: Hook up 'tokenizeLine2'

### DIFF
--- a/src/editor/Core/TextmateClient.re
+++ b/src/editor/Core/TextmateClient.re
@@ -33,13 +33,13 @@ let parseTokenizeResultItem = (json: Yojson.Safe.json) => {
 };
 
 let parseColorResultItem = (json: Yojson.Safe.json) => {
-    switch (json) {
-    | `Int(x) => 
-    prerr_endline ("parseColorResultItem: " ++ string_of_int(x));
-                   x;
-    | _ => -1;
-    }
-}
+  switch (json) {
+  | `Int(x) =>
+    prerr_endline("parseColorResultItem: " ++ string_of_int(x));
+    x;
+  | _ => (-1)
+  };
+};
 
 type simpleCallback = unit => unit;
 let defaultCallback: simpleCallback = () => ();
@@ -120,13 +120,13 @@ let setTheme = (v: t, themePath: string) => {
 };
 
 type tokenizeLineResult = {
-    tokens: list(tokenizeResult),
-    colors: list(int),
+  tokens: list(tokenizeResult),
+  colors: list(int),
 };
 
 let tokenizeLineSync = (v: t, scopeName: string, line: string) => {
   let gotResponse = ref(false);
-  let result: ref(option(tokenizeLineResult)) = ref(None)
+  let result: ref(option(tokenizeLineResult)) = ref(None);
 
   Rpc.sendRequest(
     v.rpc,
@@ -135,12 +135,13 @@ let tokenizeLineSync = (v: t, scopeName: string, line: string) => {
     (response, _) => {
       let tokens: option(tokenizeLineResult) =
         switch (response) {
-        | Ok(`Assoc([("tokens", `List(items)), ("colors", `List(colors))])) => {
-        let tokens =    List.map(parseTokenizeResultItem, items)
-            let colors = List.map(parseColorResultItem, colors);
+        | Ok(
+            `Assoc([("tokens", `List(items)), ("colors", `List(colors))]),
+          ) =>
+          let tokens = List.map(parseTokenizeResultItem, items);
+          let colors = List.map(parseColorResultItem, colors);
 
-        Some({tokens, colors});
-        }
+          Some({tokens, colors});
         | _ => None
         };
 

--- a/src/editor/Core/TextmateClient.re
+++ b/src/editor/Core/TextmateClient.re
@@ -23,42 +23,45 @@ type tokenizeResult = {
   scopes: list(string),
 };
 
-module ColorizedToken {
-    /* From:
-     * https://github.com/Microsoft/vscode-textmate/blob/master/src/main.ts
-     */
-    let languageId_mask = 0b00000000000000000000000011111111;
-	let token_type_mask = 0b00000000000000000000011100000000;
-	let font_style_mask= 0b00000000000000000011100000000000;
-	let foreground_mask = 0b00000000011111111100000000000000;
-	let background_mask = 0b11111111100000000000000000000000;
+module ColorizedToken = {
+  /* From:
+   * https://github.com/Microsoft/vscode-textmate/blob/master/src/main.ts
+   */
+  let languageId_mask = 0b00000000000000000000000011111111;
+  let token_type_mask = 0b00000000000000000000011100000000;
+  let font_style_mask = 0b00000000000000000011100000000000;
+  let foreground_mask = 0b00000000011111111100000000000000;
+  let background_mask = 0b11111111100000000000000000000000;
 
-    let languageid_offset = 0;
-	let token_type_offset = 8;
-	let font_style_offset = 11;
-	let foreground_offset = 14;
-	let background_offset = 23;
+  let languageid_offset = 0;
+  let token_type_offset = 8;
+  let font_style_offset = 11;
+  let foreground_offset = 14;
+  let background_offset = 23;
 
-    type t = {
-        index: int,
-        foregroundColor: int,
-        backgroundColor: int,
+  type t = {
+    index: int,
+    foregroundColor: int,
+    backgroundColor: int,
+  };
+
+  let getForegroundColor: int => int =
+    v => {
+      (v land foreground_mask) lsr foreground_offset;
     };
 
-    let getForegroundColor: int => int = (v) => {
-        (v land foreground_mask) lsr foreground_offset;
-    }
-
-    let getBackgroundColor: int => int = (v) => {
-        (v land background_mask) lsr background_offset;
-    }
-
-    let create: (int, int) => t = (idx, v) => {
-        index: idx,
-        foregroundColor: getForegroundColor(v) - 1,
-        backgroundColor: getBackgroundColor(v) - 1,
+  let getBackgroundColor: int => int =
+    v => {
+      (v land background_mask) lsr background_offset;
     };
-}
+
+  let create: (int, int) => t =
+    (idx, v) => {
+      index: idx,
+      foregroundColor: getForegroundColor(v) - 1,
+      backgroundColor: getBackgroundColor(v) - 1,
+    };
+};
 
 let parseTokenizeResultItem = (json: Yojson.Safe.json) => {
   switch (json) {
@@ -71,9 +74,10 @@ let parseTokenizeResultItem = (json: Yojson.Safe.json) => {
 
 let rec parseColorResult = (json: list(Yojson.Safe.json)) => {
   switch (json) {
-  | [`Int(v1), `Int(v2), ...tail] => {
-    [ColorizedToken.create(v1, v2), ...parseColorResult(tail)] 
-  }
+  | [`Int(v1), `Int(v2), ...tail] => [
+      ColorizedToken.create(v1, v2),
+      ...parseColorResult(tail),
+    ]
   | _ => []
   };
 };

--- a/src/editor/Core/TextmateClient.re
+++ b/src/editor/Core/TextmateClient.re
@@ -121,7 +121,7 @@ let tokenizeLineSync = (v: t, scopeName: string, line: string) => {
     (response, _) => {
       let tokens =
         switch (response) {
-        | Ok(`List(items)) => List.map(parseTokenizeResultItem, items)
+        | Ok(`Assoc([("tokens", `List(items))])) => List.map(parseTokenizeResultItem, items)
         | _ => []
         };
 

--- a/src/editor/Core/TextmateClient.re
+++ b/src/editor/Core/TextmateClient.re
@@ -23,6 +23,43 @@ type tokenizeResult = {
   scopes: list(string),
 };
 
+module ColorizedToken {
+    /* From:
+     * https://github.com/Microsoft/vscode-textmate/blob/master/src/main.ts
+     */
+    let languageId_mask = 0b00000000000000000000000011111111;
+	let token_type_mask = 0b00000000000000000000011100000000;
+	let font_style_mask= 0b00000000000000000011100000000000;
+	let foreground_mask = 0b00000000011111111100000000000000;
+	let background_mask = 0b11111111100000000000000000000000;
+
+    let languageid_offset = 0;
+	let token_type_offset = 8;
+	let font_style_offset = 11;
+	let foreground_offset = 14;
+	let background_offset = 23;
+
+    type t = {
+        index: int,
+        foregroundColor: int,
+        backgroundColor: int,
+    };
+
+    let getForegroundColor: int => int = (v) => {
+        (v land foreground_mask) lsr foreground_offset;
+    }
+
+    let getBackgroundColor: int => int = (v) => {
+        (v land background_mask) lsr background_offset;
+    }
+
+    let create: (int, int) => t = (idx, v) => {
+        index: idx,
+        foregroundColor: getForegroundColor(v) - 1,
+        backgroundColor: getBackgroundColor(v) - 1,
+    };
+}
+
 let parseTokenizeResultItem = (json: Yojson.Safe.json) => {
   switch (json) {
   | `List([`Int(startIndex), `Int(endIndex), `List(jsonScopes)]) =>
@@ -32,12 +69,12 @@ let parseTokenizeResultItem = (json: Yojson.Safe.json) => {
   };
 };
 
-let parseColorResultItem = (json: Yojson.Safe.json) => {
+let rec parseColorResult = (json: list(Yojson.Safe.json)) => {
   switch (json) {
-  | `Int(x) =>
-    prerr_endline("parseColorResultItem: " ++ string_of_int(x));
-    x;
-  | _ => (-1)
+  | [`Int(v1), `Int(v2), ...tail] => {
+    [ColorizedToken.create(v1, v2), ...parseColorResult(tail)] 
+  }
+  | _ => []
   };
 };
 
@@ -121,7 +158,7 @@ let setTheme = (v: t, themePath: string) => {
 
 type tokenizeLineResult = {
   tokens: list(tokenizeResult),
-  colors: list(int),
+  colors: list(ColorizedToken.t),
 };
 
 let tokenizeLineSync = (v: t, scopeName: string, line: string) => {
@@ -139,7 +176,7 @@ let tokenizeLineSync = (v: t, scopeName: string, line: string) => {
             `Assoc([("tokens", `List(items)), ("colors", `List(colors))]),
           ) =>
           let tokens = List.map(parseTokenizeResultItem, items);
-          let colors = List.map(parseColorResultItem, colors);
+          let colors = parseColorResult(colors);
 
           Some({tokens, colors});
         | _ => None

--- a/src/editor/Core/Theme.re
+++ b/src/editor/Core/Theme.re
@@ -24,7 +24,7 @@ module EditorColors = {
   };
 
   let default: t = {
-    background: Color.hex("#212733"),
+    background: Color.hex("#282C35"),
     foreground: Color.hex("#ECEFF4"),
     editorBackground: Color.hex("#2F3440"),
     editorForeground: Color.hex("#DCDCDC"),

--- a/src/textmate_service/src/index.ts
+++ b/src/textmate_service/src/index.ts
@@ -104,9 +104,6 @@ connection.onRequest<ITokenizeLineRequestParams, ITokenizeLineResponse, string, 
 });
 
 connection.onRequest<ISetThemeRequestParams, string[], string, {}>(textmateSetThemeRequest, (params) => {
-
-    console.error("setTheme - loading from: " + JSON.stringify(params));
-
     let themeFile = fs.readFileSync(params.path);
     let parsedTheme = JSON.parse(themeFile.toString("utf8"));
 
@@ -117,10 +114,6 @@ connection.onRequest<ISetThemeRequestParams, string[], string, {}>(textmateSetTh
 
     registry.setTheme(rawTheme);
     const precolors = registry.getColorMap();
-    console.error("Before filter: " + JSON.stringify(precolors));
-
     const colors = precolors.filter((c) => !!c);
-
-    console.error("Returned colors: " + JSON.stringify(colors));
     return colors;
 })

--- a/src/textmate_service/src/index.ts
+++ b/src/textmate_service/src/index.ts
@@ -86,12 +86,17 @@ connection.onRequest<ITokenizeLineRequestParams, ITokenizeLineResponse, string, 
                 tokens: [],
             }
         } else {
+            const colors = grammar.tokenizeLine2(params.line, <any>null);
             const parsedTokens = tokens.tokens;
             const filteredTokens = parsedTokens.filter((t) => t.scopes.length > 1);
             const result: tokenResult[] = filteredTokens.map((t) => [t.startIndex, t.endIndex, t.scopes] as tokenResult);
+
+            const colorTokens = Array.prototype.slice.call(colors.tokens);
             console.error(JSON.stringify(result));
+            console.error(JSON.stringify(colors));
             return {
-                tokens: result
+                tokens: result,
+                colors: colorTokens,
             };
         }
 

--- a/src/textmate_service/src/index.ts
+++ b/src/textmate_service/src/index.ts
@@ -92,8 +92,6 @@ connection.onRequest<ITokenizeLineRequestParams, ITokenizeLineResponse, string, 
             const result: tokenResult[] = filteredTokens.map((t) => [t.startIndex, t.endIndex, t.scopes] as tokenResult);
 
             const colorTokens = Array.prototype.slice.call(colors.tokens);
-            console.error(JSON.stringify(result));
-            console.error(JSON.stringify(colors));
             return {
                 tokens: result,
                 colors: colorTokens,

--- a/test/editor/Core/TextmateTokenizerTests.re
+++ b/test/editor/Core/TextmateTokenizerTests.re
@@ -92,11 +92,21 @@ describe("Textmate Service", ({test, _}) => {
             "let abc = 100;",
           );
 
-        expect.int(List.length(tokenizeResult)).toBe(5);
+        switch (tokenizeResult) {
+        | Some(v) => {
+            
+        expect.int(List.length(v.tokens)).toBe(5);
 
-        let firstResult = List.hd(tokenizeResult);
+        /* Only a single color since no theme set */
+        expect.int(List.length(v.colors)).toBe(2);
+
+        let firstResult = List.hd(v.tokens);
         expect.int(firstResult.startIndex).toBe(0);
         expect.int(firstResult.endIndex).toBe(3);
+        } 
+        | None => expect.string("fail").toEqual("no token result");
+        };
+
       },
     );
   });

--- a/test/editor/Core/TextmateTokenizerTests.re
+++ b/test/editor/Core/TextmateTokenizerTests.re
@@ -97,7 +97,12 @@ describe("Textmate Service", ({test, _}) => {
           expect.int(List.length(v.tokens)).toBe(5);
 
           /* Only a single color since no theme set */
-          expect.int(List.length(v.colors)).toBe(2);
+          expect.int(List.length(v.colors)).toBe(1);
+
+          let onlyColor = List.hd(v.colors);
+          expect.int(onlyColor.index).toBe(0);
+          expect.int(onlyColor.foregroundColor).toBe(0);
+          expect.int(onlyColor.backgroundColor).toBe(1);
 
           let firstResult = List.hd(v.tokens);
           expect.int(firstResult.startIndex).toBe(0);

--- a/test/editor/Core/TextmateTokenizerTests.re
+++ b/test/editor/Core/TextmateTokenizerTests.re
@@ -93,20 +93,17 @@ describe("Textmate Service", ({test, _}) => {
           );
 
         switch (tokenizeResult) {
-        | Some(v) => {
-            
-        expect.int(List.length(v.tokens)).toBe(5);
+        | Some(v) =>
+          expect.int(List.length(v.tokens)).toBe(5);
 
-        /* Only a single color since no theme set */
-        expect.int(List.length(v.colors)).toBe(2);
+          /* Only a single color since no theme set */
+          expect.int(List.length(v.colors)).toBe(2);
 
-        let firstResult = List.hd(v.tokens);
-        expect.int(firstResult.startIndex).toBe(0);
-        expect.int(firstResult.endIndex).toBe(3);
-        } 
-        | None => expect.string("fail").toEqual("no token result");
+          let firstResult = List.hd(v.tokens);
+          expect.int(firstResult.startIndex).toBe(0);
+          expect.int(firstResult.endIndex).toBe(3);
+        | None => expect.string("fail").toEqual("no token result")
         };
-
       },
     );
   });


### PR DESCRIPTION
This sets up some initial integration of `tokenizeLine2`, which sends us color information in a packed format - this hooks up to that call, and verifies we can unpack it and get the correct coloring info per-theme.