### PR TITLE
Feature/let ppx

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "06bea8d0670db23d003d280efc5b313c",
+  "checksum": "593f079dbead93e7892bd66d7505224b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "universalify@0.1.2@d41d8cd9": {
@@ -385,6 +385,7 @@
         "reason-glfw@3.2.1023@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.0.1@d41d8cd9", "@opam/zed@opam:1.6@004ea65e",
         "@opam/yojson@opam:1.5.0@890db858",
+        "@opam/ppx_let@opam:v0.12.0@8bca1692",
         "@opam/ppx_deriving_yojson@opam:3.3@80aab5d8",
         "@opam/ppx_deriving@opam:4.2.1@7927b93a",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -578,6 +579,55 @@
         "@opam/ocamlbuild@opam:0.14.0@427a2331"
       ]
     },
+    "@opam/stdio@opam:v0.12.0@1d18adcb": {
+      "id": "@opam/stdio@opam:v0.12.0@1d18adcb",
+      "name": "@opam/stdio",
+      "version": "opam:v0.12.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/b2/b261ff2d5667fde960c95e50cff668da#md5:b261ff2d5667fde960c95e50cff668da",
+          "archive:https://ocaml.janestreet.com/ocaml-core/v0.12/files/stdio-v0.12.0.tar.gz#md5:b261ff2d5667fde960c95e50cff668da"
+        ],
+        "opam": {
+          "name": "stdio",
+          "version": "v0.12.0",
+          "path": "esy.lock/opam/stdio.v0.12.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@72aad784",
+        "@opam/base@opam:v0.12.0@bd6e6655",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/base@opam:v0.12.0@bd6e6655"
+      ]
+    },
+    "@opam/sexplib0@opam:v0.12.0@e823b4e9": {
+      "id": "@opam/sexplib0@opam:v0.12.0@e823b4e9",
+      "name": "@opam/sexplib0",
+      "version": "opam:v0.12.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/24/2486a25d3a94da9a94acc018b5f09061#md5:2486a25d3a94da9a94acc018b5f09061",
+          "archive:https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib0-v0.12.0.tar.gz#md5:2486a25d3a94da9a94acc018b5f09061"
+        ],
+        "opam": {
+          "name": "sexplib0",
+          "version": "v0.12.0",
+          "path": "esy.lock/opam/sexplib0.v0.12.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@72aad784",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "@opam/seq@opam:base@d8d7de1d": {
       "id": "@opam/seq@opam:base@d8d7de1d",
       "name": "@opam/seq",
@@ -697,6 +747,39 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
+    "@opam/ppxlib@opam:0.5.0@674193ca": {
+      "id": "@opam/ppxlib@opam:0.5.0@674193ca",
+      "name": "@opam/ppxlib",
+      "version": "opam:0.5.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/bb/bb278ff6e819e0e4a4d8a005bb2512a4#md5:bb278ff6e819e0e4a4d8a005bb2512a4",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.5.0/ppxlib-0.5.0.tbz#md5:bb278ff6e819e0e4a4d8a005bb2512a4"
+        ],
+        "opam": {
+          "name": "ppxlib",
+          "version": "0.5.0",
+          "path": "esy.lock/opam/ppxlib.0.5.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdio@opam:v0.12.0@1d18adcb",
+        "@opam/ppx_derivers@opam:1.0@78655ff8",
+        "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3",
+        "@opam/ocaml-compiler-libs@opam:v0.11.0@7e9ced39",
+        "@opam/dune@opam:1.7.3@72aad784", "@opam/base@opam:v0.12.0@bd6e6655",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdio@opam:v0.12.0@1d18adcb",
+        "@opam/ppx_derivers@opam:1.0@78655ff8",
+        "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3",
+        "@opam/ocaml-compiler-libs@opam:v0.11.0@7e9ced39",
+        "@opam/base@opam:v0.12.0@bd6e6655"
+      ]
+    },
     "@opam/ppxfind@opam:1.2@0443ec6f": {
       "id": "@opam/ppxfind@opam:1.2@0443ec6f",
       "name": "@opam/ppxfind",
@@ -776,6 +859,33 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+      ]
+    },
+    "@opam/ppx_let@opam:v0.12.0@8bca1692": {
+      "id": "@opam/ppx_let@opam:v0.12.0@8bca1692",
+      "name": "@opam/ppx_let",
+      "version": "opam:v0.12.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/8e/8ebaa03cb252e29c3152cf32e5769e83#md5:8ebaa03cb252e29c3152cf32e5769e83",
+          "archive:https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_let-v0.12.0.tar.gz#md5:8ebaa03cb252e29c3152cf32e5769e83"
+        ],
+        "opam": {
+          "name": "ppx_let",
+          "version": "v0.12.0",
+          "path": "esy.lock/opam/ppx_let.v0.12.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/dune@opam:1.7.3@72aad784", "@opam/base@opam:v0.12.0@bd6e6655",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/base@opam:v0.12.0@bd6e6655"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.3@80aab5d8": {
@@ -988,6 +1098,29 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
         "@opam/ppx_derivers@opam:1.0@78655ff8"
       ]
+    },
+    "@opam/ocaml-compiler-libs@opam:v0.11.0@7e9ced39": {
+      "id": "@opam/ocaml-compiler-libs@opam:v0.11.0@7e9ced39",
+      "name": "@opam/ocaml-compiler-libs",
+      "version": "opam:v0.11.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/e1/e170c16186aa55b7e8b11e461418a10a#md5:e170c16186aa55b7e8b11e461418a10a",
+          "archive:https://ocaml.janestreet.com/ocaml-core/v0.11/files/ocaml-compiler-libs-v0.11.0.tar.gz#md5:e170c16186aa55b7e8b11e461418a10a"
+        ],
+        "opam": {
+          "name": "ocaml-compiler-libs",
+          "version": "v0.11.0",
+          "path": "esy.lock/opam/ocaml-compiler-libs.v0.11.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/jbuilder@opam:transition@58bdfe0a",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
     "@opam/msgpck@opam:1.4@eb408207": {
       "id": "@opam/msgpck@opam:1.4@eb408207",
@@ -1784,6 +1917,31 @@
       "overrides": [],
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
+    },
+    "@opam/base@opam:v0.12.0@bd6e6655": {
+      "id": "@opam/base@opam:v0.12.0@bd6e6655",
+      "name": "@opam/base",
+      "version": "opam:v0.12.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/e5/e522176bc2cca7c12745539fa72356ad#md5:e522176bc2cca7c12745539fa72356ad",
+          "archive:https://ocaml.janestreet.com/ocaml-core/v0.12/files/base-v0.12.0.tar.gz#md5:e522176bc2cca7c12745539fa72356ad"
+        ],
+        "opam": {
+          "name": "base",
+          "version": "v0.12.0",
+          "path": "esy.lock/opam/base.v0.12.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/sexplib0@opam:v0.12.0@e823b4e9",
+        "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/sexplib0@opam:v0.12.0@e823b4e9"
+      ]
     },
     "@opam/astring@opam:0.8.3@4e5e17d5": {
       "id": "@opam/astring@opam:0.8.3@4e5e17d5",

--- a/esy.lock/opam/base.v0.12.0/opam
+++ b/esy.lock/opam/base.v0.12.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.04.2" & < "4.08.0"}
+  "sexplib0"          {>= "v0.12" & < "v0.13"}
+  "dune"              {build & >= "1.5.1"}
+]
+depopts: [
+  "base-native-int63"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/base-v0.12.0.tar.gz"
+  checksum: "md5=e522176bc2cca7c12745539fa72356ad"
+}

