### PR TITLE
Add note on required build packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,7 @@ The goal of this project is to build an editor that doesn't exist today - the _s
 
 - Install [Git](https://git-scm.com/)
 - Install [Esy](https://esy.sh) (__0.5.6__ is required)
-
-##### `macOS`
-
-- `brew install cmake`
-- `brew install libpng ragel`
-
-##### `Linux`
-
-Install the following packages with your package manager of choice:
-- `cmake`
-- `ragel`
+- [Check and install any system packages for Revery](https://github.com/revery-ui/revery#building)
 
 ### Build
 


### PR DESCRIPTION
Saw a few comments on twitter about this, when really we should just be linking straight to revery so there is one source of truth and we don't require any specific packages.

The only thing that we require that Revery does not is the `windows-build-tools` for the TextMate service. I've not tried this on Windows yet, so not 100% the easiest way of installing it.