### PR TITLE
Performance: Reduce input delay

### DIFF
--- a/src/editor/Neovim/NeovimApi.re
+++ b/src/editor/Neovim/NeovimApi.re
@@ -11,6 +11,7 @@ open Rench;
 
 module M = Msgpck;
 
+type requestFunction = (string, M.t) => unit;
 type requestSyncFunction = (string, M.t) => M.t;
 
 type response = {
@@ -25,6 +26,14 @@ type notification = {
 
 type t = {
   requestSync: requestSyncFunction,
+
+  /*
+   * request is a 'fire-and-forget' method - 
+   * does not block on response.
+   */
+  request: requestFunction,
+
+
   /*
    * Pump should be called periodically to dispatch any queued notifications.
    */
@@ -115,6 +124,15 @@ let make = (msgpack: MsgpackTransport.t) => {
     List.rev(notifications) |> List.iter(f);
   };
 
+  let request = (methodName: string, args: M.t) => {
+      let requestId = getNextId();
+
+      let request =
+        M.List([M.Int(0), M.Int(requestId), M.String(methodName), args]);
+
+      msgpack.write(request);
+  };
+
   let requestSync: requestSyncFunction =
     (methodName: string, args: M.t) => {
       let requestId = getNextId();
@@ -149,6 +167,6 @@ let make = (msgpack: MsgpackTransport.t) => {
       ret;
     };
 
-  let ret: t = {pump, requestSync, onNotification};
+  let ret: t = {pump, request, requestSync, onNotification};
   ret;
 };

--- a/src/editor/Neovim/NeovimApi.re
+++ b/src/editor/Neovim/NeovimApi.re
@@ -26,14 +26,11 @@ type notification = {
 
 type t = {
   requestSync: requestSyncFunction,
-
   /*
-   * request is a 'fire-and-forget' method - 
+   * request is a 'fire-and-forget' method -
    * does not block on response.
    */
   request: requestFunction,
-
-
   /*
    * Pump should be called periodically to dispatch any queued notifications.
    */
@@ -125,12 +122,12 @@ let make = (msgpack: MsgpackTransport.t) => {
   };
 
   let request = (methodName: string, args: M.t) => {
-      let requestId = getNextId();
+    let requestId = getNextId();
 
-      let request =
-        M.List([M.Int(0), M.Int(requestId), M.String(methodName), args]);
+    let request =
+      M.List([M.Int(0), M.Int(requestId), M.String(methodName), args]);
 
-      msgpack.write(request);
+    msgpack.write(request);
   };
 
   let requestSync: requestSyncFunction =

--- a/src/editor/Neovim/NeovimProtocol.re
+++ b/src/editor/Neovim/NeovimProtocol.re
@@ -59,7 +59,7 @@ let make = (nvimApi: NeovimApi.t) => {
   };
 
   let input = (key: string) =>
-    nvimApi.requestSync("nvim_input", M.List([M.String(key)])) |> ignore;
+    nvimApi.request("nvim_input", M.List([M.String(key)]));
 
   let bufAttach = id => {
     let _error =


### PR DESCRIPTION
__Issue:__ For `nvim_input` calls (the API call we make to Neovim to send keystrokes), we were blocking on a response. There's actually no need for us to block the thread (which is the rendering thread at the moment!) for this, since we do not act on the result.

__Fix:__
- Add a `request` method to the nvim api, which is a fire-and-forget non-blocking method when we don't need a return result.
- Use the `request` method for `input` instead of `requestSync`.

