### PR TITLE
Textmate: Launch textmate server on startup

### DIFF
--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -32,4 +32,5 @@ type t =
   | EditorMoveCursorToTop(Cursor.move)
   | EditorMoveCursorToMiddle(Cursor.move)
   | EditorMoveCursorToBottom(Cursor.move)
+  | SyntaxHighlightColorMap(ColorMap.t)
   | Noop;

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -39,10 +39,10 @@ let init = app => {
   let initVimPath = Revery.Environment.getExecutingDirectory() ++ "init.vim";
   Core.Log.debug("initVimPath: " ++ initVimPath);
 
-  let {neovimPath, _}: Oni_Core.Setup.t = Oni_Core.Setup.init();
+  let setup: Oni_Core.Setup.t = Oni_Core.Setup.init();
 
   let nvim =
-    NeovimProcess.start(~neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
+    NeovimProcess.start(~neovimPath = setup.neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,
@@ -52,6 +52,21 @@ let init = app => {
 
   let nvimApi = NeovimApi.make(msgpackTransport);
   let neovimProtocol = NeovimProtocol.make(nvimApi);
+
+  let defaultThemePath = setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
+  let reasonSyntaxPath = setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
+
+  let onScopeLoaded = (s) => prerr_endline ("SCOPE LOADED: " ++ s);
+  let onColorMap = (_) => prerr_endline ("COLOR MAP LOADED" );
+
+  let tmClient = Oni_Core.TextmateClient.start(
+      ~onScopeLoaded,
+      ~onColorMap,
+      setup, 
+      [{scopeName: "source.reason", path: reasonSyntaxPath}],
+  );
+
+  Oni_Core.TextmateClient.setTheme(tmClient, defaultThemePath);
 
   let render = () => {
     let state: Core.State.t = App.getState(app);
@@ -162,7 +177,10 @@ let init = app => {
       },
     );
 
-  let _ = Tick.interval(_ => nvimApi.pump(), Seconds(0.));
+  let _ = Tick.interval(_ => {
+      nvimApi.pump()
+      Oni_Core.TextmateClient.pump(tmClient);
+  }, Seconds(0.));
 
   /* let _ = */
   /*   Event.subscribe(nvimApi.onNotification, n => */

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -42,7 +42,10 @@ let init = app => {
   let setup: Oni_Core.Setup.t = Oni_Core.Setup.init();
 
   let nvim =
-    NeovimProcess.start(~neovimPath = setup.neovimPath, ~args=[|"-u", initVimPath, "--embed"|]);
+    NeovimProcess.start(
+      ~neovimPath=setup.neovimPath,
+      ~args=[|"-u", initVimPath, "--embed"|],
+    );
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,
@@ -53,18 +56,22 @@ let init = app => {
   let nvimApi = NeovimApi.make(msgpackTransport);
   let neovimProtocol = NeovimProtocol.make(nvimApi);
 
-  let defaultThemePath = setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
-  let reasonSyntaxPath = setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
+  let defaultThemePath =
+    setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
+  let reasonSyntaxPath =
+    setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
 
-  let onScopeLoaded = (s) => prerr_endline ("SCOPE LOADED: " ++ s);
-  let onColorMap = (cm) => App.dispatch(app, Core.Actions.SyntaxHighlightColorMap(cm));
+  let onScopeLoaded = s => prerr_endline("SCOPE LOADED: " ++ s);
+  let onColorMap = cm =>
+    App.dispatch(app, Core.Actions.SyntaxHighlightColorMap(cm));
 
-  let tmClient = Oni_Core.TextmateClient.start(
+  let tmClient =
+    Oni_Core.TextmateClient.start(
       ~onScopeLoaded,
       ~onColorMap,
-      setup, 
+      setup,
       [{scopeName: "source.reason", path: reasonSyntaxPath}],
-  );
+    );
 
   Oni_Core.TextmateClient.setTheme(tmClient, defaultThemePath);
 
@@ -177,10 +184,14 @@ let init = app => {
       },
     );
 
-  let _ = Tick.interval(_ => {
-      nvimApi.pump()
-      Oni_Core.TextmateClient.pump(tmClient);
-  }, Seconds(0.));
+  let _ =
+    Tick.interval(
+      _ => {
+        nvimApi.pump();
+        Oni_Core.TextmateClient.pump(tmClient);
+      },
+      Seconds(0.),
+    );
 
   /* let _ = */
   /*   Event.subscribe(nvimApi.onNotification, n => */

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -57,7 +57,7 @@ let init = app => {
   let reasonSyntaxPath = setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
 
   let onScopeLoaded = (s) => prerr_endline ("SCOPE LOADED: " ++ s);
-  let onColorMap = (_) => prerr_endline ("COLOR MAP LOADED" );
+  let onColorMap = (cm) => App.dispatch(app, Core.Actions.SyntaxHighlightColorMap(cm));
 
   let tmClient = Oni_Core.TextmateClient.start(
       ~onScopeLoaded,


### PR DESCRIPTION
This spins up the textmate server on launch, sets a hardcoded grammar (just reason for now), sets a default theme, and starts hooking up some logging in response to events from the textmate client (currently - gets the color map when the theme loads). 

The `node` process by itself is fairly lightweight - it has a minimal impact on startup time and starts out ~10MB (much lighter than the processes used by Electron, at least!)

We'll want to set up discovery of all the extensions that provide grammars, and hook them up as part of this initialization step.