### PR TITLE
Extension Host: Extension info / activation

### DIFF
--- a/src/editor/Extensions/ExtensionHostClient.re
+++ b/src/editor/Extensions/ExtensionHostClient.re
@@ -68,38 +68,38 @@ let start =
   };
 
   let handleMessage = (_reqId: int, payload: Yojson.Safe.json) =>
-      switch (payload) {
-      | `List([`String(scopeName), `String(methodName), args]) =>
-        let _ = onMessage(scopeName, methodName, args);
-        ();
-      | _ =>
-        print_endline("Unknown message: " ++ Yojson.Safe.to_string(payload))
-      /* switch (onMessage(id, payload)) { */
-      /* | Ok(None) => () */
-      /* | Ok(Some(_)) => */
-      /*   /1* TODO: Send response *1/ */
-      /*   () */
-      /* | Error(_) => */
-      /*   /1* TODO: Send error *1/ */
-      /*   () */
-      /* }; */
+    switch (payload) {
+    | `List([`String(scopeName), `String(methodName), args]) =>
+      let _ = onMessage(scopeName, methodName, args);
+      ();
+    | _ =>
+      print_endline("Unknown message: " ++ Yojson.Safe.to_string(payload))
+    /* switch (onMessage(id, payload)) { */
+    /* | Ok(None) => () */
+    /* | Ok(Some(_)) => */
+    /*   /1* TODO: Send response *1/ */
+    /*   () */
+    /* | Error(_) => */
+    /*   /1* TODO: Send error *1/ */
+    /*   () */
+    /* }; */
     };
 
   let _sendInitData = () => {
-      send(
-        ~msgType=Protocol.MessageType.initData,
-        ExtensionHostInitData.to_yojson(initData),
-      );
+    send(
+      ~msgType=Protocol.MessageType.initData,
+      ExtensionHostInitData.to_yojson(initData),
+    );
   };
 
   let _handleInitialization = () => {
-      onInitialized();
-      /* Send workspace and configuration info to get the extensions started */
-      open ExtensionHostProtocol.OutgoingNotifications;
+    onInitialized();
+    /* Send workspace and configuration info to get the extensions started */
+    open ExtensionHostProtocol.OutgoingNotifications;
 
-      Configuration.initializeConfiguration() |> send;
-      Workspace.initializeWorkspace("onivim-workspace-id", "onivim-workspace")
-      |> send;
+    Configuration.initializeConfiguration() |> send;
+    Workspace.initializeWorkspace("onivim-workspace-id", "onivim-workspace")
+    |> send;
   };
 
   let onNotification = (n: Notification.t, _) => {
@@ -111,8 +111,8 @@ let start =
       | Request(req) => handleMessage(req.reqId, req.payload)
       | Reply(_) => ()
       | Ack(_) => ()
-      | Ready => _sendInitData();
-      | Initialized => _handleInitialization();
+      | Ready => _sendInitData()
+      | Initialized => _handleInitialization()
       };
 
     | _ =>

