### PR TITLE
Feature/command palette

### DIFF
--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,0 +1,8 @@
+{
+    "bindings": [
+        { "key": "<C-P>", "command": "commandPalette.open", "condition": ["neovim"] },
+        { "key": "<ESC>", "command": "commandPalette.close", "condition": ["oni"] },
+        { "key": "<C-N>", "command": "commandPalette.next", "condition": ["oni"] },
+        { "key": "<C-P>", "command": "commandPalette.previous", "condition": ["oni"] }
+    ]
+}

--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,8 +1,9 @@
 {
     "bindings": [
         { "key": "<C-P>", "command": "commandPalette.open", "condition": ["neovim"] },
-        { "key": "<ESC>", "command": "commandPalette.close", "condition": ["oni"] },
-        { "key": "<C-N>", "command": "commandPalette.next", "condition": ["oni"] },
-        { "key": "<C-P>", "command": "commandPalette.previous", "condition": ["oni"] }
+        { "key": "<ESC>", "command": "commandPalette.close", "condition": ["commandPalette"] },
+        { "key": "<C-N>", "command": "commandPalette.next", "condition": ["commandPalette"] },
+        { "key": "<C-P>", "command": "commandPalette.previous", "condition": ["commandPalette"] },
+        { "key": "<ENTER>", "command": "commandPalette.select", "condition": ["commandPalette"] }
     ]
 }

--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -4,6 +4,6 @@
         { "key": "<ESC>", "command": "commandPalette.close", "condition": ["commandPalette"] },
         { "key": "<C-N>", "command": "commandPalette.next", "condition": ["commandPalette"] },
         { "key": "<C-P>", "command": "commandPalette.previous", "condition": ["commandPalette"] },
-        { "key": "<ENTER>", "command": "commandPalette.select", "condition": ["commandPalette"] }
+        { "key": "<CR>", "command": "commandPalette.select", "condition": ["commandPalette"] }
     ]
 }

--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,9 +1,9 @@
 {
     "bindings": [
-        { "key": "<C-P>", "command": "commandPalette.open", "when": ["neovim"] },
-        { "key": "<ESC>", "command": "commandPalette.close", "when": ["commandPalette"] },
-        { "key": "<C-N>", "command": "commandPalette.next", "when": ["commandPalette"] },
-        { "key": "<C-P>", "command": "commandPalette.previous", "when": ["commandPalette"] },
-        { "key": "<CR>", "command": "commandPalette.select", "when": ["commandPalette"] }
+        { "key": "<C-P>", "command": "commandPalette.open", "when": ["editorTextFocus"] },
+        { "key": "<ESC>", "command": "commandPalette.close", "when": ["commandPaletteFocus"] },
+        { "key": "<C-N>", "command": "commandPalette.next", "when": ["commandPaletteFocus"] },
+        { "key": "<C-P>", "command": "commandPalette.previous", "when": ["commandPaletteFocus"] },
+        { "key": "<CR>", "command": "commandPalette.select", "when": ["commandPaletteFocus"] }
     ]
 }

--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,9 +1,9 @@
 {
     "bindings": [
-        { "key": "<C-P>", "command": "commandPalette.open", "condition": ["neovim"] },
-        { "key": "<ESC>", "command": "commandPalette.close", "condition": ["commandPalette"] },
-        { "key": "<C-N>", "command": "commandPalette.next", "condition": ["commandPalette"] },
-        { "key": "<C-P>", "command": "commandPalette.previous", "condition": ["commandPalette"] },
-        { "key": "<CR>", "command": "commandPalette.select", "condition": ["commandPalette"] }
+        { "key": "<C-P>", "command": "commandPalette.open", "when": ["neovim"] },
+        { "key": "<ESC>", "command": "commandPalette.close", "when": ["commandPalette"] },
+        { "key": "<C-N>", "command": "commandPalette.next", "when": ["commandPalette"] },
+        { "key": "<C-P>", "command": "commandPalette.previous", "when": ["commandPalette"] },
+        { "key": "<CR>", "command": "commandPalette.select", "when": ["commandPalette"] }
     ]
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -37,13 +37,15 @@ case "${machine}" in
       TEXTMATE_SERVICE_PATH="$(pwd)/src/textmate_service/lib/src/index.js"
       EXTENSIONS_PATH="$(pwd)/extensions"
       NEOVIM_PATH="$(pwd)/vendor/neovim-0.3.3/nvim-linux64/bin/nvim"
-      CONFIGURATION_PATH="$(pwd)/assets/configuration/configuration.json";;
+      CONFIGURATION_PATH="$(pwd)/assets/configuration/configuration.json"
+      KEYBINDINGS_PATH="$(pwd)/assets/configuration/keybindings.json";;
   Mac)
       NODE_PATH="$(pwd)/vendor/node-v10.15.1/osx/node"
       TEXTMATE_SERVICE_PATH="$(pwd)/src/textmate_service/lib/src/index.js"
       EXTENSIONS_PATH="$(pwd)/extensions"
       NEOVIM_PATH="$(pwd)/vendor/neovim-0.3.3/nvim-osx64/bin/nvim"
-      CONFIGURATION_PATH="$(pwd)/assets/configuration/configuration.json";;
+      CONFIGURATION_PATH="$(pwd)/assets/configuration/configuration.json"
+      KEYBINDINGS_PATH="$(pwd)/assets/configuration/keybindings.json";;
   *)
       NEOVIM_PATH="$(pwd)/vendor/neovim-0.3.3/nvim-win64/bin/nvim.exe"
       NEOVIM_PATH="$(cygpath -m "$NEOVIM_PATH")"