--- a/esy.lock/opam/ocaml-compiler-libs.v0.11.0/opam
+++ b/esy.lock/opam/ocaml-compiler-libs.v0.11.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+synopsis: "OCaml compiler libraries repackaged"
+description: """
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, ..."""
+url {
+  src:
+    "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ocaml-compiler-libs-v0.11.0.tar.gz"
+  checksum: "md5=e170c16186aa55b7e8b11e461418a10a"
+}

--- a/esy.lock/opam/ppx_let.v0.12.0/opam
+++ b/esy.lock/opam/ppx_let.v0.12.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_let"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "4.04.2"}
+  "base"   {>= "v0.12" & < "v0.13"}
+  "dune"   {build & >= "1.5.1"}
+  "ppxlib" {>= "0.5.0"}
+]
+synopsis: "Monadic let-bindings"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_let-v0.12.0.tar.gz"
+  checksum: "md5=8ebaa03cb252e29c3152cf32e5769e83"
+}

--- a/esy.lock/opam/ppxlib.0.5.0/opam
+++ b/esy.lock/opam/ppxlib.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "base"                    {>= "v0.11.0" & < "v0.13"}
+  "dune"                    {build}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.9"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0" & < "v0.13"}
+  "ocamlfind"               {with-test}
+]
+synopsis: "Base library and tools for ppx rewriters"
+description: """
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.5.0/ppxlib-0.5.0.tbz"
+  checksum: "md5=bb278ff6e819e0e4a4d8a005bb2512a4"
+}

--- a/esy.lock/opam/sexplib0.v0.12.0/opam
+++ b/esy.lock/opam/sexplib0.v0.12.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib0"
+bug-reports: "https://github.com/janestreet/sexplib0/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib0.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"  {build & >= "1.5.1"}
+]
+synopsis: "Library containing the definition of S-expressions and some base converters"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib0-v0.12.0.tar.gz"
+  checksum: "md5=2486a25d3a94da9a94acc018b5f09061"
+}

--- a/esy.lock/opam/stdio.v0.12.0/opam
+++ b/esy.lock/opam/stdio.v0.12.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/stdio"
+bug-reports: "https://github.com/janestreet/stdio/issues"
+dev-repo: "git+https://github.com/janestreet/stdio.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "base"  {>= "v0.12" & < "v0.13"}
+  "dune"  {build & >= "1.5.1"}
+]
+synopsis: "Standard IO library for OCaml"
+description: "
+Stdio implements simple input/output functionalities for OCaml.
+
+It re-exports the input/output functions of the OCaml standard
+libraries using a more consistent API.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/stdio-v0.12.0.tar.gz"
+  checksum: "md5=b261ff2d5667fde960c95e50cff668da"
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@opam/lwt": "*",
     "@opam/camomile": "^1.0.1",
     "@opam/msgpck": "*",
+    "@opam/ppx_let": "*",
     "@opam/ppx_deriving": "*",
     "@opam/ppx_deriving_yojson": "*",
     "@opam/yojson": "1.5.0",

--- a/src/editor/Core/Filesystem.re
+++ b/src/editor/Core/Filesystem.re
@@ -301,11 +301,13 @@ let getPath = (dir, file) => return(Utility.join([dir, file]));
 
 let createConfigIfNecessary = (configDir, file) => {
   open Let_syntax;
+
   let filepath = Utility.join([configDir, file]);
-  let%map dirStats = stat(filepath);
+
+  let%map dirStats = stat(configDir);
   switch%bind (dirStats) {
-  | Some(dirStats) =>
-    isDir(dirStats)
+  | Some(stats) =>
+    isDir(stats)
     /\/= (
       _msg =>
         mkdir(configDir, ())
@@ -327,6 +329,7 @@ let createConfigIfNecessary = (configDir, file) => {
 
 let createOniConfigFile = filename => {
   open Let_syntax;
+
   let%bind home = getHomeDirectory();
   let%bind configDir = getOniDirectory(home);
   let%bind configFilePath = getPath(configDir, filename);

--- a/src/editor/Core/Filesystem.re
+++ b/src/editor/Core/Filesystem.re
@@ -72,6 +72,12 @@ let (/\/=) = onError;
 
   a few caveats are that there is no way to bind the [onError] handler
   as only bind,return,map,switch are supported
+
+  Re. deciding which to use i.e. infix or let ppx, let% is recommended
+  when a meaningfulVariable is returned from an operation as there
+  is no syntactic sugart for unit bindings
+
+  reference: https://blog.janestreet.com/let-syntax-and-why-you-should-use-it/
  */
 module Let_syntax = {
   let return = return;
@@ -296,8 +302,8 @@ let getPath = (dir, file) => return(Utility.join([dir, file]));
 open Let_syntax;
 
 let createConfigIfNecessary = (configDir, file) => {
-  let configFilePath = Utility.join([configDir, file]);
-  let%map dirStats = stat(configFilePath);
+  let filepath = Utility.join([configDir, file]);
+  let%map dirStats = stat(filepath);
   switch%bind (dirStats) {
   | Some(dirStats) =>
     isDir(dirStats)
@@ -311,12 +317,12 @@ let createConfigIfNecessary = (configDir, file) => {
       () =>
         createOniConfiguration(~configDir, ~file)
         /\/= error("Error creating configuration files because: %s")
-        >>= (() => return(configFilePath))
+        >>= (() => return(filepath))
     )
   | None =>
     mkdir(configDir, ())
     >>= (() => createOniConfiguration(~configDir, ~file))
-    >>= (() => return(configFilePath))
+    >>= (() => return(filepath))
   };
 };
 

--- a/src/editor/Core/Filesystem.re
+++ b/src/editor/Core/Filesystem.re
@@ -75,7 +75,7 @@ let (/\/=) = onError;
 
   Re. deciding which to use i.e. infix or let ppx, let% is recommended
   when a meaningfulVariable is returned from an operation as there
-  is no syntactic sugart for unit bindings
+  is no syntactic sugar for unit bindings
 
   reference: https://blog.janestreet.com/let-syntax-and-why-you-should-use-it/
  */
@@ -90,7 +90,7 @@ module Let_syntax = {
 
   let map = (t, ~f) => f(t);
 
-  let both = (a: t('a), b: t('b)): t(('a, 'b)) =>
+  let _both = (a: t('a), b: t('b)): t(('a, 'b)) =>
     switch (a, b) {
     | (Ok(first), Ok(second)) => return((first, second))
     | (Error(err), Ok(result)) => return((err, result))
@@ -299,9 +299,8 @@ let createOniConfiguration = (~configDir, ~file) => {
 
 let getPath = (dir, file) => return(Utility.join([dir, file]));
 
-open Let_syntax;
-
 let createConfigIfNecessary = (configDir, file) => {
+  open Let_syntax;
   let filepath = Utility.join([configDir, file]);
   let%map dirStats = stat(filepath);
   switch%bind (dirStats) {
@@ -327,6 +326,7 @@ let createConfigIfNecessary = (configDir, file) => {
 };
 
 let createOniConfigFile = filename => {
+  open Let_syntax;
   let%bind home = getHomeDirectory();
   let%bind configDir = getOniDirectory(home);
   let%bind configFilePath = getPath(configDir, filename);

--- a/src/editor/Core/dune
+++ b/src/editor/Core/dune
@@ -12,8 +12,9 @@
         Rench
         Revery
         yojson
+        ppx_let
         ppx_deriving.runtime
         ppx_deriving_yojson.runtime
         reason-jsonrpc
     )
-    (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))
+    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show)))


### PR DESCRIPTION
Use [`ppx_let`](https://blog.janestreet.com/let-syntax-and-why-you-should-use-it/) to simplify *some* `Filesystem` monadic operations.

Caveats: the `onError` handler and its associated infix operator `//=` are a powerful utility that `let%` currently does not handle (as far as I know) as the ppx only provides `%bind, %map, %switch, and`. The linked article goes into detail re potential use cases for infix vs. for let ppx and suggests using them where there are meaningful variables returned from the operation which is what I've opted for