### PR TITLE
Performance: Use immediate mode drawing for buffer surface

### DIFF
--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -48,35 +48,42 @@ let tokensToElement =
 
   let yF = float_of_int(yOffset);
 
-let lineNumber = string_of_int(
-  LineNumber.getLineNumber(
-    ~bufferLine=lineNumber + 1,
-    ~cursorLine=cursorLine + 1,
-    ~setting=Relative,
-    (),
-  ));
+  let lineNumber =
+    string_of_int(
+      LineNumber.getLineNumber(
+        ~bufferLine=lineNumber + 1,
+        ~cursorLine=cursorLine + 1,
+        ~setting=Relative,
+        (),
+      ),
+    );
 
   Revery.Draw.Text.drawString(
-      ~transform,
-      ~x=0.,
-      ~y=yF,
-      ~backgroundColor=theme.colors.editorLineNumberBackground, 
-      ~color=lineNumberTextColor,
-      ~fontFamily="FiraCode-Regular.ttf",
-      ~fontSize=14,
-      lineNumber
+    ~transform,
+    ~x=0.,
+    ~y=yF,
+    ~backgroundColor=theme.colors.editorLineNumberBackground,
+    ~color=lineNumberTextColor,
+    ~fontFamily="FiraCode-Regular.ttf",
+    ~fontSize=14,
+    lineNumber,
   );
 
   let f = (token: Tokenizer.t) => {
     Revery.Draw.Text.drawString(
-        ~transform,
-        ~x=float_of_int(lineNumberWidth + fontWidth * Index.toZeroBasedInt(token.startPosition)),
-        ~y=yF,
-        ~backgroundColor=theme.colors.background,
-        ~color=token.color,
-        ~fontFamily="FiraCode-Regular.ttf",
-        ~fontSize=14,
-        token.text
+      ~transform,
+      ~x=
+        float_of_int(
+          lineNumberWidth
+          + fontWidth
+          * Index.toZeroBasedInt(token.startPosition),
+        ),
+      ~y=yF,
+      ~backgroundColor=theme.colors.background,
+      ~color=token.color,
+      ~fontFamily="FiraCode-Regular.ttf",
+      ~fontSize=14,
+      token.text,
     );
   };
 
@@ -218,28 +225,39 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     (
       hooks,
       <View style onDimensionsChanged>
-        <View style={bufferViewStyle}>
-          <OpenGL style={bufferViewStyle} render={(transform, _ctx) => { 
-
+        <View style=bufferViewStyle>
+          <OpenGL
+            style=bufferViewStyle
+            render={(transform, _ctx) => {
               let count = lineCount;
               let height = state.editor.size.pixelHeight;
               let rowHeight = state.editorFont.measuredHeight;
               let scrollY = state.editor.scrollY;
 
-              Shapes.drawRect(~transform, ~x=0., ~y=0., ~width=float_of_int(lineNumberWidth), ~height=float_of_int(height), ~color=theme.colors.editorLineNumberBackground, ());
+              Shapes.drawRect(
+                ~transform,
+                ~x=0.,
+                ~y=0.,
+                ~width=float_of_int(lineNumberWidth),
+                ~height=float_of_int(height),
+                ~color=theme.colors.editorLineNumberBackground,
+                (),
+              );
 
               FlatList.render(
                 ~scrollY,
                 ~rowHeight,
                 ~height,
                 ~count,
-                ~render=(item, offset) => {
-                   let _ = render(item, offset, transform);
-                },
-                ()
+                ~render=
+                  (item, offset) => {
+                    let _ = render(item, offset, transform);
+                    ();
+                  },
+                (),
               );
-
-          }} />
+            }}
+          />
           <View style=cursorStyle />
         </View>
         <View style=minimapViewStyle>

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -5,7 +5,10 @@
  * the view of the buffer in the window.
  */
 
+open Reglfw.Glfw;
+
 open Revery;
+open Revery.Draw;
 open Revery.UI;
 
 open CamomileLibraryDefault.Camomile;
@@ -59,7 +62,7 @@ let tokensToElement =
         textWrap(Revery.TextWrapping.NoWrap),
       ];
 
-    <Text style text={token.text} />;
+    let _ = <Text style text={token.text} />;
   };
 
   let lineStyle = Style.[position(`Absolute), top(0), left(0), right(0)];
@@ -76,14 +79,15 @@ let tokensToElement =
       alignItems(lineNumberAlignment),
     ];
 
-  let lineContentsStyle =
-    Style.[
-      position(`Absolute),
-      top(0),
-      left(lineNumberWidth),
-      right(0),
-      height(fontLineHeight),
-    ];
+  /* TODO:  Incorporate */
+  /* let lineContentsStyle = */
+  /*   Style.[ */
+  /*     position(`Absolute), */
+  /*     top(0), */
+  /*     left(lineNumberWidth), */
+  /*     right(0), */
+  /*     height(fontLineHeight), */
+  /*   ]; */
 
   let lineNumberTextStyle =
     Style.[
@@ -96,7 +100,7 @@ let tokensToElement =
       textWrap(Revery.TextWrapping.NoWrap),
     ];
 
-  let tokens = List.map(f, tokens);
+  List.iter(f, tokens);
 
   <View style=lineStyle>
     <View style=lineNumberStyle>
@@ -112,7 +116,6 @@ let tokensToElement =
         )}
       />
     </View>
-    <View style=lineContentsStyle> ...tokens </View>
   </View>;
 };
 
@@ -174,7 +177,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
       Tokenizer.tokenize(line, state.theme);
     };
 
-    let render = i => {
+    let _render = i => {
       let tokens = getTokensForLine(i);
 
       tokensToElement(
@@ -246,18 +249,15 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         bottom(0),
       ];
 
-    let ret = (
+    (
       hooks,
       <View style onDimensionsChanged>
-        <View style=bufferViewStyle>
-          <FlatList
-            render
-            count=lineCount
-            width=bufferPixelWidth
-            height={state.editor.size.pixelHeight}
-            rowHeight={state.editorFont.measuredHeight}
-            scrollY={state.editor.scrollY}
-          />
+        <View style={bufferViewStyle}>
+          <OpenGL style={bufferViewStyle} render={(transform, _ctx) => { 
+              glClearColor(1.0, 0.0, 0.0, 1.0);
+
+              Shapes.drawRect(~transform, ~x=0., ~y=0., ~width=float_of_int(lineNumberWidth), ~height=float_of_int(state.editor.size.pixelHeight), ~color=theme.colors.editorLineNumberBackground, ());
+          }} />
           <View style=cursorStyle />
         </View>
         <View style=minimapViewStyle>
@@ -278,5 +278,4 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         </View>
       </View>,
     );
-    ret;
   });

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -28,7 +28,6 @@ let init = app => {
     App.createWindow(
       ~createOptions={
         ...Window.defaultCreateOptions,
-        vsync: false,
         maximized: false,
         icon: Some("logo.png"),
       },


### PR DESCRIPTION
This change uses the new `<OpenGL />` node for drawing text in the buffer surface; avoiding the cost of reconciliation and layout for that layer.