### PR TITLE
Reset configuration to buffers mode, add borders to tabs

### DIFF
--- a/assets/configuration/configuration.json
+++ b/assets/configuration/configuration.json
@@ -2,5 +2,5 @@
   "editor.lineNumbers": ["relative"],
   "editor.minimap.enabled": true,
   "editor.minimap.showSlider": true,
-  "editor.tablineMode": ["tabs"]
+  "editor.tablineMode": ["buffers"]
 }

--- a/src/editor/UI/Tab.re
+++ b/src/editor/UI/Tab.re
@@ -24,7 +24,7 @@ let horizontalBorderStyles = (tabPosition, numberOfTabs) =>
     | (1, 1) => []
     /* The last tab should also have no borders */
     | (i, l) when i == l => []
-    /* every other tab should have a right border */
+    /* Every other tab should have a right border */
     | (_, _) => [borderRight(~width=1, ~color=Color.rgba(0., 0., 0., 0.1))]
     }
   );

--- a/src/editor/UI/Tab.re
+++ b/src/editor/UI/Tab.re
@@ -17,10 +17,24 @@ let proportion = p => float_of_int(minWidth_) *. p |> int_of_float;
 
 let component = React.component("Tab");
 
+let horizontalBorderStyles = (tabPosition, numberOfTabs) =>
+  Style.(
+    switch (tabPosition, numberOfTabs) {
+    /* A single tab should have no borders */
+    | (1, 1) => []
+    /* The last tab should also have no borders */
+    | (i, l) when i == l => []
+    /* every other tab should have a right border */
+    | (_, _) => [borderRight(~width=1, ~color=Color.rgba(0., 0., 0., 0.1))]
+    }
+  );
+
 let createElement =
     (
       ~title,
-      ~active, /* Where is this being set? */
+      ~tabPosition,
+      ~numberOfTabs,
+      ~active,
       ~modified,
       ~onClick,
       ~onClose,
@@ -33,10 +47,7 @@ let createElement =
   component(hooks => {
     let (modeColor, _) = Theme.getColorsForMode(theme, mode);
 
-    /* TODO: Active flag doesn't seem to be working? */
-    let _borderColor = active ? modeColor : Colors.transparentBlack;
-
-    let borderColor = modeColor;
+    let borderColor = active ? modeColor : Colors.transparentBlack;
 
     let opacityValue = 1.0;
 
@@ -53,6 +64,7 @@ let createElement =
         flexDirection(`Row),
         justifyContent(`Center),
         alignItems(`Center),
+        ...horizontalBorderStyles(tabPosition, numberOfTabs),
       ];
 
     let textStyle =
@@ -63,6 +75,7 @@ let createElement =
         fontSize(uiFont.fontSize),
         color(theme.colors.tabActiveForeground),
         backgroundColor(theme.colors.editorBackground),
+        marginLeft(5),
       ];
 
     let icon = modified ? FontAwesome.circle : FontAwesome.times;
@@ -77,7 +90,6 @@ let createElement =
             flexDirection(`Row),
             alignItems(`Center),
             justifyContent(`Center),
-            paddingHorizontal(5),
           ]>
           <Text style=textStyle text=title />
         </Clickable>

--- a/src/editor/UI/Tabs.re
+++ b/src/editor/UI/Tabs.re
@@ -21,9 +21,11 @@ type tabInfo = {
 
 let component = React.component("Tabs");
 
-let toTab = (theme, mode, uiFont, t: tabInfo) =>
+let toTab = (theme, mode, uiFont, numberOfTabs, index, t: tabInfo) =>
   <Tab
     theme
+    tabPosition={index + 1}
+    numberOfTabs
     title={Path.filename(t.title)}
     active={t.active}
     modified={t.modified}
@@ -45,6 +47,8 @@ let createElement =
       (),
     ) =>
   component(hooks => {
-    let tabComponents = List.map(toTab(theme, mode, uiFont), tabs);
+    let tabCount = List.length(tabs);
+    let tabComponents =
+      List.mapi(toTab(theme, mode, uiFont, tabCount), tabs);
     (hooks, <View style=viewStyle> ...tabComponents </View>);
   });


### PR DESCRIPTION
This change primarily resets the tabline mode to `buffers` as that maps to files and was causing it to seem like the tabs were not rendering properly

It also adds a border between tabs, as an interim measure till we have `inset` shadowing in revery

![border-tab](https://user-images.githubusercontent.com/22454918/54489663-99959980-48a6-11e9-8a24-e4539e17a348.png)
