### PR TITLE
Extensions: Use filetype from VSCode extension

### DIFF
--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -61,7 +61,6 @@ function OniGetBufferContext(bufnum)
     let l:context = {}
     let l:context.bufferNumber = a:bufnum
     let l:context.bufferFullPath = expand("#".a:bufnum.":p")
-    let l:context.filetype = getbufvar(a:bufnum, "&filetype")
     let l:context.buftype = getbufvar(a:bufnum, "&buftype")
     let l:context.modified = getbufvar(a:bufnum, "&mod")
     let l:context.hidden = getbufvar(a:bufnum, "&hidden")

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -10,6 +10,7 @@ module LineNumber = LineNumber;
 module Log = Log;
 module Node = Node;
 module Setup = Setup;
+module StringMap = StringMap;
 module Types = Types;
 module Utility = Utility;
 module Configuration = Configuration;

--- a/src/editor/Core/StringMap.re
+++ b/src/editor/Core/StringMap.re
@@ -1,0 +1,10 @@
+/*
+ * StringMap.re
+ *
+ * Map from string -> 'a
+ */
+
+include Map.Make({
+  type t = string;
+  let compare = String.compare;
+});

--- a/src/editor/Extensions/ExtensionScanner.re
+++ b/src/editor/Extensions/ExtensionScanner.re
@@ -51,16 +51,3 @@ let scan = (directory: string) => {
   |> List.filter(Sys.file_exists)
   |> List.map(loadPackageJson);
 };
-
-let _remapGrammarsForExtension = (extension: t) => {
-  ExtensionContributions.Grammar.(
-    List.map(
-      grammar => {...grammar, path: Path.join(extension.path, grammar.path)},
-      extension.manifest.contributes.grammars,
-    )
-  );
-};
-
-let getGrammars = extensions => {
-  extensions |> List.map(v => _remapGrammarsForExtension(v)) |> List.flatten;
-};

--- a/src/editor/Extensions/ExtensionScanner.rei
+++ b/src/editor/Extensions/ExtensionScanner.rei
@@ -10,5 +10,3 @@ type t = {
 };
 
 let scan: string => list(t);
-
-let getGrammars: list(t) => list(ExtensionContributions.Grammar.t);

--- a/src/editor/Extensions/TextmateClient.re
+++ b/src/editor/Extensions/TextmateClient.re
@@ -170,15 +170,13 @@ type tokenizeLineResult = {
   colors: list(ColorizedToken.t),
 };
 
-let notifyBufferUpdate = (v: t, scope: string, bufUpdate: Types.BufferUpdate.t) => {
+let notifyBufferUpdate =
+    (v: t, scope: string, bufUpdate: Types.BufferUpdate.t) => {
   Rpc.sendNotification(
     v.rpc,
     "textmate/bufferUpdate",
     /* TODO: Don't hardcode this */
-    `List([
-      `String(scope),
-      Types.BufferUpdate.to_yojson(bufUpdate),
-    ]),
+    `List([`String(scope), Types.BufferUpdate.to_yojson(bufUpdate)]),
   );
 };
 

--- a/src/editor/Extensions/TextmateClient.re
+++ b/src/editor/Extensions/TextmateClient.re
@@ -170,13 +170,13 @@ type tokenizeLineResult = {
   colors: list(ColorizedToken.t),
 };
 
