### PR TITLE
Feature/add quickopen

### DIFF
--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,7 +1,7 @@
 {
     "bindings": [
-        { "key": "<S-C-P>", "command": "quickOpen.open", "when": ["editorTextFocus"] },
-        { "key": "<C-P>", "command": "commandPalette.open", "when": ["editorTextFocus"] },
+        { "key": "<C-P>", "command": "quickOpen.open", "when": ["editorTextFocus"] },
+        { "key": "<S-C-P>", "command": "commandPalette.open", "when": ["editorTextFocus"] },
         { "key": "<ESC>", "command": "menu.close", "when": ["menuFocus"] },
         { "key": "<C-N>", "command": "menu.next", "when": ["menuFocus"] },
         { "key": "<C-P>", "command": "menu.previous", "when": ["menuFocus"] },

--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,9 +1,10 @@
 {
     "bindings": [
+        { "key": "<S-C-P>", "command": "quickOpen.open", "when": ["editorTextFocus"] },
         { "key": "<C-P>", "command": "commandPalette.open", "when": ["editorTextFocus"] },
-        { "key": "<ESC>", "command": "commandPalette.close", "when": ["commandPaletteFocus"] },
-        { "key": "<C-N>", "command": "commandPalette.next", "when": ["commandPaletteFocus"] },
-        { "key": "<C-P>", "command": "commandPalette.previous", "when": ["commandPaletteFocus"] },
-        { "key": "<CR>", "command": "commandPalette.select", "when": ["commandPaletteFocus"] }
+        { "key": "<ESC>", "command": "menu.close", "when": ["menuFocus"] },
+        { "key": "<C-N>", "command": "menu.next", "when": ["menuFocus"] },
+        { "key": "<C-P>", "command": "menu.previous", "when": ["menuFocus"] },
+        { "key": "<CR>", "command": "menu.select", "when": ["menuFocus"] }
     ]
 }

--- a/src/editor/Core/Filter.re
+++ b/src/editor/Core/Filter.re
@@ -4,14 +4,13 @@
    Module to handle searching and filtering of items using
    various strategies
  */
-open Oni_Core;
 
 let menu = (query, items) =>
   Types.UiMenu.(
     List.sort(
       (item1, item2) => {
-        let firstMatches = Utility.contains(item1.name, query);
-        let secondMatches = Utility.contains(item2.name, query);
+        let firstMatches = Utility.stringContains(item1.name, query);
+        let secondMatches = Utility.stringContains(item2.name, query);
         switch (firstMatches, secondMatches) {
         | (true, true) => 0
         | (false, false) => 0

--- a/src/editor/Core/Filter.re
+++ b/src/editor/Core/Filter.re
@@ -1,8 +1,7 @@
 /**
-   Search
+   Filter
 
-   Module to handle searching and filtering of items using
-   various strategies
+   Module to handle filtering of items using various strategies
  */
 
 let menu = (query, items) =>
@@ -11,12 +10,19 @@ let menu = (query, items) =>
       (item1, item2) => {
         let firstMatches = Utility.stringContains(item1.name, query);
         let secondMatches = Utility.stringContains(item2.name, query);
-        switch (firstMatches, secondMatches) {
-        | (true, true) => 0
-        | (false, false) => 0
-        | (true, false) => (-1)
-        | (false, true) => 1
-        };
+        /**
+           if both values are the same then no position change is required
+           if the first item is a match then move it closer to the start
+           if the second is a match move the first lower down
+         */
+        (
+          switch (firstMatches, secondMatches) {
+          | (true, true) => 0
+          | (false, false) => 0
+          | (true, false) => (-1)
+          | (false, true) => 1
+          }
+        );
       },
       items,
     )

--- a/src/editor/Core/Oni_Core.re
+++ b/src/editor/Core/Oni_Core.re
@@ -17,3 +17,4 @@ module Configuration = Configuration;
 module Theme = Theme;
 module Keybindings = Keybindings;
 module Filesystem = Filesystem;
+module Filter = Filter;

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -252,7 +252,10 @@ module Input = {
 
 module Effects = {
   [@deriving show]
-  type t = {openFile: Views.viewOperation};
+  type t = {
+    openFile: Views.viewOperation,
+    getCurrentDir: unit => option(string),
+  };
 };
 
 module UiMenu = {

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -59,6 +59,7 @@ module Mode = {
    * A buffer: represents a file
  */
 module Views = {
+  [@deriving show]
   type t =
     | Window
     | Tab
@@ -68,6 +69,7 @@ module Views = {
     | Buffer
     | Tab;
 
+  [@deriving show]
   type viewOperation =
     (~path: string=?, ~id: int=?, ~openMethod: openMethod=?, unit) => unit;
 };
@@ -235,21 +237,6 @@ type commandline = {
   show: bool,
 };
 
-module Palette = {
-  [@deriving show]
-  type command = {
-    name: string,
-    command: unit => unit,
-  };
-
-  [@deriving show]
-  type t = {
-    isOpen: bool,
-    commands: list(command),
-    selectedItem: int,
-  };
-};
-
 module Input = {
   [@deriving (show, yojson({strict: false, exn: false}))]
   type controlMode =
@@ -264,5 +251,31 @@ module Input = {
 };
 
 module Effects = {
+  [@deriving show]
   type t = {openFile: Views.viewOperation};
+};
+
+module UiMenu = {
+  [@deriving show]
+  type menuType =
+    | QuickOpen
+    | CommandPalette
+    | Closed;
+
+  [@deriving show]
+  type command = {
+    name: string,
+    command: unit => unit,
+  };
+
+  type commandFactory = Effects.t => list(command);
+
+  [@deriving show]
+  type t = {
+    effects: option(Effects.t),
+    menuType,
+    isOpen: bool,
+    commands: list(command),
+    selectedItem: int,
+  };
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -240,7 +240,7 @@ type commandline = {
 module Input = {
   [@deriving (show, yojson({strict: false, exn: false}))]
   type controlMode =
-    | [@name "commandPaletteFocus"] CommandPaletteFocus
+    | [@name "menuFocus"] MenuFocus
     | [@name "editorTextFocus"] EditorTextFocus;
 
   [@deriving show]

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -277,6 +277,7 @@ module UiMenu = {
   [@deriving show]
   type t = {
     effects: option(Effects.t),
+    searchQuery: string,
     menuType,
     isOpen: bool,
     commands: list(command),

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -269,6 +269,7 @@ module UiMenu = {
   type command = {
     name: string,
     command: unit => unit,
+    icon: option(string),
   };
 
   type commandFactory = Effects.t => list(command);

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -260,7 +260,7 @@ module Effects = {
 
 module UiMenu = {
   [@deriving show]
-  type menuType =
+  type menu =
     | QuickOpen
     | CommandPalette
     | Closed;
@@ -278,7 +278,7 @@ module UiMenu = {
   type t = {
     effects: option(Effects.t),
     searchQuery: string,
-    menuType,
+    menu,
     isOpen: bool,
     commands: list(command),
     selectedItem: int,

--- a/src/editor/Core/Utility.re
+++ b/src/editor/Core/Utility.re
@@ -53,3 +53,14 @@ let join = paths => {
     };
   List.fold_left((accum, p) => accum ++ sep ++ p, head, rest);
 };
+
+/**
+  This is a very rudimentary search case insensitvely checks to see if a substring
+  is contained in a larger string.
+ */
+let contains = (word, substring) => {
+  let re = Str.regexp_string_case_fold(substring);
+  try (Str.search_forward(re, word, 0) |> ignore |> (_ => true)) {
+  | Not_found => false
+  };
+};

--- a/src/editor/Core/Utility.re
+++ b/src/editor/Core/Utility.re
@@ -55,8 +55,8 @@ let join = paths => {
 };
 
 /**
-  This is a very rudimentary search case insensitvely checks to see if a substring
-  is contained in a larger string.
+  This is a very rudimentary search, which works case insensitvely
+  to see if a substring is contained in a larger string.
  */
 let stringContains = (word, substring) => {
   let re = Str.regexp_string_case_fold(substring);

--- a/src/editor/Core/Utility.re
+++ b/src/editor/Core/Utility.re
@@ -58,7 +58,7 @@ let join = paths => {
   This is a very rudimentary search case insensitvely checks to see if a substring
   is contained in a larger string.
  */
-let contains = (word, substring) => {
+let stringContains = (word, substring) => {
   let re = Str.regexp_string_case_fold(substring);
   try (Str.search_forward(re, word, 0) |> ignore |> (_ => true)) {
   | Not_found => false

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -35,10 +35,10 @@ type t =
   | EditorMoveCursorToBottom(Cursor.move)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
-  | CommandPaletteStart(list(Palette.command))
-  | CommandPaletteOpen
-  | CommandPaletteClose
-  | CommandPaletteSelect
-  | CommandPalettePosition(int)
+  | MenuRegisterEffects(Effects.t)
+  | MenuOpen((UiMenu.menuType, UiMenu.commandFactory))
+  | MenuClose
+  | MenuSelect
+  | MenuPosition(int)
   | SetInputControlMode(Input.controlMode)
   | Noop;

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -37,7 +37,7 @@ type t =
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
   | MenuRegisterEffects(Effects.t)
   | MenuSearch(string)
-  | MenuOpen((UiMenu.menuType, UiMenu.commandFactory))
+  | MenuOpen((UiMenu.menu, UiMenu.commandFactory))
   | MenuClose
   | MenuSelect
   | MenuPosition(int)

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -36,6 +36,7 @@ type t =
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
   | MenuRegisterEffects(Effects.t)
+  | MenuSearch(string)
   | MenuOpen((UiMenu.menuType, UiMenu.commandFactory))
   | MenuClose
   | MenuSelect

--- a/src/editor/Model/CommandPalette.re
+++ b/src/editor/Model/CommandPalette.re
@@ -1,8 +1,7 @@
 open Oni_Core;
 open Types;
 
-type t = Palette.t;
-open Palette;
+open UiMenu;
 
 let openConfigurationFile = (effects: Effects.t, name) =>
   switch (Filesystem.createOniConfigFile(name)) {
@@ -20,39 +19,3 @@ let commandPaletteCommands = (effects: Effects.t) => [
     command: () => openConfigurationFile(effects, "keybindings.json"),
   },
 ];
-
-let create = (~effects: option(Effects.t)=?, ()) =>
-  switch (effects) {
-  | Some(e) => {
-      isOpen: false,
-      commands: commandPaletteCommands(e),
-      selectedItem: 0,
-    }
-  | None => {isOpen: false, commands: [], selectedItem: 0}
-  };
-
-let make = (~effects: Effects.t) =>
-  create(~effects, ()) |> (c => Actions.CommandPaletteStart(c.commands));
-
-let position = (selectedItem, change, commands: list(command)) =>
-  selectedItem + change >= List.length(commands) ? 0 : selectedItem + change;
-
-let reduce = (state: t, action: Actions.t) =>
-  switch (action) {
-  | CommandPaletteStart(commands) => {...state, commands}
-  | CommandPalettePosition(pos) => {
-      ...state,
-      selectedItem: position(state.selectedItem, pos, state.commands),
-    }
-  | CommandPaletteOpen => {...state, isOpen: true}
-  | CommandPaletteClose => {...state, isOpen: false}
-  | CommandPaletteSelect =>
-    /**
-       TODO: Refactor this to middleware so this action is handled like a redux side-effect
-       as this makes the reducer impure
-     */
-    let selected = List.nth(state.commands, state.selectedItem);
-    selected.command();
-    {...state, isOpen: false};
-  | _ => state
-  };

--- a/src/editor/Model/CommandPalette.re
+++ b/src/editor/Model/CommandPalette.re
@@ -9,7 +9,7 @@ let openConfigurationFile = (effects: Effects.t, name) =>
   | Error(e) => print_endline(e)
   };
 
-let commandPaletteCommands = (effects: Effects.t) => [
+let commands = (effects: Effects.t) => [
   {
     name: "Open configuration file",
     command: () => openConfigurationFile(effects, "configuration.json"),

--- a/src/editor/Model/CommandPalette.re
+++ b/src/editor/Model/CommandPalette.re
@@ -13,9 +13,11 @@ let commands = (effects: Effects.t) => [
   {
     name: "Open configuration file",
     command: () => openConfigurationFile(effects, "configuration.json"),
+    icon: None,
   },
   {
     name: "Open keybindings file",
     command: () => openConfigurationFile(effects, "keybindings.json"),
+    icon: None,
   },
 ];

--- a/src/editor/Model/Commands.re
+++ b/src/editor/Model/Commands.re
@@ -9,28 +9,19 @@ let oniCommands = [
   {
     name: "commandPalette.open",
     command: _ => [
-      CommandPaletteOpen,
+      MenuOpen((CommandPalette, CommandPalette.commandPaletteCommands)),
       SetInputControlMode(CommandPaletteFocus),
     ],
   },
   {
     name: "commandPalette.close",
-    command: _ => [
-      CommandPaletteClose,
-      SetInputControlMode(EditorTextFocus),
-    ],
+    command: _ => [MenuClose, SetInputControlMode(EditorTextFocus)],
   },
-  {name: "commandPalette.next", command: _ => [CommandPalettePosition(1)]},
-  {
-    name: "commandPalette.previous",
-    command: _ => [CommandPalettePosition(-1)],
-  },
+  {name: "commandPalette.next", command: _ => [MenuPosition(1)]},
+  {name: "commandPalette.previous", command: _ => [MenuPosition(-1)]},
   {
     name: "commandPalette.select",
-    command: _ => [
-      CommandPaletteSelect,
-      SetInputControlMode(EditorTextFocus),
-    ],
+    command: _ => [MenuSelect, SetInputControlMode(EditorTextFocus)],
   },
 ];
 

--- a/src/editor/Model/Commands.re
+++ b/src/editor/Model/Commands.re
@@ -9,7 +9,7 @@ let oniCommands = [
   {
     name: "commandPalette.open",
     command: _ => [
-      MenuOpen((CommandPalette, CommandPalette.commandPaletteCommands)),
+      MenuOpen((CommandPalette, CommandPalette.commands)),
       SetInputControlMode(CommandPaletteFocus),
     ],
   },

--- a/src/editor/Model/Commands.re
+++ b/src/editor/Model/Commands.re
@@ -10,18 +10,25 @@ let oniCommands = [
     name: "commandPalette.open",
     command: _ => [
       MenuOpen((CommandPalette, CommandPalette.commands)),
-      SetInputControlMode(CommandPaletteFocus),
+      SetInputControlMode(MenuFocus),
     ],
   },
   {
-    name: "commandPalette.close",
+    name: "menu.close",
     command: _ => [MenuClose, SetInputControlMode(EditorTextFocus)],
   },
-  {name: "commandPalette.next", command: _ => [MenuPosition(1)]},
-  {name: "commandPalette.previous", command: _ => [MenuPosition(-1)]},
+  {name: "menu.next", command: _ => [MenuPosition(1)]},
+  {name: "menu.previous", command: _ => [MenuPosition(-1)]},
   {
-    name: "commandPalette.select",
+    name: "menu.select",
     command: _ => [MenuSelect, SetInputControlMode(EditorTextFocus)],
+  },
+  {
+    name: "quickOpen.open",
+    command: _ => [
+      MenuOpen((QuickOpen, QuickOpen.content)),
+      SetInputControlMode(MenuFocus),
+    ],
   },
 ];
 

--- a/src/editor/Model/Commands.re
+++ b/src/editor/Model/Commands.re
@@ -14,6 +14,13 @@ let oniCommands = [
     ],
   },
   {
+    name: "quickOpen.open",
+    command: _ => [
+      MenuOpen((QuickOpen, QuickOpen.content)),
+      SetInputControlMode(MenuFocus),
+    ],
+  },
+  {
     name: "menu.close",
     command: _ => [MenuClose, SetInputControlMode(EditorTextFocus)],
   },
@@ -22,13 +29,6 @@ let oniCommands = [
   {
     name: "menu.select",
     command: _ => [MenuSelect, SetInputControlMode(EditorTextFocus)],
-  },
-  {
-    name: "quickOpen.open",
-    command: _ => [
-      MenuOpen((QuickOpen, QuickOpen.content)),
-      SetInputControlMode(MenuFocus),
-    ],
   },
 ];
 

--- a/src/editor/Model/Filter.re
+++ b/src/editor/Model/Filter.re
@@ -1,0 +1,24 @@
+/**
+   Search
+
+   Module to handle searching and filtering of items using
+   various strategies
+ */
+open Oni_Core;
+
+let menu = (query, items) =>
+  Types.UiMenu.(
+    List.sort(
+      (item1, item2) => {
+        let firstMatches = Utility.contains(item1.name, query);
+        let secondMatches = Utility.contains(item2.name, query);
+        switch (firstMatches, secondMatches) {
+        | (true, true) => 0
+        | (false, false) => 0
+        | (true, false) => (-1)
+        | (false, true) => 1
+        };
+      },
+      items,
+    )
+  );

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -2,25 +2,13 @@ open Oni_Core;
 open Types;
 open UiMenu;
 
-let emptyCommands = _effects => [];
-
-let create = (~effects: option(Effects.t)=?, ~commands=emptyCommands, ()) =>
-  switch (effects) {
-  | Some(e) => {
-      menuType: Closed,
-      isOpen: false,
-      commands: commands(e),
-      selectedItem: 0,
-      effects,
-    }
-  | None => {
-      menuType: Closed,
-      isOpen: false,
-      commands: [],
-      selectedItem: 0,
-      effects: None,
-    }
-  };
+let create = (~effects: option(Effects.t)=?, ()) => {
+  menuType: Closed,
+  isOpen: false,
+  commands: [],
+  selectedItem: 0,
+  effects,
+};
 
 let addEffects = (effects: Effects.t) =>
   Actions.MenuRegisterEffects(effects);
@@ -36,6 +24,7 @@ let addCommands = (factory: commandFactory, effects: option(Effects.t)) =>
 
 let reduce = (state, action: Actions.t) =>
   switch (action) {
+  | MenuRegisterEffects(effects) => {...state, effects: Some(effects)}
   | MenuPosition(pos) => {
       ...state,
       selectedItem: position(state.selectedItem, pos, state.commands),

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -1,4 +1,5 @@
-open Oni_Core.Types;
+open Oni_Core;
+open Types;
 open UiMenu;
 
 let create = (~effects: option(Effects.t)=?, ()) => {

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -3,6 +3,7 @@ open UiMenu;
 
 let create = (~effects: option(Effects.t)=?, ()) => {
   menuType: Closed,
+  searchQuery: "",
   isOpen: false,
   commands: [],
   selectedItem: 0,
@@ -29,6 +30,11 @@ let reduce = (state, action: Actions.t) =>
   | MenuPosition(pos) => {
       ...state,
       selectedItem: position(state.selectedItem, pos, state.commands),
+    }
+  | MenuSearch(query) => {
+      ...state,
+      searchQuery: query,
+      commands: Filter.menu(query, state.commands),
     }
   | MenuOpen((menu, commands)) =>
     /**

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -3,7 +3,7 @@ open Types;
 open UiMenu;
 
 let create = (~effects: option(Effects.t)=?, ()) => {
-  menuType: Closed,
+  menu: Closed,
   searchQuery: "",
   isOpen: false,
   commands: [],
@@ -47,9 +47,9 @@ let reduce = (state, action: Actions.t) =>
     |> (
       cmds =>
         List.length(cmds) > 0
-          ? {...state, isOpen: true, menuType: menu, commands: cmds} : state
+          ? {...state, isOpen: true, menu, commands: cmds} : state
     )
-  | MenuClose => {...state, isOpen: false, menuType: Closed, selectedItem: 0}
+  | MenuClose => {...state, isOpen: false, menu: Closed, selectedItem: 0}
   | MenuSelect =>
     /**
       TODO: Refactor this to middleware so this action is handled like a redux side-effect
@@ -57,6 +57,6 @@ let reduce = (state, action: Actions.t) =>
      */
     List.nth(state.commands, state.selectedItem)
     |> (selected => selected.command());
-    {...state, isOpen: false, menuType: Closed};
+    {...state, isOpen: false, menu: Closed};
   | _ => state
   };

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -46,8 +46,8 @@ let reduce = (state, action: Actions.t) =>
     addCommands(commands, state.effects)
     |> (
       cmds =>
-        List.length(cmds) > 0 ?
-          {...state, isOpen: true, menuType: menu, commands: cmds} : state
+        List.length(cmds) > 0
+          ? {...state, isOpen: true, menuType: menu, commands: cmds} : state
     )
   | MenuClose => {...state, isOpen: false, menuType: Closed, selectedItem: 0}
   | MenuSelect =>

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -30,12 +30,18 @@ let reduce = (state, action: Actions.t) =>
       ...state,
       selectedItem: position(state.selectedItem, pos, state.commands),
     }
-  | MenuOpen((menu, commands)) => {
-      ...state,
-      isOpen: true,
-      menuType: menu,
-      commands: addCommands(commands, state.effects),
-    }
+  | MenuOpen((menu, commands)) =>
+    /**
+     If the command factory for a module trying to open a menu returns
+     0 options/commands for the menu do not open an empty menu.
+     this is a safeguard *IF* a command factory function fails
+   */
+    addCommands(commands, state.effects)
+    |> (
+      cmds =>
+        List.length(cmds) > 0 ?
+          {...state, isOpen: true, menuType: menu, commands: cmds} : state
+    )
   | MenuClose => {...state, isOpen: false, menuType: Closed, selectedItem: 0}
   | MenuSelect =>
     /**

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -1,5 +1,4 @@
-open Oni_Core;
-open Types;
+open Oni_Core.Types;
 open UiMenu;
 
 let create = (~effects: option(Effects.t)=?, ()) => {

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -14,8 +14,7 @@ let addEffects = (effects: Effects.t) =>
 
 let position = (selectedItem, change, commands: list(command)) => {
   let nextIndex = selectedItem + change;
-  nextIndex >= List.length(commands) || nextIndex < 0 ?
-    0 : selectedItem + change;
+  nextIndex >= List.length(commands) || nextIndex < 0 ? 0 : nextIndex;
 };
 
 let addCommands = (factory: commandFactory, effects: option(Effects.t)) =>

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -12,8 +12,11 @@ let create = (~effects: option(Effects.t)=?, ()) => {
 let addEffects = (effects: Effects.t) =>
   Actions.MenuRegisterEffects(effects);
 
-let position = (selectedItem, change, commands: list(command)) =>
-  selectedItem + change >= List.length(commands) ? 0 : selectedItem + change;
+let position = (selectedItem, change, commands: list(command)) => {
+  let nextIndex = selectedItem + change;
+  nextIndex >= List.length(commands) || nextIndex < 0 ?
+    0 : selectedItem + change;
+};
 
 let addCommands = (factory: commandFactory, effects: option(Effects.t)) =>
   switch (effects) {

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -37,14 +37,14 @@ let reduce = (state, action: Actions.t) =>
       menuType: menu,
       commands: addCommands(commands, state.effects),
     }
-  | MenuClose => {...state, isOpen: false, menuType: Closed}
+  | MenuClose => {...state, isOpen: false, menuType: Closed, selectedItem: 0}
   | MenuSelect =>
     /**
-    TODO: Refactor this to middleware so this action is handled like a redux side-effect
-    as this makes the reducer impure
-   */
-    let selected = List.nth(state.commands, state.selectedItem);
-    selected.command();
-    {...state, isOpen: false};
+      TODO: Refactor this to middleware so this action is handled like a redux side-effect
+      as this makes the reducer impure
+     */
+    List.nth(state.commands, state.selectedItem)
+    |> (selected => selected.command());
+    {...state, isOpen: false, menuType: Closed};
   | _ => state
   };

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -1,0 +1,59 @@
+open Oni_Core;
+open Types;
+open UiMenu;
+
+let emptyCommands = _effects => [];
+
+let create = (~effects: option(Effects.t)=?, ~commands=emptyCommands, ()) =>
+  switch (effects) {
+  | Some(e) => {
+      menuType: Closed,
+      isOpen: false,
+      commands: commands(e),
+      selectedItem: 0,
+      effects,
+    }
+  | None => {
+      menuType: Closed,
+      isOpen: false,
+      commands: [],
+      selectedItem: 0,
+      effects: None,
+    }
+  };
+
+let addEffects = (effects: Effects.t) =>
+  Actions.MenuRegisterEffects(effects);
+
+let position = (selectedItem, change, commands: list(command)) =>
+  selectedItem + change >= List.length(commands) ? 0 : selectedItem + change;
+
+let addCommands = (factory: commandFactory, effects: option(Effects.t)) =>
+  switch (effects) {
+  | Some(e) => factory(e)
+  | None => []
+  };
+
+let reduce = (state, action: Actions.t) =>
+  switch (action) {
+  | MenuPosition(pos) => {
+      ...state,
+      selectedItem: position(state.selectedItem, pos, state.commands),
+    }
+  | MenuOpen((menu, commands)) => {
+      ...state,
+      isOpen: true,
+      menuType: menu,
+      commands: addCommands(commands, state.effects),
+    }
+  | MenuClose => {...state, isOpen: false, menuType: Closed}
+  | MenuSelect =>
+    /**
+    TODO: Refactor this to middleware so this action is handled like a redux side-effect
+    as this makes the reducer impure
+   */
+    let selected = List.nth(state.commands, state.selectedItem);
+    selected.command();
+    {...state, isOpen: false};
+  | _ => state
+  };

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -22,3 +22,4 @@ module Tokenizer = Tokenizer;
 module Wildmenu = Wildmenu;
 module Menu = Menu;
 module QuickOpen = QuickOpen;
+module Filter = Filter;

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -22,4 +22,3 @@ module Tokenizer = Tokenizer;
 module Wildmenu = Wildmenu;
 module Menu = Menu;
 module QuickOpen = QuickOpen;
-module Filter = Filter;

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -20,3 +20,4 @@ module State = State;
 module SyntaxHighlighting = SyntaxHighlighting;
 module Tokenizer = Tokenizer;
 module Wildmenu = Wildmenu;
+module Menu = Menu;

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -21,3 +21,4 @@ module SyntaxHighlighting = SyntaxHighlighting;
 module Tokenizer = Tokenizer;
 module Wildmenu = Wildmenu;
 module Menu = Menu;
+module QuickOpen = QuickOpen;

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -1,5 +1,9 @@
 open Oni_Core.Types;
 
-let content = (effects: Effects.t): list(UiMenu.command) => [
-  {name: "test.txt", command: () => effects.openFile(~path="test.txt", ())},
-];
+let content = (effects: Effects.t) => {
+  let dirs = Revery.Environment.getWorkingDirectory() |> Sys.readdir;
+  Array.to_list(dirs)
+  |> List.map(file =>
+       UiMenu.{name: file, command: () => effects.openFile(~path=file, ())}
+     );
+};

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -9,7 +9,10 @@ let content = (effects: Effects.t) =>
     | None => [||]
   )
   |> Array.to_list
-  /* In the future we might want to allow functionality like switching to a directory on select */
+  /*
+     In the future we might want to allow
+     functionality like switching to a directory on select
+   */
   |> List.filter(item => !Sys.is_directory(item))
   |> List.map(file =>
        {

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -1,4 +1,5 @@
 open Oni_Core.Types;
+open UiMenu;
 
 let content = (effects: Effects.t) =>
   effects.getCurrentDir()
@@ -8,6 +9,7 @@ let content = (effects: Effects.t) =>
     | None => [||]
   )
   |> Array.to_list
+  |> List.filter(item => !Sys.is_directory(item))
   |> List.map(file =>
-       UiMenu.{name: file, command: () => effects.openFile(~path=file, ())}
+       {name: file, command: () => effects.openFile(~path=file, ())}
      );

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -1,0 +1,5 @@
+open Oni_Core.Types;
+
+let content = (effects: Effects.t): list(UiMenu.command) => [
+  {name: "test.txt", command: () => effects.openFile(~path="test.txt", ())},
+];

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -9,7 +9,12 @@ let content = (effects: Effects.t) =>
     | None => [||]
   )
   |> Array.to_list
+  /* In the future we might want to allow functionality like switching to a directory on select */
   |> List.filter(item => !Sys.is_directory(item))
   |> List.map(file =>
-       {name: file, command: () => effects.openFile(~path=file, ())}
+       {
+         name: file,
+         command: () => effects.openFile(~path=file, ()),
+         icon: Some({||}),
+       }
      );

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -12,6 +12,7 @@ let content = (effects: Effects.t) =>
   /*
      In the future we might want to allow
      functionality like switching to a directory on select
+     ...for now we filter out all directories
    */
   |> List.filter(item => !Sys.is_directory(item))
   |> List.map(file =>

--- a/src/editor/Model/QuickOpen.re
+++ b/src/editor/Model/QuickOpen.re
@@ -1,9 +1,13 @@
 open Oni_Core.Types;
 
-let content = (effects: Effects.t) => {
-  let dirs = Revery.Environment.getWorkingDirectory() |> Sys.readdir;
-  Array.to_list(dirs)
+let content = (effects: Effects.t) =>
+  effects.getCurrentDir()
+  |> (
+    fun
+    | Some(dir) => Sys.readdir(dir)
+    | None => [||]
+  )
+  |> Array.to_list
   |> List.map(file =>
        UiMenu.{name: file, command: () => effects.openFile(~path=file, ())}
      );
-};

--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -70,7 +70,7 @@ let reduce: (State.t, Actions.t) => State.t =
       syntaxHighlighting: SyntaxHighlighting.reduce(s.syntaxHighlighting, a),
       wildmenu: Wildmenu.reduce(s.wildmenu, a),
       commandline: Commandline.reduce(s.commandline, a),
-      commandPalette: CommandPalette.reduce(s.commandPalette, a),
+      menu: Menu.reduce(s.menu, a),
     };
 
     switch (a) {

--- a/src/editor/Model/State.re
+++ b/src/editor/Model/State.re
@@ -25,7 +25,7 @@ type t = {
   activeBufferId: int,
   editorFont: EditorFont.t,
   uiFont: UiFont.t,
-  commandPalette: CommandPalette.t,
+  menu: UiMenu.t,
   commandline: Commandline.t,
   wildmenu: Wildmenu.t,
   configuration: Configuration.t,
@@ -39,7 +39,7 @@ let create: unit => t =
   () => {
     configuration: Configuration.create(),
     mode: Insert,
-    commandPalette: CommandPalette.create(),
+    menu: Menu.create(),
     commandline: Commandline.create(),
     wildmenu: Wildmenu.create(),
     activeBufferId: 0,

--- a/src/editor/Neovim/NeovimApi.re
+++ b/src/editor/Neovim/NeovimApi.re
@@ -32,7 +32,7 @@ type t = {
   onNotification: Event.t(notification),
 };
 
-exception RequestFailed;
+exception RequestFailed(string);
 
 let currentId = ref(0);
 
@@ -130,14 +130,14 @@ let make = (msgpack: MsgpackTransport.t) => {
       );
 
       if (List.length(getQueuedResponses()) == 0) {
-        prerr_endline(
+        let errorMessage =
           "Request timed out: "
           ++ methodName
           ++ " ("
           ++ string_of_int(requestId)
-          ++ ")",
-        );
-        raise(RequestFailed);
+          ++ ")";
+        prerr_endline(errorMessage);
+        raise(RequestFailed(errorMessage));
       };
 
       let matchingResponse =

--- a/src/editor/Neovim/NeovimProtocol.re
+++ b/src/editor/Neovim/NeovimProtocol.re
@@ -20,6 +20,8 @@ type t = {
   openFile: Views.viewOperation,
   closeFile: Views.viewOperation,
   moveCursor: Cursor.move,
+  getCurrentDir: unit => option(string),
+  setCurrentDir: string => unit,
   /* TODO */
   /* Typed notifications */
   onNotification: Event.t(Notification.t),
@@ -132,6 +134,21 @@ let make = (nvimApi: NeovimApi.t) => {
       |> ignore;
     };
 
+  let getCurrentDir = () =>
+    nvimApi.requestSync(
+      "nvim_call_function",
+      M.List([M.String("getcwd"), M.List([])]),
+    )
+    |> (
+      fun
+      | M.String(dir) => Some(dir)
+      | _ => None
+    );
+
+  let setCurrentDir = dir =>
+    nvimApi.requestSync("nvim_get_current_dir", M.List([M.String(dir)]))
+    |> ignore;
+
   {
     uiAttach,
     input,
@@ -139,6 +156,8 @@ let make = (nvimApi: NeovimApi.t) => {
     bufAttach,
     openFile,
     closeFile,
+    setCurrentDir,
+    getCurrentDir,
     moveCursor,
   };
 };

--- a/src/editor/Neovim/NeovimProtocol.re
+++ b/src/editor/Neovim/NeovimProtocol.re
@@ -135,14 +135,20 @@ let make = (nvimApi: NeovimApi.t) => {
     };
 
   let getCurrentDir = () =>
-    nvimApi.requestSync(
-      "nvim_call_function",
-      M.List([M.String("getcwd"), M.List([])]),
-    )
-    |> (
-      fun
-      | M.String(dir) => Some(dir)
-      | _ => None
+    NeovimApi.(
+      try (
+        nvimApi.requestSync(
+          "nvim_call_function",
+          M.List([M.String("getcwd"), M.List([])]),
+        )
+        |> (
+          fun
+          | M.String(dir) => Some(dir)
+          | _ => None
+        )
+      ) {
+      | RequestFailed(_) => None
+      }
     );
 
   let setCurrentDir = dir =>

--- a/src/editor/Neovim/NeovimProtocol.re
+++ b/src/editor/Neovim/NeovimProtocol.re
@@ -146,7 +146,7 @@ let make = (nvimApi: NeovimApi.t) => {
     );
 
   let setCurrentDir = dir =>
-    nvimApi.requestSync("nvim_get_current_dir", M.List([M.String(dir)]))
+    nvimApi.requestSync("nvim_set_current_dir", M.List([M.String(dir)]))
     |> ignore;
 
   {

--- a/src/editor/UI/CommandPaletteView.re
+++ b/src/editor/UI/CommandPaletteView.re
@@ -1,8 +1,8 @@
 open Revery;
 open Oni_Core;
-open Oni_Model;
 open Revery.UI;
 open Revery.UI.Components;
+open Types;
 
 let component = React.component("commandPalette");
 
@@ -25,29 +25,30 @@ let containerStyles = (theme: Theme.t) =>
 
 let paletteItemStyle = Style.[fontSize(14)];
 
-let createElement =
-    (~children as _, ~commandPalette: CommandPalette.t, ~theme: Theme.t, ()) =>
+let createElement = (~children as _, ~menu: UiMenu.t, ~theme: Theme.t, ()) =>
   component(hooks =>
     (
       hooks,
-      commandPalette.isOpen
-        ? <View style={containerStyles(theme)}>
-            /* <Input style=Style.[width(paletteWidth)] /> */
+      menu.isOpen ?
+        <View style={containerStyles(theme)}>
+          /* <Input style=Style.[width(paletteWidth)] /> */
 
-              <ScrollView style=Style.[height(350)]>
-                ...{List.mapi(
-                  (index, cmd: Types.Palette.command) =>
-                    <MenuItem
-                      icon=""
-                      style=paletteItemStyle
-                      label={cmd.name}
-                      selected={index == commandPalette.selectedItem}
-                      theme
-                    />,
-                  commandPalette.commands,
-                )}
-              </ScrollView>
-            </View>
-        : React.listToElement([]),
+            <ScrollView style=Style.[height(350)]>
+              ...{
+                   List.mapi(
+                     (index, cmd: UiMenu.command) =>
+                       <MenuItem
+                         icon=""
+                         style=paletteItemStyle
+                         label={cmd.name}
+                         selected={index == menu.selectedItem}
+                         theme
+                       />,
+                     menu.commands,
+                   )
+                 }
+            </ScrollView>
+          </View> :
+        React.listToElement([]),
     )
   );

--- a/src/editor/UI/GlobalContext.re
+++ b/src/editor/UI/GlobalContext.re
@@ -18,6 +18,7 @@ type t = {
   editorScroll,
   openFile: Views.viewOperation,
   closeFile: Views.viewOperation,
+  dispatch: Actions.t => unit,
   state: State.t,
 };
 
@@ -29,6 +30,7 @@ let default = {
   notifySizeChanged: (~width as _, ~height as _, ()) => (),
   editorScroll: (~deltaY as _, ()) => (),
   openFile: viewNoop,
+  dispatch: _ => (),
   closeFile: viewNoop,
 };
 

--- a/src/editor/UI/MenuItem.re
+++ b/src/editor/UI/MenuItem.re
@@ -21,7 +21,7 @@ let containerStyles = (~bg, ()) =>
 
 let iconStyles =
   Style.[
-    fontFamily("FontAwesome5FreeRegular.otf"),
+    fontFamily("FontAwesome5FreeSolid.otf"),
     fontSize(menuItemFontSize),
     marginRight(10),
   ];

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -4,7 +4,7 @@ open Revery.UI;
 open Revery.UI.Components;
 open Types;
 
-let component = React.component("commandPalette");
+let component = React.component("Menu");
 
 let paletteWidth = 400;
 

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -47,11 +47,20 @@ let createElement =
       hooks,
       menu.isOpen ?
         <View style={containerStyles(theme)}>
-          <Input
-            placeholder="type here to search the menu"
-            style=Style.[width(menuWidth), fontFamily(font.fontFile)]
-            onChange=handleChange
-          />
+          <View style=Style.[width(menuWidth), padding(5)]>
+            <Input
+              placeholder="type here to search the menu"
+              cursorColor=Colors.white
+              style=Style.[
+                border(~width=2, ~color=Color.rgba(0., 0., 0., 0.1)),
+                backgroundColor(Color.rgba(0., 0., 0., 0.3)),
+                width(menuWidth - 10),
+                color(Colors.white),
+                fontFamily(font.fontFile),
+              ]
+              onChange=handleChange
+            />
+          </View>
           <ScrollView style=Style.[height(menuHeight - 50)]>
             ...{
                  List.mapi(

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -54,33 +54,31 @@ let createElement =
   component(hooks =>
     (
       hooks,
-      menu.isOpen ?
-        <View style={containerStyles(theme)}>
-          <View style=Style.[width(menuWidth), padding(5)]>
-            <Input
-              autofocus=true
-              placeholder="type here to search the menu"
-              cursorColor=Colors.white
-              style={inputStyles(font.fontFile)}
-              onChange=handleChange
-            />
+      menu.isOpen
+        ? <View style={containerStyles(theme)}>
+            <View style=Style.[width(menuWidth), padding(5)]>
+              <Input
+                autofocus=true
+                placeholder="type here to search the menu"
+                cursorColor=Colors.white
+                style={inputStyles(font.fontFile)}
+                onChange=handleChange
+              />
+            </View>
+            <ScrollView style=Style.[height(menuHeight - 50)]>
+              ...{List.mapi(
+                (index, cmd: Types.UiMenu.command) =>
+                  <MenuItem
+                    icon={getIcon(cmd.icon)}
+                    style=menuItemStyle
+                    label={cmd.name}
+                    selected={index == menu.selectedItem}
+                    theme
+                  />,
+                menu.commands,
+              )}
+            </ScrollView>
           </View>
-          <ScrollView style=Style.[height(menuHeight - 50)]>
-            ...{
-                 List.mapi(
-                   (index, cmd: Types.UiMenu.command) =>
-                     <MenuItem
-                       icon={getIcon(cmd.icon)}
-                       style=menuItemStyle
-                       label={cmd.name}
-                       selected={index == menu.selectedItem}
-                       theme
-                     />,
-                   menu.commands,
-                 )
-               }
-          </ScrollView>
-        </View> :
-        React.listToElement([]),
+        : React.listToElement([]),
     )
   );

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -54,32 +54,30 @@ let createElement =
   component(hooks =>
     (
       hooks,
-      menu.isOpen ?
-        <View style={containerStyles(theme)}>
-          <View style=Style.[width(menuWidth), padding(5)]>
-            <Input
-              placeholder="type here to search the menu"
-              cursorColor=Colors.white
-              style={inputStyles(font.fontFile)}
-              onChange=handleChange
-            />
+      menu.isOpen
+        ? <View style={containerStyles(theme)}>
+            <View style=Style.[width(menuWidth), padding(5)]>
+              <Input
+                placeholder="type here to search the menu"
+                cursorColor=Colors.white
+                style={inputStyles(font.fontFile)}
+                onChange=handleChange
+              />
+            </View>
+            <ScrollView style=Style.[height(menuHeight - 50)]>
+              ...{List.mapi(
+                (index, cmd: Types.UiMenu.command) =>
+                  <MenuItem
+                    icon={getIcon(cmd.icon)}
+                    style=menuItemStyle
+                    label={cmd.name}
+                    selected={index == menu.selectedItem}
+                    theme
+                  />,
+                menu.commands,
+              )}
+            </ScrollView>
           </View>
-          <ScrollView style=Style.[height(menuHeight - 50)]>
-            ...{
-                 List.mapi(
-                   (index, cmd: Types.UiMenu.command) =>
-                     <MenuItem
-                       icon={getIcon(cmd.icon)}
-                       style=menuItemStyle
-                       label={cmd.name}
-                       selected={index == menu.selectedItem}
-                       theme
-                     />,
-                   menu.commands,
-                 )
-               }
-          </ScrollView>
-        </View> :
-        React.listToElement([]),
+        : React.listToElement([]),
     )
   );

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -25,6 +25,12 @@ let containerStyles = (theme: Theme.t) =>
 
 let paletteItemStyle = Style.[fontSize(14)];
 
+let getIcon = icon =>
+  switch (icon) {
+  | Some(i) => i
+  | None => ""
+  };
+
 let createElement = (~children as _, ~menu: UiMenu.t, ~theme: Theme.t, ()) =>
   component(hooks =>
     (
@@ -38,7 +44,7 @@ let createElement = (~children as _, ~menu: UiMenu.t, ~theme: Theme.t, ()) =>
                    List.mapi(
                      (index, cmd: UiMenu.command) =>
                        <MenuItem
-                         icon=""
+                         icon={getIcon(cmd.icon)}
                          style=paletteItemStyle
                          label={cmd.name}
                          selected={index == menu.selectedItem}

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -1,13 +1,12 @@
 open Revery;
-open Oni_Core;
 open Revery.UI;
 open Revery.UI.Components;
-open Types;
+open Oni_Core;
 
 let component = React.component("Menu");
 
 let menuWidth = 400;
-let menuHeight = 300;
+let menuHeight = 350;
 
 let containerStyles = (theme: Theme.t) =>
   Style.[
@@ -32,30 +31,43 @@ let getIcon = icon =>
   | None => ""
   };
 
-let createElement = (~children as _, ~menu: UiMenu.t, ~theme: Theme.t, ()) =>
+let handleChange = (~value) =>
+  GlobalContext.current().dispatch(MenuSearch(value));
+
+let createElement =
+    (
+      ~children as _,
+      ~font: Types.UiFont.t,
+      ~menu: Types.UiMenu.t,
+      ~theme: Theme.t,
+      (),
+    ) =>
   component(hooks =>
     (
       hooks,
       menu.isOpen ?
         <View style={containerStyles(theme)}>
-          /* <Input style=Style.[width(paletteWidth)] /> */
-
-            <ScrollView style=Style.[height(menuHeight)]>
-              ...{
-                   List.mapi(
-                     (index, cmd: UiMenu.command) =>
-                       <MenuItem
-                         icon={getIcon(cmd.icon)}
-                         style=paletteItemStyle
-                         label={cmd.name}
-                         selected={index == menu.selectedItem}
-                         theme
-                       />,
-                     menu.commands,
-                   )
-                 }
-            </ScrollView>
-          </View> :
+          <Input
+            placeholder="type here to search the menu"
+            style=Style.[width(menuWidth), fontFamily(font.fontFile)]
+            onChange=handleChange
+          />
+          <ScrollView style=Style.[height(menuHeight - 50)]>
+            ...{
+                 List.mapi(
+                   (index, cmd: Types.UiMenu.command) =>
+                     <MenuItem
+                       icon={getIcon(cmd.icon)}
+                       style=paletteItemStyle
+                       label={cmd.name}
+                       selected={index == menu.selectedItem}
+                       theme
+                     />,
+                   menu.commands,
+                 )
+               }
+          </ScrollView>
+        </View> :
         React.listToElement([]),
     )
   );

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -6,14 +6,15 @@ open Types;
 
 let component = React.component("Menu");
 
-let paletteWidth = 400;
+let menuWidth = 400;
+let menuHeight = 300;
 
 let containerStyles = (theme: Theme.t) =>
   Style.[
     backgroundColor(theme.colors.editorMenuBackground),
     color(theme.colors.editorMenuForeground),
-    width(paletteWidth),
-    height(300),
+    width(menuWidth),
+    height(menuHeight),
     boxShadow(
       ~xOffset=-15.,
       ~yOffset=5.,
@@ -39,7 +40,7 @@ let createElement = (~children as _, ~menu: UiMenu.t, ~theme: Theme.t, ()) =>
         <View style={containerStyles(theme)}>
           /* <Input style=Style.[width(paletteWidth)] /> */
 
-            <ScrollView style=Style.[height(350)]>
+            <ScrollView style=Style.[height(menuHeight)]>
               ...{
                    List.mapi(
                      (index, cmd: UiMenu.command) =>

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -40,7 +40,7 @@ let getIcon = icon =>
   | None => ""
   };
 
-let handleChange = (~value) =>
+let handleChange = ({value, _}: Input.changeEvent) =>
   GlobalContext.current().dispatch(MenuSearch(value));
 
 let createElement =

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -23,7 +23,16 @@ let containerStyles = (theme: Theme.t) =>
     ),
   ];
 
-let paletteItemStyle = Style.[fontSize(14)];
+let menuItemStyle = Style.[fontSize(14)];
+
+let inputStyles = font =>
+  Style.[
+    border(~width=2, ~color=Color.rgba(0., 0., 0., 0.1)),
+    backgroundColor(Color.rgba(0., 0., 0., 0.3)),
+    width(menuWidth - 10),
+    color(Colors.white),
+    fontFamily(font),
+  ];
 
 let getIcon = icon =>
   switch (icon) {
@@ -51,13 +60,7 @@ let createElement =
             <Input
               placeholder="type here to search the menu"
               cursorColor=Colors.white
-              style=Style.[
-                border(~width=2, ~color=Color.rgba(0., 0., 0., 0.1)),
-                backgroundColor(Color.rgba(0., 0., 0., 0.3)),
-                width(menuWidth - 10),
-                color(Colors.white),
-                fontFamily(font.fontFile),
-              ]
+              style={inputStyles(font.fontFile)}
               onChange=handleChange
             />
           </View>
@@ -67,7 +70,7 @@ let createElement =
                    (index, cmd: Types.UiMenu.command) =>
                      <MenuItem
                        icon={getIcon(cmd.icon)}
-                       style=paletteItemStyle
+                       style=menuItemStyle
                        label={cmd.name}
                        selected={index == menu.selectedItem}
                        theme

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -54,30 +54,33 @@ let createElement =
   component(hooks =>
     (
       hooks,
-      menu.isOpen
-        ? <View style={containerStyles(theme)}>
-            <View style=Style.[width(menuWidth), padding(5)]>
-              <Input
-                placeholder="type here to search the menu"
-                cursorColor=Colors.white
-                style={inputStyles(font.fontFile)}
-                onChange=handleChange
-              />
-            </View>
-            <ScrollView style=Style.[height(menuHeight - 50)]>
-              ...{List.mapi(
-                (index, cmd: Types.UiMenu.command) =>
-                  <MenuItem
-                    icon={getIcon(cmd.icon)}
-                    style=menuItemStyle
-                    label={cmd.name}
-                    selected={index == menu.selectedItem}
-                    theme
-                  />,
-                menu.commands,
-              )}
-            </ScrollView>
+      menu.isOpen ?
+        <View style={containerStyles(theme)}>
+          <View style=Style.[width(menuWidth), padding(5)]>
+            <Input
+              autofocus=true
+              placeholder="type here to search the menu"
+              cursorColor=Colors.white
+              style={inputStyles(font.fontFile)}
+              onChange=handleChange
+            />
           </View>
-        : React.listToElement([]),
+          <ScrollView style=Style.[height(menuHeight - 50)]>
+            ...{
+                 List.mapi(
+                   (index, cmd: Types.UiMenu.command) =>
+                     <MenuItem
+                       icon={getIcon(cmd.icon)}
+                       style=menuItemStyle
+                       label={cmd.name}
+                       selected={index == menu.selectedItem}
+                       theme
+                     />,
+                   menu.commands,
+                 )
+               }
+          </ScrollView>
+        </View> :
+        React.listToElement([]),
     )
   );

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -59,7 +59,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         <Overlay>
           <CommandlineView theme command={state.commandline} />
           <WildmenuView theme wildmenu={state.wildmenu} />
-          <MenuView theme menu={state.menu} />
+          <MenuView theme menu={state.menu} font={state.uiFont} />
         </Overlay>
         <View style=statusBarStyle>
           <StatusBar height=statusBarHeight state />

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -59,7 +59,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         <Overlay>
           <CommandlineView theme command={state.commandline} />
           <WildmenuView theme wildmenu={state.wildmenu} />
-          <CommandPaletteView theme menu={state.menu} />
+          <MenuView theme menu={state.menu} />
         </Overlay>
         <View style=statusBarStyle>
           <StatusBar height=statusBarHeight state />

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -59,7 +59,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
         <Overlay>
           <CommandlineView theme command={state.commandline} />
           <WildmenuView theme wildmenu={state.wildmenu} />
-          <CommandPaletteView theme commandPalette={state.commandPalette} />
+          <CommandPaletteView theme menu={state.menu} />
         </Overlay>
         <View style=statusBarStyle>
           <StatusBar height=statusBarHeight state />

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -108,5 +108,5 @@ let handle =
       default;
     | actions => actions
     }
-  | _ => getActionsForBinding(inputKey, commands, state)
+  | MenuFocus => getActionsForBinding(inputKey, commands, state)
   };

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -199,7 +199,7 @@ let init = app => {
       /**
        If a Revery UI element is focused but <ESC> is hit this should
        unfocus the element, this should probably eventually live in
-       Revery itself as default behaviour?
+       Revery itself as default behaviour
      */
       Focus.loseFocus();
       inputHandler(~state=App.getState(app), v)

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -192,25 +192,31 @@ let init = app => {
 
   let inputHandler = Input.handle(~api=neovimProtocol, ~commands);
 
-  Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
-    switch (Input.charToCommand(codepoint, mods), Focus.focused) {
+  let keyEventListener = key =>
+    switch (key, Focus.focused) {
     | (None, _) => ()
+    | (Some("<ESC>" as v), {contents: Some(_)}) =>
+      /**
+       If a Revery UI element is focused but <ESC> is hit this should
+       unfocus the element, this should probably eventually live in
+       Revery itself as default behaviour?
+     */
+      Focus.loseFocus();
+      inputHandler(~state=App.getState(app), v)
+      |> List.iter(App.dispatch(app));
     | (Some(_), {contents: Some(_)}) => ()
     | (Some(v), {contents: None}) =>
       inputHandler(~state=App.getState(app), v)
       |> List.iter(App.dispatch(app))
-    }
+    };
+
+  Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
+    Input.charToCommand(codepoint, mods) |> keyEventListener
   );
 
   Reglfw.Glfw.glfwSetKeyCallback(
     w.glfwWindow, (_w, key, _scancode, buttonState, mods) =>
-    switch (Input.keyPressToCommand(key, buttonState, mods), Focus.focused) {
-    | (None, _) => ()
-    | (Some(_), {contents: Some(_)}) => ()
-    | (Some(v), {contents: None}) =>
-      inputHandler(~state=App.getState(app), v)
-      |> List.iter(App.dispatch(app))
-    }
+    Input.keyPressToCommand(key, buttonState, mods) |> keyEventListener
   );
 
   let _ =

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -182,7 +182,10 @@ let init = app => {
 
   let commands = Core.Keybindings.get();
 
-  Model.Menu.addEffects({openFile: neovimProtocol.openFile})
+  Model.Menu.addEffects({
+    openFile: neovimProtocol.openFile,
+    getCurrentDir: neovimProtocol.getCurrentDir,
+  })
   |> App.dispatch(app)
   |> ignore;
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -125,6 +125,7 @@ let init = app => {
         App.dispatch(app, Model.Actions.EditorScroll(deltaY)),
       openFile: neovimProtocol.openFile,
       closeFile: neovimProtocol.closeFile,
+      dispatch: App.dispatch(app),
     });
 
     <Root state />;
@@ -192,9 +193,10 @@ let init = app => {
   let inputHandler = Input.handle(~api=neovimProtocol, ~commands);
 
   Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
-    switch (Input.charToCommand(codepoint, mods)) {
-    | None => ()
-    | Some(v) =>
+    switch (Input.charToCommand(codepoint, mods), Focus.focused) {
+    | (None, _) => ()
+    | (Some(_), {contents: Some(_)}) => ()
+    | (Some(v), {contents: None}) =>
       inputHandler(~state=App.getState(app), v)
       |> List.iter(App.dispatch(app))
     }
@@ -202,9 +204,10 @@ let init = app => {
 
   Reglfw.Glfw.glfwSetKeyCallback(
     w.glfwWindow, (_w, key, _scancode, buttonState, mods) =>
-    switch (Input.keyPressToCommand(key, buttonState, mods)) {
-    | None => ()
-    | Some(v) =>
+    switch (Input.keyPressToCommand(key, buttonState, mods), Focus.focused) {
+    | (None, _) => ()
+    | (Some(_), {contents: Some(_)}) => ()
+    | (Some(v), {contents: None}) =>
       inputHandler(~state=App.getState(app), v)
       |> List.iter(App.dispatch(app))
     }

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -182,7 +182,7 @@ let init = app => {
 
   let commands = Core.Keybindings.get();
 
-  Model.CommandPalette.make(~effects={openFile: neovimProtocol.openFile})
+  Model.Menu.addEffects({openFile: neovimProtocol.openFile})
   |> App.dispatch(app)
   |> ignore;
 


### PR DESCRIPTION
![quickopen](https://user-images.githubusercontent.com/22454918/54567902-508c3500-49cd-11e9-95be-3c001ec73728.gif)

**Update**: with input
![quickopen-2](https://user-images.githubusercontent.com/22454918/54644792-2cdef280-4a92-11e9-807d-f831bbb5d219.gif)

### Outstanding (for a separate PR: see revery-ui/revery#408):
There's still a few kinks to iron out which primarily relate to things in revery
so I'd like to tie those up and then return to this in a separate PR once those changes are in.

- [x] Input should autofocus on open
- [x] Expose the key pressed (in Revery) so that logic based on the specific key can be handled in the onchange - use this to handle pressing escape which should return focus to Oni2
- [x] Fix cursor positioning on start
- [x] Add arrow key behaviour to input
- [ ] Fix backspace not responding
