### PR TITLE
Performance: Don't render when state hasn't changed

### DIFF
--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -58,62 +58,61 @@ let applyBufferUpdate = (bufferUpdate, buffer) =>
   };
 
 let reduce: (State.t, Actions.t) => State.t =
-  (s, a) => {
-
+  (s, a) =>
     if (a == Actions.Tick) {
-        s
+      s;
     } else {
-        let s = {
-          ...s,
-          editor:
-            Editor.reduce(
-              s.editor,
-              a,
-              BufferMap.getBuffer(s.activeBufferId, s.buffers),
-            ),
-          syntaxHighlighting: SyntaxHighlighting.reduce(s.syntaxHighlighting, a),
-          wildmenu: Wildmenu.reduce(s.wildmenu, a),
-          commandline: Commandline.reduce(s.commandline, a),
-          statusBar: StatusBarReducer.reduce(s.statusBar, a),
-        };
+      let s = {
+        ...s,
+        editor:
+          Editor.reduce(
+            s.editor,
+            a,
+            BufferMap.getBuffer(s.activeBufferId, s.buffers),
+          ),
+        syntaxHighlighting:
+          SyntaxHighlighting.reduce(s.syntaxHighlighting, a),
+        wildmenu: Wildmenu.reduce(s.wildmenu, a),
+        commandline: Commandline.reduce(s.commandline, a),
+        statusBar: StatusBarReducer.reduce(s.statusBar, a),
+      };
 
-        switch (a) {
-        | SetLanguageInfo(languageInfo) => {...s, languageInfo}
-        | SetIconTheme(iconTheme) => {...s, iconTheme}
-        | ChangeMode(m) =>
-          let ret: State.t = {...s, mode: m};
-          ret;
-        | BufferWritePost(bs) => {
-            ...s,
-            activeBufferId: bs.bufferId,
-            buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
-            tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
-          }
-        | BufferDelete(bd) => {
-            ...s,
-            tabs: showTablineBuffers(s, bd.buffers, bd.bufferId),
-          }
-        | BufferEnter(bs) => {
-            ...s,
-            activeBufferId: bs.bufferId,
-            buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
-            tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
-          }
-        | BufferUpdate(bu) => {
-            ...s,
-            buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
-          }
-        | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
-        | SetEditorFont(font) => {...s, editorFont: font}
-        | TextChanged({activeBufferId, modified})
-        | TextChangedI({activeBufferId, modified}) => {
-            ...s,
-            tabs: updateTabs(activeBufferId, modified, s.tabs),
-          }
-        | SetInputControlMode(m) => {...s, inputControlMode: m}
-        | CommandlineShow(_) => {...s, inputControlMode: NeovimMenuFocus}
-        | CommandlineHide(_) => {...s, inputControlMode: EditorTextFocus}
-        | _ => s
-        };
+      switch (a) {
+      | SetLanguageInfo(languageInfo) => {...s, languageInfo}
+      | SetIconTheme(iconTheme) => {...s, iconTheme}
+      | ChangeMode(m) =>
+        let ret: State.t = {...s, mode: m};
+        ret;
+      | BufferWritePost(bs) => {
+          ...s,
+          activeBufferId: bs.bufferId,
+          buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
+          tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
+        }
+      | BufferDelete(bd) => {
+          ...s,
+          tabs: showTablineBuffers(s, bd.buffers, bd.bufferId),
+        }
+      | BufferEnter(bs) => {
+          ...s,
+          activeBufferId: bs.bufferId,
+          buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
+          tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
+        }
+      | BufferUpdate(bu) => {
+          ...s,
+          buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
+        }
+      | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
+      | SetEditorFont(font) => {...s, editorFont: font}
+      | TextChanged({activeBufferId, modified})
+      | TextChangedI({activeBufferId, modified}) => {
+          ...s,
+          tabs: updateTabs(activeBufferId, modified, s.tabs),
+        }
+      | SetInputControlMode(m) => {...s, inputControlMode: m}
+      | CommandlineShow(_) => {...s, inputControlMode: NeovimMenuFocus}
+      | CommandlineHide(_) => {...s, inputControlMode: EditorTextFocus}
+      | _ => s
+      };
     };
-  };

