### PR TITLE
Extension Host: Test for executing command against VSCode extension

### DIFF
--- a/src/editor/Extensions/ExtensionHostClient.re
+++ b/src/editor/Extensions/ExtensionHostClient.re
@@ -24,7 +24,7 @@ type simpleCallback = unit => unit;
 let defaultCallback: simpleCallback = () => ();
 
 type messageHandler =
-  (string, string, Yojson.Safe.json) =>
+  (string, string, list(Yojson.Safe.json)) =>
   result(option(Yojson.Safe.json), string);
 let defaultMessageHandler = (_, _, _) => Ok(None);
 
@@ -71,7 +71,11 @@ let start =
 
   let handleMessage = (_reqId: int, payload: Yojson.Safe.json) =>
     switch (payload) {
-    | `List([`String(scopeName), `String(methodName), args]) =>
+    | `Assoc([
+        ("rpcName", `String(scopeName)),
+        ("methodName", `String(methodName)),
+        ("args", `List(args))
+    ]) =>
       let _ = onMessage(scopeName, methodName, args);
       ();
     | _ =>
@@ -113,6 +117,7 @@ let start =
       | Request(req) => handleMessage(req.reqId, req.payload)
       | Reply(_) => ()
       | Ack(_) => ()
+      | Error => ()
       | Ready => _sendInitData()
       | Initialized => _handleInitialization()
       };

--- a/src/editor/Extensions/ExtensionHostClient.re
+++ b/src/editor/Extensions/ExtensionHostClient.re
@@ -72,16 +72,14 @@ let start =
   let sendResponse = (msgType, reqId, msg) => {
     switch (rpcRef^) {
     | None => prerr_endline("RPC not initialized.")
-    | Some(v) => {
-        let response =
-            `Assoc([
-                ("type", `Int(msgType)),
-                ("reqId", `Int(reqId)),
-                ("payload", msg),
-            ]);
-        Rpc.sendNotification(v, "ext/msg", response);
-        
-    }
+    | Some(v) =>
+      let response =
+        `Assoc([
+          ("type", `Int(msgType)),
+          ("reqId", `Int(reqId)),
+          ("payload", msg),
+        ]);
+      Rpc.sendNotification(v, "ext/msg", response);
     };
   };
 
@@ -90,17 +88,11 @@ let start =
     | `Assoc([
         ("rpcName", `String(scopeName)),
         ("methodName", `String(methodName)),
-        ("args", `List(args))
-    ]) =>
-      switch(onMessage(scopeName, methodName, args)) {
-      | Ok(None) => {
-          prerr_endline ("sending response for reqid: " ++ string_of_int(reqId));
-        sendResponse(12, reqId, `Assoc([]));
-      }
-      | _ => {
-          prerr_endline ("sending response for reqid: " ++ string_of_int(reqId));
-        sendResponse(12, reqId, `Assoc([]));
-      }
+        ("args", `List(args)),
+      ]) =>
+      switch (onMessage(scopeName, methodName, args)) {
+      | Ok(None) => sendResponse(12, reqId, `Assoc([]))
+      | _ => sendResponse(12, reqId, `Assoc([]))
       }
     | _ =>
       print_endline("Unknown message: " ++ Yojson.Safe.to_string(payload))

--- a/src/editor/Extensions/ExtensionHostInitData.re
+++ b/src/editor/Extensions/ExtensionHostInitData.re
@@ -30,6 +30,7 @@ module ExtensionInfo = {
     name: string,
     /* displayName: string, */
     /* publisher: string, */
+    main: option(string),
     version: string,
     engines: Engine.t,
     activationEvents: list(string),
@@ -46,6 +47,7 @@ module ExtensionInfo = {
       extensionLocationPath: path,
       name: manifest.name,
       /* publisher: manifest.publisher, */
+      main: manifest.main,
       version: manifest.version,
       engines: manifest.engines,
       activationEvents: manifest.activationEvents,
@@ -78,6 +80,7 @@ type t = {
   environment: Environment.t,
   logsLocationPath: string,
   autoStart: bool,
+  workspace: Workspace.t,
 };
 
 let create =
@@ -94,4 +97,5 @@ let create =
   environment,
   logsLocationPath,
   autoStart,
+  workspace: { __test: "" },
 };

--- a/src/editor/Extensions/ExtensionHostInitData.re
+++ b/src/editor/Extensions/ExtensionHostInitData.re
@@ -97,5 +97,7 @@ let create =
   environment,
   logsLocationPath,
   autoStart,
-  workspace: { __test: "" },
+  workspace: {
+    __test: "",
+  },
 };

--- a/src/editor/Extensions/ExtensionHostProtocol.re
+++ b/src/editor/Extensions/ExtensionHostProtocol.re
@@ -13,6 +13,7 @@ module MessageType = {
   let requestJsonArgs = 4;
   let acknowledged = 8;
   let replyOkJson = 12;
+  let replyErrError = 13;
 };
 
 module LogLevel = {
@@ -108,6 +109,7 @@ module Notification = {
     | Ready
     | Request(requestOrReply)
     | Reply(requestOrReply)
+    | Error
     | Ack(ack);
 
   let of_yojson = (json: Yojson.Safe.json) => {
@@ -142,6 +144,7 @@ module Notification = {
     | `Assoc([("type", `Int(4)), ..._]) => Request(of_yojson(json))
     | `Assoc([("type", `Int(8)), ..._]) => Ack(ack_of_yojson_exn(json))
     | `Assoc([("type", `Int(12)), ..._]) => Reply(of_yojson(json))
