### PR TITLE
Documentation: Updated and (hopefully final!) EULA

### DIFF
--- a/Outrun-Labs-EULA-v1.0.md
+++ b/Outrun-Labs-EULA-v1.0.md
@@ -1,0 +1,151 @@
+# Outrun Labs End User License Agreement (EULA)
+
+Copyright 2019 Outrun Labs LLC
+
+Outrun Labs LLC
+END USER LICENSE AGREEMENT
+3/7/2019
+
+PLEASE READ CAREFULLY BEFORE USING THIS PRODUCT: This End-User License Agreement ("EULA") is a legal agreement ("Agreement") between (a) you, either an individual or a single entity ("Licensee") and (b) Outrun Labs LLC ("Outrun Labs") that governs your use of software programs ("Software").
+
+BY DOWNLOADING, INSTALLING, OR USING THE SOFTWARE, YOU REPRESENT THAT YOU HAVE ACQUIRED THE SOFTWARE FROM AN APPROVED SOURCE AND YOU AGREE TO BE BOUND BY THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING THESE TERMS ON BEHALF OF ANOTHER PERSON,  OR OTHER LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE FULL AUTHORITY TO BIND THAT PERSON, COMPANY OR LEGAL ENTITY TO THESE TERMS.
+
+## 1. GRANT OF LICENSE
+
+__1.1 License Grant.__ 
+
+Subject to terms and the scope of the applicable license model as set out in clause 2, Outrun Labs grants You a limited, revocable, non-exclusive, non-transferable license to download, install, and use a machine-readable, object code version of the software programs purchased by Licensee ("Software"), and any accompanying user guide and other documentation (the "Documentation"), solely for Licensee's own internal purposes, provided, however, that Licensee's right to download, install, and use the Software and the Documentation is limited to those rights expressly set out in this EULA.
+
+__1.2 Title and Ownership.__ 
+
+The Software is licensed, not sold to you, by Outrun Labs, and Outrun Labs reserves any rights not expressly granted to you. Licensee may not remove any titles, trademarks or trade names, copyright notices, legends, or other proprietary markings in or on the Software or Documentation and will not acquire any rights in the Software, except the limited license specified in this Agreement. Title to the Software, Documentation, Updates, and all copyrights and other worldwide proprietary and intellectual property rights in or related thereto are and will remain the exclusive property of Outrun Labs and its licensors.
+
+__1.3 Third Party Software.__ 
+
+The Software may include various third-party software components or software services ("Third-Party Software" and together with the Software, the "Package"). Notwithstanding the terms and conditions of this EULA, all or any portion of the Software Product which constitutes Third Party Software, is licensed to you subject to the terms and conditions of the software license agreement accompanying such Third Party Software whether in the form of a discrete agreement, shrink wrap license, or electronic license terms accepted at time of download. Use of the Third Party Software by you shall be governed entirely by the terms and conditions of such license. Outrun Labs shall have no liability for Licensee's use of any third-party software.
+
+__1.4 Restrictions on Use.__ 
+
+You shall use the Software strictly in accordance with the terms of the this Agreements and shall not: (a) distribute the Software (b) make the Software available over a network or other environment permitting access or use by multiple users at the same time; (c) violate any applicable laws, rules, or regulations in connection with Your access or use of the Software; (d) use the Software for any revenue generating endeavor, commercial enterprise, employment, or other purpose for which it is not designed or intended; (e) use the Software for creating a product, service, or software that is, directly or indirectly, competitive with or in any way a substitute for services, product or software offered by Company; (f) remove proprietary notices from the Software or the Documentation.
+
+__1.5 Reservation of Rights.__ 
+
+Except as expressly granted in this Agreement, there are no other licenses granted to you, express, implied, or by way of estoppel. All rights not granted in this Agreement are reserved by Outrun Labs.
+
+## 2. LICENSE MODELS
+
+2.1 For each software product that you purchase from Outrun Labs, the product will be licensed (and not sold) to you on the terms of one or more of the license models set out in this clause as specified in Outrun Labs' invoice or order confirmation, and subject to the other terms and conditions of this EULA. Please note that some licensing models set out below do not apply to certain Software products of Outrun Labs.
+
+(a) "Non-Commercial License"
+
+If the License is a Non-Commercial License, Licensee warrants and represents that Licensee is a natural person, that they will only access and/or use one copy of a Non-Commercial License for personal, recreational, and non-commercial purposes and that only Licensee will use the Software. Under a Non-Commercial License, Licensee will not use the Software: (a) in conjunction with any other copies or versions of the Software, under any type of License model; (b) for any commercial, professional, for-profit and/or on-sale purpose or otherwise to provide any commercial service(s) to a third-party. (c) in the course of any employment or business undertaking of Licensee; (d) on any commercial premises during business hours (except where use of the Software is solely for a personal, recreational, educational, or other non-commercial purpose); and/or (e) to create any commercial tools or plugins.
+
+(b) "Commercial Subscription License"
+
+If the Licensee purchases a License for Commercial Use, then the provisions of clause 6 shall apply.
+
+## 3. SOURCE CODE
+
+Notwithstanding that clause 1.1 defines "Software" as an object code version and that clause 1.4 provides that Licensee may use the Software in object code form only:
+
+__3.1__ Licensee shall be licensed to use the source code or elements of the source code ("Source Code") as Software on the terms of this EULA and (a) Licensee may use the Source Code at its own risk in any reasonable way for the limited purpose of enhancing its use of the Software solely for its own internal business purposes and in all respects in accordancew ith this EULA; (b) Licensee shall in respect of the Source Code comply strictly with all other restrictions applying to its use of the Software under this EULA as well as any other restriction or instruction that is communicated to it by Outrun Labs at any time during the Agreement.
+
+__3.2__ To the extent that the Software links to any open source software libraries ("Third-Party Software") that are provided to Licensee with the software, nothing in the EULA shall affect Licensee's rights under the licenses on which the relevant Third Party licensor has licensed the OSS Libraries. To the extent that Third Party Licensors have licensed Third-Party Software on the terms of v2.1 of the Lesser General Public License issued by the Free Software Foundation (see http://www.gnu.org/licenses/lgpl-2.1.html) (the "LGPL"), those OSS Libraries are licensed to Licensee on the terms of the LGPL and are referred to in this caluse 2.2 as the LGPL Libraries.
+
+__3.3__ Notwithstanding any other term of the EULA, Outrun Labs gives no express or implied warranty, undertaking or indemnity whatsoever in respect of the Source Code, the Third-Party Software, all of which are licensed on an "as is" basis, or in respect of any modification of the Source Code, Licensee may not use the Software for any purpose other than its use of the Software in accordance with this EULA. Notwithstanding any other term of the Agreement, Outrun Labs shall have no obligation to provide support, maintenance, upgrades or updates of or in respect of any of the Source Code or Third-Party Libraries. Licensee shall indemnify Outrun Labs against all liabilities and expenses (including reasonable legal costs) incurred by Outrun Labs in relation to any claim asserting that any modification infringes the intellectual property rights of any third party.
+
+## 4. OWNERSHIP
+
+__4.1 Intellectual Property.__ 
+
+Outrun Labs owns and will retain all legal rights in the software, including all copies, alterations, derivatives, or modifications of Software, whether in whole or in part. Software is licensed, not sold. Licensee acknowledges that the Software (including, for the avoidance of doubt, any Source Code that is licensed to Licensee) and Documentation and all related intellectual property rights and other proprietary rights are and shall remain the sole property of Outrun Labs. The Software, Source Code, and Documentation are protected under United States copyright and other intellectual property laws and international treaties.
+
+## 5. LICENSE FEE
+
+__5.1__ Licensee acknowledges that the rights granted to Licensee under this EULA are conditional on Licensee's timely payment of the license fee payable to Outrun Labs in connection with the Agreement. 
+
+__5.2__ Licensee will be charged and agrees to pay Outrun Labs: (a) the License Fee as notified by Outrun Labs at the time of the initial purchase of the License; and (b) in respect of any Subscription Autorenewal Period for a Subscription License, the License Fee as notified by Outrun Labs on or about the applicable Renewal Date; in each case toegether with any/all applicable taxes or other duties or levies.
+
+__5.3__ In the cases of Non-Commercial License, for the avoidance of doubt, the fact that no License Fee may be payable shall not be construed as a waiver by Outrun Labs of any right or remedy avaiable to it in relation to any breach by Licensee of this EULA or the Agreement, or of any other right or remedy arising under applicable law, all of which are expressly reserved.
+
+## 6. Subscription Licenses and Auto-Renewal
+
+__6.1__ If Licensee has purchased a Subscription License, the License shall be limited to the Initial Subscription Period and any/all Auto-Renewal Periods after which it shall automatically expire.
+
+__6.2__ The Subscription License shall begin as soon as Outrun Labs accepts Licensee's order by issuing Licensee with a license key (the "Subscription Start Date") and shall continue for an initial period of one (1) month (the "Initial Subscription Period") unless earlier terminated in accordance the terms of this EULA.
+
+__6.3__ Unless Licensee opts out of auto-renewal in accordance with clause 6.5 then upon the first monthly anniversay of the Subscription Start Date and each subsequent anniversary (each a "Subscription Renewal Date"), Licensee's Subscription Licence shall renew automatically for a further one (1) month (each an "Auto-renewal Period"). Licensee's Subscription License will continue to renew in this manner until Licensee opts out of auto-renewal or unless earlier terminated in accordance with the terms of this EULA.
+
+__6.4.__ No maintenance and support services are included with the License Fee.
+
+__6.5 Opting Out of Auto-Renewal.__ 
+
+If Licensee wishes to opt out of auto-renewal, then You must email license@outrunlabs.com providing details of the Subscription Licenses which you wish to opt-out not less than seventy-two hours prior to the relevant Subscription Renewal Date. Provided that Licensee notifies Outrun Labs in accordance with the provisions of this clause 6.5, then your Subscription License will not auto-renew.
+
+__6.7 Increases to the License Fee for Subscription Licenses.__ 
+
+Outrun Labs reserves the right to increase the License Fee for Subscription Licenses from time-to-time provided that it shall provide Licensee with not less than thirty (30) day's notice of any increase prior to the relevant Subscription Renewal Date.
+
+## 7. Term and Termination
+
+__7.1__ This Agreement is effective upon your acceptance herof, or upon your downloading, installing, accessing and using the Software and Source Code, even if you have not expressly accepted this Agreement. This Agreement shall continue in effect until expiration or termination as provided herein (the "Term"). If Licensee breaches the Agreement, Outrun Labs may terminate the License immediately by notice to Licensee.
+
+__7.2__ If the Agreement expires or is terminated, the License will cease immediately and Licensee will immediately cease use of any Software, Documentation, and Source Code, or, if Outrun Labs directs in writing, destroy all such copies.
+
+__7.3__ Outrun Labs reserves the right to terminate and/or suspend the License as it deems reasonable in its sole discretion by notice to Licensee if it becomes aware that Licensee has failed to pay any sum due to Outrun Labs.
+
+## 8. LIMITATION OF LIABILITY
+
+__8.1 LIMITATION OF LIABILITY__ 
+
+IN NO EVENT SHALL OUTRUN LABS BE LIABLE TO YOU OR ANY PARTY RELATED TO YOU FOR ANY INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL, EXEMPLARY, OR PUNITIVE DAMAGES (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, LOSS OF DATA OR OTHER SUCH PECUNIARY LOSS), WHETHER UNDER A THEORY OF CONTRACT, WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCTS LIABILITY, OR OTHERWISE, EVEN IF OUTRUN LABS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL OUTRUN LABS' TOTAL AGGREGATE AND CUMULATIVE LIABILITY TO YOU FOR ANY AND ALL CLAIMS OF ANY KIND ARISING HEREUNDER EXCEED THE AMOUNT OF LICENSE FEES ACTUALLY PAID BY YOU FOR THE SOFTWARE GIVING RISE TO THE CLAIM IN THE TWELVE MONTHS PRECEDING THE CLAIM. THE FOREGOING LIMITATIONS WILL APPLY EVEN IF THE ABOVE STATED REMEDY FAILS OF ITS ESSENTIAL PURPOSE.
+
+__8.2 CERTAIN LIMITATIONS.__ 
+
+SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF OR LIMITATION OR EXCLUSION OF CERTAIN TYPES OF WARRANTIES, DAMAGES, OR LIABILITIES, SO THE ABOVE EXCLUSION AND LIMITATIONS MAY NOT APPLY TO YOU, BUT IN SUCH A CASE THE EXCLUSIONS AND LIMITATIONS SET FORTH IN THIS SECTION 4 SHALL BE APPLIED TO THE GREATEST EXTENT ENFORCEABLE UNDER APPLICABLE LAW.
+
+__8.3 NO GUARANTEES.__ 
+
+Outrun Labs does not guarantee that Software will meet all of your requirements, or that any errors in Software will be corrected. Outrun Labs is not obligated to provide upgrades, fixes, or changes.
+
+## 9. Warranty Disclaimer
+
+__9.1 DISCLAIMER.__ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## 10. General Terms
+
+__10.1 FEEDBACK.__
+
+If you provide any ideas, feedback, suggestions, materials, information, opinions, or other input to Outrun Labs, whether by letter, email, telephone, or otherwise ("Feedback"), all such submissions are made on a non-confidential basis and Outrun Labs has no obligation to review, consider, or implement such Feedback, and you shall grant herewith Outrun Labs and its successors and assignees (the "Outrun Labs Licensees") an exclusive, transferable, worldwide, royalty-free, fully-paid-up license (including the right to sublicense) to use, reproduce, modify, disclose, and otherwise exploit such Feedback as the Outrun Labs Licensees may determine in their sole discretion without any compensation or attribution. You waive and agree not to assert any so-called "moral rights" you may have in the Feedback, and you understand and agree the the Outrun Labs Licensers are not obligated to use, display, reproduce, or distribute any such ideas, know-how, concepts, or techniques contained in the Feedback, and you have no right to compel such use, display, reproduction, or distribution.
+
+__10.2 Governing Law and Choice of Forum__
+
+This Agreement shall be governed by and interpreted in accordance with the laws of the United States' State of Washington, without regard to the conflicts of law rules thereof, to the extent such rules would result in the application of another jurisdiction's laws. Any claim or dispute arising in connection with this Agreement shall be resolved in the federal or state courts situated within the Western District of Washington. To the maximum extent permitted by law, you hereby consent to the jurisdiction and venue of such courts and waive any objections to the jursidiction or venue of such courts. This Agreement shall not be governed by the United Nations Convention on Contracts for the International Sale of Goods or the Uniform Computer Information Transactions Act, the application of each of which is expressly excluded.
+
+__10.3 Severability__
+
+If any term or provision of this Agreement is declared void or unenforcable in a particular situation, by any judicial or administrative authority, this declaration shall not affect the validity or enforceability of the remaining terms and provisions hereof or the validity or enforceability of the offending term or provision in any other situation. To the extent possible the provision will be interpreted and enforced to the greatest extent legally permissible in order to effectuate the original intent, and if no such interpretation or enforcement is legally permissible, shall be deemed severed from the Aggreement.
+
+__10.4 Headings__
+
+The Article and Section headings contained in this Agreement are included for reference purposes only and shall not affect the meaning or interpretation of this agreement.
+
+__10.5 No Waiver__
+
+The failure of either party to enforce any rights granted hereunder or to take action against the other party in the event of any breach hereunder shall not be deemed a waiver by that party as to subsequent enforcement of rights or subsequent actions in the event of future breaches.
+
+__10.6 Amendment__
+
+Outrun Labs reserves the right, in its sole discretion, to amend this Agreement from time to time by posting an updated version of this Agreement on www.outrunlabs.com. Your continued use of the Software or Source Code will signify your assent to and acceptance of the amended Agreement. If you do not accept amendments made to this Agreement, then it is your responsibility to cease all use of the Software and terminate this Agreement pursuant to Article 7. 
+
+__10.7 Legal and Export Control Compliance__
+
+Customer agrees to comply with all applicable laws. Without limiting the foregoing, Customer agrees to comply with all United States export laws and applicable import laws of Customer's locality (if Customer is not located in the United States), and Customer agrees not to export any Software without first obtaining all required authorizations or licenses. In particular, but without limitation, the Software may not be exported or re-exported (a) into any U.S. embargoed countries; or (b) to anyone on the U.S. Treasury Department's list of Specially Designated nationals of the U.S. Department of Commerce Denied Person's List or Entity List. By using the Software, Customer makes representations and warranties of not being located in any such country or on any such list. Customer also agrees not to use the Software for any purposes prohibited by United States law, including, without limitation, the development, design, manufacture or production of nuclear, missiles, or chemical or biological weapons.
+
+__10.8 Indemnification__
+
+You agree to indemnify, hold harmless and defend Outrun Labs from all claims, defense costs (including, but not limited to, legal fees), judgments, settlements and other expenses arising from or connected with any claim that any authorized or unauthorized modification of the Software or Documentation by Licensee or any person connected with Licensee infringes the intellectual property rights or other proprietary rights of any third party.
+
+__10.9 Contact Information__
+
+You may contact Outrun Labs by e-mail via license@outrunlabs.com, or by visiting our website: http://www.outrunlabs.com

