### PR TITLE
Fix #216: add Neovim menu focus to input control mode

### DIFF
--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -104,13 +104,12 @@ module Range = {
     endPosition,
   };
 
-  let create = (~startLine, ~startCharacter, ~endLine, ~endCharacter, ()) => {
+  let create = (~startLine, ~startCharacter, ~endLine, ~endCharacter, ()) =>
     createFromPositions(
       ~startPosition=Position.create(startLine, startCharacter),
       ~endPosition=Position.create(endLine, endCharacter),
       (),
     );
-  };
 };
 
 [@deriving show({with_path: false})]
@@ -304,7 +303,8 @@ module Input = {
   type controlMode =
     | [@name "menuFocus"] MenuFocus
     | [@name "textInputFocus"] TextInputFocus
-    | [@name "editorTextFocus"] EditorTextFocus;
+    | [@name "editorTextFocus"] EditorTextFocus
+    | [@name "neovimMenuFocus"] NeovimMenuFocus;
 
   [@deriving show({with_path: false})]
   type keyBindings = {

--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -107,6 +107,8 @@ let reduce: (State.t, Actions.t) => State.t =
         tabs: updateTabs(activeBufferId, modified, s.tabs),
       }
     | SetInputControlMode(m) => {...s, inputControlMode: m}
+    | CommandlineShow(_) => {...s, inputControlMode: NeovimMenuFocus}
+    | CommandlineHide(_) => {...s, inputControlMode: EditorTextFocus}
     | _ => s
     };
   };

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -106,10 +106,10 @@ let getActionsForBinding =
 
 /**
   Handle Input from Oni or Neovim
-
  */
-let handle = (~state: State.t, ~commands: Keybindings.t, inputKey) => {
+let handle = (~state: State.t, ~commands: Keybindings.t, inputKey) =>
   switch (state.inputControlMode) {
+  | NeovimMenuFocus
   | EditorTextFocus =>
     switch (getActionsForBinding(inputKey, commands, state)) {
     | [] => [Actions.KeyboardInput(inputKey)]
@@ -118,4 +118,3 @@ let handle = (~state: State.t, ~commands: Keybindings.t, inputKey) => {
   | TextInputFocus
   | MenuFocus => getActionsForBinding(inputKey, commands, state)
   };
-};


### PR DESCRIPTION
Add an `inputControlMode` for neovim externalized components so that we can specify their input behaviour. This fixes #216, as previously the input mode was `editorText` so the mapping for the quickopen was still valid whilst the commandline was open, which it shouldn't be.

This also opens the door for allowing oni specific binding for neovim gui externalisations :man_shrugging: