### PR TITLE
Refactoring: Buffer module interface

### DIFF
--- a/bench/lib/BufferBench.re
+++ b/bench/lib/BufferBench.re
@@ -8,11 +8,15 @@ let rootNode = (new node)();
 let setup = () => ();
 
 let emptyBuffer = Buffer.ofLines([||]);
+let emptyBufferId = Buffer.getMetadata(emptyBuffer).id;
 
 let hundredThousandLineBuffer =
   Buffer.ofLines(Array.make(100000, "This buffer is pretty big"));
+let hundredThousandLineBufferId = Buffer.getMetadata(hundredThousandLineBuffer).id;
+
 let smallBuffer =
   Buffer.ofLines(Array.make(100, "This buffer is a bit smaller"));
+let smallBufferId = Buffer.getMetadata(smallBuffer).id;
 
 let hundredThousandLines =
   Array.make(100000, "Another big buffer update") |> Array.to_list;
@@ -20,7 +24,7 @@ let hundredThousandLines =
 let addLinesToEmptyBuffer = () => {
   let _ =
     Types.BufferUpdate.create(
-      ~id=emptyBuffer.metadata.id,
+      ~id=emptyBufferId,
       ~startLine=0,
       ~endLine=-1,
       ~lines=hundredThousandLines,
@@ -34,7 +38,7 @@ let addLinesToEmptyBuffer = () => {
 let clearLargeBuffer = () => {
   let _ =
     Types.BufferUpdate.create(
-      ~id=hundredThousandLineBuffer.metadata.id,
+      ~id=hundredThousandLineBufferId,
       ~startLine=0,
       ~endLine=-1,
       ~lines=[],
@@ -48,7 +52,7 @@ let clearLargeBuffer = () => {
 let insertInMiddleOfSmallBuffer = () => {
   let _ =
     Types.BufferUpdate.create(
-      ~id=smallBuffer.metadata.id,
+      ~id=smallBufferId,
       ~startLine=50,
       ~endLine=51,
       ~lines=["this is a new line"],
@@ -62,7 +66,7 @@ let insertInMiddleOfSmallBuffer = () => {
 let insertInMiddleOfLargeBuffer = () => {
   let _ =
     Types.BufferUpdate.create(
-      ~id=hundredThousandLineBuffer.metadata.id,
+      ~id=hundredThousandLineBufferId,
       ~startLine=5000,
       ~endLine=50001,
       ~lines=["this is a new line"],

--- a/bench/lib/BufferBench.re
+++ b/bench/lib/BufferBench.re
@@ -12,7 +12,8 @@ let emptyBufferId = Buffer.getMetadata(emptyBuffer).id;
 
 let hundredThousandLineBuffer =
   Buffer.ofLines(Array.make(100000, "This buffer is pretty big"));
-let hundredThousandLineBufferId = Buffer.getMetadata(hundredThousandLineBuffer).id;
+let hundredThousandLineBufferId =
+  Buffer.getMetadata(hundredThousandLineBuffer).id;
 
 let smallBuffer =
   Buffer.ofLines(Array.make(100, "This buffer is a bit smaller"));

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -19,6 +19,12 @@ let ofLines = (lines: array(string)) => {
 
 let ofMetadata = (metadata: BufferMetadata.t) => {metadata, lines: [||]};
 
+let getMetadata = (buffer: t) => buffer.metadata;
+
+let getLine = (buffer: t, line: int) => buffer.lines[line];
+
+let getNumberOfLines = (buffer: t) => Array.length(buffer.lines);
+
 let slice = (~lines: array(string), ~start, ~length, ()) => {
   let len = Array.length(lines);
   if (start >= len) {
@@ -77,3 +83,8 @@ let update = (buf: t, update: BufferUpdate.t) =>
     {metadata, lines: applyUpdate(buf.lines, update)};
   | _ => buf
   };
+
+let updateMetadata = (buf: t, metadata: BufferMetadata.t) => {
+    ...buf,
+    metadata,
+};

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -17,6 +17,8 @@ let ofLines = (lines: array(string)) => {
   lines,
 };
 
+let empty = ofLines([||]);
+
 let ofMetadata = (metadata: BufferMetadata.t) => {metadata, lines: [||]};
 
 let getMetadata = (buffer: t) => buffer.metadata;

--- a/src/editor/Core/Buffer.re
+++ b/src/editor/Core/Buffer.re
@@ -87,6 +87,6 @@ let update = (buf: t, update: BufferUpdate.t) =>
   };
 
 let updateMetadata = (buf: t, metadata: BufferMetadata.t) => {
-    ...buf,
-    metadata,
+  ...buf,
+  metadata,
 };

--- a/src/editor/Core/Buffer.rei
+++ b/src/editor/Core/Buffer.rei
@@ -20,3 +20,5 @@ let getNumberOfLines: (t) => int;
 let update: (t, BufferUpdate.t) => t;
 
 let updateMetadata: (t, BufferMetadata.t) => t;
+
+let empty: t;

--- a/src/editor/Core/Buffer.rei
+++ b/src/editor/Core/Buffer.rei
@@ -1,0 +1,22 @@
+/*
+ * Buffer.rei
+ *
+ * In-memory text buffer representation
+ */
+
+open Types;
+
+[@deriving show]
+type t;
+
+let ofLines: array(string) => t;
+let ofMetadata: BufferMetadata.t => t;
+
+let getLine: (t, int) => string;
+let getMetadata: (t) => BufferMetadata.t;
+
+let getNumberOfLines: (t) => int;
+
+let update: (t, BufferUpdate.t) => t;
+
+let updateMetadata: (t, BufferMetadata.t) => t;

--- a/src/editor/Core/Buffer.rei
+++ b/src/editor/Core/Buffer.rei
@@ -13,9 +13,9 @@ let ofLines: array(string) => t;
 let ofMetadata: BufferMetadata.t => t;
 
 let getLine: (t, int) => string;
-let getMetadata: (t) => BufferMetadata.t;
+let getMetadata: t => BufferMetadata.t;
 
-let getNumberOfLines: (t) => int;
+let getNumberOfLines: t => int;
 
 let update: (t, BufferUpdate.t) => t;
 

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -37,7 +37,8 @@ let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) => {
     Buffers.filter(
       (_, b: Buffer.t) =>
         List.exists(
-          (newBuf: BufferMetadata.t) => newBuf.id == Buffer.getMetadata(b).id,
+          (newBuf: BufferMetadata.t) =>
+            newBuf.id == Buffer.getMetadata(b).id,
           newBuffers,
         ),
       buffersMap,

--- a/src/editor/Core/BufferMap.re
+++ b/src/editor/Core/BufferMap.re
@@ -37,7 +37,7 @@ let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) => {
     Buffers.filter(
       (_, b: Buffer.t) =>
         List.exists(
-          (newBuf: BufferMetadata.t) => newBuf.id == b.metadata.id,
+          (newBuf: BufferMetadata.t) => newBuf.id == Buffer.getMetadata(b).id,
           newBuffers,
         ),
       buffersMap,
@@ -49,7 +49,7 @@ let updateMetadata = (buffersMap: t, newBuffers: list(BufferMetadata.t)) => {
         original =>
           switch (original) {
           | None => Some(Buffer.ofMetadata(metadata))
-          | Some(v) => Some({...v, metadata}: Buffer.t)
+          | Some(v) => Some(Buffer.updateMetadata(v, metadata))
           },
         m,
       ),

--- a/src/editor/Core/Editor.re
+++ b/src/editor/Core/Editor.re
@@ -150,7 +150,7 @@ let moveCursorToPosition = (~moveCursor, view, position) =>
 
 let recalculate = (view: t, buffer: option(Buffer.t)) =>
   switch (buffer) {
-  | Some(b) => {...view, viewLines: Buffer.getNumberOfLines(b) }
+  | Some(b) => {...view, viewLines: Buffer.getNumberOfLines(b)}
   | None => view
   };
 

--- a/src/editor/Core/Editor.re
+++ b/src/editor/Core/Editor.re
@@ -150,7 +150,7 @@ let moveCursorToPosition = (~moveCursor, view, position) =>
 
 let recalculate = (view: t, buffer: option(Buffer.t)) =>
   switch (buffer) {
-  | Some(b) => {...view, viewLines: Array.length(b.lines)}
+  | Some(b) => {...view, viewLines: Buffer.getNumberOfLines(b), },
   | None => view
   };
 

--- a/src/editor/Core/Editor.re
+++ b/src/editor/Core/Editor.re
@@ -150,7 +150,7 @@ let moveCursorToPosition = (~moveCursor, view, position) =>
 
 let recalculate = (view: t, buffer: option(Buffer.t)) =>
   switch (buffer) {
-  | Some(b) => {...view, viewLines: Buffer.getNumberOfLines(b), },
+  | Some(b) => {...view, viewLines: Buffer.getNumberOfLines(b) }
   | None => view
   };
 

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -106,13 +106,13 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let activeBuffer =
       Oni_Core.BufferMap.getBuffer(state.activeBufferId, state.buffers);
 
-    let lines =
+    let buffer =
       switch (activeBuffer) {
-      | Some(buffer) => buffer.lines
-      | None => [||]
+      | Some(buffer) => buffer
+      | None => Buffer.empty
       };
 
-    let lineCount = Array.length(lines);
+    let lineCount = Buffer.getNumberOfLines(buffer);
 
     let lineNumberWidth =
       LineNumber.getLineNumberPixelWidth(
@@ -151,7 +151,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
       ];
 
     let getTokensForLine = i => {
-      let line = lines[i];
+      let line = Buffer.getLine(buffer, i);
       let tokenColors =
         SyntaxHighlighting.getTokensForLine(
           state.syntaxHighlighting,

--- a/test/editor/Core/BufferMapTests.re
+++ b/test/editor/Core/BufferMapTests.re
@@ -14,7 +14,7 @@ let getOrFail = (v: option(Buffer.t)) => {
     switch (metadata.filePath) {
     | Some(path) => path
     | None => failedMsg
-    }
+    };
   | None => failedMsg
   };
 };

--- a/test/editor/Core/BufferMapTests.re
+++ b/test/editor/Core/BufferMapTests.re
@@ -10,7 +10,8 @@ let getOrFail = (v: option(Buffer.t)) => {
   let failedMsg = "failed - no buffer was specified";
   switch (v) {
   | Some(v) =>
-    switch (v.metadata.filePath) {
+    let metadata = Buffer.getMetadata(v);
+    switch (metadata.filePath) {
     | Some(path) => path
     | None => failedMsg
     }

--- a/test/editor/Core/BufferTests.re
+++ b/test/editor/Core/BufferTests.re
@@ -104,7 +104,8 @@ describe("Buffer", ({describe, _}) =>
         );
       let updatedBuffer = Buffer.update(buffer, update);
       validateBuffer(expect, updatedBuffer, [|"a", "b", "c", "d"|]);
-      expect.int(updatedBuffer.metadata.version).toBe(5);
+      let metadata = Buffer.getMetadata(updatedBuffer);
+      expect.int(metadata.version).toBe(5);
     });
 
     test("buffer update with lower version gets rejected", ({expect}) => {
@@ -131,7 +132,8 @@ describe("Buffer", ({describe, _}) =>
       let updatedBuffer = Buffer.update(bufferUpdate1, update);
 
       validateBuffer(expect, updatedBuffer, [|"d"|]);
-      expect.int(updatedBuffer.metadata.version).toBe(6);
+      let metadata = Buffer.getMetadata(updatedBuffer);
+      expect.int(metadata.version).toBe(6);
     });
   })
 );

--- a/test/editor/Core/Helpers.re
+++ b/test/editor/Core/Helpers.re
@@ -56,7 +56,7 @@ let validateBuffer =
       actualBuffer: Buffer.t,
       expectedLines: array(string),
     ) => {
-  expect.int(Array.length(actualBuffer.lines)).toBe(
+  expect.int(Buffer.getNumberOfLines(actualBuffer)).toBe(
     Array.length(expectedLines),
   );
 
@@ -64,9 +64,10 @@ let validateBuffer =
     expect.string(actualLine).toEqual(expectedLine);
   };
 
-  let f = (actual, expected) => {
+  let f = (i, expected) => {
+    let actual = Buffer.getLine(actualBuffer, i);
     validateLine(actual, expected);
   };
 
-  Array.iter2(f, actualBuffer.lines, expectedLines);
+  Array.iteri(f, expectedLines);
 };


### PR DESCRIPTION
This change abstracts the `Buffer.t` so consumers don't rely on the internal implementation being a linear array. This is important as we implement optimizations and changes to the internal buffer model - like #80 - so that consumers can rely on a consistent API.