--- a/README.md
+++ b/README.md
@@ -63,19 +63,17 @@ The TL;DR is:
 - __Commercial use__ requires the purchase of a license.
 - You may not redistribute source code or binaries under a different license.
 
-You can pre-order a commercial license here with a pay-what-you-want model: https://v2.onivim.io
+You can pre-order a commercial license here (pay-what-you-want): https://v2.onivim.io
 
-As we get closer to shipping, we'll start bumping up the minimum required pre-order, until we settle on our full pricing model - $5/mo, $50/yr, or $99 lifetime.
+As we get closer to shipping, we'll bump up the minimum required pre-order, until we settle on our full pricing model - $5/mo, $50/yr, or $99 lifetime.
 
-__Anyone who has contributed financially to the project__ - via BountySource, Patreon, PayPal, or OpenCollective - __will automatically get a free lifetime license__ (we're still working out the logistics, but we got you!). Early adopters will never have to pay again, unless they wish to contribute more to the project.
+__Anyone who has contributed financially to the project__ - via BountySource, Patreon, PayPal, or OpenCollective - __will automatically get a free lifetime license__ (we're still working out the logistics, but we got you!). You're welcome to contribute more, of course, but we're tremendously appreciative of our early adopters.
 
-Alternatively, you can contribute to the project through one of these avenues:
-- [Patreon](https://www.patreon.com/onivim)
-- [Open Collective](https://opencollective.com/oni)
+Alternatively, you can contribute to the project through [Patreon](https://www.patreon.com/onivim), which helps us with ongoing costs.
 
-Because of the support we've received from open source communities (both Neovim and Reason), we've decided also to __dual-license the code after 18 months__ - every commit, starting with [017c5131b4bba3006f726a3ef0f5a33028e059b5](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c5131b4bba3006f726a3ef0f5a33028e059b5](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), that means it would be dual-licensed with __MIT License__ on __10/18/2020__. We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities.
+### 'Time-bombed' dual license
 
-If you wish to ship a product based on the Onivim 2 source code, and don't want to wait 18 months for a specific commit, we do offer an SDK license. Contact sales@outrunlabs.com for more info. However, it's possible you just want [Revery](https://github.com/revery-ui/revery), which is totally free and MIT licensed.
+Because of the support we've received from open source communities, we've decided to __dual-license the code after 18 months__ - every commit, starting with [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), that means it would be dual-licensed with __MIT License__ on __10/18/2020__. We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities (and ensuring that contributions to the project end up back in the open!).
 
 ### Third-Party Code
 

--- a/README.md
+++ b/README.md
@@ -82,23 +82,28 @@ We'd :heart: help building Oni 2 - more info soon.
 
 ## License
 
-Onivim 2 is currently licensed under the [CC-BY-NC-4.0](https://creativecommons.org/licenses/by-nc/4.0/legalcode) license.
+Onivim 2 is licensed under the [Outrun Labs EULA 1.0](./Outrun-Labs-EULA-v1.0.md).
 
-This means that Onivim 2 is __free to use__ for __non-commercial__ or __educational__ uses. 
+The TL;DR is:
+- __Free__ for __non-commercial__ and __educational use__.
+- __Commercial use__ requires the purchase of a license.
+- You may not redistribute source code or binaries under a different license.
 
-> __NOTE:__ We're reviewing our license terms with a lawyer, so they may change slightly (it turns out the CC-BY-NC-4.0 isn't the perfect fit for software - we might need a more official EULA).
+You can pre-order a commercial license here with a pay-what-you-want model: https://v2.onivim.io
 
-For __commercial use licenses__, we're still working through the details - but once Onivim 2 has reached "MVP" (target - end of May), we'll transition from crowdfunding to selling commercial licenses. Our current planned price point is $10/month.
+As we get closer to shipping, we'll start bumping up the minimum required pre-order, until we settle on our full pricing model - $5/mo, $50/yr, or $99 lifetime.
 
-However, until that time, __we're offering anyone who donates to the project - any dollar amount__ - an individual, perpetual-use commercial license. We don't want early adopters to have to pay again, ever, as we launch Onivim 2 - we truly appreciate the support as we transition to a commercial offering, and we know it's a leap of faith to back an early-stage project!
+__Anyone who has contributed financially to the project__ - via BountySource, Patreon, PayPal, or OpenCollective - __will automatically get a free lifetime license__ (we're still working out the logistics, but we got you!). Early adopters will never have to pay again, unless they wish to contribute more to the project.
 
-More information about this decision in this [Reddit Thread: Question About Oni 2 License](https://www.reddit.com/r/neovim/comments/ae7ef6/question_about_oni_2_license/).
-
-You can pre-order a commercial license here: https://v2.onivim.io
-
-Alternatively, you can donate to the project through one of these avenues:
+Alternatively, you can contribute to the project through one of these avenues:
 - [Patreon](https://www.patreon.com/onivim)
 - [Open Collective](https://opencollective.com/oni)
+
+Because of the support we've received from open source communities (both Neovim and Reason), we've decided also to __dual-license the code after 18 months__ - every commit, starting with [017c5131b4bba3006f726a3ef0f5a33028e059b5](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c5131b4bba3006f726a3ef0f5a33028e059b5](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), that means it would be dual-licensed with __MIT License__ on __10/18/2020__. We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities.
+
+If you wish to ship a product based on the Onivim 2 source code, and don't want to wait 18 months for a specific commit, we do offer an SDK license. Contact sales@outrunlabs.com for more info. However, it's possible you just want [Revery](https://github.com/revery-ui/revery), which is totally free and MIT licensed.
+
+### Third-Party Code
 
 Several dependencies have their own set of license terms here: [ThirdPartyLicenses.txt](ThirdPartyLicenses.txt)
 

--- a/README.md
+++ b/README.md
@@ -65,17 +65,19 @@ The TL;DR is:
 
 You can pre-order a commercial license here (pay-what-you-want): https://v2.onivim.io
 
-As we get closer to shipping, we'll bump up the minimum required pre-order, until we settle on our full pricing model - $5/mo, $50/yr, or $99 lifetime.
+As we get closer to shipping our MVP, we'll increase the minimum required pre-order, until we settle on our full pricing model - $5/mo, $50/yr, or $99 lifetime.
 
-__Anyone who has contributed financially to the project__ - via BountySource, Patreon, PayPal, or OpenCollective - __will automatically get a free lifetime license__ (we're still working out the logistics, but we got you!). You're welcome to contribute more, of course, but we're tremendously appreciative of our early adopters.
+__Anyone who has contributed financially to the project__ - via BountySource, Patreon, PayPal, or OpenCollective - __will automatically get a free lifetime license__ (we're still working out the logistics, but we got you!). 
 
 Alternatively, you can contribute to the project through [Patreon](https://www.patreon.com/onivim), which helps us with ongoing costs.
 
-### 'Time-bombed' dual license
+#### 'Time-Bomb' Dual License
 
-Because of the support we've received from open source communities, we've decided to __dual-license the code after 18 months__ - every commit, starting with [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), that means it would be dual-licensed with __MIT License__ on __10/18/2020__. We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities (and ensuring that contributions to the project end up back in the open!).
+Because of the support we've received from open source communities, we've decided to __dual-license the code after 18 months__ - every commit, starting with [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), as it was committed to `master` on __4/18/2019__ that means it would be dual-licensed with __MIT License__ on __10/18/2020__. 
 
-### Third-Party Code
+We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities (and ensuring that contributions to the project eventually end up back in the open!)
+
+#### Third-Party Code
 
 Several dependencies have their own set of license terms here: [ThirdPartyLicenses.txt](ThirdPartyLicenses.txt)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The TL;DR is:
 
 You can pre-order a commercial license here (pay-what-you-want): https://v2.onivim.io
 
-As we get closer to shipping our MVP, we'll increase the minimum required pre-order, until we settle on our full pricing model - $5/mo, $50/yr, or $99 lifetime.
+As we get closer to shipping our MVP, we'll increase the minimum required pre-order, until we settle on our full pricing model.
 
 __Anyone who has contributed financially to the project__ - via BountySource, Patreon, PayPal, or OpenCollective - __will automatically get a free lifetime license__ (we're still working out the logistics, but we got you!). 
 


### PR DESCRIPTION
Move from the CC-BY-NC-ND to our official EULA, and implement 'time-bomb' dual-license.