### PR TITLE
Bugfix: ':q' doesn't quit Onivim2

### DIFF
--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -70,14 +70,15 @@ let init = app => {
       (),
     );
 
-  let _ = Event.subscribe(nvim.onClose, (code) => { 
+  let _ =
+    Event.subscribe(nvim.onClose, code =>
       if (code === 0) {
-          App.quit(0); 
+        App.quit(0);
       } else {
+        ();
           /* TODO: What to do in case Neovim crashes? */
-          ();
       }
-  });
+    );
 
   let nvimApi = NeovimApi.make(msgpackTransport);
   let neovimProtocol = NeovimProtocol.make(nvimApi);

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -70,6 +70,8 @@ let init = app => {
       (),
     );
 
+  let _ = Event.subscribe(nvim.onClose, (_) => { App.quit(0); });
+
   let nvimApi = NeovimApi.make(msgpackTransport);
   let neovimProtocol = NeovimProtocol.make(nvimApi);
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -70,7 +70,14 @@ let init = app => {
       (),
     );
 
-  let _ = Event.subscribe(nvim.onClose, (_) => { App.quit(0); });
+  let _ = Event.subscribe(nvim.onClose, (code) => { 
+      if (code === 0) {
+          App.quit(0); 
+      } else {
+          /* TODO: What to do in case Neovim crashes? */
+          ();
+      }
+  });
 
   let nvimApi = NeovimApi.make(msgpackTransport);
   let neovimProtocol = NeovimProtocol.make(nvimApi);


### PR DESCRIPTION
__Issue:__ `:q` doesn't quit Onivim 2

__Defect:__ `:q` does close the `nvim` process, but we weren't listening to the Neovim process close event

__Fix:__ If the `nvim` process closes, with a success status code (`0`), we'll also close the Onivim 2 process via `App.quit`
