### PR TITLE
Update Rely.

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -9,13 +9,21 @@ steps:
     displayName: 'Bootstrap Oni2 setup with system specific build variables'
   - script: esy build
     displayName: 'Build: esy build'
-  - script: esy x OniUnitTestRunner
-    displayName: 'Unit Tests: esy x OniUnitTestRunner (round 1)'
+  - script: esy test-ci
+    displayName: 'Unit Tests: esy test-ci (round 1)'
   # TODO: Stabilize and bring back!
   # - script: esy x OniUnitTestRunner
   #   displayName: 'Unit Tests: esy x OniUnitTestRunner (round 2)'
   # - script: esy x OniUnitTestRunner
   #   displayName: 'Unit Tests: esy x OniUnitTestRunner (round 3)'
+  - task: PublishTestResults@2
+    displayName: 'Publish JUnit file'
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: '**/*junit.xml'
+      buildPlatform: ${{ parameters.platform }}
+      testRunTitle: ${{ parameters.platform }}
+      failTaskOnFailedTests: true
   - script: esy @bench install
     displayName: "Bench: install"
   - script: esy @bench build

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ _release/
 .DS_Store
 setup.txt
 setup.json
+
+# JUnit test output for CI
+*junit\.xml

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b2432cbcc7e76b83d5dbdf43773759d8",
+  "checksum": "4f2403b3293d9e549beaf8afcf3d7087",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "universalify@0.1.2@d41d8cd9": {
@@ -76,7 +76,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@reason-native/rely@1.0.1@d41d8cd9",
+        "@reason-native/rely@1.3.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.1.0@4db5bd2a",
         "@opam/lambda-term@opam:1.13@a3d28a27",
@@ -152,7 +152,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@reason-native/rely@1.0.1@d41d8cd9",
+        "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@opam:1.5.0@890db858",
         "@opam/merlin@opam:3.2.2@829ee6dd", "@opam/lwt@opam:4.1.0@4db5bd2a",
         "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/reason@3.4.0@d41d8cd9"
@@ -384,7 +384,7 @@
         "rench@1.4.0@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#a73f349@d41d8cd9",
         "reason-glfw@3.2.1023@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@reason-native/rely@1.0.1@d41d8cd9", "@opam/zed@opam:1.6@004ea65e",
+        "@reason-native/rely@1.3.1@d41d8cd9", "@opam/zed@opam:1.6@004ea65e",
         "@opam/yojson@opam:1.5.0@890db858",
         "@opam/ppx_deriving_yojson@opam:3.3@80aab5d8",
         "@opam/ppx_deriving@opam:4.2.1@7927b93a",
@@ -399,14 +399,14 @@
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@829ee6dd"
       ]
     },
-    "@reason-native/rely@1.0.1@d41d8cd9": {
-      "id": "@reason-native/rely@1.0.1@d41d8cd9",
+    "@reason-native/rely@1.3.1@d41d8cd9": {
+      "id": "@reason-native/rely@1.3.1@d41d8cd9",
       "name": "@reason-native/rely",
-      "version": "1.0.1",
+      "version": "1.3.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native/rely/-/rely-1.0.1.tgz#sha1:14afdbf5bada7739dd9a68d4817c53e7d5ddd50c"
+          "archive:https://registry.npmjs.org/@reason-native/rely/-/rely-1.3.1.tgz#sha1:f57050aac6887196d1a41f0d42c7b5ec0adee271"
         ]
       },
       "overrides": [],
@@ -414,6 +414,7 @@
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/pastel@0.1.0@d41d8cd9",
         "@reason-native/file-context-printer@0.0.3@d41d8cd9",
+        "@opam/re@opam:1.8.0@7baac1a7", "@opam/junit@opam:2.0.1@c25e35a7",
         "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/reason@3.4.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -528,6 +529,35 @@
         "@opam/biniou@opam:1.2.0@c8516f18"
       ]
     },