+    | `Assoc([("type", `Int(13)), ..._]) => Error;
     | _ =>
       raise(
         NotificationParseException(

--- a/src/editor/Extensions/ExtensionHostProtocol.re
+++ b/src/editor/Extensions/ExtensionHostProtocol.re
@@ -45,6 +45,16 @@ module OutgoingNotifications = {
     `List([`String(scopeName), `String(methodName), payload]);
   };
 
+  module Commands = {
+    let executeContributedCommand = cmd => {
+      _buildNotification(
+        "ExtHostCommands",
+        "$executeContributedCommand",
+        `List([`String(cmd)]),
+      );
+    };
+  };
+
   module Configuration = {
     let initializeConfiguration = () => {
       _buildNotification(

--- a/src/editor/Extensions/ExtensionHostProtocol.re
+++ b/src/editor/Extensions/ExtensionHostProtocol.re
@@ -144,7 +144,7 @@ module Notification = {
     | `Assoc([("type", `Int(4)), ..._]) => Request(of_yojson(json))
     | `Assoc([("type", `Int(8)), ..._]) => Ack(ack_of_yojson_exn(json))
     | `Assoc([("type", `Int(12)), ..._]) => Reply(of_yojson(json))
-    | `Assoc([("type", `Int(13)), ..._]) => Error;
+    | `Assoc([("type", `Int(13)), ..._]) => Error
     | _ =>
       raise(
         NotificationParseException(

--- a/src/editor/Extensions/ExtensionScanner.re
+++ b/src/editor/Extensions/ExtensionScanner.re
@@ -29,13 +29,10 @@ let readFileSync = path => {
 };
 
 let remapManifest = (directory: string, manifest: ExtensionManifest.t) => {
-    switch (manifest.main) {
-    | None => manifest
-    | Some(v) => {
-        ...manifest,
-        main: Some(Path.join(directory, v))
-    }
-    }
+  switch (manifest.main) {
+  | None => manifest
+  | Some(v) => {...manifest, main: Some(Path.join(directory, v))}
+  };
 };
 
 let scan = (directory: string) => {

--- a/src/editor/Extensions/ExtensionScanner.re
+++ b/src/editor/Extensions/ExtensionScanner.re
@@ -28,6 +28,16 @@ let readFileSync = path => {
   };
 };
 
+let remapManifest = (directory: string, manifest: ExtensionManifest.t) => {
+    switch (manifest.main) {
+    | None => manifest
+    | Some(v) => {
+        ...manifest,
+        main: Some(Path.join(directory, v))
+    }
+    }
+};
+
 let scan = (directory: string) => {
   let items = Sys.readdir(directory) |> Array.to_list;
 
@@ -37,10 +47,11 @@ let scan = (directory: string) => {
   let packageManifestPath = d => Path.join(d, "package.json");
 
   let loadPackageJson = pkg => {
+    let path = Path.dirname(pkg);
     let json = readFileSync(pkg) |> Yojson.Safe.from_string;
     {
-      manifest: ExtensionManifest.of_yojson_exn(json),
-      path: Path.dirname(pkg),
+      manifest: ExtensionManifest.of_yojson_exn(json) |> remapManifest(path),
+      path,
     };
   };
 

--- a/src/editor/Extensions/Oni_Extensions.re
+++ b/src/editor/Extensions/Oni_Extensions.re
@@ -9,6 +9,7 @@ module ColorizedToken = ColorizedToken;
 module ExtensionContributions = ExtensionContributions;
 module ExtensionHostClient = ExtensionHostClient;
 module ExtensionHostInitData = ExtensionHostInitData;
+module ExtensionHostProtocol = ExtensionHostProtocol;
 module ExtensionManifest = ExtensionManifest;
 module ExtensionScanner = ExtensionScanner;
 module TextmateClient = TextmateClient;

--- a/test/editor/Extensions/ExtensionClientHelper.re
+++ b/test/editor/Extensions/ExtensionClientHelper.re
@@ -8,60 +8,68 @@
 open Oni_Core;
 open Oni_Extensions;
 
-type filterFunction = (Yojson.Safe.json) => bool;
+type filterFunction = Yojson.Safe.json => bool;
 type waiterFunction = unit => unit;
 
 type internalWaiter = {
-    isActive: ref(bool),
-    scope: string,
-    method: string,
-    filterFunction: filterFunction,
-}
-
-type extHostApi = {
-    createWaiterForMessage: (string, string, filterFunction) => waiterFunction,
-    send: unit => unit,
+  isActive: ref(bool),
+  scope: string,
+  method: string,
+  filterFunction,
 };
 
- let withExtensionClient = (
-   f: (extHostApi) => unit
- ) => {
-    let setup = Setup.init();
+type extHostApi = {
+  createWaiterForMessage: (string, string, filterFunction) => waiterFunction,
+  send: Yojson.Safe.json => unit,
+};
 
-    let initialized = ref(false);
-    let closed = ref(false);
+let withExtensionClient = (f: extHostApi => unit) => {
+  let setup = Setup.init();
 
-    let onClosed = () => closed := true;
-    let onInitialized = () => initialized := true;
-    let extClient =
-      ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+  let initialized = ref(false);
+  let closed = ref(false);
+
+  let onClosed = () => closed := true;
+  let onInitialized = () => initialized := true;
+
+  let extClient = ref(None);
+
+  let start = () => {
+    let v = ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
 
     Oni_Core.Utility.waitForCondition(() => {
-      ExtensionHostClient.pump(extClient);
+      ExtensionHostClient.pump(v);
       initialized^;
     });
 
-    if (!initialized^) {
-        failwith("extension host client did not initialize successfully");
-    }
-
-    let createWaiterForMessage = (scope, method, filterFunction) => {
-        () => ();   
+    if (! initialized^) {
+      failwith("extension host client did not initialize successfully");
     };
 
-    let send = () => ();
+    extClient := v;
+  };
 
-    let api: extHostApi = {
-        createWaiterForMessage,
-        send,
-    }
+  let createWaiterForMessage = (_scope, _method, _filterFunction, ()) => ();
 
-    f(api);
+  let send = json => {
+    switch (extClient) {
+    | None =>
+      failwith("Extension client not started - call start() before send()")
+    | Some(extClient) => ExtensionHostClient.send(extClient, json)
+    };
+  };
 
+  let api: extHostApi = {createWaiterForMessage, send, start};
 
+  f(api);
+
+  switch (extClient) {
+  | None => ()
+  | Some(extClient) =>
     ExtensionHostClient.close(extClient);
     Oni_Core.Utility.waitForCondition(() => {
       ExtensionHostClient.pump(extClient);
       closed^;
     });
- };
+  };
+};

--- a/test/editor/Extensions/ExtensionClientHelper.re
+++ b/test/editor/Extensions/ExtensionClientHelper.re
@@ -1,0 +1,67 @@
+/*
+ * ExtensionClientHelper
+ *
+ * A module providing a helper API to make it easier to test
+ * against the extension client API
+ */
+
+open Oni_Core;
+open Oni_Extensions;
+
+type filterFunction = (Yojson.Safe.json) => bool;
+type waiterFunction = unit => unit;
+
+type internalWaiter = {
+    isActive: ref(bool),
+    scope: string,
+    method: string,
+    filterFunction: filterFunction,
+}
+
+type extHostApi = {
+    createWaiterForMessage: (string, string, filterFunction) => waiterFunction,
+    send: unit => unit,
+};
+
+ let withExtensionClient = (
+   f: (extHostApi) => unit
+ ) => {
+    let setup = Setup.init();
+
+    let initialized = ref(false);
+    let closed = ref(false);
+
+    let onClosed = () => closed := true;
+    let onInitialized = () => initialized := true;
+    let extClient =
+      ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtensionHostClient.pump(extClient);
+      initialized^;
+    });
+
+    if (!initialized^) {
+        failwith("extension host client did not initialize successfully");
+    }
+
+    let createWaiterForMessage = (scope, method, filterFunction) => {
+        () => ();   
+    };
+
+    let send = () => ();
+
+    let api: extHostApi = {
+        createWaiterForMessage,
+        send,
+    }
+
+    f(api);
+
+
+    ExtensionHostClient.close(extClient);
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtensionHostClient.pump(extClient);
+      closed^;
+    });
+ };

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -1,4 +1,4 @@
-/* open Oni_Core; */
+open Oni_Core;
 open Oni_Core_Test;
 open Oni_Extensions;
 
@@ -7,7 +7,7 @@ open TestFramework;
 open ExtensionClientHelper;
 open ExtensionHostProtocol.OutgoingNotifications;
 
-describe("Extension Client", ({describe, _}) =>
+describe("Extension Client", ({describe, _}) => {
   describe("commands", ({test, _})
     =>
       test("executes simple command", _ =>
@@ -126,4 +126,4 @@ describe("Extension Client", ({describe, _}) =>
         ExtensionHostClient.close(extClient);
       });
     });
-);
+});

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -4,17 +4,20 @@ open Oni_Extensions;
 
 open TestFramework;
 
-open ExtensionClientTestHelper;
+open ExtensionClientHelper;
 open ExtensionHostProtocol.OutgoingNotifications;
 
-describe("Extension Client", ({test, _}) => {
+describe("Extension Client", ({describe, _}) => {
   describe("commands", ({test, _}) =>
-    test("executes simple command", ({expect}) =>
+    test("executes simple command", (_) =>
       withExtensionClient(api => {
         let waitForCommandRegistration =
           api.createWaiterForMessage(
-            "MainThreadCommands", "$registerCommand", _ =>
-            true
+            "MainThreadCommands", "$registerCommand", args =>
+            switch(args) {
+            | [`String("extension.helloWorld"), ..._] => true
+            | _ => false
+            }
           );
         let waitForShowMessage =
           api.createWaiterForMessage(
@@ -22,9 +25,14 @@ describe("Extension Client", ({test, _}) => {
             true
           );
 
+        prerr_endline ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+        prerr_endline ("[STARTING]");
         api.start();
+        prerr_endline ("[STARTING DONE]");
 
+        prerr_endline ("[WAITING FOR COMMAND REGISTRATION]");
         waitForCommandRegistration();
+        prerr_endline ("[GOT COMMAND REGISTRATION]");
 
         api.send(Commands.executeContributedCommand("extension.helloWorld"));
 

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -1,4 +1,4 @@
-open Oni_Core;
+/* open Oni_Core; */
 open Oni_Core_Test;
 open Oni_Extensions;
 
@@ -41,122 +41,122 @@ describe("Extension Client", ({describe, _}) => {
     )
   );
 
-  describe("lifecycle", ({test, _}) => {
-    test("gets initialized message", ({expect}) =>
-      Helpers.repeat(() => {
-        let setup = Setup.init();
+  /* describe("lifecycle", ({test, _}) => { */
+  /*   test("gets initialized message", ({expect}) => */
+  /*     Helpers.repeat(() => { */
+  /*       let setup = Setup.init(); */
 
-        let initialized = ref(false);
+  /*       let initialized = ref(false); */
 
-        let onInitialized = () => initialized := true;
-        let extClient = ExtensionHostClient.start(~onInitialized, setup);
+  /*       let onInitialized = () => initialized := true; */
+  /*       let extClient = ExtensionHostClient.start(~onInitialized, setup); */
 
-        Oni_Core.Utility.waitForCondition(() => {
-          ExtensionHostClient.pump(extClient);
-          initialized^;
-        });
-        expect.bool(initialized^).toBe(true);
+  /*       Oni_Core.Utility.waitForCondition(() => { */
+  /*         ExtensionHostClient.pump(extClient); */
+  /*         initialized^; */
+  /*       }); */
+  /*       expect.bool(initialized^).toBe(true); */
 
-        ExtensionHostClient.close(extClient);
-      })
-    );
+  /*       ExtensionHostClient.close(extClient); */
+  /*     }) */
+  /*   ); */
 
-    test("doesn't die after a few seconds", ({expect}) => {
-      let setup = Setup.init();
+  /*   test("doesn't die after a few seconds", ({expect}) => { */
+  /*     let setup = Setup.init(); */
 
-      let initialized = ref(false);
-      let closed = ref(false);
+  /*     let initialized = ref(false); */
+  /*     let closed = ref(false); */
 
-      let onClosed = () => closed := true;
-      let onInitialized = () => initialized := true;
-      let extClient =
-        ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+  /*     let onClosed = () => closed := true; */
+  /*     let onInitialized = () => initialized := true; */
+  /*     let extClient = */
+  /*       ExtensionHostClient.start(~onInitialized, ~onClosed, setup); */
 
-      Oni_Core.Utility.waitForCondition(() => {
-        ExtensionHostClient.pump(extClient);
-        initialized^;
-      });
+  /*     Oni_Core.Utility.waitForCondition(() => { */
+  /*       ExtensionHostClient.pump(extClient); */
+  /*       initialized^; */
+  /*     }); */
 
-      expect.bool(initialized^).toBe(true);
+  /*     expect.bool(initialized^).toBe(true); */
 
-      /* The extension host process will die after a second if it doesn't see the parent PID */
-      /* We'll sleep for two seconds to be safe */
-      Unix.sleep(2);
+  /*     /1* The extension host process will die after a second if it doesn't see the parent PID *1/ */
+  /*     /1* We'll sleep for two seconds to be safe *1/ */
+  /*     Unix.sleep(2); */
 
-      expect.bool(closed^).toBe(false);
-    });
+  /*     expect.bool(closed^).toBe(false); */
+  /*   }); */
 
-    test("closes after close is called", ({expect}) => {
-      let setup = Setup.init();
+  /*   test("closes after close is called", ({expect}) => { */
+  /*     let setup = Setup.init(); */
 
-      let initialized = ref(false);
-      let closed = ref(false);
+  /*     let initialized = ref(false); */
+  /*     let closed = ref(false); */
 
-      let onClosed = () => closed := true;
-      let onInitialized = () => initialized := true;
-      let extClient =
-        ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+  /*     let onClosed = () => closed := true; */
+  /*     let onInitialized = () => initialized := true; */
+  /*     let extClient = */
+  /*       ExtensionHostClient.start(~onInitialized, ~onClosed, setup); */
 
-      Oni_Core.Utility.waitForCondition(() => {
-        ExtensionHostClient.pump(extClient);
-        initialized^;
-      });
+  /*     Oni_Core.Utility.waitForCondition(() => { */
+  /*       ExtensionHostClient.pump(extClient); */
+  /*       initialized^; */
+  /*     }); */
 
-      expect.bool(initialized^).toBe(true);
+  /*     expect.bool(initialized^).toBe(true); */
 
-      ExtensionHostClient.close(extClient);
+  /*     ExtensionHostClient.close(extClient); */
 
-      Oni_Core.Utility.waitForCondition(() => {
-        ExtensionHostClient.pump(extClient);
-        closed^;
-      });
+  /*     Oni_Core.Utility.waitForCondition(() => { */
+  /*       ExtensionHostClient.pump(extClient); */
+  /*       closed^; */
+  /*     }); */
 
-      expect.bool(closed^).toBe(false);
-    });
+  /*     expect.bool(closed^).toBe(false); */
+  /*   }); */
 
-    test("basic extension activation", _ => {
-      let setup = Setup.init();
+  /*   test("basic extension activation", _ => { */
+  /*     let setup = Setup.init(); */
 
-      let rootPath = Rench.Environment.getWorkingDirectory();
-      let testExtensionsPath =
-        Rench.Path.join(rootPath, "test/test_extensions");
+  /*     let rootPath = Rench.Environment.getWorkingDirectory(); */
+  /*     let testExtensionsPath = */
+  /*       Rench.Path.join(rootPath, "test/test_extensions"); */
 
-      let extensions =
-        ExtensionScanner.scan(testExtensionsPath)
-        |> List.map(ext =>
-             ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext)
-           );
+  /*     let extensions = */
+  /*       ExtensionScanner.scan(testExtensionsPath) */
+  /*       |> List.map(ext => */
+  /*            ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext) */
+  /*          ); */
 
-      let gotWillActivateMessage = ref(false);
-      let gotDidActivateMessage = ref(false);
+  /*     let gotWillActivateMessage = ref(false); */
+  /*     let gotDidActivateMessage = ref(false); */
 
-      let onMessage = (a, b, _c) => {
-        switch (a, b) {
-        | ("MainThreadExtensionService", "$onWillActivateExtension") =>
-          gotWillActivateMessage := true
-        | ("MainThreadExtensionService", "$onDidActivateExtension") =>
-          gotDidActivateMessage := true
-        | _ => ()
-        };
+  /*     let onMessage = (a, b, _c) => { */
+  /*       switch (a, b) { */
+  /*       | ("MainThreadExtensionService", "$onWillActivateExtension") => */
+  /*         gotWillActivateMessage := true */
+  /*       | ("MainThreadExtensionService", "$onDidActivateExtension") => */
+  /*         gotDidActivateMessage := true */
+  /*       | _ => () */
+  /*       }; */
 
-        Ok(None);
-      };
+  /*       Ok(None); */
+  /*     }; */
 
-      let initData = ExtensionHostInitData.create(~extensions, ());
+  /*     let initData = ExtensionHostInitData.create(~extensions, ()); */
 
-      let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup);
+  /*     let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup); */
 
-      Oni_Core.Utility.waitForCondition(() => {
-        ExtensionHostClient.pump(extClient);
-        gotWillActivateMessage^;
-      });
+  /*     Oni_Core.Utility.waitForCondition(() => { */
+  /*       ExtensionHostClient.pump(extClient); */
+  /*       gotWillActivateMessage^; */
+  /*     }); */
 
-      Oni_Core.Utility.waitForCondition(() => {
-        ExtensionHostClient.pump(extClient);
-        gotDidActivateMessage^;
-      });
+  /*     Oni_Core.Utility.waitForCondition(() => { */
+  /*       ExtensionHostClient.pump(extClient); */
+  /*       gotDidActivateMessage^; */
+  /*     }); */
 
-      ExtensionHostClient.close(extClient);
-    });
-  });
+  /*     ExtensionHostClient.close(extClient); */
+  /*   }); */
+  /* }); */
 });

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -8,122 +8,119 @@ open ExtensionClientHelper;
 open ExtensionHostProtocol.OutgoingNotifications;
 
 describe("Extension Client", ({describe, _}) => {
-  describe("commands", ({test, _})
-    =>
-      test("executes simple command", _ =>
-        withExtensionClient(api => {
-          let waitForCommandRegistration =
-            api.createWaiterForMessage(
-              "MainThreadCommands", "$registerCommand", args =>
-              switch (args) {
-              | [`String("extension.helloWorld"), ..._] => true
-              | _ => false
-              }
-            );
-          let waitForShowMessage =
-            api.createWaiterForMessage(
-              "MainThreadMessageService", "$showMessage", _ =>
-              true
-            );
-
-          api.start();
-
-          waitForCommandRegistration();
-
-          api.send(
-            Commands.executeContributedCommand("extension.helloWorld"),
+  describe("commands", ({test, _}) =>
+    test("executes simple command", _ =>
+      withExtensionClient(api => {
+        let waitForCommandRegistration =
+          api.createWaiterForMessage(
+            "MainThreadCommands", "$registerCommand", args =>
+            switch (args) {
+            | [`String("extension.helloWorld"), ..._] => true
+            | _ => false
+            }
+          );
+        let waitForShowMessage =
+          api.createWaiterForMessage(
+            "MainThreadMessageService", "$showMessage", _ =>
+            true
           );
 
-          waitForShowMessage();
-        })
-      )
+        api.start();
+
+        waitForCommandRegistration();
+
+        api.send(Commands.executeContributedCommand("extension.helloWorld"));
+
+        waitForShowMessage();
+      })
     )
-    describe("lifecycle", ({test, _}) => {
-      test("gets initialized message", ({expect}) =>
-        Helpers.repeat(() => {
-          let setup = Setup.init();
-          let initialized = ref(false);
-          let onInitialized = () => initialized := true;
-          let extClient = ExtensionHostClient.start(~onInitialized, setup);
-          Oni_Core.Utility.waitForCondition(() => {
-            ExtensionHostClient.pump(extClient);
-            initialized^;
-          });
-          expect.bool(initialized^).toBe(true);
-          ExtensionHostClient.close(extClient);
-        })
-      );
-      test("doesn't die after a few seconds", ({expect}) => {
+  );
+  describe("lifecycle", ({test, _}) => {
+    test("gets initialized message", ({expect}) =>
+      Helpers.repeat(() => {
         let setup = Setup.init();
         let initialized = ref(false);
-        let closed = ref(false);
-        let onClosed = () => closed := true;
         let onInitialized = () => initialized := true;
-        let extClient =
-          ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
-        Oni_Core.Utility.waitForCondition(() => {
-          ExtensionHostClient.pump(extClient);
-          initialized^;
-        });
-        expect.bool(initialized^).toBe(true);
-        /* The extension host process will die after a second if it doesn't see the parent PID */
-        /* We'll sleep for two seconds to be safe */
-        Unix.sleep(2);
-        expect.bool(closed^).toBe(false);
-      });
-      test("closes after close is called", ({expect}) => {
-        let setup = Setup.init();
-        let initialized = ref(false);
-        let closed = ref(false);
-        let onClosed = () => closed := true;
-        let onInitialized = () => initialized := true;
-        let extClient =
-          ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+        let extClient = ExtensionHostClient.start(~onInitialized, setup);
         Oni_Core.Utility.waitForCondition(() => {
           ExtensionHostClient.pump(extClient);
           initialized^;
         });
         expect.bool(initialized^).toBe(true);
         ExtensionHostClient.close(extClient);
-        Oni_Core.Utility.waitForCondition(() => {
-          ExtensionHostClient.pump(extClient);
-          closed^;
-        });
-        expect.bool(closed^).toBe(false);
+      })
+    );
+    test("doesn't die after a few seconds", ({expect}) => {
+      let setup = Setup.init();
+      let initialized = ref(false);
+      let closed = ref(false);
+      let onClosed = () => closed := true;
+      let onInitialized = () => initialized := true;
+      let extClient =
+        ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        initialized^;
       });
-      test("basic extension activation", _ => {
-        let setup = Setup.init();
-        let rootPath = Rench.Environment.getWorkingDirectory();
-        let testExtensionsPath =
-          Rench.Path.join(rootPath, "test/test_extensions");
-        let extensions =
-          ExtensionScanner.scan(testExtensionsPath)
-          |> List.map(ext =>
-               ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext)
-             );
-        let gotWillActivateMessage = ref(false);
-        let gotDidActivateMessage = ref(false);
-        let onMessage = (a, b, _c) => {
-          switch (a, b) {
-          | ("MainThreadExtensionService", "$onWillActivateExtension") =>
-            gotWillActivateMessage := true
-          | ("MainThreadExtensionService", "$onDidActivateExtension") =>
-            gotDidActivateMessage := true
-          | _ => ()
-          };
-          Ok(None);
-        };
-        let initData = ExtensionHostInitData.create(~extensions, ());
-        let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup);
-        Oni_Core.Utility.waitForCondition(() => {
-          ExtensionHostClient.pump(extClient);
-          gotWillActivateMessage^;
-        });
-        Oni_Core.Utility.waitForCondition(() => {
-          ExtensionHostClient.pump(extClient);
-          gotDidActivateMessage^;
-        });
-        ExtensionHostClient.close(extClient);
-      });
+      expect.bool(initialized^).toBe(true);
+      /* The extension host process will die after a second if it doesn't see the parent PID */
+      /* We'll sleep for two seconds to be safe */
+      Unix.sleep(2);
+      expect.bool(closed^).toBe(false);
     });
+    test("closes after close is called", ({expect}) => {
+      let setup = Setup.init();
+      let initialized = ref(false);
+      let closed = ref(false);
+      let onClosed = () => closed := true;
+      let onInitialized = () => initialized := true;
+      let extClient =
+        ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        initialized^;
+      });
+      expect.bool(initialized^).toBe(true);
+      ExtensionHostClient.close(extClient);
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        closed^;
+      });
+      expect.bool(closed^).toBe(false);
+    });
+    test("basic extension activation", _ => {
+      let setup = Setup.init();
+      let rootPath = Rench.Environment.getWorkingDirectory();
+      let testExtensionsPath =
+        Rench.Path.join(rootPath, "test/test_extensions");
+      let extensions =
+        ExtensionScanner.scan(testExtensionsPath)
+        |> List.map(ext =>
+             ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext)
+           );
+      let gotWillActivateMessage = ref(false);
+      let gotDidActivateMessage = ref(false);
+      let onMessage = (a, b, _c) => {
+        switch (a, b) {
+        | ("MainThreadExtensionService", "$onWillActivateExtension") =>
+          gotWillActivateMessage := true
+        | ("MainThreadExtensionService", "$onDidActivateExtension") =>
+          gotDidActivateMessage := true
+        | _ => ()
+        };
+        Ok(None);
+      };
+      let initData = ExtensionHostInitData.create(~extensions, ());
+      let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup);
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        gotWillActivateMessage^;
+      });
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        gotDidActivateMessage^;
+      });
+      ExtensionHostClient.close(extClient);
+    });
+  });
 });

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -4,121 +4,151 @@ open Oni_Extensions;
 
 open TestFramework;
 
+open ExtensionClientTestHelper;
+open ExtensionHostProtocol.OutgoingNotifications;
+
 describe("Extension Client", ({test, _}) => {
-  test("gets initialized message", ({expect}) =>
-    Helpers.repeat(() => {
+  describe("commands", ({test, _}) =>
+    test("executes simple command", ({expect}) =>
+      withExtensionClient(api => {
+        let waitForCommandRegistration =
+          api.createWaiterForMessage(
+            "MainThreadCommands", "$registerCommand", _ =>
+            true
+          );
+        let waitForShowMessage =
+          api.createWaiterForMessage(
+            "MainThreadMessageService", "$showMessage", _ =>
+            true
+          );
+
+        api.start();
+
+        waitForCommandRegistration();
+
+        api.send(Commands.executeContributedCommand("extension.helloWorld"));
+
+        waitForShowMessage();
+      })
+    )
+  );
+
+  describe("lifecycle", ({test, _}) => {
+    test("gets initialized message", ({expect}) =>
+      Helpers.repeat(() => {
+        let setup = Setup.init();
+
+        let initialized = ref(false);
+
+        let onInitialized = () => initialized := true;
+        let extClient = ExtensionHostClient.start(~onInitialized, setup);
+
+        Oni_Core.Utility.waitForCondition(() => {
+          ExtensionHostClient.pump(extClient);
+          initialized^;
+        });
+        expect.bool(initialized^).toBe(true);
+
+        ExtensionHostClient.close(extClient);
+      })
+    );
+
+    test("doesn't die after a few seconds", ({expect}) => {
       let setup = Setup.init();
 
       let initialized = ref(false);
+      let closed = ref(false);
 
+      let onClosed = () => closed := true;
       let onInitialized = () => initialized := true;
-      let extClient = ExtensionHostClient.start(~onInitialized, setup);
+      let extClient =
+        ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
 
       Oni_Core.Utility.waitForCondition(() => {
         ExtensionHostClient.pump(extClient);
         initialized^;
       });
+
+      expect.bool(initialized^).toBe(true);
+
+      /* The extension host process will die after a second if it doesn't see the parent PID */
+      /* We'll sleep for two seconds to be safe */
+      Unix.sleep(2);
+
+      expect.bool(closed^).toBe(false);
+    });
+
+    test("closes after close is called", ({expect}) => {
+      let setup = Setup.init();
+
+      let initialized = ref(false);
+      let closed = ref(false);
+
+      let onClosed = () => closed := true;
+      let onInitialized = () => initialized := true;
+      let extClient =
+        ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        initialized^;
+      });
+
       expect.bool(initialized^).toBe(true);
 
       ExtensionHostClient.close(extClient);
-    })
-  );
 
-  test("doesn't die after a few seconds", ({expect}) => {
-    let setup = Setup.init();
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        closed^;
+      });
 
-    let initialized = ref(false);
-    let closed = ref(false);
-
-    let onClosed = () => closed := true;
-    let onInitialized = () => initialized := true;
-    let extClient =
-      ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
-
-    Oni_Core.Utility.waitForCondition(() => {
-      ExtensionHostClient.pump(extClient);
-      initialized^;
+      expect.bool(closed^).toBe(false);
     });
 
-    expect.bool(initialized^).toBe(true);
+    test("basic extension activation", _ => {
+      let setup = Setup.init();
 
-    /* The extension host process will die after a second if it doesn't see the parent PID */
-    /* We'll sleep for two seconds to be safe */
-    Unix.sleep(2);
+      let rootPath = Rench.Environment.getWorkingDirectory();
+      let testExtensionsPath =
+        Rench.Path.join(rootPath, "test/test_extensions");
 
-    expect.bool(closed^).toBe(false);
-  });
+      let extensions =
+        ExtensionScanner.scan(testExtensionsPath)
+        |> List.map(ext =>
+             ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext)
+           );
 
-  test("closes after close is called", ({expect}) => {
-    let setup = Setup.init();
+      let gotWillActivateMessage = ref(false);
+      let gotDidActivateMessage = ref(false);
 
-    let initialized = ref(false);
-    let closed = ref(false);
+      let onMessage = (a, b, _c) => {
+        switch (a, b) {
+        | ("MainThreadExtensionService", "$onWillActivateExtension") =>
+          gotWillActivateMessage := true
+        | ("MainThreadExtensionService", "$onDidActivateExtension") =>
+          gotDidActivateMessage := true
+        | _ => ()
+        };
 
-    let onClosed = () => closed := true;
-    let onInitialized = () => initialized := true;
-    let extClient =
-      ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
-
-    Oni_Core.Utility.waitForCondition(() => {
-      ExtensionHostClient.pump(extClient);
-      initialized^;
-    });
-
-    expect.bool(initialized^).toBe(true);
-
-    ExtensionHostClient.close(extClient);
-
-    Oni_Core.Utility.waitForCondition(() => {
-      ExtensionHostClient.pump(extClient);
-      closed^;
-    });
-
-    expect.bool(closed^).toBe(false);
-  });
-
-  test("basic extension activation", _ => {
-    let setup = Setup.init();
-
-    let rootPath = Rench.Environment.getWorkingDirectory();
-    let testExtensionsPath =
-      Rench.Path.join(rootPath, "test/test_extensions");
-
-    let extensions =
-      ExtensionScanner.scan(testExtensionsPath)
-      |> List.map(ext =>
-           ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext)
-         );
-
-    let gotWillActivateMessage = ref(false);
-    let gotDidActivateMessage = ref(false);
-
-    let onMessage = (a, b, _c) => {
-      switch (a, b) {
-      | ("MainThreadExtensionService", "$onWillActivateExtension") =>
-        gotWillActivateMessage := true
-      | ("MainThreadExtensionService", "$onDidActivateExtension") =>
-        gotDidActivateMessage := true
-      | _ => ()
+        Ok(None);
       };
 
-      Ok(None);
-    };
+      let initData = ExtensionHostInitData.create(~extensions, ());
 
-    let initData = ExtensionHostInitData.create(~extensions, ());
+      let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup);
 
-    let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup);
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        gotWillActivateMessage^;
+      });
 
-    Oni_Core.Utility.waitForCondition(() => {
-      ExtensionHostClient.pump(extClient);
-      gotWillActivateMessage^;
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtensionHostClient.pump(extClient);
+        gotDidActivateMessage^;
+      });
+
+      ExtensionHostClient.close(extClient);
     });
-
-    Oni_Core.Utility.waitForCondition(() => {
-      ExtensionHostClient.pump(extClient);
-      gotDidActivateMessage^;
-    });
-
-    ExtensionHostClient.close(extClient);
   });
 });

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -7,156 +7,123 @@ open TestFramework;
 open ExtensionClientHelper;
 open ExtensionHostProtocol.OutgoingNotifications;
 
