### PR TITLE
Rename no name buffer to untitled

### DIFF
--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -13,7 +13,7 @@ let sortTabsById = tabs =>
 let truncateFilepath = path =>
   switch (path) {
   | Some(p) => Filename.basename(p)
-  | None => "[No Name]"
+  | None => "untitled"
   };
 
 let showTablineTabs = (state: State.t, tabs) =>

--- a/src/editor/Model/State.re
+++ b/src/editor/Model/State.re
@@ -46,7 +46,7 @@ let create: unit => t =
     commandline: Commandline.create(),
     wildmenu: Wildmenu.create(),
     activeBufferId: 0,
-    buffers: BufferMap.Buffers.add(0, Buffer.ofLines([||]), BufferMap.empty),
+    buffers: BufferMap.empty,
     editorFont:
       EditorFont.create(
         ~fontFile="FiraCode-Regular.ttf",
@@ -57,7 +57,7 @@ let create: unit => t =
       ),
     uiFont: UiFont.create(~fontFile="selawk.ttf", ~fontSize=12, ()),
     syntaxHighlighting: SyntaxHighlighting.create(),
-    tabs: [Tab.create(0, "[No Name]")],
+    tabs: [],
     theme: Theme.create(),
     editor: Editor.create(),
     inputControlMode: EditorTextFocus,


### PR DESCRIPTION
Name any buffer's with an empty name `untitled` rather than `[no name]`. This is a bit of a break from what neovim does, I think untitled is more commonly used in other editors and *to my mind* reads better.

Also don't create dummy buffers and dummy state, these aren't necessary as neovim starts with an empty buffer so we don't need to create one beforehand