+    "@opam/uutf@opam:1.0.2@4440868f": {
+      "id": "@opam/uutf@opam:1.0.2@4440868f",
+      "name": "@opam/uutf",
+      "version": "opam:1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a7/a7c542405a39630c689a82bd7ef2292c#md5:a7c542405a39630c689a82bd7ef2292c",
+          "archive:http://erratique.ch/software/uutf/releases/uutf-1.0.2.tbz#md5:a7c542405a39630c689a82bd7ef2292c"
+        ],
+        "opam": {
+          "name": "uutf",
+          "version": "1.0.2",
+          "path": "bench.esy.lock/opam/uutf.1.0.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
+        "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/cmdliner@opam:1.0.2@b29b7491",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+      ]
+    },
     "@opam/uchar@opam:0.0.2@c8218eea": {
       "id": "@opam/uchar@opam:0.0.2@c8218eea",
       "name": "@opam/uchar",
@@ -551,6 +581,33 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
+    "@opam/tyxml@opam:4.3.0@b35a7c40": {
+      "id": "@opam/tyxml@opam:4.3.0@b35a7c40",
+      "name": "@opam/tyxml",
+      "version": "opam:4.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fd/fd834a567f813bf447cab5f4c3a723e2#md5:fd834a567f813bf447cab5f4c3a723e2",
+          "archive:https://github.com/ocsigen/tyxml/releases/download/4.3.0/tyxml-4.3.0.tbz#md5:fd834a567f813bf447cab5f4c3a723e2"
+        ],
+        "opam": {
+          "name": "tyxml",
+          "version": "4.3.0",
+          "path": "bench.esy.lock/opam/tyxml.4.3.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.8.0@7baac1a7",
+        "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.8.0@7baac1a7"
+      ]
+    },
     "@opam/topkg@opam:1.0.0@61f4ccf9": {
       "id": "@opam/topkg@opam:1.0.0@61f4ccf9",
       "name": "@opam/topkg",
@@ -570,7 +627,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -640,7 +697,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -672,6 +729,35 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d"
       ]
     },
+    "@opam/ptime@opam:0.8.4@23eca65b": {
+      "id": "@opam/ptime@opam:0.8.4@23eca65b",
+      "name": "@opam/ptime",
+      "version": "opam:0.8.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12fb5e8c3eb1d2e6075ac31ce93f7dd6#md5:12fb5e8c3eb1d2e6075ac31ce93f7dd6",
+          "archive:http://erratique.ch/software/ptime/releases/ptime-0.8.4.tbz#md5:12fb5e8c3eb1d2e6075ac31ce93f7dd6"
+        ],
+        "opam": {
+          "name": "ptime",
+          "version": "0.8.4",
+          "path": "bench.esy.lock/opam/ptime.0.8.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/result@opam:1.3@bee8bf2e",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e"
+      ]
+    },
     "@opam/printbox@opam:0.2@31968522": {
       "id": "@opam/printbox@opam:0.2@31968522",
       "name": "@opam/printbox",
@@ -690,7 +776,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@72aad784",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/tyxml@opam:4.3.0@b35a7c40",
+        "@opam/dune@opam:1.7.3@72aad784",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -716,13 +803,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71"
       ]
     },
@@ -772,11 +859,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.3@80aab5d8": {
@@ -836,7 +923,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
         "@opam/ppx_tools@opam:5.1+4.06.0@a9357225",
         "@opam/ppx_derivers@opam:1.0@78655ff8",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/cppo_ocamlbuild@opam:1.6.0@7c1eb503",
@@ -895,20 +982,20 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ocamlfind@opam:1.8.0@96572762": {
-      "id": "@opam/ocamlfind@opam:1.8.0@96572762",
+    "@opam/ocamlfind@opam:1.8.0@4eaa30d0": {
+      "id": "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
       "name": "@opam/ocamlfind",
       "version": "opam:1.8.0",
       "source": {
@@ -1039,7 +1126,7 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -1063,12 +1150,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
-        "@opam/ocamlfind@opam:1.8.0@96572762"
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/menhir@opam:20181113@0c8257a8": {
@@ -1089,7 +1176,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1200,7 +1287,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -1248,6 +1335,31 @@
         "@opam/lwt_react@opam:1.1.1@a034a5ae",
         "@opam/lwt_log@opam:1.1.0@72575e04", "@opam/lwt@opam:4.1.0@4db5bd2a",
         "@opam/camomile@opam:1.0.1@4a2e8bdd"
+      ]
+    },
+    "@opam/junit@opam:2.0.1@c25e35a7": {
+      "id": "@opam/junit@opam:2.0.1@c25e35a7",
+      "name": "@opam/junit",
+      "version": "opam:2.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/40/40224fb3d4f5e47dc5ff4605587d383b#md5:40224fb3d4f5e47dc5ff4605587d383b",
+          "archive:https://github.com/Khady/ocaml-junit/releases/download/2.0.1/junit-2.0.1.tbz#md5:40224fb3d4f5e47dc5ff4605587d383b"
+        ],
+        "opam": {
+          "name": "junit",
+          "version": "2.0.1",
+          "path": "bench.esy.lock/opam/junit.2.0.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/tyxml@opam:4.3.0@b35a7c40", "@opam/ptime@opam:0.8.4@23eca65b",
+        "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "@opam/tyxml@opam:4.3.0@b35a7c40", "@opam/ptime@opam:0.8.4@23eca65b"
       ]
     },
     "@opam/js_of_ocaml-ppx@opam:3.3.0@6d90d7d2": {
@@ -1326,7 +1438,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/dune@opam:1.7.3@72aad784", "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/cmdliner@opam:1.0.2@b29b7491",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1402,7 +1514,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bigarray@opam:base@b03491b0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1431,7 +1543,7 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/astring@opam:0.8.3@4e5e17d5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1514,13 +1626,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cppo@opam:1.6.5@bec3dbd9"
       ]
