### PR TITLE
Bugfix: Add '--noplugin' flag

### DIFF
--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -43,7 +43,7 @@ let init = app => {
   let nvim =
     NeovimProcess.start(
       ~neovimPath=setup.neovimPath,
-      ~args=[|"-u", initVimPath, "--embed"|],
+      ~args=[|"-u", initVimPath, "--noplugin", "--embed"|],
     );
   let msgpackTransport =
     MsgpackTransport.make(

--- a/test/editor/Neovim/Helpers.re
+++ b/test/editor/Neovim/Helpers.re
@@ -31,7 +31,10 @@ let uiAttach = (api: NeovimApi.t) => {
 let withNeovimApi = f => {
   let {neovimPath, _}: Setup.t = Setup.init();
   let nvim =
-    NeovimProcess.start(~neovimPath, ~args=[|"-u", "NORC", "--noplugin", "--embed"|]);
+    NeovimProcess.start(
+      ~neovimPath,
+      ~args=[|"-u", "NORC", "--noplugin", "--embed"|],
+    );
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,

--- a/test/editor/Neovim/Helpers.re
+++ b/test/editor/Neovim/Helpers.re
@@ -31,7 +31,7 @@ let uiAttach = (api: NeovimApi.t) => {
 let withNeovimApi = f => {
   let {neovimPath, _}: Setup.t = Setup.init();
   let nvim =
-    NeovimProcess.start(~neovimPath, ~args=[|"-u", "NORC", "--embed"|]);
+    NeovimProcess.start(~neovimPath, ~args=[|"-u", "NORC", "--noplugin", "--embed"|]);
   let msgpackTransport =
     MsgpackTransport.make(
       ~onData=nvim.stdout.onData,


### PR DESCRIPTION
This adds the `--noplugin` flag for now, so that we get a predictable baseline for nvim integration to start (we'll later explore the way to include VimL plugins). I believe this might be the root cause of #86 crashing.