-let notifyBufferUpdate = (v: t, bufUpdate: Types.BufferUpdate.t) => {
+let notifyBufferUpdate = (v: t, scope: string, bufUpdate: Types.BufferUpdate.t) => {
   Rpc.sendNotification(
     v.rpc,
     "textmate/bufferUpdate",
     /* TODO: Don't hardcode this */
     `List([
-      `String("source.reason"),
+      `String(scope),
       Types.BufferUpdate.to_yojson(bufUpdate),
     ]),
   );

--- a/src/editor/Model/LanguageInfo.re
+++ b/src/editor/Model/LanguageInfo.re
@@ -1,0 +1,10 @@
+/*
+ * LanguageInfo.re
+ */
+
+open Oni_Extensions;
+
+type t = {
+    extensions: ExtensionScanner.t,
+};
+

--- a/src/editor/Model/LanguageInfo.re
+++ b/src/editor/Model/LanguageInfo.re
@@ -2,9 +2,80 @@
  * LanguageInfo.re
  */
 
+open Oni_Core;
 open Oni_Extensions;
 
+open Rench;
+
 type t = {
-    extensions: ExtensionScanner.t,
+    grammars: list(ExtensionContributions.Grammar.t),
+    languages: list(ExtensionContributions.Language.t),
+    extToLanguage: StringMap.t(string),
 };
 
+let getGrammars = (li: t) => {
+    li.grammars
+}
+
+let getLanguageFromExtension = (li: t, ext: string) => {
+    StringMap.find_opt(ext, li.extToLanguage);   
+};
+
+let _getLanguageTuples = (lang: ExtensionContributions.Language.t) => {
+   List.map((extension) => {
+    (extension, lang.id) 
+   }, lang.extensions);
+}
+
+let _remapGrammarsForExtension = (extension: ExtensionScanner.t) => {
+  ExtensionContributions.Grammar.(
+    List.map(
+      grammar => {...grammar, path: Path.join(extension.path, grammar.path)},
+      extension.manifest.contributes.grammars,
+    )
+  );
+};
+
+let _remapLanguagesForExtension = (extension: ExtensionScanner.t) => {
+    ExtensionContributions.Language.(
+      List.map(
+        language => switch(language.configuration) {
+        | None => language
+        | Some(v) => {
+            ...language,
+            configuration: Some(Path.join(extension.path, v)),
+        }
+        },
+        extension.manifest.contributes.languages,
+      )   
+    );
+}
+
+let _getGrammars = (extensions: list(ExtensionScanner.t)) => {
+  extensions |> List.map(v => _remapGrammarsForExtension(v)) |> List.flatten;
+};
+
+let _getLanguages = (extensions: list(ExtensionScanner.t)) => {
+  extensions |> List.map(v => _remapLanguagesForExtension(v)) |> List.flatten;
+}
+
+let ofExtensions = (extensions: list(ExtensionScanner.t)) => {
+   let grammars = _getGrammars(extensions); 
+   let languages = _getLanguages(extensions);
+
+   let extToLanguage = languages
+   |> List.map(_getLanguageTuples)
+   |> List.flatten
+   |> List.fold_left((prev, v) => {
+      let (extension, language) = v;
+      StringMap.add(extension, language, prev); 
+   }, StringMap.empty);
+   
+
+   {
+    grammars,
+    languages,
+    extToLanguage,
+   }
+
+};

--- a/src/editor/Model/LanguageInfo.re
+++ b/src/editor/Model/LanguageInfo.re
@@ -11,6 +11,7 @@ type t = {
     grammars: list(ExtensionContributions.Grammar.t),
     languages: list(ExtensionContributions.Language.t),
     extToLanguage: StringMap.t(string),
+    languageToScope: StringMap.t(string),
 };
 
 let getGrammars = (li: t) => {
@@ -20,6 +21,17 @@ let getGrammars = (li: t) => {
 let getLanguageFromExtension = (li: t, ext: string) => {
     StringMap.find_opt(ext, li.extToLanguage);   
 };
+
+let getScopeFromLanguage = (li: t, languageId: string) => {
+    StringMap.find_opt(languageId, li.languageToScope);
+};
+
+let getScopeFromExtension = (li: t, ext: string) => {
+    switch(getLanguageFromExtension(li, ext)) {
+    | None => None
+    | Some(v) => getScopeFromLanguage(li, v);
+    };
+}
 
 let _getLanguageTuples = (lang: ExtensionContributions.Language.t) => {
    List.map((extension) => {
@@ -72,10 +84,20 @@ let ofExtensions = (extensions: list(ExtensionScanner.t)) => {
    }, StringMap.empty);
    
 
+   open ExtensionContributions.Grammar;
+   let languageToScope = grammars
+   |> List.fold_left((prev, curr) => {
+       switch (curr.language) {
+       | None => prev
+       | Some(v) => StringMap.add(v, curr.scopeName, prev);
+       };
+   }, StringMap.empty);
+
    {
     grammars,
     languages,
     extToLanguage,
+    languageToScope,
    }
 
 };

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -14,6 +14,7 @@ module CommandPalette = CommandPalette;
 module Commands = Commands;
 module Editor = Editor;
 module EditorLayout = EditorLayout;
+module LanguageInfo = LanguageInfo;
 module Reducer = Reducer;
 module State = State;
 module SyntaxHighlighting = SyntaxHighlighting;

--- a/src/editor/Neovim/NeovimBuffer.re
+++ b/src/editor/Neovim/NeovimBuffer.re
@@ -30,10 +30,6 @@ let parseBufferContext = map =>
           ...accum,
           bufType: getBufType(buftype),
         }
-      | (M.String("filetype"), M.String(fileType)) => {
-          ...accum,
-          fileType: Some(fileType),
-        }
       | (M.String("hidden"), M.Bool(hidden)) => {...accum, hidden}
       | _ => accum
       },

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -85,12 +85,6 @@ let init = app => {
 
   let grammars = Model.LanguageInfo.getGrammars(languageInfo);
 
-  let getOrNull = v =>
-    switch (v) {
-    | None => ""
-    | Some(v) => v
-    };
-
   let tmClient =
     Extensions.TextmateClient.start(
       ~onScopeLoaded,

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -85,16 +85,19 @@ let init = app => {
 
   let grammars = Model.LanguageInfo.getGrammars(languageInfo);
 
-  let getOrNull = (v) => switch(v) {
-  | None => ""
-  | Some(v) => v;
-  };
+  let getOrNull = v =>
+    switch (v) {
+    | None => ""
+    | Some(v) => v
+    };
 
   /* let re = Model.LanguageInfo.getLanguageFromExtension(languageInfo, ".json") |> getOrNull; */
   /* print_endline (".json: " ++ re); */
 
-  let re = Model.LanguageInfo.getScopeFromLanguage(languageInfo, "reason") |> getOrNull;
-  print_endline ("reason: " ++ re);
+  let re =
+    Model.LanguageInfo.getScopeFromLanguage(languageInfo, "reason")
+    |> getOrNull;
+  print_endline("reason: " ++ re);
 
   let tmClient =
     Extensions.TextmateClient.start(
@@ -310,27 +313,33 @@ let init = app => {
          */
         switch (msg) {
         | BufferUpdate(bc) =>
-
-          let bufferId =  bc.id;
+          let bufferId = bc.id;
           let state = App.getState(app);
           let buffer = Model.BufferMap.getBuffer(bufferId, state.buffers);
 
           switch (buffer) {
           | None => ()
-          | Some(buffer) => switch(Model.Buffer.getMetadata(buffer).filePath) {
-            | None => ();
-            | Some(v) => {
-                
-                let extension = Path.extname(v); 
-                switch(Model.LanguageInfo.getScopeFromExtension(languageInfo, extension)) {
-                | None => ();
-                | Some(scope) => Extensions.TextmateClient.notifyBufferUpdate(tmClient, scope, bc);
-                }
-
+          | Some(buffer) =>
+            switch (Model.Buffer.getMetadata(buffer).filePath) {
+            | None => ()
+            | Some(v) =>
+              let extension = Path.extname(v);
+              switch (
+                Model.LanguageInfo.getScopeFromExtension(
+                  languageInfo,
+                  extension,
+                )
+              ) {
+              | None => ()
+              | Some(scope) =>
+                Extensions.TextmateClient.notifyBufferUpdate(
+                  tmClient,
+                  scope,
+                  bc,
+                )
+              };
             }
-            
-          }
-          }
+          };
 
         | _ => ()
         };

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -91,14 +91,6 @@ let init = app => {
     | Some(v) => v
     };
 
-  /* let re = Model.LanguageInfo.getLanguageFromExtension(languageInfo, ".json") |> getOrNull; */
-  /* print_endline (".json: " ++ re); */
-
-  let re =
-    Model.LanguageInfo.getScopeFromLanguage(languageInfo, "reason")
-    |> getOrNull;
-  print_endline("reason: " ++ re);
-
   let tmClient =
     Extensions.TextmateClient.start(
       ~onScopeLoaded,

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -50,6 +50,8 @@ let init = app => {
 
   let extensions = ExtensionScanner.scan(setup.bundledExtensionsPath);
 
+  let languageInfo = Model.LanguageInfo.ofExtensions(extensions);
+
   Core.Log.debug(
     "-- Discovered: "
     ++ string_of_int(List.length(extensions))
@@ -81,7 +83,15 @@ let init = app => {
   let onTokens = tr =>
     App.dispatch(app, Model.Actions.SyntaxHighlightTokens(tr));
 
-  let grammars = Extensions.ExtensionScanner.getGrammars(extensions);
+  let grammars = Model.LanguageInfo.getGrammars(languageInfo);
+
+  let getOrNull = (v) => switch(v) {
+  | None => ""
+  | Some(v) => v;
+  };
+
+  /* let re = Model.LanguageInfo.getLanguageFromExtension(languageInfo, ".json") |> getOrNull; */
+  /* print_endline (".json: " ++ re); */
 
   let tmClient =
     Extensions.TextmateClient.start(


### PR DESCRIPTION
This leverages the `contributes: language` section and `contributes: grammar` sections of the VSCode extension JSON to pick the right language ID for a file, to find the right textmate scope, in order to apply textmate highlighting.

This fixes the existing behavior / bug where everything is highlighted with 'reason' syntax (removes the hardcoding).