-describe("Extension Client", ({describe, _}) => {
-  describe("commands", ({test, _}) =>
-    test("executes simple command", (_) =>
-      withExtensionClient(api => {
-        let waitForCommandRegistration =
-          api.createWaiterForMessage(
-            "MainThreadCommands", "$registerCommand", args =>
-            switch(args) {
-            | [`String("extension.helloWorld"), ..._] => true
-            | _ => false
-            }
+describe("Extension Client", ({describe, _}) =>
+  describe("commands", ({test, _})
+    =>
+      test("executes simple command", _ =>
+        withExtensionClient(api => {
+          let waitForCommandRegistration =
+            api.createWaiterForMessage(
+              "MainThreadCommands", "$registerCommand", args =>
+              switch (args) {
+              | [`String("extension.helloWorld"), ..._] => true
+              | _ => false
+              }
+            );
+          let waitForShowMessage =
+            api.createWaiterForMessage(
+              "MainThreadMessageService", "$showMessage", _ =>
+              true
+            );
+
+          api.start();
+
+          waitForCommandRegistration();
+
+          api.send(
+            Commands.executeContributedCommand("extension.helloWorld"),
           );
-        let waitForShowMessage =
-          api.createWaiterForMessage(
-            "MainThreadMessageService", "$showMessage", _ =>
-            true
-          );
 
-        prerr_endline ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-        prerr_endline ("[STARTING]");
-        api.start();
-        prerr_endline ("[STARTING DONE]");
-
-        prerr_endline ("[WAITING FOR COMMAND REGISTRATION]");
-        waitForCommandRegistration();
-        prerr_endline ("[GOT COMMAND REGISTRATION]");
-
-        api.send(Commands.executeContributedCommand("extension.helloWorld"));
-
-        waitForShowMessage();
-      })
+          waitForShowMessage();
+        })
+      )
     )
