### PR TITLE
Performance: Start using direct OpenGL calls for minimap

### DIFF
--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -14,37 +14,30 @@ let additionalRowsToRender = 1;
 
 type glRenderFunction = (int, int) => unit;
 
-let render = (~scrollY=0, ~rowHeight, ~height, ~count, ~render: glRenderFunction, ()) => {
-    let rowsToRender = rowHeight > 0 ? height / rowHeight : 0;
-    let startRowOffset = rowHeight > 0 ? scrollY / rowHeight : 0;
-    let pixelOffset = scrollY mod rowHeight;
+let render =
+    (~scrollY=0, ~rowHeight, ~height, ~count, ~render: glRenderFunction, ()) => {
+  let rowsToRender = rowHeight > 0 ? height / rowHeight : 0;
+  let startRowOffset = rowHeight > 0 ? scrollY / rowHeight : 0;
+  let pixelOffset = scrollY mod rowHeight;
 
-    let i = ref(max(startRowOffset - additionalRowsToRender, 0));
+  let i = ref(max(startRowOffset - additionalRowsToRender, 0));
 
-    let len = count;
+  let len = count;
 
-    while (i^ < rowsToRender
-           + additionalRowsToRender
-           + startRowOffset
-           && i^ < len) {
-      let rowOffset = (i^ - startRowOffset) * rowHeight;
-      /* let rowContainerStyle = */
-      /*   Style.[ */
-      /*     position(`Absolute), */
-      /*     top(rowOffset - pixelOffset), */
-      /*     left(0), */
-      /*     right(0), */
-      /*     height(rowHeight), */
-      /*   ]; */
+  while (i^ < rowsToRender
+         + additionalRowsToRender
+         + startRowOffset
+         && i^ < len) {
+    let rowOffset = (i^ - startRowOffset) * rowHeight;
 
-      let top = rowOffset - pixelOffset;
+    let top = rowOffset - pixelOffset;
 
-      let item = i^;
-      render(item, top);
+    let item = i^;
+    render(item, top);
 
-      incr(i);
-    };
-}
+    incr(i);
+  };
+};
 
 let createElement =
     (

--- a/src/editor/UI/FlatList.re
+++ b/src/editor/UI/FlatList.re
@@ -12,6 +12,40 @@ let component = React.component("FlatList");
 
 let additionalRowsToRender = 1;
 
+type glRenderFunction = (int, int) => unit;
+
+let render = (~scrollY=0, ~rowHeight, ~height, ~count, ~render: glRenderFunction, ()) => {
+    let rowsToRender = rowHeight > 0 ? height / rowHeight : 0;
+    let startRowOffset = rowHeight > 0 ? scrollY / rowHeight : 0;
+    let pixelOffset = scrollY mod rowHeight;
+
+    let i = ref(max(startRowOffset - additionalRowsToRender, 0));
+
+    let len = count;
+
+    while (i^ < rowsToRender
+           + additionalRowsToRender
+           + startRowOffset
+           && i^ < len) {
+      let rowOffset = (i^ - startRowOffset) * rowHeight;
+      /* let rowContainerStyle = */
+      /*   Style.[ */
+      /*     position(`Absolute), */
+      /*     top(rowOffset - pixelOffset), */
+      /*     left(0), */
+      /*     right(0), */
+      /*     height(rowHeight), */
+      /*   ]; */
+
+      let top = rowOffset - pixelOffset;
+
+      let item = i^;
+      render(item, top);
+
+      incr(i);
+    };
+}
+
 let createElement =
     (
       ~scrollY=0,

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -4,6 +4,8 @@
  * Component that handles Minimap rendering
  */
 
+/* open Reglfw.Glfw; */
+open Revery.Draw
 open Revery.UI;
 
 open Oni_Core;
@@ -12,35 +14,41 @@ open Types;
 
 let lineStyle = Style.[position(`Absolute), top(0)];
 
-let tokensToElement = (tokens: list(Tokenizer.t)) => {
+let tokensToElement = (transform, yOffset, tokens: list(Tokenizer.t)) => {
   let f = (token: Tokenizer.t) => {
     let tokenWidth =
       Index.toZeroBasedInt(token.endPosition)
       - Index.toZeroBasedInt(token.startPosition);
-    let style =
-      Style.[
-        position(`Absolute),
-        layoutMode(`Minimal),
-        top(0),
-        left(
-          Constants.default.minimapCharacterWidth
-          * Index.toZeroBasedInt(token.startPosition),
-        ),
-        height(Constants.default.minimapCharacterHeight),
-        width(tokenWidth * Constants.default.minimapCharacterWidth),
-        backgroundColor(token.color),
-      ];
+    /* let style = */
+    /*   Style.[ */
+    /*     position(`Absolute), */
+    /*     layoutMode(`Minimal), */
+    /*     top(0), */
+    /*     left( */
+    /*       Constants.default.minimapCharacterWidth */
+    /*       * Index.toZeroBasedInt(token.startPosition), */
+    /*     ), */
+    /*     height(Constants.default.minimapCharacterHeight), */
+    /*     width(tokenWidth * Constants.default.minimapCharacterWidth), */
+    /*     backgroundColor(token.color), */
+    /*   ]; */
 
-    <View style />;
+    /* <View style />; */
+
+    let x = float_of_int(Constants.default.minimapCharacterWidth * Index.toZeroBasedInt(token.startPosition));
+    let height = float_of_int(Constants.default.minimapCharacterHeight);
+    let width = float_of_int(tokenWidth * Constants.default.minimapCharacterWidth);
+
+    Shapes.drawRect(~transform, ~y=float_of_int(yOffset), ~x=x, ~color=token.color, ~width, ~height, ());
   };
 
-  let tokens = List.map(f, tokens);
+  List.iter(f, tokens);
 
-  <View style=lineStyle> ...tokens </View>;
+  /* <View style=lineStyle> ...tokens </View>; */
 };
 
-let renderLine = (_theme, tokens) => {
-  tokensToElement(tokens);
+let renderLine = (_theme, transform, yOffset, tokens) => {
+  tokensToElement(transform, yOffset, tokens);
 };
 
 let component = React.component("Minimap");
@@ -62,22 +70,32 @@ let createElement =
     let rowHeight =
       Constants.default.minimapCharacterHeight
       + Constants.default.minimapLineSpacing;
-    let render = i => {
-      let tokens = getTokensForLine(i);
-      renderLine(state.theme, tokens);
-    };
+
+    let scrollY = state.editor.minimapScrollY;
+
+    /* let render = i => { */
+    /*   let tokens = getTokensForLine(i); */
+    /*   renderLine(state.theme, tokens); */
+    /* }; */
+
+    /* ignore((width, height, count, rowHeight, render)); */
+    ignore(width);
 
     (
       hooks,
       <View style=absoluteStyle>
-        <FlatList
-          width
-          height
-          rowHeight
-          render
-          count
-          scrollY={state.editor.minimapScrollY}
-        />
+        <OpenGL style=absoluteStyle render={(transform, _) => {
+            FlatList.render(
+                ~scrollY,
+                ~rowHeight,
+                ~height,
+                ~count,
+                ~render={(item, offset) => {
+                   let tokens = getTokensForLine(item);
+                   renderLine(state.theme, transform, offset, tokens) 
+                }}, ());
+
+        }} />
       </View>,
     );
   });

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -5,7 +5,7 @@
  */
 
 /* open Reglfw.Glfw; */