--- a/src/editor/Extensions/ExtensionHostInitData.re
+++ b/src/editor/Extensions/ExtensionHostInitData.re
@@ -46,7 +46,7 @@ module ExtensionInfo = {
            extensionLocationPath: path,
            name: manifest.name,
            /* publisher: manifest.publisher, */
-           /* version: manifest.version, */
+           version: manifest.version,
            engines: manifest.engines,
            activationEvents: manifest.activationEvents,
            extensionDependencies: manifest.extensionDependencies,
@@ -82,7 +82,7 @@ type t = {
 
 let create =
     (
-      ~parentPid=Unix.getpid(),
+      ~parentPid=Rench.Process.pid(),
       ~extensions=[],
       ~environment=Environment.create(),
       ~logsLocationPath=Filesystem.unsafeFindHome(),

--- a/src/editor/Extensions/ExtensionHostInitData.re
+++ b/src/editor/Extensions/ExtensionHostInitData.re
@@ -6,10 +6,54 @@
  */
 
 open Oni_Core;
+open ExtensionManifest;
+open ExtensionScanner;
 
+/*
+ * ExtensionInfo
+ *
+ * This is the type we pass to the extension host.
+ * Must be kept in sync with the `IRawExtensionDescription` defined in extHost.protocol.ts:
+ * https://github.com/onivim/vscode/blob/051b81fd1fa4fb656a5e1dab7235ac62dea58cfd/src/vs/workbench/api/node/extHost.protocol.ts#L79
+ */ 
 module ExtensionInfo = {
   [@deriving (show({with_path: false}), yojson({strict: false, exn: true}))]
-  type t = {identifier: string};
+  type t = {
+      /* TODO:  */
+      /* isBuiltIn: bool, */
+      /* isUnderDevelopment: bool, */
+      /* enableProposedApi: bool */
+
+      identifier: string,
+      extensionLocationPath: string,
+
+      name: string,
+      /* displayName: string, */
+      /* publisher: string, */
+      version: string,
+      engines: Engine.t,
+      activationEvents: list(string),
+      extensionDependencies: list(string),
+      extensionKind: ExtensionKind.t,
+      contributes: ExtensionContributions.t,
+  };
+
+  let ofExtensionInfo = (extensionInfo: ExtensionScanner.t) => {
+       let { path, manifest } = extensionInfo;
+
+       {
+           identifier: manifest.name,  
+           extensionLocationPath: path,
+           name: manifest.name,
+           /* publisher: manifest.publisher, */
+           /* version: manifest.version, */
+           engines: manifest.engines,
+           activationEvents: manifest.activationEvents,
+           extensionDependencies: manifest.extensionDependencies,
+           extensionKind: manifest.extensionKind,
+           contributes: manifest.contributes,
+       }
+  };
 };
 
 module Workspace = {

--- a/src/editor/Extensions/ExtensionHostInitData.re
+++ b/src/editor/Extensions/ExtensionHostInitData.re
@@ -52,7 +52,7 @@ module ExtensionInfo = {
            extensionDependencies: manifest.extensionDependencies,
            extensionKind: manifest.extensionKind,
            contributes: manifest.contributes,
-       }
+       };
   };
 };
 

--- a/src/editor/Extensions/ExtensionHostInitData.re
+++ b/src/editor/Extensions/ExtensionHostInitData.re
@@ -15,44 +15,42 @@ open ExtensionScanner;
  * This is the type we pass to the extension host.
  * Must be kept in sync with the `IRawExtensionDescription` defined in extHost.protocol.ts:
  * https://github.com/onivim/vscode/blob/051b81fd1fa4fb656a5e1dab7235ac62dea58cfd/src/vs/workbench/api/node/extHost.protocol.ts#L79
- */ 
+ */
 module ExtensionInfo = {
   [@deriving (show({with_path: false}), yojson({strict: false, exn: true}))]
   type t = {
-      /* TODO:  */
-      /* isBuiltIn: bool, */
-      /* isUnderDevelopment: bool, */
-      /* enableProposedApi: bool */
-
-      identifier: string,
-      extensionLocationPath: string,
-
-      name: string,
-      /* displayName: string, */
-      /* publisher: string, */
-      version: string,
-      engines: Engine.t,
-      activationEvents: list(string),
-      extensionDependencies: list(string),
-      extensionKind: ExtensionKind.t,
-      contributes: ExtensionContributions.t,
+    /* TODO:  */
+    /* isBuiltIn: bool, */
+    /* isUnderDevelopment: bool, */
+    /* enableProposedApi: bool */
+    identifier: string,
+    extensionLocationPath: string,
+    name: string,
+    /* displayName: string, */
+    /* publisher: string, */
+    version: string,
+    engines: Engine.t,
+    activationEvents: list(string),
+    extensionDependencies: list(string),
+    extensionKind: ExtensionKind.t,
+    contributes: ExtensionContributions.t,
   };
 
-  let ofExtensionInfo = (extensionInfo: ExtensionScanner.t) => {
-       let { path, manifest } = extensionInfo;
+  let ofScannedExtension = (extensionInfo: ExtensionScanner.t) => {
+    let {path, manifest} = extensionInfo;
 
-       {
-           identifier: manifest.name,  
-           extensionLocationPath: path,
-           name: manifest.name,
-           /* publisher: manifest.publisher, */
-           version: manifest.version,
-           engines: manifest.engines,
-           activationEvents: manifest.activationEvents,
-           extensionDependencies: manifest.extensionDependencies,
-           extensionKind: manifest.extensionKind,
-           contributes: manifest.contributes,
-       };
+    {
+      identifier: manifest.name,
+      extensionLocationPath: path,
+      name: manifest.name,
+      /* publisher: manifest.publisher, */
+      version: manifest.version,
+      engines: manifest.engines,
+      activationEvents: manifest.activationEvents,
+      extensionDependencies: manifest.extensionDependencies,
+      extensionKind: manifest.extensionKind,
+      contributes: manifest.contributes,
+    };
   };
 };
 

--- a/src/editor/Extensions/ExtensionHostProtocol.re
+++ b/src/editor/Extensions/ExtensionHostProtocol.re
@@ -11,6 +11,8 @@ module MessageType = {
   let initData = 2;
   let terminate = 3;
   let requestJsonArgs = 4;
+  let acknowledged = 8;
+  let replyOkJson = 12;
 };
 
 module LogLevel = {
@@ -38,14 +40,61 @@ module Environment = {
   };
 };
 
+
+module OutgoingNotifications = {
+
+    let _buildNotification = (scopeName, methodName, payload) => {
+        `List([`String(scopeName), `String(methodName), payload]);
+    }
+   
+    module Configuration = {
+
+        let initializeConfiguration = () => {
+            _buildNotification("ExtHostConfiguration", "$initializeConfiguration", `List([`Assoc([])]));
+        };
+    };
+
+    module  Workspace = {
+
+        [@deriving (show({with_path: false}), yojson({strict: false, exn: true}))]
+        type workspaceInfo = {
+            id: string,
+            name: string,
+            folders: list(string),
+        };
+
+        let initializeWorkspace = (id: string, name: string) => {
+            let wsinfo = {
+                id,
+                name,
+                folders: [],
+            }; 
+
+            _buildNotification("ExtHostWorkspace", "$initializeWorkspace", `List([
+                workspaceInfo_to_yojson(wsinfo)
+            ]));
+        }
+    }
+};
+
 module Notification = {
   exception NotificationParseException(string);
 
-  type t = {
+  type requestOrReply = {
     msgType: int,
     reqId: int,
     payload: Yojson.Safe.json,
   };
+
+  type ack = {
+      msgType: int,
+      reqId: int,
+  };
+
+  type t = 
+  | Request(requestOrReply)
+  | Reply(requestOrReply)
+  | Ack(ack);
 
   let of_yojson = (json: Yojson.Safe.json) => {
     switch (json) {
@@ -64,6 +113,19 @@ module Notification = {
           "Unable to parse: " ++ Yojson.Safe.to_string(json),
         ),
       )
+    };
+  };
+
+  let parse = (json: Yojson.Safe.json) => {
+    switch(json) {
+    | `Assoc([("type", MessageType.replyOkJson), ..._]) => {
+       Reply(of_yojson(json))
+    }
+    | `Assoc([("type", MessageType.requestJsonArgs), ..._]) => {
+       Request(of_yojson(json))
+    }
+    | `Assoc([("type", MessageType.ack), ..._]) => Ack(ack_of_yojson(json));
+    | _ => raise(NotificationParseException("Unknown message: " ++ Yojson.Safe.to_string(json)))
     };
   };
 };

--- a/src/editor/Extensions/ExtensionManifest.re
+++ b/src/editor/Extensions/ExtensionManifest.re
@@ -12,11 +12,9 @@ module ExtensionKind = {
 };
 
 module Engine = {
-   [@deriving (show, yojson({strict: false, exn: true}))]
-   type t = {
-        vscode: string,
-   }
-}
+  [@deriving (show, yojson({strict: false, exn: true}))]
+  type t = {vscode: string};
+};
 
 [@deriving (show, yojson({strict: false, exn: true}))]
 type t = {

--- a/src/editor/Extensions/ExtensionManifest.re
+++ b/src/editor/Extensions/ExtensionManifest.re
@@ -11,6 +11,13 @@ module ExtensionKind = {
     | [@name "workspace"] Workspace;
 };
 
+module Engine = {
+   [@deriving (show, yojson({strict: false, exn: true}))]
+   type t = {
+        vscode: string,
+   }
+}
+
 [@deriving (show, yojson({strict: false, exn: true}))]
 type t = {
   name: string,
@@ -20,6 +27,7 @@ type t = {
   icon: [@default None] option(string),
   categories: [@default []] list(string),
   keywords: [@default []] list(string),
+  engines: Engine.t,
   activationEvents: [@default []] list(string),
   extensionDependencies: [@default []] list(string),
   extensionPack: [@default []] list(string),

--- a/src/editor/Extensions/ExtensionManifest.re
+++ b/src/editor/Extensions/ExtensionManifest.re
@@ -21,6 +21,7 @@ module Engine = {
 [@deriving (show, yojson({strict: false, exn: true}))]
 type t = {
   name: string,
+  version: string,
   displayName: [@default None] option(string),
   description: [@default None] option(string),
   main: [@default None] option(string),

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -39,10 +39,12 @@ describe("Extension Client", ({test, _}) => {
     let gotDidActivateMessage = ref(false);
 
     let onMessage = (a, b, _c) => {
-      switch ((a, b)) {
-      | ("MainThreadExtensionService", "$onWillActivateExtension") => gotWillActivateMessage := true
-      | ("MainThreadExtensionService", "$onDidActivateExtension") => gotDidActivateMessage := true
-      | _ => ();
+      switch (a, b) {
+      | ("MainThreadExtensionService", "$onWillActivateExtension") =>
+        gotWillActivateMessage := true
+      | ("MainThreadExtensionService", "$onDidActivateExtension") =>
+        gotDidActivateMessage := true
+      | _ => ()
       };
 
       Ok(None);

--- a/test/test_extensions/oni-api-tests/extension.js
+++ b/test/test_extensions/oni-api-tests/extension.js
@@ -1,0 +1,56 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	// Use the console to output diagnostic information (console.log) and errors (console.error)
+	// This line of code will only be executed once when your extension is activated
+
+	// console.log('Congratulations, your extension "helloworld-minimal-sample" is now active!');
+
+    let showData = (val) => {
+        vscode.window.showInformationMessage(JSON.stringify(val));
+    }
+
+	// The command has been defined in the package.json file
+	// Now provide the implementation of the command with  registerCommand
+	// The commandId parameter must match the command field in package.json
+	let disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
+		// The code you place here will be executed every time your command is executed
+
+		// Display a message box to the user
+		vscode.window.showInformationMessage('Hello World!');
+	});
+
+    let disposable2 = vscode.workspace.onDidOpenTextDocument((e) => {
+        showData({
+            type: "workspace.onDidOpenTextDocument",
+            filename: e.fileName,
+        });
+    });
+
+    let disposable3 = vscode.workspace.onDidCloseTextDocument((e) => {
+        showData({
+            type: "workspace.onDidCloseTextDocument",
+            filename: e.fileName,
+        });
+    });
+
+	context.subscriptions.push(disposable);
+    context.subscriptions.push(disposable2);
+    context.subscriptions.push(disposable3);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/test_extensions/oni-api-tests/package.json
+++ b/test/test_extensions/oni-api-tests/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "helloworld-minimal-sample",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": [
+		"*"
+	],
+	"main": "./extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.helloWorld",
+				"title": "Hello World"
+			}
+		]
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
This brings in a simple test extension that we can use to test interop of the VSCode API surface.

Right now, we only test that the extension gets activated - later, we can extend it to round-tripping and handling API messages.