@@ -1630,7 +1742,7 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1656,11 +1768,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/camomile@opam:1.0.1@4a2e8bdd": {
@@ -1762,11 +1874,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/base-bigarray@opam:base@b03491b0": {
@@ -1805,7 +1917,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1841,7 +1953,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/merlin-extend@opam:0.3@e1fc0d08",
         "@opam/menhir@opam:20181113@0c8257a8",

--- a/bench.esy.lock/opam/junit.2.0.1/opam
+++ b/bench.esy.lock/opam/junit.2.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-junit"
+bug-reports: "https://github.com/Khady/ocaml-junit/issues"
+license: "LGPLv3+ with OCaml linking exception"
+dev-repo: "git+https://github.com/Khady/ocaml-junit.git"
+doc: "https://khady.github.io/ocaml-junit/"
+tags: ["junit" "jenkins"]
+depends: [
+  "dune" {build & >= "1.0"}
+  "ptime"
+  "tyxml" {>= "4.0.0"}
+  "odoc" {with-doc & >= "1.1.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs] {with-doc}
+]
+name: "junit"
+synopsis: "JUnit XML reports generation library"
+description: "JUnit XML reports generation library"
+url {
+  src:
+    "https://github.com/Khady/ocaml-junit/releases/download/2.0.1/junit-2.0.1.tbz"
+  checksum: "md5=40224fb3d4f5e47dc5ff4605587d383b"
+}

--- a/bench.esy.lock/opam/ocamlfind.1.8.0/files/no-awk-check.patch
+++ b/bench.esy.lock/opam/ocamlfind.1.8.0/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/bench.esy.lock/opam/ocamlfind.1.8.0/opam
+++ b/bench.esy.lock/opam/ocamlfind.1.8.0/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -56,6 +57,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.8.0.tar.gz"

--- a/bench.esy.lock/opam/ptime.0.8.4/opam
+++ b/bench.esy.lock/opam/ptime.0.8.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The ptime programmers"]
+homepage: "http://erratique.ch/software/ptime"
+doc: "http://erratique.ch/software/ptime/doc"
+dev-repo: "git+http://erratique.ch/repos/ptime.git"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+tags: [ "time" "posix" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+]
+depopts: [ "js_of_ocaml" ]
+build:[[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]
+synopsis: "POSIX time for OCaml"
+description: """
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
+distributed under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+[jsoo]: http://ocsigen.org/js_of_ocaml/"""
+url {
+  src: "http://erratique.ch/software/ptime/releases/ptime-0.8.4.tbz"
+  checksum: "md5=12fb5e8c3eb1d2e6075ac31ce93f7dd6"
+}

--- a/bench.esy.lock/opam/tyxml.4.3.0/opam
+++ b/bench.esy.lock/opam/tyxml.4.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1 with OCaml linking exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "seq"
+  "uutf" {>= "1.0.0"}
+  "re" {>= "1.5.0"}
+]
+
+synopsis:"TyXML is a library for building correct HTML and SVG documents"
+description:"""
+TyXML provides a set of convenient combinators that uses the OCaml
+type system to ensure the validity of the generated documents. TyXML
+can be used with any representation of HTML and SVG: the textual one,
+provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`)
+virtual DOM (`virtual-dom`) and reactive or replicated trees
+(`eliom`). You can also create your own representation and use it to
+instantiate a new set of combinators.
+
+```ocaml
+open Tyxml
+let to_ocaml = Html.(a ~a:[a_href "ocaml.org"] [txt "OCaml!"])
+```
+"""
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.3.0/tyxml-4.3.0.tbz"
+  checksum: "md5=fd834a567f813bf447cab5f4c3a723e2"
+}

