### PR TITLE
Minimap mouse support

### DIFF
--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -90,14 +90,17 @@ let createElement =
     let getScrollTo = (mouseY: float) => {
       let totalHeight: int = Editor.getTotalSizeInPixels(state.editor);
       let visibleHeight: int = state.editor.size.pixelHeight;
-      let offsetMouseY: int = int_of_float(mouseY) - Tab.tabHeight; 
-      (float_of_int(offsetMouseY) /. float_of_int(visibleHeight)) *. 
-        float_of_int(totalHeight);
-    }
+      let offsetMouseY: int = int_of_float(mouseY) - Tab.tabHeight;
+      float_of_int(offsetMouseY)
+      /. float_of_int(visibleHeight)
+      *. float_of_int(totalHeight);
+    };
+
+    let doScroll = () => {};
 
     let scrollComplete = () => {
       setActive(false);
-    }
+    };
 
     let hooks =
       React.Hooks.effect(
@@ -106,26 +109,27 @@ let createElement =
           let isCaptured = isActive;
           let startPosition = state.editor.scrollY;
 
-              Mouse.setCapture(
-                ~onMouseMove=
-                  evt =>
-                    {
-                      let scrollTo = getScrollTo(evt.mouseY);
-                      if (isCaptured) {
-                        let minimapLineSize =
-                        Constants.default.minimapCharacterWidth
-                        + Constants.default.minimapCharacterHeight;
-                        let linesInMinimap = state.editor.size.pixelHeight / minimapLineSize;
-                        GlobalContext.current().editorScroll(
-                          ~deltaY=((startPosition -. scrollTo) *. -1.) -. 
-                            float_of_int(linesInMinimap),
-                          ()
-                        );
-                      };
+          Mouse.setCapture(
+            ~onMouseMove=
+              evt =>
+                if (isCaptured) {
+                  let scrollTo = getScrollTo(evt.mouseY);
+                  let minimapLineSize =
+                    Constants.default.minimapCharacterWidth
+                    + Constants.default.minimapCharacterHeight;
+                  let linesInMinimap =
+                    state.editor.size.pixelHeight / minimapLineSize;
+                  GlobalContext.current().editorScroll(
+                    ~deltaY=
+                      (startPosition -. scrollTo)
+                      *. (-1.)
+                      -. float_of_int(linesInMinimap),
+                    (),
+                  );
                 },
-                ~onMouseUp= _evt => scrollComplete(),
-                (),
-              );
+            ~onMouseUp=_evt => scrollComplete(),
+            (),
+          );
 
           Some(
             () =>
@@ -142,11 +146,12 @@ let createElement =
     let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
       let scrollTo = getScrollTo(evt.mouseY);
       let minimapLineSize =
-      Constants.default.minimapCharacterWidth
-      + Constants.default.minimapCharacterHeight;
+        Constants.default.minimapCharacterWidth
+        + Constants.default.minimapCharacterHeight;
       let linesInMinimap = state.editor.size.pixelHeight / minimapLineSize;
       GlobalContext.current().editorScroll(
-        ~deltaY=(scrollTo -. state.editor.scrollY) -. float_of_int(linesInMinimap),
+        ~deltaY=
+          scrollTo -. state.editor.scrollY -. float_of_int(linesInMinimap),
         (),
       );
       setActive(true);

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -96,8 +96,6 @@ let createElement =
       *. float_of_int(totalHeight);
     };
 
-    let doScroll = () => {};
-
     let scrollComplete = () => {
       setActive(false);
     };

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -112,10 +112,15 @@ let createElement =
                     {
                       let scrollTo = getScrollTo(evt.mouseY);
                       if (isCaptured) {
+                        let minimapLineSize =
+                        Constants.default.minimapCharacterWidth
+                        + Constants.default.minimapCharacterHeight;
+                        let linesInMinimap = state.editor.size.pixelHeight / minimapLineSize;
                         GlobalContext.current().editorScroll(
-                                    ~deltaY=(startPosition -. scrollTo) *. -1.,
-                                    ()
-                                  );
+                          ~deltaY=((startPosition -. scrollTo) *. -1.) -. 
+                            float_of_int(linesInMinimap),
+                          ()
+                        );
                       };
                 },
                 ~onMouseUp= _evt => scrollComplete(),
@@ -136,9 +141,12 @@ let createElement =
 
     let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
       let scrollTo = getScrollTo(evt.mouseY);
-
+      let minimapLineSize =
+      Constants.default.minimapCharacterWidth
+      + Constants.default.minimapCharacterHeight;
+      let linesInMinimap = state.editor.size.pixelHeight / minimapLineSize;
       GlobalContext.current().editorScroll(
-        ~deltaY=scrollTo -. state.editor.scrollY,
+        ~deltaY=(scrollTo -. state.editor.scrollY) -. float_of_int(linesInMinimap),
         (),
       );
       setActive(true);

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -87,11 +87,22 @@ let createElement =
 
     let scrollY = state.editor.minimapScrollY;
 
+    let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
+      let totalHeight: int = Editor.getTotalSizeInPixels(state.editor);
+      let visibleHeight: int = state.editor.size.pixelHeight;
+      let offsetMouseY: int = int_of_float(evt.mouseY) - Tab.tabHeight; 
+      let scrollTo: float = (float_of_int(offsetMouseY) /. float_of_int(visibleHeight)) *. float_of_int(totalHeight);
+      GlobalContext.current().editorScroll(
+        ~deltaY=scrollTo -. state.editor.scrollY,
+        (),
+      );
+    };
+
     ignore(width);
 
     (
       hooks,
-      <View style=absoluteStyle>
+      <View style=absoluteStyle onMouseDown>
         <OpenGL
           style=absoluteStyle
           render={(transform, _) => {

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -85,17 +85,63 @@ let createElement =
         + Constants.default.minimapLineSpacing,
       );
 
+    let (isActive, setActive, hooks) = React.Hooks.state(false, hooks);
+
+    let getScrollTo = (mouseY: float) => {
+      let totalHeight: int = Editor.getTotalSizeInPixels(state.editor);
+      let visibleHeight: int = state.editor.size.pixelHeight;
+      let offsetMouseY: int = int_of_float(mouseY) - Tab.tabHeight; 
+      (float_of_int(offsetMouseY) /. float_of_int(visibleHeight)) *. 
+        float_of_int(totalHeight);
+    }
+
+    let scrollComplete = () => {
+      setActive(false);
+    }
+
+    let hooks =
+      React.Hooks.effect(
+        Always,
+        () => {
+          let isCaptured = isActive;
+          let startPosition = state.editor.scrollY;
+
+              Mouse.setCapture(
+                ~onMouseMove=
+                  evt =>
+                    {
+                      let scrollTo = getScrollTo(evt.mouseY);
+                      if (isCaptured) {
+                        GlobalContext.current().editorScroll(
+                                    ~deltaY=(startPosition -. scrollTo) *. -1.,
+                                    ()
+                                  );
+                      };
+                },
+                ~onMouseUp= _evt => scrollComplete(),
+                (),
+              );
+
+          Some(
+            () =>
+              if (isCaptured) {
+                Mouse.releaseCapture();
+              },
+          );
+        },
+        hooks,
+      );
+
     let scrollY = state.editor.minimapScrollY;
 
     let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
-      let totalHeight: int = Editor.getTotalSizeInPixels(state.editor);
-      let visibleHeight: int = state.editor.size.pixelHeight;
-      let offsetMouseY: int = int_of_float(evt.mouseY) - Tab.tabHeight; 
-      let scrollTo: float = (float_of_int(offsetMouseY) /. float_of_int(visibleHeight)) *. float_of_int(totalHeight);
+      let scrollTo = getScrollTo(evt.mouseY);
+
       GlobalContext.current().editorScroll(
         ~deltaY=scrollTo -. state.editor.scrollY,
         (),
       );
+      setActive(true);
     };
 
     ignore(width);


### PR DESCRIPTION
Adding minimap mouse support for scrolling.

[x] Click to move thumb immediately
[x] Drag to scroll

was able to mimic implementation from Revery Slider.

Completes: #159 

![w9fVpNbTfr](https://user-images.githubusercontent.com/20171781/55923046-07409700-5bc1-11e9-9935-88235aeac7da.gif)

PS: please let me know of any improvements that could be made or better practices implemented as I'm just getting started with ReasonML.