### PR TITLE
Fix #203: Stop ripgrep process when QuickOpen is closed

### DIFF
--- a/src/editor/Core/Ripgrep.re
+++ b/src/editor/Core/Ripgrep.re
@@ -1,7 +1,9 @@
 open Rench;
 
+type disposeFunction = unit => unit;
+
 [@deriving show]
-type t = {search: (string, list(string) => unit) => unit};
+type t = {search: (string, list(string) => unit) => disposeFunction};
 
 let process = (rgPath, args, callback) => {
   let cp = ChildProcess.spawn(rgPath, args);
@@ -13,6 +15,8 @@ let process = (rgPath, args, callback) => {
     |> callback
   )
   |> ignore;
+
+  () => cp.kill(Sys.sigkill);
 };
 
 /**

--- a/src/editor/Core/Ripgrep.rei
+++ b/src/editor/Core/Ripgrep.rei
@@ -1,4 +1,3 @@
-
 type disposeFunction = unit => unit;
 
 [@deriving show]

--- a/src/editor/Core/Ripgrep.rei
+++ b/src/editor/Core/Ripgrep.rei
@@ -1,4 +1,7 @@
+
+type disposeFunction = unit => unit;
+
 [@deriving show]
-type t = {search: (string, list(string) => unit) => unit};
+type t = {search: (string, list(string) => unit) => disposeFunction};
 
 let make: string => t;

--- a/src/editor/Store/QuickOpenStoreConnector.re
+++ b/src/editor/Store/QuickOpenStoreConnector.re
@@ -27,17 +27,18 @@ let start = (rg: Core.Ripgrep.t) => {
     /* TODO: Track 'currentDirectory' in state as part of a workspace type  */
     let currentDirectory = Rench.Environment.getWorkingDirectory();
 
-    let dispose = rg.search(
-      currentDirectory,
-      items => {
-        let result =
-          items
-          |> List.filter(item => !Sys.is_directory(item))
-          |> List.map(stringToCommand(currentDirectory));
+    let dispose =
+      rg.search(
+        currentDirectory,
+        items => {
+          let result =
+            items
+            |> List.filter(item => !Sys.is_directory(item))
+            |> List.map(stringToCommand(currentDirectory));
 
-        setItems(result);
-      },
-    );
+          setItems(result);
+        },
+      );
 
     dispose;
   };

--- a/src/editor/Store/QuickOpenStoreConnector.re
+++ b/src/editor/Store/QuickOpenStoreConnector.re
@@ -27,7 +27,7 @@ let start = (rg: Core.Ripgrep.t) => {
     /* TODO: Track 'currentDirectory' in state as part of a workspace type  */
     let currentDirectory = Rench.Environment.getWorkingDirectory();
 
-    rg.search(
+    let dispose = rg.search(
       currentDirectory,
       items => {
         let result =
@@ -39,7 +39,7 @@ let start = (rg: Core.Ripgrep.t) => {
       },
     );
 
-    () => ();
+    dispose;
   };
 
   let openQuickOpenEffect =


### PR DESCRIPTION
__Issue:__ Even after closing QuickOpen, the ripgrep process is still running.

__Fix:__ 
- In `Ripgrep` module, return a dispose function so that consumers can kill the process.
- In `QuickOpen`, use `Ripgrep`'s dispose when the menu closes

Fixes #203 