### PR TITLE
Extensions: Send scopes from plugins to the textmate service

### DIFF
--- a/src/editor/Extensions/ExtensionScanner.re
+++ b/src/editor/Extensions/ExtensionScanner.re
@@ -52,14 +52,16 @@ let scan = (directory: string) => {
   |> List.map(loadPackageJson);
 };
 
+let _remapGrammarsForExtension = (extension: t) => {
+    open ExtensionContributions.Grammar;
+    List.map((grammar) => {
+        ...grammar,
+        path: Path.join(extension.path, grammar.path),
+    }, extension.manifest.contributes.grammars);
+}
+
 let getGrammars = extensions => {
-  List.fold_left(
-    (prev, ext) =>
-      List.append((ext.path, ext.manifest.contributes.grammars), prev),
-    [],
-    extensions,
-  )
-  |> List.map(((path, grammar)) =>
-       {...grammar, path: Path.join(path, grammar.path)}
-     );
+    extensions
+  |> List.map((v) => _remapGrammarsForExtension(v))
+  |> List.flatten;
 };

--- a/src/editor/Extensions/ExtensionScanner.re
+++ b/src/editor/Extensions/ExtensionScanner.re
@@ -53,15 +53,14 @@ let scan = (directory: string) => {
 };
 
 let _remapGrammarsForExtension = (extension: t) => {
-    open ExtensionContributions.Grammar;
-    List.map((grammar) => {
-        ...grammar,
-        path: Path.join(extension.path, grammar.path),
-    }, extension.manifest.contributes.grammars);
-}
+  ExtensionContributions.Grammar.(
+    List.map(
+      grammar => {...grammar, path: Path.join(extension.path, grammar.path)},
+      extension.manifest.contributes.grammars,
+    )
+  );
+};
 
 let getGrammars = extensions => {
-    extensions
-  |> List.map((v) => _remapGrammarsForExtension(v))
-  |> List.flatten;
+  extensions |> List.map(v => _remapGrammarsForExtension(v)) |> List.flatten;
 };

--- a/src/editor/Extensions/ExtensionScanner.re
+++ b/src/editor/Extensions/ExtensionScanner.re
@@ -6,6 +6,11 @@
 
 open Rench;
 
+type t = {
+  manifest: ExtensionManifest.t,
+  path: string,
+};
+
 let readFileSync = path => {
   let chan = open_in_bin(path);
   let data = ref("");
@@ -32,10 +37,11 @@ let scan = (directory: string) => {
   let packageManifestPath = d => Path.join(d, "package.json");
 
   let loadPackageJson = pkg => {
-    print_endline("Reading : " ++ pkg);
     let json = readFileSync(pkg) |> Yojson.Safe.from_string;
-
-    ExtensionManifest.of_yojson_exn(json);
+    {
+      manifest: ExtensionManifest.of_yojson_exn(json),
+      path: Path.dirname(pkg),
+    };
   };
 
   items
@@ -44,4 +50,16 @@ let scan = (directory: string) => {
   |> List.map(packageManifestPath)
   |> List.filter(Sys.file_exists)
   |> List.map(loadPackageJson);
+};
+
+let getGrammars = extensions => {
+  List.fold_left(
+    (prev, ext) =>
+      List.append((ext.path, ext.manifest.contributes.grammars), prev),
+    [],
+    extensions,
+  )
+  |> List.map(((path, grammar)) =>
+       {...grammar, path: Path.join(path, grammar.path)}
+     );
 };

--- a/src/editor/Extensions/ExtensionScanner.rei
+++ b/src/editor/Extensions/ExtensionScanner.rei
@@ -4,4 +4,11 @@
  * Module to get and discover extension manifests
  */
 
-let scan: string => list(ExtensionManifest.t);
+type t = {
+  manifest: ExtensionManifest.t,
+  path: string,
+};
+
+let scan: string => list(t);
+
+let getGrammars: t => list(ExtensionContributions.Grammar.t);

--- a/src/editor/Extensions/ExtensionScanner.rei
+++ b/src/editor/Extensions/ExtensionScanner.rei
@@ -11,4 +11,4 @@ type t = {
 
 let scan: string => list(t);
 
-let getGrammars: t => list(ExtensionContributions.Grammar.t);
+let getGrammars: list(t) => list(ExtensionContributions.Grammar.t);

--- a/src/editor/Extensions/TextmateClient.re
+++ b/src/editor/Extensions/TextmateClient.re
@@ -12,12 +12,9 @@ open Reason_jsonrpc;
 
 open Oni_Core;
 
-type scopeInfo = {
-  scopeName: string,
-  path: string,
-};
+open ExtensionContributions;
 
-type initializationInfo = list(scopeInfo);
+type initializationInfo = list(Grammar.t);
 
 type tokenizeResult = {
   startIndex: int,
@@ -137,7 +134,7 @@ let start =
       process.stdin,
     );
 
-  let mapScopeInfoToJson = (v: scopeInfo) => {
+  let mapScopeInfoToJson = (v: Grammar.t) => {
     (v.scopeName, `String(v.path));
   };
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -80,20 +80,8 @@ let init = app => {
 
   let onTokens = tr =>
     App.dispatch(app, Model.Actions.SyntaxHighlightTokens(tr));
-  open Extensions.ExtensionManifest;
-  open Extensions.ExtensionScanner;
-  open Extensions.ExtensionContributions;
-  /* open Extensions.ExtensionContributions.Grammar; */
-  let grammars =
-    List.fold_left(
-      (prev, ext) =>
-        List.append(
-          Path.join(ext.path, ext.manifest.contributes.grammars),
-          prev,
-        ),
-      [],
-      extensions,
-    );
+
+  let grammars = Extensions.ExtensionScanner.getGrammars(extensions);
 
   let tmClient =
     Extensions.TextmateClient.start(

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -73,8 +73,6 @@ let init = app => {
 
   let defaultThemePath =
     setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
-  let reasonSyntaxPath =
-    setup.bundledExtensionsPath ++ "/vscode-reasonml/syntaxes/reason.json";
 
   let onScopeLoaded = s => prerr_endline("Scope loaded: " ++ s);
   let onColorMap = cm =>
@@ -82,6 +80,20 @@ let init = app => {
 
   let onTokens = tr =>
     App.dispatch(app, Model.Actions.SyntaxHighlightTokens(tr));
+  open Extensions.ExtensionManifest;
+  open Extensions.ExtensionScanner;
+  open Extensions.ExtensionContributions;
+  /* open Extensions.ExtensionContributions.Grammar; */
+  let grammars =
+    List.fold_left(
+      (prev, ext) =>
+        List.append(
+          Path.join(ext.path, ext.manifest.contributes.grammars),
+          prev,
+        ),
+      [],
+      extensions,
+    );
 
   let tmClient =
     Extensions.TextmateClient.start(
@@ -89,7 +101,7 @@ let init = app => {
       ~onColorMap,
       ~onTokens,
       setup,
-      [{scopeName: "source.reason", path: reasonSyntaxPath}],
+      grammars,
     );
 
   Extensions.TextmateClient.setTheme(tmClient, defaultThemePath);


### PR DESCRIPTION
This removes the hardcoded scope we send to our textmate service, and sends out the full set of scopes from the grammars we parse from extension metadata.