### PR TITLE
Bugfix: text clipped in fractional lines

### DIFF
--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -118,7 +118,7 @@ let init = app => {
               ~fontSize,
               ~measuredWidth=
                 float_of_int(glyph.advance) /. (64. *. scaleFactor),
-              ~measuredHeight=actualHeight,
+              ~measuredHeight=floor(actualHeight +. 0.5),
               (),
             ),
           ),


### PR DESCRIPTION
__Issue:__ Text would be clipped in some lines:
![image](https://user-images.githubusercontent.com/13532591/55432083-e20bb300-5546-11e9-8c74-570390589ba8.png)

__Fix:__ Clamp text to integer y coordinates