--- a/bench.esy.lock/opam/uutf.1.0.2/opam
+++ b/bench.esy.lock/opam/uutf.1.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uutf"
+doc: "http://erratique.ch/software/uutf/doc/Uutf"
+dev-repo: "git+http://erratique.ch/repos/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+]
+depopts: ["cmdliner"]
+conflicts: ["cmdliner" { < "0.9.6"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+synopsis: """Non-blocking streaming Unicode codec for OCaml"""
+description: """\
+
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values.
+
+Uutf has no dependency and is distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/uutf/releases/uutf-1.0.2.tbz"
+checksum: "a7c542405a39630c689a82bd7ef2292c"
+}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b2432cbcc7e76b83d5dbdf43773759d8",
+  "checksum": "4f2403b3293d9e549beaf8afcf3d7087",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "universalify@0.1.2@d41d8cd9": {
@@ -76,7 +76,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@reason-native/rely@1.0.1@d41d8cd9",
+        "@reason-native/rely@1.3.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.1.0@4db5bd2a",
         "@opam/lambda-term@opam:1.13@a3d28a27",
@@ -152,7 +152,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@reason-native/rely@1.0.1@d41d8cd9",
+        "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@opam:1.5.0@890db858",
         "@opam/merlin@opam:3.2.2@829ee6dd", "@opam/lwt@opam:4.1.0@4db5bd2a",
         "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/reason@3.4.0@d41d8cd9"
@@ -383,7 +383,7 @@
         "revery@0.14.1@d41d8cd9", "rench@1.4.0@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#a73f349@d41d8cd9",
         "reason-glfw@3.2.1023@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@reason-native/rely@1.0.1@d41d8cd9", "@opam/zed@opam:1.6@004ea65e",
+        "@reason-native/rely@1.3.1@d41d8cd9", "@opam/zed@opam:1.6@004ea65e",
         "@opam/yojson@opam:1.5.0@890db858",
         "@opam/ppx_deriving_yojson@opam:3.3@80aab5d8",
         "@opam/ppx_deriving@opam:4.2.1@7927b93a",
@@ -398,14 +398,14 @@
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@829ee6dd"
       ]
     },
-    "@reason-native/rely@1.0.1@d41d8cd9": {
-      "id": "@reason-native/rely@1.0.1@d41d8cd9",
+    "@reason-native/rely@1.3.1@d41d8cd9": {
+      "id": "@reason-native/rely@1.3.1@d41d8cd9",
       "name": "@reason-native/rely",
-      "version": "1.0.1",
+      "version": "1.3.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native/rely/-/rely-1.0.1.tgz#sha1:14afdbf5bada7739dd9a68d4817c53e7d5ddd50c"
+          "archive:https://registry.npmjs.org/@reason-native/rely/-/rely-1.3.1.tgz#sha1:f57050aac6887196d1a41f0d42c7b5ec0adee271"
         ]
       },
       "overrides": [],
@@ -413,6 +413,7 @@
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/pastel@0.1.0@d41d8cd9",
         "@reason-native/file-context-printer@0.0.3@d41d8cd9",
+        "@opam/re@opam:1.8.0@7baac1a7", "@opam/junit@opam:2.0.1@c25e35a7",
         "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/reason@3.4.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -527,6 +528,35 @@
         "@opam/biniou@opam:1.2.0@c8516f18"
       ]
     },
+    "@opam/uutf@opam:1.0.2@4440868f": {
+      "id": "@opam/uutf@opam:1.0.2@4440868f",
+      "name": "@opam/uutf",
+      "version": "opam:1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a7/a7c542405a39630c689a82bd7ef2292c#md5:a7c542405a39630c689a82bd7ef2292c",
+          "archive:http://erratique.ch/software/uutf/releases/uutf-1.0.2.tbz#md5:a7c542405a39630c689a82bd7ef2292c"
+        ],
+        "opam": {
+          "name": "uutf",
+          "version": "1.0.2",
+          "path": "esy.lock/opam/uutf.1.0.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
+        "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/cmdliner@opam:1.0.2@b29b7491",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+      ]
+    },
     "@opam/uchar@opam:0.0.2@c8218eea": {
       "id": "@opam/uchar@opam:0.0.2@c8218eea",
       "name": "@opam/uchar",
@@ -550,6 +580,33 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
+    "@opam/tyxml@opam:4.3.0@b35a7c40": {
+      "id": "@opam/tyxml@opam:4.3.0@b35a7c40",
+      "name": "@opam/tyxml",
+      "version": "opam:4.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fd/fd834a567f813bf447cab5f4c3a723e2#md5:fd834a567f813bf447cab5f4c3a723e2",
+          "archive:https://github.com/ocsigen/tyxml/releases/download/4.3.0/tyxml-4.3.0.tbz#md5:fd834a567f813bf447cab5f4c3a723e2"
+        ],
+        "opam": {
+          "name": "tyxml",
+          "version": "4.3.0",
+          "path": "esy.lock/opam/tyxml.4.3.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.8.0@7baac1a7",
+        "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.8.0@7baac1a7"
+      ]
+    },
     "@opam/topkg@opam:1.0.0@61f4ccf9": {
       "id": "@opam/topkg@opam:1.0.0@61f4ccf9",
       "name": "@opam/topkg",
@@ -569,7 +626,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -639,7 +696,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -671,6 +728,35 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d"
       ]
     },
+    "@opam/ptime@opam:0.8.4@23eca65b": {
+      "id": "@opam/ptime@opam:0.8.4@23eca65b",
+      "name": "@opam/ptime",
+      "version": "opam:0.8.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12fb5e8c3eb1d2e6075ac31ce93f7dd6#md5:12fb5e8c3eb1d2e6075ac31ce93f7dd6",
+          "archive:http://erratique.ch/software/ptime/releases/ptime-0.8.4.tbz#md5:12fb5e8c3eb1d2e6075ac31ce93f7dd6"
+        ],
+        "opam": {
+          "name": "ptime",
+          "version": "0.8.4",
+          "path": "esy.lock/opam/ptime.0.8.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/result@opam:1.3@bee8bf2e",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e"
+      ]
+    },
     "@opam/printbox@opam:0.2@31968522": {
       "id": "@opam/printbox@opam:0.2@31968522",
       "name": "@opam/printbox",
@@ -689,7 +775,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@72aad784",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/tyxml@opam:4.3.0@b35a7c40",
+        "@opam/dune@opam:1.7.3@72aad784",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -715,13 +802,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71"
       ]
     },
@@ -771,11 +858,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.3@80aab5d8": {
@@ -835,7 +922,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
         "@opam/ppx_tools@opam:5.1+4.06.0@a9357225",
         "@opam/ppx_derivers@opam:1.0@78655ff8",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/cppo_ocamlbuild@opam:1.6.0@7c1eb503",
@@ -894,20 +981,20 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ocamlfind@opam:1.8.0@96572762": {
-      "id": "@opam/ocamlfind@opam:1.8.0@96572762",
+    "@opam/ocamlfind@opam:1.8.0@4eaa30d0": {
+      "id": "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
       "name": "@opam/ocamlfind",
       "version": "opam:1.8.0",
       "source": {
@@ -1038,7 +1125,7 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -1062,12 +1149,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
-        "@opam/ocamlfind@opam:1.8.0@96572762"
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/menhir@opam:20181113@0c8257a8": {
@@ -1088,7 +1175,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1199,7 +1286,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -1247,6 +1334,31 @@
         "@opam/lwt_react@opam:1.1.1@a034a5ae",
         "@opam/lwt_log@opam:1.1.0@72575e04", "@opam/lwt@opam:4.1.0@4db5bd2a",
         "@opam/camomile@opam:1.0.1@4a2e8bdd"
+      ]
+    },
+    "@opam/junit@opam:2.0.1@c25e35a7": {
+      "id": "@opam/junit@opam:2.0.1@c25e35a7",
+      "name": "@opam/junit",
+      "version": "opam:2.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/40/40224fb3d4f5e47dc5ff4605587d383b#md5:40224fb3d4f5e47dc5ff4605587d383b",
+          "archive:https://github.com/Khady/ocaml-junit/releases/download/2.0.1/junit-2.0.1.tbz#md5:40224fb3d4f5e47dc5ff4605587d383b"
+        ],
+        "opam": {
+          "name": "junit",
+          "version": "2.0.1",
+          "path": "esy.lock/opam/junit.2.0.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/tyxml@opam:4.3.0@b35a7c40", "@opam/ptime@opam:0.8.4@23eca65b",
+        "@opam/dune@opam:1.7.3@72aad784", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "@opam/tyxml@opam:4.3.0@b35a7c40", "@opam/ptime@opam:0.8.4@23eca65b"
       ]
     },
     "@opam/js_of_ocaml-ppx@opam:3.3.0@6d90d7d2": {
@@ -1325,7 +1437,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/dune@opam:1.7.3@72aad784", "@opam/cppo@opam:1.6.5@bec3dbd9",
         "@opam/cmdliner@opam:1.0.2@b29b7491",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1401,7 +1513,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bigarray@opam:base@b03491b0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1430,7 +1542,7 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/astring@opam:0.8.3@4e5e17d5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1513,13 +1625,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cppo@opam:1.6.5@bec3dbd9"
       ]
@@ -1629,7 +1741,7 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1655,11 +1767,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/camomile@opam:1.0.1@4a2e8bdd": {
@@ -1761,11 +1873,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
       ]
     },
     "@opam/base-bigarray@opam:base@b03491b0": {
@@ -1804,7 +1916,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1840,7 +1952,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/merlin-extend@opam:0.3@e1fc0d08",
         "@opam/menhir@opam:20181113@0c8257a8",

--- a/esy.lock/opam/junit.2.0.1/opam
+++ b/esy.lock/opam/junit.2.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-junit"
+bug-reports: "https://github.com/Khady/ocaml-junit/issues"
+license: "LGPLv3+ with OCaml linking exception"
+dev-repo: "git+https://github.com/Khady/ocaml-junit.git"
+doc: "https://khady.github.io/ocaml-junit/"
+tags: ["junit" "jenkins"]
+depends: [
+  "dune" {build & >= "1.0"}
+  "ptime"
+  "tyxml" {>= "4.0.0"}
+  "odoc" {with-doc & >= "1.1.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs] {with-doc}
+]
+name: "junit"
+synopsis: "JUnit XML reports generation library"
+description: "JUnit XML reports generation library"
+url {
+  src:
+    "https://github.com/Khady/ocaml-junit/releases/download/2.0.1/junit-2.0.1.tbz"
+  checksum: "md5=40224fb3d4f5e47dc5ff4605587d383b"
+}

--- a/esy.lock/opam/ocamlfind.1.8.0/files/no-awk-check.patch
+++ b/esy.lock/opam/ocamlfind.1.8.0/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/esy.lock/opam/ocamlfind.1.8.0/opam
+++ b/esy.lock/opam/ocamlfind.1.8.0/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -56,6 +57,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.8.0.tar.gz"

--- a/esy.lock/opam/ptime.0.8.4/opam
+++ b/esy.lock/opam/ptime.0.8.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The ptime programmers"]
+homepage: "http://erratique.ch/software/ptime"
+doc: "http://erratique.ch/software/ptime/doc"
+dev-repo: "git+http://erratique.ch/repos/ptime.git"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+tags: [ "time" "posix" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+]
+depopts: [ "js_of_ocaml" ]
+build:[[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]
+synopsis: "POSIX time for OCaml"
+description: """
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
+distributed under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+[jsoo]: http://ocsigen.org/js_of_ocaml/"""
+url {
+  src: "http://erratique.ch/software/ptime/releases/ptime-0.8.4.tbz"
+  checksum: "md5=12fb5e8c3eb1d2e6075ac31ce93f7dd6"
+}

--- a/esy.lock/opam/tyxml.4.3.0/opam
+++ b/esy.lock/opam/tyxml.4.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1 with OCaml linking exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "seq"
+  "uutf" {>= "1.0.0"}
+  "re" {>= "1.5.0"}
+]
+
+synopsis:"TyXML is a library for building correct HTML and SVG documents"
+description:"""
+TyXML provides a set of convenient combinators that uses the OCaml
+type system to ensure the validity of the generated documents. TyXML
+can be used with any representation of HTML and SVG: the textual one,
+provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`)
+virtual DOM (`virtual-dom`) and reactive or replicated trees
+(`eliom`). You can also create your own representation and use it to
+instantiate a new set of combinators.
+
+```ocaml
+open Tyxml
+let to_ocaml = Html.(a ~a:[a_href "ocaml.org"] [txt "OCaml!"])
+```
+"""
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.3.0/tyxml-4.3.0.tbz"
+  checksum: "md5=fd834a567f813bf447cab5f4c3a723e2"
+}

