### PR TITLE
Fit & Finish - Tab: Use same location for modified/close indicator

### DIFF
--- a/src/editor/UI/FontAwesome.re
+++ b/src/editor/UI/FontAwesome.re
@@ -1,0 +1,9 @@
+/*
+ * FontAwesome.re
+ *
+ * Helper constants for FontAwesome
+ */
+
+
+let circle = 0xf111;
+let times = 0xf00d;

--- a/src/editor/UI/FontAwesome.re
+++ b/src/editor/UI/FontAwesome.re
@@ -4,6 +4,5 @@
  * Helper constants for FontAwesome
  */
 
-
 let circle = 0xf111;
 let times = 0xf00d;

--- a/src/editor/UI/FontIcon.re
+++ b/src/editor/UI/FontIcon.re
@@ -9,7 +9,7 @@ open CamomileLibraryDefault.Camomile;
 
 let component = React.component("FontIcon");
 
-let codeToIcon = (icon) => Zed_utf8.singleton(UChar.of_int(icon));
+let codeToIcon = icon => Zed_utf8.singleton(UChar.of_int(icon));
 
 let createElement =
     (
@@ -22,18 +22,23 @@ let createElement =
       (),
     ) =>
   component(hooks => {
-
-      let (fontFamily_, fontSize_, backgroundColor_, color_) = (fontFamily, fontSize, backgroundColor, color);
+    let (fontFamily_, fontSize_, backgroundColor_, color_) = (
+      fontFamily,
+      fontSize,
+      backgroundColor,
+      color,
+    );
 
     (
       hooks,
       <Text
-          text={codeToIcon(icon)}
-          style=Style.[
-            fontFamily(fontFamily_),
-            fontSize(fontSize_),
-            color(color_),
-            backgroundColor(backgroundColor_),
-          ] />
+        text={codeToIcon(icon)}
+        style=Style.[
+          fontFamily(fontFamily_),
+          fontSize(fontSize_),
+          color(color_),
+          backgroundColor(backgroundColor_),
+        ]
+      />,
     );
   });

--- a/src/editor/UI/FontIcon.re
+++ b/src/editor/UI/FontIcon.re
@@ -1,0 +1,39 @@
+/*
+ * FontIcon.re
+ *
+ * Helper component for using icon fonts, like FontAwesome
+ */
+
+open Revery.UI;
+open CamomileLibraryDefault.Camomile;
+
+let component = React.component("FontIcon");
+
+let codeToIcon = (icon) => Zed_utf8.singleton(UChar.of_int(icon));
+
+let createElement =
+    (
+      ~icon,
+      ~fontFamily="FontAwesome5FreeSolid.otf",
+      ~fontSize=15,
+      ~backgroundColor,
+      ~color,
+      ~children as _,
+      (),
+    ) =>
+  component(hooks => {
+
+      let (fontFamily_, fontSize_, backgroundColor_, color_) = (fontFamily, fontSize, backgroundColor, color);
+
+    (
+      hooks,
+      <Text
+          text={codeToIcon(icon)}
+          style=Style.[
+            fontFamily(fontFamily_),
+            fontSize(fontSize_),
+            color(color_),
+            backgroundColor(backgroundColor_),
+          ] />
+    );
+  });

--- a/src/editor/UI/Tab.re
+++ b/src/editor/UI/Tab.re
@@ -53,9 +53,7 @@ let createElement =
         color(theme.colors.tabActiveForeground),
       ];
 
-    let icon = modified ?
-        FontAwesome.circle :
-        FontAwesome.times;
+    let icon = modified ? FontAwesome.circle : FontAwesome.times;
 
     (
       hooks,

--- a/src/editor/UI/Tab.re
+++ b/src/editor/UI/Tab.re
@@ -53,13 +53,9 @@ let createElement =
         color(theme.colors.tabActiveForeground),
       ];
 
-    let modifiedStyles =
-      Style.[
-        color(theme.colors.tabActiveForeground),
-        marginHorizontal(5),
-        fontSize(fontPixelSize),
-        fontFamily("FontAwesome5FreeSolid.otf"),
-      ];
+    let icon = modified ?
+        FontAwesome.circle :
+        FontAwesome.times;
 
     (
       hooks,
@@ -73,9 +69,6 @@ let createElement =
             justifyContent(`Center),
           ]>
           <Text style=textStyle text=title />
-          {modified
-             ? <Text text={||} style=modifiedStyles />
-             : React.listToElement([])}
         </Clickable>
         <Clickable
           onClick=onClose
@@ -86,13 +79,11 @@ let createElement =
             justifyContent(`Center),
             width(proportion(0.20)),
           ]>
-          <Text
-            text={||}
-            style=Style.[
-              color(theme.colors.tabActiveForeground),
-              fontFamily("FontAwesome5FreeSolid.otf"),
-              fontSize(15),
-            ]
+          <FontIcon
+            icon
+            backgroundColor={theme.colors.editorBackground}
+            color={theme.colors.tabActiveForeground}
+            fontSize={modified ? 10 : 12}
           />
         </Clickable>
       </View>,


### PR DESCRIPTION
This change puts the modified 'dot' in the same spot as the 'close' indicator (standard UX paradigm used by other editors).

It also refactors the code a bit and adds a home for FontAwesome constants, as well as a helper `<FontIcon />` component for rendering icon fonts.