@@ -54,10 +56,12 @@ case "${machine}" in
       NODE_PATH="$(pwd)/vendor/node-v10.15.1/win-x64/node.exe"
       NODE_PATH="$(cygpath -m "$NODE_PATH")"
       CONFIGURATION_PATH="$(pwd)/assets/configuration/configuration.json"
-      CONFIGURATION_PATH="$(cygpath -m "$CONFIGURATION_PATH")";;
+      CONFIGURATION_PATH="$(cygpath -m "$CONFIGURATION_PATH")"
+      KEYBINDINGS_PATH="$(pwd)/assets/configuration/keybindings.json"
+      KEYBINDINGS_PATH="$(cygpath -m "$KEYBINDINGS_PATH")";;
 esac
 
-oni_bin_path="{neovim:\"$NEOVIM_PATH\",node:\"$NODE_PATH\",configuration:\"$CONFIGURATION_PATH\",textmateService:\"$TEXTMATE_SERVICE_PATH\",bundledExtensions:\"$EXTENSIONS_PATH\"}"
+oni_bin_path="{neovim:\"$NEOVIM_PATH\",node:\"$NODE_PATH\",configuration:\"$CONFIGURATION_PATH\",textmateService:\"$TEXTMATE_SERVICE_PATH\",bundledExtensions:\"$EXTENSIONS_PATH\",keybindings:\"$KEYBINDINGS_PATH\"}"
 
 # create the current bin path as this might not exist yet
 if [ ! -d "$config_path" ]; then

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -34,8 +34,10 @@ type t =
   | EditorMoveCursorToBottom(Cursor.move)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
+  | CommandPaletteStart(list(Palette.command))
   | CommandPaletteOpen
   | CommandPaletteClose
+  | CommandPaletteSelect
   | CommandPalettePosition(int)
   | SetInputControlMode(Input.controlMode)
   | Noop;

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -34,7 +34,8 @@ type t =
   | EditorMoveCursorToBottom(Cursor.move)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
-  | CommandPaletteToggle(bool)
+  | CommandPaletteOpen
+  | CommandPaletteClose
   | CommandPalettePosition(int)
   | SetInputControlMode(Input.controlMode)
   | Noop;

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -34,7 +34,7 @@ type t =
   | EditorMoveCursorToBottom(Cursor.move)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
-  | CommandPaletteOpen
-  | CommandPaletteClose
+  | CommandPaletteToggle(bool)
+  | CommandPalettePosition(int)
   | SetInputControlMode(Input.controlMode)
   | Noop;

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -34,4 +34,5 @@ type t =
   | EditorMoveCursorToBottom(Cursor.move)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
+  | OniCommand(string)
   | Noop;

--- a/src/editor/Core/Actions.re
+++ b/src/editor/Core/Actions.re
@@ -34,5 +34,7 @@ type t =
   | EditorMoveCursorToBottom(Cursor.move)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
-  | OniCommand(string)
+  | CommandPaletteOpen
+  | CommandPaletteClose
+  | SetInputControlMode(Input.controlMode)
   | Noop;

--- a/src/editor/Core/CommandPalette.re
+++ b/src/editor/Core/CommandPalette.re
@@ -1,0 +1,11 @@
+type command = {
+  name: string,
+  action: unit => Oni_Core.Actions.t,
+};
+
+type t = {
+  isOpen: bool,
+  commands: list(command),
+};
+
+let create = () => {isOpen: false, commands: []};

