### PR TITLE
Bugfix: Get BufferViewTokenizer tests green again

### DIFF
--- a/test/editor/Model/BufferViewTokenizerTests.re
+++ b/test/editor/Model/BufferViewTokenizerTests.re
@@ -41,6 +41,13 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
 
       let expectedTokens: list(BufferViewTokenizer.t) = [
         {
+          tokenType: Tab,
+          text: "\t",
+          startPosition: ZeroBasedIndex(0),
+          endPosition: ZeroBasedIndex(4),
+          color: Colors.red,
+        },
+        {
           tokenType: Text,
           text: "abc",
           startPosition: ZeroBasedIndex(4),
@@ -62,7 +69,7 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
         colorMap,
         indentation,
       );
-    expect.int(List.length(result)).toBe(0);
+    expect.int(List.length(result)).toBe(2);
   });
 
   test("single word token", ({expect}) => {
@@ -100,10 +107,24 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
       {
+        tokenType: Whitespace,
+        text: "  ",
+        startPosition: ZeroBasedIndex(0),
+        endPosition: ZeroBasedIndex(2),
+        color: Colors.red,
+      },
+      {
         tokenType: Text,
         text: "testWord",
         startPosition: ZeroBasedIndex(2),
         endPosition: ZeroBasedIndex(10),
+        color: Colors.red,
+      },
+      {
+        tokenType: Whitespace,
+        text: "  ",
+        startPosition: ZeroBasedIndex(10),
+        endPosition: ZeroBasedIndex(12),
         color: Colors.red,
       },
     ];
@@ -180,6 +201,13 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
       {
+        tokenType: Whitespace,
+        text: " ",
+        startPosition: ZeroBasedIndex(0),
+        endPosition: ZeroBasedIndex(1),
+        color: Colors.red,
+      },
+      {
         tokenType: Text,
         text: "a",
         startPosition: ZeroBasedIndex(1),
@@ -187,10 +215,24 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
         color: Colors.red,
       },
       {
+        tokenType: Whitespace,
+        text: " ",
+        startPosition: ZeroBasedIndex(2),
+        endPosition: ZeroBasedIndex(3),
+        color: Colors.red,
+      },
+      {
         tokenType: Text,
         text: "btest",
         startPosition: ZeroBasedIndex(3),
         endPosition: ZeroBasedIndex(8),
+        color: Colors.red,
+      },
+      {
+        tokenType: Whitespace,
+        text: " ",
+        startPosition: ZeroBasedIndex(8),
+        endPosition: ZeroBasedIndex(9),
         color: Colors.red,
       },
     ];

--- a/test/editor/Model/BufferViewTokenizerTests.re
+++ b/test/editor/Model/BufferViewTokenizerTests.re
@@ -13,7 +13,7 @@ let colorMap = ColorMap.create();
 
 let indentation = IndentationSettings.default;
 
-describe("tokenize", ({test, _}) => {
+describe("BufferViewTokenizer", ({describe, test, _}) => {
   test("empty string", ({expect}) => {
     let result =
       BufferViewTokenizer.tokenize(


### PR DESCRIPTION
The `BufferViewTokenizer` tests weren't updated with whitespace settings / parsing - this change gets them green and passing again.

(#241 fixes the root cause - we weren't properly failing CI builds when tests failed!)