### PR TITLE
Fix #193: Add place to start 'pre-flight' checks

### DIFF
--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -40,6 +40,8 @@ let init = app => {
   let cliOptions = Core.Cli.parse(setup);
   Sys.chdir(cliOptions.folder);
 
+  PreflightChecks.run();
+
   let currentState = ref(Model.State.create());
 
   let onStateChanged = v => {

--- a/src/editor/bin/PreflightChecks.re
+++ b/src/editor/bin/PreflightChecks.re
@@ -1,0 +1,15 @@
+/*
+ * PreflightChecks.re
+ *
+ * This establishes and verifies a set of invariants to ensure the environment
+ * is set up correctly for the application to run.
+ */
+
+let checkHomeDirectoryOrThrow = () => {
+    let home = Filesystem.unsafeFindHome();
+};
+
+
+let run = () => {
+    checkHomeDirectoryorThrow();
+};

--- a/src/editor/bin/PreflightChecks.re
+++ b/src/editor/bin/PreflightChecks.re
@@ -5,11 +5,13 @@
  * is set up correctly for the application to run.
  */
 
+open Oni_Core;
+
 let checkHomeDirectoryOrThrow = () => {
-  let home = Filesystem.unsafeFindHome();
+  let _ = Filesystem.unsafeFindHome();
   ();
 };
 
 let run = () => {
-  checkHomeDirectoryorThrow();
+  checkHomeDirectoryOrThrow();
 };

--- a/src/editor/bin/PreflightChecks.re
+++ b/src/editor/bin/PreflightChecks.re
@@ -6,10 +6,10 @@
  */
 
 let checkHomeDirectoryOrThrow = () => {
-    let home = Filesystem.unsafeFindHome();
+  let home = Filesystem.unsafeFindHome();
+  ();
 };
 
-
 let run = () => {
-    checkHomeDirectoryorThrow();
+  checkHomeDirectoryorThrow();
 };


### PR DESCRIPTION
Fix for #193 - add a module where we can place checks and establish invariants for the runtime of the application. The first check validates that we can find a `HOME` directory.