--- a/esy.lock/opam/uutf.1.0.2/opam
+++ b/esy.lock/opam/uutf.1.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uutf"
+doc: "http://erratique.ch/software/uutf/doc/Uutf"
+dev-repo: "git+http://erratique.ch/repos/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+]
+depopts: ["cmdliner"]
+conflicts: ["cmdliner" { < "0.9.6"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+synopsis: """Non-blocking streaming Unicode codec for OCaml"""
+description: """\
+
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values.
+
+Uutf has no dependency and is distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/uutf/releases/uutf-1.0.2.tbz"
+checksum: "a7c542405a39630c689a82bd7ef2292c"
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "format": "esy dune build @fmt --auto-promote",
     "run": "esy x Oni2",
     "create-release": "esy node ./scripts/release.js",
-    "test": "esy x OniUnitTestRunner"
+    "test": "esy x OniUnitTestRunner",
+    "testci": "esy x OniUnitTestRunnerCI"
   },
   "dependencies": {
     "ocaml": "~4.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@opam/yojson": "1.5.0",
     "@opam/zed": "1.6",
     "rench": "^1.4.0",
-    "@reason-native/rely": "1.0.1",
+    "@reason-native/rely": "1.3.1",
     "reason-jsonrpc": "*",
     "reason-glfw": "^3.2.1022"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "run": "esy x Oni2",
     "create-release": "esy node ./scripts/release.js",
     "test": "esy x OniUnitTestRunner",
-    "testci": "esy x OniUnitTestRunnerCI"
+    "test-ci": "esy x OniUnitTestRunnerCI"
   },
   "dependencies": {
     "ocaml": "~4.7.0",

--- a/test/editor/OniUnitTestRunnerCI.re
+++ b/test/editor/OniUnitTestRunnerCI.re
@@ -1,0 +1,13 @@
+Oni_Core_Test.TestFramework.run(
+    Rely.RunConfig.withReporters(
+        [Default, JUnit("./junit.xml")],
+        Rely.RunConfig.initialize(),
+    ),
+);
+
+Oni_Neovim_Test.TestFramework.run(
+    Rely.RunConfig.withReporters(
+        [Default, JUnit("./junit.xml")],
+        Rely.RunConfig.initialize(),
+    ),
+);

--- a/test/editor/OniUnitTestRunnerCI.re
+++ b/test/editor/OniUnitTestRunnerCI.re
@@ -1,13 +1,13 @@
 Oni_Core_Test.TestFramework.run(
-    Rely.RunConfig.withReporters(
-        [Default, JUnit("./junit.xml")],
-        Rely.RunConfig.initialize(),
-    ),
+  Rely.RunConfig.withReporters(
+    [Default, JUnit("./junit.xml")],
+    Rely.RunConfig.initialize(),
+  ),
 );
 
 Oni_Neovim_Test.TestFramework.run(
-    Rely.RunConfig.withReporters(
-        [Default, JUnit("./junit.xml")],
-        Rely.RunConfig.initialize(),
-    ),
+  Rely.RunConfig.withReporters(
+    [Default, JUnit("./junit.xml")],
+    Rely.RunConfig.initialize(),
+  ),
 );

--- a/test/editor/dune
+++ b/test/editor/dune
@@ -1,6 +1,19 @@
 (executable
     (name OniUnitTestRunner)
     (public_name OniUnitTestRunner)
+    (modules OniUnitTestRunner)
+    (package OniUnitTestRunner)
+    (libraries
+        yojson
+        Oni_Core_Test
+        Oni_Model_Test
+        Oni_Neovim_Test
+            ))
+
+(executable
+    (name OniUnitTestRunnerCI)
+    (public_name OniUnitTestRunnerCI)
+    (modules OniUnitTestRunnerCI)
     (package OniUnitTestRunner)
     (libraries
         yojson


### PR DESCRIPTION
This bumps the version of Rely we are using, and hooks up the JUnit tests into Azure.

(As an aside, we should perhaps consider adding the lock folders to our `.gitattributes` as generated files. That way, they aren't expanded by default so looking over PR diffs is a bit simpler. The diff is visible if you click through still. If we do that, we could also consider adding the `extensions` folder as vendored code, since it currently comes up as JS code in the repo. Not a bad thing, but also doesn't show of the OCaml/Reason as much!)