-open Revery.Draw
+open Revery.Draw;
 open Revery.UI;
 
 open Oni_Core;
@@ -19,32 +19,28 @@ let tokensToElement = (transform, yOffset, tokens: list(Tokenizer.t)) => {
     let tokenWidth =
       Index.toZeroBasedInt(token.endPosition)
       - Index.toZeroBasedInt(token.startPosition);
-    /* let style = */
-    /*   Style.[ */
-    /*     position(`Absolute), */
-    /*     layoutMode(`Minimal), */
-    /*     top(0), */
-    /*     left( */
-    /*       Constants.default.minimapCharacterWidth */
-    /*       * Index.toZeroBasedInt(token.startPosition), */
-    /*     ), */
-    /*     height(Constants.default.minimapCharacterHeight), */
-    /*     width(tokenWidth * Constants.default.minimapCharacterWidth), */
-    /*     backgroundColor(token.color), */
-    /*   ]; */
 
-    /* <View style />; */
-
-    let x = float_of_int(Constants.default.minimapCharacterWidth * Index.toZeroBasedInt(token.startPosition));
+    let x =
+      float_of_int(
+        Constants.default.minimapCharacterWidth
+        * Index.toZeroBasedInt(token.startPosition),
+      );
     let height = float_of_int(Constants.default.minimapCharacterHeight);
-    let width = float_of_int(tokenWidth * Constants.default.minimapCharacterWidth);
+    let width =
+      float_of_int(tokenWidth * Constants.default.minimapCharacterWidth);
 
-    Shapes.drawRect(~transform, ~y=float_of_int(yOffset), ~x=x, ~color=token.color, ~width, ~height, ());
+    Shapes.drawRect(
+      ~transform,
+      ~y=float_of_int(yOffset),
+      ~x,
+      ~color=token.color,
+      ~width,
+      ~height,
+      (),
+    );
   };
 
   List.iter(f, tokens);
-
-  /* <View style=lineStyle> ...tokens </View>; */
 };
 
 let renderLine = (_theme, transform, yOffset, tokens) => {
@@ -73,29 +69,28 @@ let createElement =
 
     let scrollY = state.editor.minimapScrollY;
 
-    /* let render = i => { */
-    /*   let tokens = getTokensForLine(i); */
-    /*   renderLine(state.theme, tokens); */
-    /* }; */
-
-    /* ignore((width, height, count, rowHeight, render)); */
     ignore(width);
 
     (
       hooks,
       <View style=absoluteStyle>
-        <OpenGL style=absoluteStyle render={(transform, _) => {
+        <OpenGL
+          style=absoluteStyle
+          render={(transform, _) =>
             FlatList.render(
-                ~scrollY,
-                ~rowHeight,
-                ~height,
-                ~count,
-                ~render={(item, offset) => {
-                   let tokens = getTokensForLine(item);
-                   renderLine(state.theme, transform, offset, tokens) 
-                }}, ());
-
-        }} />
+              ~scrollY,
+              ~rowHeight,
+              ~height,
+              ~count,
+              ~render=
+                (item, offset) => {
+                  let tokens = getTokensForLine(item);
+                  renderLine(state.theme, transform, offset, tokens);
+                },
+              (),
+            )
+          }
+        />
       </View>,
     );
   });


### PR DESCRIPTION
This refactors our minimap to use the new `<OpenGL />` node introduced in revery-ui/revery#381 - this greatly reduces layout/reconciliation cost because we no longer need to apply reconciliation/layout to individual minimap elements.

This is a big step forward but still isn't as efficient as it could be - the next step would be to batch up the draw calls and minimize the overhead there. We're making lots of small GL calls that could be avoided with batching.