--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -59,56 +59,61 @@ let applyBufferUpdate = (bufferUpdate, buffer) =>
 
 let reduce: (State.t, Actions.t) => State.t =
   (s, a) => {
-    let s = {
-      ...s,
-      editor:
-        Editor.reduce(
-          s.editor,
-          a,
-          BufferMap.getBuffer(s.activeBufferId, s.buffers),
-        ),
-      syntaxHighlighting: SyntaxHighlighting.reduce(s.syntaxHighlighting, a),
-      wildmenu: Wildmenu.reduce(s.wildmenu, a),
-      commandline: Commandline.reduce(s.commandline, a),
-      statusBar: StatusBarReducer.reduce(s.statusBar, a),
-    };
 
-    switch (a) {
-    | SetLanguageInfo(languageInfo) => {...s, languageInfo}
-    | SetIconTheme(iconTheme) => {...s, iconTheme}
-    | ChangeMode(m) =>
-      let ret: State.t = {...s, mode: m};
-      ret;
-    | BufferWritePost(bs) => {
-        ...s,
-        activeBufferId: bs.bufferId,
-        buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
-        tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
-      }
-    | BufferDelete(bd) => {
-        ...s,
-        tabs: showTablineBuffers(s, bd.buffers, bd.bufferId),
-      }
-    | BufferEnter(bs) => {
-        ...s,
-        activeBufferId: bs.bufferId,
-        buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
-        tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
-      }
-    | BufferUpdate(bu) => {
-        ...s,
-        buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
-      }
-    | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
-    | SetEditorFont(font) => {...s, editorFont: font}
-    | TextChanged({activeBufferId, modified})
-    | TextChangedI({activeBufferId, modified}) => {
-        ...s,
-        tabs: updateTabs(activeBufferId, modified, s.tabs),
-      }
-    | SetInputControlMode(m) => {...s, inputControlMode: m}
-    | CommandlineShow(_) => {...s, inputControlMode: NeovimMenuFocus}
-    | CommandlineHide(_) => {...s, inputControlMode: EditorTextFocus}
-    | _ => s
+    if (a == Actions.Tick) {
+        s
+    } else {
+        let s = {
+          ...s,
+          editor:
+            Editor.reduce(
+              s.editor,
+              a,
+              BufferMap.getBuffer(s.activeBufferId, s.buffers),
+            ),
+          syntaxHighlighting: SyntaxHighlighting.reduce(s.syntaxHighlighting, a),
+          wildmenu: Wildmenu.reduce(s.wildmenu, a),
+          commandline: Commandline.reduce(s.commandline, a),
+          statusBar: StatusBarReducer.reduce(s.statusBar, a),
+        };
+
+        switch (a) {
+        | SetLanguageInfo(languageInfo) => {...s, languageInfo}
+        | SetIconTheme(iconTheme) => {...s, iconTheme}
+        | ChangeMode(m) =>
+          let ret: State.t = {...s, mode: m};
+          ret;
+        | BufferWritePost(bs) => {
+            ...s,
+            activeBufferId: bs.bufferId,
+            buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
+            tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
+          }
+        | BufferDelete(bd) => {
+            ...s,
+            tabs: showTablineBuffers(s, bd.buffers, bd.bufferId),
+          }
+        | BufferEnter(bs) => {
+            ...s,
+            activeBufferId: bs.bufferId,
+            buffers: BufferMap.updateMetadata(s.buffers, bs.buffers),
+            tabs: showTablineBuffers(s, bs.buffers, bs.bufferId),
+          }
+        | BufferUpdate(bu) => {
+            ...s,
+            buffers: BufferMap.update(bu.id, applyBufferUpdate(bu), s.buffers),
+          }
+        | TablineUpdate(tabs) => {...s, tabs: showTablineTabs(s, tabs)}
+        | SetEditorFont(font) => {...s, editorFont: font}
+        | TextChanged({activeBufferId, modified})
+        | TextChangedI({activeBufferId, modified}) => {
+            ...s,
+            tabs: updateTabs(activeBufferId, modified, s.tabs),
+          }
+        | SetInputControlMode(m) => {...s, inputControlMode: m}
+        | CommandlineShow(_) => {...s, inputControlMode: NeovimMenuFocus}
+        | CommandlineHide(_) => {...s, inputControlMode: EditorTextFocus}
+        | _ => s
+        };
     };
   };

--- a/src/editor/Store/MenuStoreConnector.re
+++ b/src/editor/Store/MenuStoreConnector.re
@@ -97,11 +97,13 @@ let start = () => {
     };
 
   let updater = (state: Model.State.t, action: Model.Actions.t) => {
-    let (menuState, menuEffect) = menuUpdater(state.menu, action);
-
-    let state = {...state, menu: menuState};
-
-    (state, menuEffect);
+    if (action === Model.Actions.Tick) {
+        (state, Isolinear.Effect.none)
+    } else {
+        let (menuState, menuEffect) = menuUpdater(state.menu, action);
+        let state = {...state, menu: menuState};
+        (state, menuEffect);
+    };
   };
 
   (updater, stream);

--- a/src/editor/Store/MenuStoreConnector.re
+++ b/src/editor/Store/MenuStoreConnector.re
@@ -96,15 +96,14 @@ let start = () => {
     | _ => (state, Isolinear.Effect.none)
     };
 
-  let updater = (state: Model.State.t, action: Model.Actions.t) => {
+  let updater = (state: Model.State.t, action: Model.Actions.t) =>
     if (action === Model.Actions.Tick) {
-        (state, Isolinear.Effect.none)
+      (state, Isolinear.Effect.none);
     } else {
-        let (menuState, menuEffect) = menuUpdater(state.menu, action);
-        let state = {...state, menu: menuState};
-        (state, menuEffect);
+      let (menuState, menuEffect) = menuUpdater(state.menu, action);
+      let state = {...state, menu: menuState};
+      (state, menuEffect);
     };
-  };
 
   (updater, stream);
 };

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -84,8 +84,8 @@ let start =
   let editorEventStream =
     Isolinear.Stream.map(storeStream, ((_state, action)) =>
       switch (action) {
-      | SetEditorFont(_)
-      | SetEditorSize(_)
+      | Model.Actions.SetEditorFont(_)
+      | Model.Actions.SetEditorSize(_)
       | Model.Actions.BufferUpdate(_)
       | Model.Actions.BufferEnter(_) =>
         Some(Model.Actions.RecalculateEditorView)

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -46,10 +46,8 @@ let init = app => {
   let isDirty = ref(false);
 
   let onStateChanged = v => {
-    if (v !== currentState^) {
-        currentState := v;
-        isDirty := true;
-    };
+    currentState := v;
+    isDirty := true;
   };
 
   let dispatch =

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -43,9 +43,13 @@ let init = app => {
   PreflightChecks.run();
 
   let currentState = ref(Model.State.create());
+  let isDirty = ref(false);
 
   let onStateChanged = v => {
-    currentState := v;
+    if (v !== currentState^) {
+        currentState := v;
+        isDirty := true;
+    };
   };
 
   let dispatch =
@@ -58,6 +62,7 @@ let init = app => {
     );
 
   let render = () => {
+    isDirty := false;
     let state = currentState^;
     GlobalContext.set({
       state,
@@ -83,7 +88,7 @@ let init = app => {
 
   UI.start(w, render);
 
-  Window.setShouldRenderCallback(w, _ => true);
+  Window.setShouldRenderCallback(w, _ => isDirty^);
 
   dispatch(Model.Actions.Init);
 
@@ -160,11 +165,6 @@ let init = app => {
   Reglfw.Glfw.glfwSetCharModsCallback(w.glfwWindow, (_w, codepoint, mods) =>
     Input.charToCommand(codepoint, mods) |> keyEventListener
   );
-
-  /* List.iter( */
-  /*   p => neovimProtocol.openFile(~path=p, ()), */
-  /*   cliOptions.filesToOpen, */
-  /* ); */
 
   ();
 };


### PR DESCRIPTION
This updates our `Window.setShouldRenderCallback` to properly test if the state has changed - if not, we shouldn't bother rendering.

With the change to use `isolinear`, we now have a high-frequency action in the form of `Tick`. We need to make sure not to update the state unnecessarily with that action, otherwise we'll always get renders - fixed a bug to that effect.