-  );
-
-  /* describe("lifecycle", ({test, _}) => { */
-  /*   test("gets initialized message", ({expect}) => */
-  /*     Helpers.repeat(() => { */
-  /*       let setup = Setup.init(); */
-
-  /*       let initialized = ref(false); */
-
-  /*       let onInitialized = () => initialized := true; */
-  /*       let extClient = ExtensionHostClient.start(~onInitialized, setup); */
-
-  /*       Oni_Core.Utility.waitForCondition(() => { */
-  /*         ExtensionHostClient.pump(extClient); */
-  /*         initialized^; */
-  /*       }); */
-  /*       expect.bool(initialized^).toBe(true); */
-
-  /*       ExtensionHostClient.close(extClient); */
-  /*     }) */
-  /*   ); */
-
-  /*   test("doesn't die after a few seconds", ({expect}) => { */
-  /*     let setup = Setup.init(); */
-
-  /*     let initialized = ref(false); */
-  /*     let closed = ref(false); */
-
-  /*     let onClosed = () => closed := true; */
-  /*     let onInitialized = () => initialized := true; */
-  /*     let extClient = */
-  /*       ExtensionHostClient.start(~onInitialized, ~onClosed, setup); */
-
-  /*     Oni_Core.Utility.waitForCondition(() => { */
-  /*       ExtensionHostClient.pump(extClient); */
-  /*       initialized^; */
-  /*     }); */
-
-  /*     expect.bool(initialized^).toBe(true); */
-
-  /*     /1* The extension host process will die after a second if it doesn't see the parent PID *1/ */
-  /*     /1* We'll sleep for two seconds to be safe *1/ */
-  /*     Unix.sleep(2); */
-
-  /*     expect.bool(closed^).toBe(false); */
-  /*   }); */
-
-  /*   test("closes after close is called", ({expect}) => { */
-  /*     let setup = Setup.init(); */
-
-  /*     let initialized = ref(false); */
-  /*     let closed = ref(false); */
-
-  /*     let onClosed = () => closed := true; */
-  /*     let onInitialized = () => initialized := true; */
-  /*     let extClient = */
-  /*       ExtensionHostClient.start(~onInitialized, ~onClosed, setup); */
-
-  /*     Oni_Core.Utility.waitForCondition(() => { */
-  /*       ExtensionHostClient.pump(extClient); */
-  /*       initialized^; */
-  /*     }); */
-
-  /*     expect.bool(initialized^).toBe(true); */
-
-  /*     ExtensionHostClient.close(extClient); */
-
-  /*     Oni_Core.Utility.waitForCondition(() => { */
-  /*       ExtensionHostClient.pump(extClient); */
-  /*       closed^; */
-  /*     }); */
-
-  /*     expect.bool(closed^).toBe(false); */
-  /*   }); */
-
-  /*   test("basic extension activation", _ => { */
-  /*     let setup = Setup.init(); */
-
-  /*     let rootPath = Rench.Environment.getWorkingDirectory(); */
-  /*     let testExtensionsPath = */
-  /*       Rench.Path.join(rootPath, "test/test_extensions"); */
-
-  /*     let extensions = */
-  /*       ExtensionScanner.scan(testExtensionsPath) */
-  /*       |> List.map(ext => */
-  /*            ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext) */
-  /*          ); */
-
-  /*     let gotWillActivateMessage = ref(false); */
-  /*     let gotDidActivateMessage = ref(false); */
-
-  /*     let onMessage = (a, b, _c) => { */
-  /*       switch (a, b) { */
-  /*       | ("MainThreadExtensionService", "$onWillActivateExtension") => */
-  /*         gotWillActivateMessage := true */
-  /*       | ("MainThreadExtensionService", "$onDidActivateExtension") => */
-  /*         gotDidActivateMessage := true */
-  /*       | _ => () */
-  /*       }; */
-
-  /*       Ok(None); */
-  /*     }; */
-
-  /*     let initData = ExtensionHostInitData.create(~extensions, ()); */
-
-  /*     let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup); */
-
-  /*     Oni_Core.Utility.waitForCondition(() => { */
-  /*       ExtensionHostClient.pump(extClient); */
-  /*       gotWillActivateMessage^; */
-  /*     }); */
-
-  /*     Oni_Core.Utility.waitForCondition(() => { */
-  /*       ExtensionHostClient.pump(extClient); */
-  /*       gotDidActivateMessage^; */
-  /*     }); */
-
-  /*     ExtensionHostClient.close(extClient); */
-  /*   }); */
-  /* }); */
-});
+    describe("lifecycle", ({test, _}) => {
+      test("gets initialized message", ({expect}) =>
+        Helpers.repeat(() => {
+          let setup = Setup.init();
+          let initialized = ref(false);
+          let onInitialized = () => initialized := true;
+          let extClient = ExtensionHostClient.start(~onInitialized, setup);
+          Oni_Core.Utility.waitForCondition(() => {
+            ExtensionHostClient.pump(extClient);
+            initialized^;
+          });
+          expect.bool(initialized^).toBe(true);
+          ExtensionHostClient.close(extClient);
+        })
+      );
+      test("doesn't die after a few seconds", ({expect}) => {
+        let setup = Setup.init();
+        let initialized = ref(false);
+        let closed = ref(false);
+        let onClosed = () => closed := true;
+        let onInitialized = () => initialized := true;
+        let extClient =
+          ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+        Oni_Core.Utility.waitForCondition(() => {
+          ExtensionHostClient.pump(extClient);
+          initialized^;
+        });
+        expect.bool(initialized^).toBe(true);
+        /* The extension host process will die after a second if it doesn't see the parent PID */
+        /* We'll sleep for two seconds to be safe */
+        Unix.sleep(2);
+        expect.bool(closed^).toBe(false);
+      });
+      test("closes after close is called", ({expect}) => {
+        let setup = Setup.init();
+        let initialized = ref(false);
+        let closed = ref(false);
+        let onClosed = () => closed := true;
+        let onInitialized = () => initialized := true;
+        let extClient =
+          ExtensionHostClient.start(~onInitialized, ~onClosed, setup);
+        Oni_Core.Utility.waitForCondition(() => {
+          ExtensionHostClient.pump(extClient);
+          initialized^;
+        });
+        expect.bool(initialized^).toBe(true);
+        ExtensionHostClient.close(extClient);
+        Oni_Core.Utility.waitForCondition(() => {
+          ExtensionHostClient.pump(extClient);
+          closed^;
+        });
+        expect.bool(closed^).toBe(false);
+      });
+      test("basic extension activation", _ => {
+        let setup = Setup.init();
+        let rootPath = Rench.Environment.getWorkingDirectory();
+        let testExtensionsPath =
+          Rench.Path.join(rootPath, "test/test_extensions");
+        let extensions =
+          ExtensionScanner.scan(testExtensionsPath)
+          |> List.map(ext =>
+               ExtensionHostInitData.ExtensionInfo.ofScannedExtension(ext)
+             );
+        let gotWillActivateMessage = ref(false);
+        let gotDidActivateMessage = ref(false);
+        let onMessage = (a, b, _c) => {
+          switch (a, b) {
+          | ("MainThreadExtensionService", "$onWillActivateExtension") =>
+            gotWillActivateMessage := true
+          | ("MainThreadExtensionService", "$onDidActivateExtension") =>
+            gotDidActivateMessage := true
+          | _ => ()
+          };
+          Ok(None);
+        };
+        let initData = ExtensionHostInitData.create(~extensions, ());
+        let extClient = ExtensionHostClient.start(~initData, ~onMessage, setup);
+        Oni_Core.Utility.waitForCondition(() => {
+          ExtensionHostClient.pump(extClient);
+          gotWillActivateMessage^;
+        });
+        Oni_Core.Utility.waitForCondition(() => {
+          ExtensionHostClient.pump(extClient);
+          gotDidActivateMessage^;
+        });
+        ExtensionHostClient.close(extClient);
+      });
+    });
+);


### PR DESCRIPTION
This adds a test case to validate the flow of us sending a command (`extension.helloWorld`) to a VSCode plugin, and having it respond (our test plugin just sends an information message via `vscode.window.showInformationMessage`). 

A few things needed to be fixed / tweaked on the way:
- Added a helper for testing the extension client to remove some of the boilerplate
- Fix a bug with the `main` path in the extension manifest - needs to be mapped to an absolute path
- Workspace wasn't being sent along with the init data
- We weren't handling Error responses at all (still needs to be improved, so that we can pick up the payload and show a reasonable message)