### PR TITLE
[WIP] Continue on test command error.

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -11,6 +11,7 @@ steps:
     displayName: 'Build: esy build'
   - script: esy test-ci
     displayName: 'Unit Tests: esy test-ci (round 1)'
+    continueOnError: true
   # TODO: Stabilize and bring back!
   # - script: esy x OniUnitTestRunner
   #   displayName: 'Unit Tests: esy x OniUnitTestRunner (round 2)'


### PR DESCRIPTION
Was pointed out on Discord, we do actually want to continue on the test errors, since that way the JUnit test results are uploaded. That upload step contains a `failTaskOnFailedTests: true` part which will then fail the CI build, so the functionality doesn't change, just we get complete metrics each time.