### PR TITLE
Fix #170 - Dead key / encoding issues

### DIFF
--- a/assets/viml/init.vim
+++ b/assets/viml/init.vim
@@ -49,7 +49,7 @@ augroup END
 function OniGetContext()
     let bufferNumber = bufnr("%")
     let line = line(".")
-    let column = col(".")
+    let column = virtcol(".")
     let modified = getbufvar(bufferNumber, "&modified")
 
     let context = [bufferNumber, line, column, modified]

--- a/src/editor/Model/Tokenizer.re
+++ b/src/editor/Model/Tokenizer.re
@@ -23,7 +23,7 @@ let _isNonWhitespace = c => !_isWhitespace(c);
 
 let _moveToNextMatchingToken = (f, str, startIdx) => {
   let idx = ref(startIdx);
-  let length = String.length(str);
+  let length = Zed_utf8.length(str);
   let found = ref(false);
 
   while (idx^ < length && ! found^) {
@@ -45,7 +45,7 @@ let _getAllTokens = (s: string, color: Color.t, startPos, endPos) => {
   let idx = ref(startPos);
   let tokens: ref(list(t)) = ref([]);
 
-  let endPos = min(endPos, String.length(s));
+  let endPos = min(endPos, Zed_utf8.length(s));
 
   while (idx^ < endPos) {
     let startToken = _moveToNextNonWhitespace(s, idx^);
@@ -53,7 +53,7 @@ let _getAllTokens = (s: string, color: Color.t, startPos, endPos) => {
 
     if (startToken < endPos) {
       let length = endToken - startToken;
-      let text = String.sub(s, startToken, length);
+      let text = Zed_utf8.sub(s, startToken, length);
 
       let token: t = {
         text,
@@ -83,7 +83,7 @@ let rec getTokens =
 
   let ret: list(t) =
     switch (tokens) {
-    | [] => _getAllTokens(s, defaultForegroundColor, pos, String.length(s))
+    | [] => _getAllTokens(s, defaultForegroundColor, pos, Zed_utf8.length(s))
     | [last] =>
       _getAllTokens(
         s,
@@ -94,7 +94,7 @@ let rec getTokens =
           defaultBackgroundColor,
         ),
         last.index,
-        String.length(s),
+        Zed_utf8.length(s),
       )
     | [v1, v2, ...tail] =>
       let nextBatch =

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -20,7 +20,7 @@ let keyPressToString = (~altKey, ~shiftKey, ~ctrlKey, ~superKey, s) => {
   let s = superKey ? "D-" ++ s : s;
 
   let ret = Zed_utf8.length(s) > 1 ? "<" ++ s ++ ">" : s;
-  print_endline ("keyPressToString: " ++ ret);
+  print_endline("keyPressToString: " ++ ret);
   ret;
 };
 
@@ -105,7 +105,7 @@ let handle =
   | EditorTextFocus =>
     switch (getActionsForBinding(inputKey, commands, state)) {
     | [] as default =>
-      print_endline ("inputting key");
+      print_endline("inputting key");
       api.input(inputKey) |> ignore;
       default;
     | actions => actions

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -105,7 +105,6 @@ let handle =
   | EditorTextFocus =>
     switch (getActionsForBinding(inputKey, commands, state)) {
     | [] as default =>
-      print_endline("inputting key");
       api.input(inputKey) |> ignore;
       default;
     | actions => actions

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -9,6 +9,8 @@ open Oni_Model;
 open Reglfw.Glfw;
 open Reglfw.Glfw.Key;
 
+open CamomileLibraryDefault.Camomile;
+
 let keyPressToString = (~altKey, ~shiftKey, ~ctrlKey, ~superKey, s) => {
   let s = s == "<" ? "lt" : s;
 
@@ -17,11 +19,13 @@ let keyPressToString = (~altKey, ~shiftKey, ~ctrlKey, ~superKey, s) => {
   let s = altKey ? "A-" ++ s : s;
   let s = superKey ? "D-" ++ s : s;
 
-  String.length(s) > 1 ? "<" ++ s ++ ">" : s;
+  let ret = Zed_utf8.length(s) > 1 ? "<" ++ s ++ ">" : s;
+  print_endline ("keyPressToString: " ++ ret);
+  ret;
 };
 
 let charToCommand = (codepoint: int, mods: Modifier.t) => {
-  let char = String.make(1, Uchar.to_char(Uchar.of_int(codepoint)));
+  let char = Zed_utf8.singleton(UChar.of_int(codepoint));
 
   let altKey = Modifier.isAltPressed(mods);
   let ctrlKey = Modifier.isControlPressed(mods);
@@ -101,6 +105,7 @@ let handle =
   | EditorTextFocus =>
     switch (getActionsForBinding(inputKey, commands, state)) {
     | [] as default =>
+      print_endline ("inputting key");
       api.input(inputKey) |> ignore;
       default;
     | actions => actions

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -20,7 +20,6 @@ let keyPressToString = (~altKey, ~shiftKey, ~ctrlKey, ~superKey, s) => {
   let s = superKey ? "D-" ++ s : s;
 
   let ret = Zed_utf8.length(s) > 1 ? "<" ++ s ++ ">" : s;
-  print_endline("keyPressToString: " ++ ret);
   ret;
 };
 


### PR DESCRIPTION
__Issue:__ Using a dead key to compose a character (for example, typing a `ä` with two keystrokes - `"` and `a` would take multiple tries to get it to write to the buffer. Then, when it finally took, the cursor position would be off.

__Defect:__ There were a couple issues blocking this:
- We were sending the character as a one-byte char, even when it was encoded. In some cases, this would throw an exception, in others, we simply wouldn't send the right thing. Downstream, in our string parsing, we need to treat the buffer strings as UTF8.
- We were using the `col` VimL function, which returns a `byte` position 

__Fixes:__
- Use `Zed_utf8` for working with the buffer strings. Send the full UTF8 string, not just a one-byte char.
- Use the `virtcol` function instead of `col`