--- a/src/editor/Core/CommandPalette.re
+++ b/src/editor/Core/CommandPalette.re
@@ -25,3 +25,14 @@ let create = () => {
 
 let position = (selectedItem, change, commands: list(command)) =>
   selectedItem + change >= List.length(commands) ? 0 : selectedItem + change;
+
+let reduce = (state: t, action: Actions.t) =>
+  switch (action) {
+  | CommandPalettePosition(pos) => {
+      ...state,
+      selectedItem: position(state.selectedItem, pos, state.commands),
+    }
+  | CommandPaletteOpen => {...state, isOpen: true}
+  | CommandPaletteClose => {...state, isOpen: false}
+  | _ => state
+  };

--- a/src/editor/Core/CommandPalette.re
+++ b/src/editor/Core/CommandPalette.re
@@ -1,11 +1,27 @@
 type command = {
   name: string,
-  action: unit => Actions.t,
+  command: unit => Actions.t,
 };
 
 type t = {
   isOpen: bool,
   commands: list(command),
+  selectedItem: int,
 };
 
-let create = () => {isOpen: false, commands: []};
+let commandPaletteCommands = [
+  {name: "testing1", command: () => Noop},
+  {name: "testing2", command: () => Noop},
+  {name: "testing3", command: () => Noop},
+];
+
+let setInputControl = isOpen => Types.Input.(isOpen ? Oni : Neovim);
+
+let create = () => {
+  isOpen: false,
+  commands: commandPaletteCommands,
+  selectedItem: 0,
+};
+
+let position = (selectedItem, change, commands: list(command)) =>
+  selectedItem + change >= List.length(commands) ? 0 : selectedItem + change;

--- a/src/editor/Core/CommandPalette.re
+++ b/src/editor/Core/CommandPalette.re
@@ -1,6 +1,6 @@
 type command = {
   name: string,
-  action: unit => Oni_Core.Actions.t,
+  action: unit => Actions.t,
 };
 
 type t = {

--- a/src/editor/Core/Commands.re
+++ b/src/editor/Core/Commands.re
@@ -1,17 +1,23 @@
 type oniCommand = {
   name: string,
-  command: unit => Actions.t,
+  command: unit => list(Actions.t),
 };
 
 type t = list(oniCommand);
 
 let oniCommands = [
-  {name: "commandPalette.open", command: () => CommandPaletteToggle(true)},
-  {name: "commandPalette.close", command: () => CommandPaletteToggle(false)},
-  {name: "commandPalette.next", command: () => CommandPalettePosition(1)},
+  {
+    name: "commandPalette.open",
+    command: () => [CommandPaletteOpen, SetInputControlMode(Oni)],
+  },
+  {
+    name: "commandPalette.close",
+    command: () => [CommandPaletteClose, SetInputControlMode(Neovim)],
+  },
+  {name: "commandPalette.next", command: () => [CommandPalettePosition(1)]},
   {
     name: "commandPalette.previous",
-    command: () => CommandPalettePosition(-1),
+    command: () => [CommandPalettePosition(-1)],
   },
 ];
 
@@ -19,6 +25,6 @@ let handleCommand = (~commands=oniCommands, name) => {
   let matchingCmd = List.find_opt(cmd => name == cmd.name, commands);
   switch (matchingCmd) {
   | Some(c) => c.command()
-  | None => Noop
+  | None => [Noop]
   };
 };

--- a/src/editor/Core/Commands.re
+++ b/src/editor/Core/Commands.re
@@ -19,7 +19,10 @@ let oniCommands = [
     name: "commandPalette.previous",
     command: _ => [CommandPalettePosition(-1)],
   },
-  {name: "commandPalette.select", command: _ => [CommandPaletteSelect]},
+  {
+    name: "commandPalette.select",
+    command: _ => [CommandPaletteSelect, SetInputControlMode(Neovim)],
+  },
 ];
 
 let handleCommand = (~commands=oniCommands, name) => {

--- a/src/editor/Core/Commands.re
+++ b/src/editor/Core/Commands.re
@@ -8,17 +8,18 @@ type t = list(oniCommand);
 let oniCommands = [
   {
     name: "commandPalette.open",
-    command: () => [CommandPaletteOpen, SetInputControlMode(Oni)],
+    command: _ => [CommandPaletteOpen, SetInputControlMode(Palette)],
   },
   {
     name: "commandPalette.close",
-    command: () => [CommandPaletteClose, SetInputControlMode(Neovim)],
+    command: _ => [CommandPaletteClose, SetInputControlMode(Neovim)],
   },
-  {name: "commandPalette.next", command: () => [CommandPalettePosition(1)]},
+  {name: "commandPalette.next", command: _ => [CommandPalettePosition(1)]},
   {
     name: "commandPalette.previous",
-    command: () => [CommandPalettePosition(-1)],
+    command: _ => [CommandPalettePosition(-1)],
   },
+  {name: "commandPalette.select", command: _ => [CommandPaletteSelect]},
 ];
 
 let handleCommand = (~commands=oniCommands, name) => {

--- a/src/editor/Core/Commands.re
+++ b/src/editor/Core/Commands.re
@@ -8,11 +8,17 @@ type t = list(oniCommand);
 let oniCommands = [
   {
     name: "commandPalette.open",
-    command: _ => [CommandPaletteOpen, SetInputControlMode(Palette)],
+    command: _ => [
+      CommandPaletteOpen,
+      SetInputControlMode(CommandPaletteFocus),
+    ],
   },
   {
     name: "commandPalette.close",
-    command: _ => [CommandPaletteClose, SetInputControlMode(Neovim)],
+    command: _ => [
+      CommandPaletteClose,
+      SetInputControlMode(EditorTextFocus),
+    ],
   },
   {name: "commandPalette.next", command: _ => [CommandPalettePosition(1)]},
   {
@@ -21,7 +27,10 @@ let oniCommands = [
   },
   {
     name: "commandPalette.select",
-    command: _ => [CommandPaletteSelect, SetInputControlMode(Neovim)],
+    command: _ => [
+      CommandPaletteSelect,
+      SetInputControlMode(EditorTextFocus),
+    ],
   },
 ];
 

--- a/src/editor/Core/Commands.re
+++ b/src/editor/Core/Commands.re
@@ -6,8 +6,13 @@ type oniCommand = {
 type t = list(oniCommand);
 
 let oniCommands = [
-  {name: "open.commandPalette", command: () => CommandPaletteOpen},
-  {name: "close.commandPalette", command: () => CommandPaletteClose},
+  {name: "commandPalette.open", command: () => CommandPaletteToggle(true)},
+  {name: "commandPalette.close", command: () => CommandPaletteToggle(false)},
+  {name: "commandPalette.next", command: () => CommandPalettePosition(1)},
+  {
+    name: "commandPalette.previous",
+    command: () => CommandPalettePosition(-1),
+  },
 ];
 
 let handleCommand = (~commands=oniCommands, name) => {

--- a/src/editor/Core/Commands.re
+++ b/src/editor/Core/Commands.re
@@ -1,0 +1,19 @@
+type oniCommand = {
+  name: string,
+  command: unit => Actions.t,
+};
+
+type t = list(oniCommand);
+
+let oniCommands = [
+  {name: "open.commandPalette", command: () => CommandPaletteOpen},
+  {name: "close.commandPalette", command: () => CommandPaletteClose},
+];
+
+let handleCommand = (~commands=oniCommands, name) => {
+  let matchingCmd = List.find_opt(cmd => name == cmd.name, commands);
+  switch (matchingCmd) {
+  | Some(c) => c.command()
+  | None => Noop
+  };
+};

--- a/src/editor/Core/Editor.re
+++ b/src/editor/Core/Editor.re
@@ -1,6 +1,7 @@
 open Actions;
 open Types;
 
+[@deriving show]
 type t = {
   id: int,
   scrollX: int,

--- a/src/editor/Core/Keybindings.re
+++ b/src/editor/Core/Keybindings.re
@@ -4,6 +4,7 @@ open Types.Input;
 type keyBindings = {
   key: string,
   command: string,
+  [@key "when"]
   condition: controlMode,
 };
 

--- a/src/editor/Core/Keybindings.re
+++ b/src/editor/Core/Keybindings.re
@@ -1,0 +1,10 @@
+open Types.Input;
+
+type t = list(keyBindings);
+
+let defaultCommands = [
+  {key: "<C-P>", command: "commandPalette.open", condition: Neovim},
+  {key: "<ESC>", command: "commandPalette.close", condition: Oni},
+  {key: "<C-N>", command: "commandPalette.next", condition: Oni},
+  {key: "<C-P>", command: "commandPalette.previous", condition: Oni},
+];

--- a/src/editor/Core/Keybindings.re
+++ b/src/editor/Core/Keybindings.re
@@ -1,10 +1,27 @@
 open Types.Input;
 
+[@deriving (show, yojson({strict: false, exn: false}))]
+type keyBindings = {
+  key: string,
+  command: string,
+  condition: controlMode,
+};
+
+[@deriving (show, yojson({strict: false, exn: false}))]
 type t = list(keyBindings);
 
-let defaultCommands = [
-  {key: "<C-P>", command: "commandPalette.open", condition: Neovim},
-  {key: "<ESC>", command: "commandPalette.close", condition: Oni},
-  {key: "<C-N>", command: "commandPalette.next", condition: Oni},
-  {key: "<C-P>", command: "commandPalette.previous", condition: Oni},
-];
+[@deriving (show, yojson({strict: false, exn: false}))]
+type json_keybindings = {bindings: t};
+
+let ofFile = filePath =>
+  Yojson.Safe.from_file(filePath) |> json_keybindings_of_yojson;
+
+let get = () => {
+  let {keybindingsPath, _}: Setup.t = Setup.init();
+  switch (ofFile(keybindingsPath)) {
+  | Ok(b) => b.bindings
+  | Error(e) =>
+    print_endline("Error parsing keybindings file ------- " ++ e);
+    [];
+  };
+};

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -28,3 +28,4 @@ module Types = Types;
 module Utility = Utility;
 module Wildmenu = Wildmenu;
 module Configuration = Configuration;
+module CommandPalette = CommandPalette;

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -30,3 +30,4 @@ module Wildmenu = Wildmenu;
 module Configuration = Configuration;
 module CommandPalette = CommandPalette;
 module Commands = Commands;
+module Keybindings = Keybindings;

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -29,3 +29,4 @@ module Utility = Utility;
 module Wildmenu = Wildmenu;
 module Configuration = Configuration;
 module CommandPalette = CommandPalette;
+module Commands = Commands;

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -104,18 +104,24 @@ let reduce: (State.t, Actions.t) => State.t =
         tabs: updateTabs(activeBufferId, modified, s.tabs),
       }
     | SetInputControlMode(m) => {...s, inputControlMode: m}
-    | CommandPaletteClose => {
+    | CommandPalettePosition(pos) => {
         ...s,
         commandPalette: {
-          isOpen: false,
-          commands: s.commandPalette.commands,
+          ...s.commandPalette,
+          selectedItem:
+            CommandPalette.position(
+              s.commandPalette.selectedItem,
+              pos,
+              s.commandPalette.commands,
+            ),
         },
       }
-    | CommandPaletteOpen => {
+    | CommandPaletteToggle(isOpen) => {
         ...s,
+        inputControlMode: CommandPalette.setInputControl(isOpen),
         commandPalette: {
-          isOpen: true,
-          commands: s.commandPalette.commands,
+          ...s.commandPalette,
+          isOpen,
         },
       }
     | _ => s

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -70,6 +70,7 @@ let reduce: (State.t, Actions.t) => State.t =
       syntaxHighlighting: SyntaxHighlighting.reduce(s.syntaxHighlighting, a),
       wildmenu: Wildmenu.reduce(s.wildmenu, a),
       commandline: Commandline.reduce(s.commandline, a),
+      commandPalette: CommandPalette.reduce(s.commandPalette, a),
     };
 
     switch (a) {
@@ -104,26 +105,6 @@ let reduce: (State.t, Actions.t) => State.t =
         tabs: updateTabs(activeBufferId, modified, s.tabs),
       }
     | SetInputControlMode(m) => {...s, inputControlMode: m}
-    | CommandPalettePosition(pos) => {
-        ...s,
-        commandPalette: {
-          ...s.commandPalette,
-          selectedItem:
-            CommandPalette.position(
-              s.commandPalette.selectedItem,
-              pos,
-              s.commandPalette.commands,
-            ),
-        },
-      }
-    | CommandPaletteToggle(isOpen) => {
-        ...s,
-        inputControlMode: CommandPalette.setInputControl(isOpen),
-        commandPalette: {
-          ...s.commandPalette,
-          isOpen,
-        },
-      }
     | _ => s
     };
   };

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -103,7 +103,15 @@ let reduce: (State.t, Actions.t) => State.t =
         ...s,
         tabs: updateTabs(activeBufferId, modified, s.tabs),
       }
-    | OniCommand("open.commandPalette") => {
+    | SetInputControlMode(m) => {...s, inputControlMode: m}
+    | CommandPaletteClose => {
+        ...s,
+        commandPalette: {
+          isOpen: false,
+          commands: s.commandPalette.commands,
+        },
+      }
+    | CommandPaletteOpen => {
         ...s,
         commandPalette: {
           isOpen: true,

--- a/src/editor/Core/Reducer.re
+++ b/src/editor/Core/Reducer.re
@@ -103,6 +103,13 @@ let reduce: (State.t, Actions.t) => State.t =
         ...s,
         tabs: updateTabs(activeBufferId, modified, s.tabs),
       }
+    | OniCommand("open.commandPalette") => {
+        ...s,
+        commandPalette: {
+          isOpen: true,
+          commands: s.commandPalette.commands,
+        },
+      }
     | _ => s
     };
   };

--- a/src/editor/Core/Setup.re
+++ b/src/editor/Core/Setup.re
@@ -16,6 +16,8 @@ type t = {
   bundledExtensionsPath: string,
   [@key "configuration"]
   configPath: string,
+  [@key "keybindings"]
+  keybindingsPath: string,
 };
 
 let ofString = str => Yojson.Safe.from_string(str) |> of_yojson_exn;

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -23,6 +23,7 @@ type t = {
   buffers: BufferMap.t,
   activeBufferId: int,
   editorFont: EditorFont.t,
+  commandPalette: CommandPalette.t,
   commandline: Commandline.t,
   wildmenu: Wildmenu.t,
   configuration: Configuration.t,
@@ -35,6 +36,7 @@ let create: unit => t =
   () => {
     configuration: Configuration.create(),
     mode: Insert,
+    commandPalette: CommandPalette.create(),
     commandline: Commandline.create(),
     wildmenu: Wildmenu.create(),
     activeBufferId: 0,

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -54,5 +54,5 @@ let create: unit => t =
     tabs: [Tab.create(0, "[No Name]")],
     theme: Theme.create(),
     editor: Editor.create(),
-    inputControlMode: Neovim,
+    inputControlMode: EditorTextFocus,
   };

--- a/src/editor/Core/State.re
+++ b/src/editor/Core/State.re
@@ -30,6 +30,7 @@ type t = {
   syntaxHighlighting: SyntaxHighlighting.t,
   theme: Theme.t,
   editor: Editor.t,
+  inputControlMode: Input.controlMode,
 };
 
 let create: unit => t =
@@ -53,4 +54,5 @@ let create: unit => t =
     tabs: [Tab.create(0, "[No Name]")],
     theme: Theme.create(),
     editor: Editor.create(),
+    inputControlMode: Neovim,
   };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -227,15 +227,8 @@ type commandline = {
 };
 
 module Input = {
-  [@deriving show]
+  [@deriving (show, yojson({strict: false, exn: false}))]
   type controlMode =
-    | Oni
-    | Neovim;
-
-  [@deriving show]
-  type keyBindings = {
-    key: string,
-    command: string,
-    condition: controlMode,
-  };
+    | [@name "oni"] Oni
+    | [@name "neovim"] Neovim;
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -244,8 +244,8 @@ module Palette = {
 module Input = {
   [@deriving (show, yojson({strict: false, exn: false}))]
   type controlMode =
-    | [@name "commandPalette"] Palette
-    | [@name "neovim"] Neovim;
+    | [@name "commandPaletteFocus"] CommandPaletteFocus
+    | [@name "editorTextFocus"] EditorTextFocus;
 };
 
 module Effects = {

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -228,13 +228,14 @@ type commandline = {
 
 module Input = {
   [@deriving show]
-  type keyBindings = {
-    key: string,
-    command: string,
-  };
-
-  [@deriving show]
   type controlMode =
     | Oni
     | Neovim;
+
+  [@deriving show]
+  type keyBindings = {
+    key: string,
+    command: string,
+    condition: controlMode,
+  };
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -249,5 +249,5 @@ module Input = {
 };
 
 module Effects = {
-  type t = {openFile: unit => unit};
+  type t = {openFile: Views.viewOperation};
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -18,6 +18,7 @@ module Index = {
 };
 
 module EditorSize = {
+  [@deriving show]
   type t = {
     pixelWidth: int,
     pixelHeight: int,
@@ -76,6 +77,7 @@ type openMethod =
   | Buffer;
 
 module BufferPosition = {
+  [@deriving show]
   type t = {
     line: Index.t,
     character: Index.t,
@@ -222,4 +224,17 @@ type commandline = {
   indent: int,
   prompt: string,
   show: bool,
+};
+
+module Input = {
+  [@deriving show]
+  type keyBindings = {
+    key: string,
+    command: string,
+  };
+
+  [@deriving show]
+  type controlMode =
+    | Oni
+    | Neovim;
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -226,9 +226,28 @@ type commandline = {
   show: bool,
 };
 
+module Palette = {
+  [@deriving show]
+  type command = {
+    name: string,
+    command: unit => unit,
+  };
+
+  [@deriving show]
+  type t = {
+    isOpen: bool,
+    commands: list(command),
+    selectedItem: int,
+  };
+};
+
 module Input = {
   [@deriving (show, yojson({strict: false, exn: false}))]
   type controlMode =
-    | [@name "oni"] Oni
+    | [@name "commandPalette"] Palette
     | [@name "neovim"] Neovim;
+};
+
+module Effects = {
+  type t = {openFile: unit => unit};
 };

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -5,11 +5,13 @@ open Revery.UI.Components;
 
 let component = React.component("commandPalette");
 
+let paletteWidth = 400;
+
 let containerStyles = (theme: Theme.t) =>
   Style.[
     backgroundColor(theme.colors.editorMenuBackground),
     color(theme.colors.editorMenuForeground),
-    width(400),
+    width(paletteWidth),
     height(300),
     boxShadow(
       ~xOffset=-15.,
@@ -27,6 +29,7 @@ let createElement =
       hooks,
       commandPalette.isOpen ?
         <ScrollView style={containerStyles(theme)}>
+          <Input style=Style.[width(paletteWidth)] />
           <MenuItem label="CommandPalette" selected=true theme />
         </ScrollView> :
         React.listToElement([]),

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -28,10 +28,23 @@ let createElement =
     (
       hooks,
       commandPalette.isOpen ?
-        <ScrollView style={containerStyles(theme)}>
+        <View style={containerStyles(theme)}>
           <Input style=Style.[width(paletteWidth)] />
-          <MenuItem label="CommandPalette" selected=true theme />
-        </ScrollView> :
+          <ScrollView style=Style.[height(350)]>
+            ...{
+                 List.mapi(
+                   (index, cmd: CommandPalette.command) =>
+                     <MenuItem
+                       icon=""
+                       label={cmd.name}
+                       selected={index == commandPalette.selectedItem}
+                       theme
+                     />,
+                   commandPalette.commands,
+                 )
+               }
+          </ScrollView>
+        </View> :
         React.listToElement([]),
     )
   );

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -29,26 +29,24 @@ let createElement =
   component(hooks =>
     (
       hooks,
-      commandPalette.isOpen ?
-        <View style={containerStyles(theme)}>
-          /* <Input style=Style.[width(paletteWidth)] /> */
+      commandPalette.isOpen
+        ? <View style={containerStyles(theme)}>
+            /* <Input style=Style.[width(paletteWidth)] /> */
 
-            <ScrollView style=Style.[height(350)]>
-              ...{
-                   List.mapi(
-                     (index, cmd: Types.Palette.command) =>
-                       <MenuItem
-                         icon=""
-                         style=paletteItemStyle
-                         label={cmd.name}
-                         selected={index == commandPalette.selectedItem}
-                         theme
-                       />,
-                     commandPalette.commands,
-                   )
-                 }
-            </ScrollView>
-          </View> :
-        React.listToElement([]),
+              <ScrollView style=Style.[height(350)]>
+                ...{List.mapi(
+                  (index, cmd: Types.Palette.command) =>
+                    <MenuItem
+                      icon=""
+                      style=paletteItemStyle
+                      label={cmd.name}
+                      selected={index == commandPalette.selectedItem}
+                      theme
+                    />,
+                  commandPalette.commands,
+                )}
+              </ScrollView>
+            </View>
+        : React.listToElement([]),
     )
   );

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -33,7 +33,7 @@ let createElement =
           <ScrollView style=Style.[height(350)]>
             ...{
                  List.mapi(
-                   (index, cmd: CommandPalette.command) =>
+                   (index, cmd: Types.Palette.command) =>
                      <MenuItem
                        icon=""
                        label={cmd.name}

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -1,0 +1,34 @@
+open Revery;
+open Oni_Core;
+open Revery.UI;
+open Revery.UI.Components;
+
+let component = React.component("commandPalette");
+
+let containerStyles = (theme: Theme.t) =>
+  Style.[
+    backgroundColor(theme.colors.editorMenuBackground),
+    color(theme.colors.editorMenuForeground),
+    width(400),
+    height(300),
+    boxShadow(
+      ~xOffset=-15.,
+      ~yOffset=5.,
+      ~blurRadius=30.,
+      ~spreadRadius=5.,
+      ~color=Color.rgba(0., 0., 0., 0.2),
+    ),
+  ];
+
+let createElement =
+    (~children as _, ~commandPalette: CommandPalette.t, ~theme: Theme.t, ()) =>
+  component(hooks =>
+    (
+      hooks,
+      commandPalette.isOpen ?
+        <ScrollView style={containerStyles(theme)}>
+          <MenuItem label="CommandPalette" selected=true theme />
+        </ScrollView> :
+        React.listToElement([]),
+    )
+  );

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -22,6 +22,8 @@ let containerStyles = (theme: Theme.t) =>
     ),
   ];
 
+let paletteItemStyle = Style.[fontSize(14)];
+
 let createElement =
     (~children as _, ~commandPalette: CommandPalette.t, ~theme: Theme.t, ()) =>
   component(hooks =>
@@ -29,22 +31,24 @@ let createElement =
       hooks,
       commandPalette.isOpen ?
         <View style={containerStyles(theme)}>
-          <Input style=Style.[width(paletteWidth)] />
-          <ScrollView style=Style.[height(350)]>
-            ...{
-                 List.mapi(
-                   (index, cmd: Types.Palette.command) =>
-                     <MenuItem
-                       icon=""
-                       label={cmd.name}
-                       selected={index == commandPalette.selectedItem}
-                       theme
-                     />,
-                   commandPalette.commands,
-                 )
-               }
-          </ScrollView>
-        </View> :
+          /* <Input style=Style.[width(paletteWidth)] /> */
+
+            <ScrollView style=Style.[height(350)]>
+              ...{
+                   List.mapi(
+                     (index, cmd: Types.Palette.command) =>
+                       <MenuItem
+                         icon=""
+                         style=paletteItemStyle
+                         label={cmd.name}
+                         selected={index == commandPalette.selectedItem}
+                         theme
+                       />,
+                     commandPalette.commands,
+                   )
+                 }
+            </ScrollView>
+          </View> :
         React.listToElement([]),
     )
   );

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -59,6 +59,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         <Overlay>
           <CommandlineView theme command={state.commandline} />
           <WildmenuView theme wildmenu={state.wildmenu} />
+          <CommandPaletteView theme commandPalette={state.commandPalette} />
         </Overlay>
         <View style=statusBarStyle>
           <StatusBar

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -85,7 +85,7 @@ let getActionsForBinding = (inputKey, commands, state: State.t) =>
     List.fold_left(
       (defaultAction, {key, command, condition}) =>
         if (inputKey == key && condition == state.inputControlMode) {
-          [Commands.handleCommand(command)];
+          Commands.handleCommand(command);
         } else {
           defaultAction;
         },
@@ -111,9 +111,9 @@ let handle = (~neovimHandler, ~state: State.t, ~commands: bindings, inputKey) =>
   | Oni => getActionsForBinding(inputKey, commands, state)
   | Neovim =>
     switch (getActionsForBinding(inputKey, commands, state)) {
-    | [] =>
+    | [] as default =>
       ignore(neovimHandler(inputKey));
-      [Actions.Noop];
+      default;
     | actions => actions
     }
   };

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -72,7 +72,7 @@ let keyPressToCommand =
   };
 
 let getActionsForBinding = (inputKey, commands, state: State.t) =>
-  Types.Input.(
+  Keybindings.(
     List.fold_left(
       (defaultAction, {key, command, condition}) =>
         if (inputKey == key && condition == state.inputControlMode) {

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -6,6 +6,7 @@
 
 open Reglfw.Glfw;
 open Reglfw.Glfw.Key;
+open Oni_Core.Actions;
 
 let keyPressToString = (~altKey, ~shiftKey, ~ctrlKey, ~superKey, s) => {
   let s = s == "<" ? "lt" : s;
@@ -81,12 +82,21 @@ let defaultCommands = [{key: "<C-P>", command: "open.commandPalette"}];
 
 /**
   Handle Input from Oni or Neovim
+
+  TODO:
+  * use value in state to determine whether or not input should be handled
+  by Oni or by Neovim e.g. when the command palette is open
+
+  * Determine if certain should be responded to by both Oni and neovim. Use case?
+
+  * Derive default commands from keyBindings.json like vscode
+
  */
 let handle = (~neovimHandler, commands: bindings, inputKey) =>
   List.fold_left(
     (defaultAction, {key, command}) =>
       if (inputKey == key) {
-        Oni_Core.Actions.OniCommand(command);
+        OniCommand(command);
       } else {
         ignore(neovimHandler(inputKey));
         defaultAction;

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -97,7 +97,7 @@ let handle =
       inputKey,
     ) =>
   switch (state.inputControlMode) {
-  | Neovim =>
+  | EditorTextFocus =>
     switch (getActionsForBinding(inputKey, commands, state)) {
     | [] as default =>
       api.input(inputKey) |> ignore;

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -71,15 +71,6 @@ let keyPressToCommand =
     None;
   };
 
-type bindings = list(Types.Input.keyBindings);
-
-let defaultCommands: bindings = [
-  {key: "<C-P>", command: "commandPalette.open", condition: Neovim},
-  {key: "<ESC>", command: "commandPalette.close", condition: Oni},
-  {key: "<C-N>", command: "commandPalette.next", condition: Oni},
-  {key: "<C-P>", command: "commandPalette.previous", condition: Oni},
-];
-
 let getActionsForBinding = (inputKey, commands, state: State.t) =>
   Types.Input.(
     List.fold_left(
@@ -100,7 +91,8 @@ let getActionsForBinding = (inputKey, commands, state: State.t) =>
   TODO: Derive default commands from keyBindings.json like vscode
 
  */
-let handle = (~neovimHandler, ~state: State.t, ~commands: bindings, inputKey) =>
+let handle =
+    (~neovimHandler, ~state: State.t, ~commands: Keybindings.t, inputKey) =>
   switch (state.inputControlMode) {
   | Oni => getActionsForBinding(inputKey, commands, state)
   | Neovim =>

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -97,13 +97,7 @@ let getActionsForBinding = (inputKey, commands, state: State.t) =>
 /**
   Handle Input from Oni or Neovim
 
-  TODO:
-  * use value in state to determine whether or not input should be handled
-  by Oni or by Neovim e.g. when the command palette is open
-
-  * Determine if certain should be responded to by both Oni and neovim. Use case?
-
-  * Derive default commands from keyBindings.json like vscode
+  TODO: Derive default commands from keyBindings.json like vscode
 
  */
 let handle = (~neovimHandler, ~state: State.t, ~commands: bindings, inputKey) =>

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -69,3 +69,28 @@ let keyPressToCommand =
   } else {
     None;
   };
+
+type keyBindings = {
+  key: string,
+  command: string,
+};
+
+type bindings = list(keyBindings);
+
+let defaultCommands = [{key: "<C-P>", command: "open.commandPalette"}];
+
+/**
+  Handle Input from Oni or Neovim
+ */
+let handle = (~neovimHandler, commands: bindings, inputKey) =>
+  List.fold_left(
+    (defaultAction, {key, command}) =>
+      if (inputKey == key) {
+        Oni_Core.Actions.OniCommand(command);
+      } else {
+        ignore(neovimHandler(inputKey));
+        defaultAction;
+      },
+    Noop,
+    commands,
+  );

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -88,18 +88,21 @@ let getActionsForBinding = (inputKey, commands, state: State.t) =>
 /**
   Handle Input from Oni or Neovim
 
-  TODO: Derive default commands from keyBindings.json like vscode
-
  */
 let handle =
-    (~neovimHandler, ~state: State.t, ~commands: Keybindings.t, inputKey) =>
+    (
+      ~api: Oni_Neovim.NeovimProtocol.t,
+      ~state: State.t,
+      ~commands: Keybindings.t,
+      inputKey,
+    ) =>
   switch (state.inputControlMode) {
-  | Oni => getActionsForBinding(inputKey, commands, state)
   | Neovim =>
     switch (getActionsForBinding(inputKey, commands, state)) {
     | [] as default =>
-      ignore(neovimHandler(inputKey));
+      api.input(inputKey) |> ignore;
       default;
     | actions => actions
     }
+  | _ => getActionsForBinding(inputKey, commands, state)
   };

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -156,7 +156,7 @@ let init = app => {
   let inputHandler =
     Input.handle(
       ~neovimHandler=neovimProtocol.input,
-      ~commands=Input.defaultCommands,
+      ~commands=Core.Keybindings.defaultCommands,
     );
 
   Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -153,11 +153,10 @@ let init = app => {
 
   setFont("FiraCode-Regular.ttf", 14);
 
+  let commands = Core.Keybindings.get();
+
   let inputHandler =
-    Input.handle(
-      ~neovimHandler=neovimProtocol.input,
-      ~commands=Core.Keybindings.defaultCommands,
-    );
+    Input.handle(~neovimHandler=neovimProtocol.input, ~commands);
 
   Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
     switch (Input.charToCommand(codepoint, mods)) {

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -154,12 +154,17 @@ let init = app => {
   setFont("FiraCode-Regular.ttf", 14);
 
   let inputHandler =
-    Input.handle(~neovimHandler=neovimProtocol.input, Input.defaultCommands);
+    Input.handle(
+      ~neovimHandler=neovimProtocol.input,
+      ~commands=Input.defaultCommands,
+    );
 
   Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
     switch (Input.charToCommand(codepoint, mods)) {
     | None => ()
-    | Some(v) => inputHandler(v) |> App.dispatch(app)
+    | Some(v) =>
+      inputHandler(~state=App.getState(app), v)
+      |> List.iter(App.dispatch(app))
     }
   );
 
@@ -167,7 +172,9 @@ let init = app => {
     w.glfwWindow, (_w, key, _scancode, buttonState, mods) =>
     switch (Input.keyPressToCommand(key, buttonState, mods)) {
     | None => ()
-    | Some(v) => inputHandler(v) |> App.dispatch(app)
+    | Some(v) =>
+      inputHandler(~state=App.getState(app), v)
+      |> List.iter(App.dispatch(app))
     }
   );
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -155,8 +155,11 @@ let init = app => {
 
   let commands = Core.Keybindings.get();
 
-  let inputHandler =
-    Input.handle(~neovimHandler=neovimProtocol.input, ~commands);
+  Core.CommandPalette.make(~effects={openFile: neovimProtocol.openFile})
+  |> App.dispatch(app)
+  |> ignore;
+
+  let inputHandler = Input.handle(~api=neovimProtocol, ~commands);
 
   Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
     switch (Input.charToCommand(codepoint, mods)) {

--- a/test/editor/Core/SetupTests.re
+++ b/test/editor/Core/SetupTests.re
@@ -3,7 +3,7 @@ open TestFramework;
 
 describe("Setup", ({test, _}) =>
   test("ofString", ({expect}) => {
-    let setupInfo = "{neovim:\"/path/to/neovim\",node:\"/path/to/node\",textmateService:\"/path/to/textmate\",bundledExtensions:\"/path/to/extensions\",configuration:\"/path/to/config\"}";
+    let setupInfo = "{neovim:\"/path/to/neovim\",node:\"/path/to/node\",textmateService:\"/path/to/textmate\",bundledExtensions:\"/path/to/extensions\",configuration:\"/path/to/config\",keybindings:\"/path/to/keybindings\"}";
     let setup = Setup.ofString(setupInfo);
     expect.string(setup.neovimPath).toEqual("/path/to/neovim");
     expect.string(setup.nodePath).toEqual("/path/to/node");
@@ -12,5 +12,6 @@ describe("Setup", ({test, _}) =>
       "/path/to/extensions",
     );
     expect.string(setup.configPath).toEqual("/path/to/config");
+    expect.string(setup.keybindingsPath).toEqual("/path/to/keybindings");
   })
 );


### PR DESCRIPTION
Add initial implementation of command palette
![palette](https://user-images.githubusercontent.com/22454918/54088077-99027d80-4351-11e9-8bb5-7403908e71a1.gif)


currently:
* hooks up input handling to either be handled by Oni or passed to Neovim
* Reads commands out of a bindings list (later to be derived from a `keybindings.json` file

### Outstanding

- [x] Hook up handler for commands on select
- [x] Setup state for managing when input control is in oni or neovim, e.g. whilst the command palette is open it should *own* user input
- [x] hook up `keybindings.json` (maybe separate PR)