### PR TITLE
Test: Extension Host - Activation Events

### DIFF
--- a/src/editor/Extensions/ExtensionHostProtocol.re
+++ b/src/editor/Extensions/ExtensionHostProtocol.re
@@ -254,13 +254,13 @@ module OutgoingNotifications = {
   };
 
   module ExtensionService = {
-      let activateByEvent = (event: string) => {
-        _buildNotification(
-            "ExtHostExtensionService",
-            "$activateByEvent",
-            `List([`String(event)])
-        )
-      };
+    let activateByEvent = (event: string) => {
+      _buildNotification(
+        "ExtHostExtensionService",
+        "$activateByEvent",
+        `List([`String(event)]),
+      );
+    };
   };
 
   module Workspace = {

--- a/src/editor/Extensions/ExtensionHostProtocol.re
+++ b/src/editor/Extensions/ExtensionHostProtocol.re
@@ -253,6 +253,16 @@ module OutgoingNotifications = {
     };
   };
 
+  module ExtensionService = {
+      let activateByEvent = (event: string) => {
+        _buildNotification(
+            "ExtHostExtensionService",
+            "$activateByEvent",
+            `List([`String(event)])
+        )
+      };
+  };
+
   module Workspace = {
     [@deriving
       (show({with_path: false}), yojson({strict: false, exn: true}))

--- a/test/editor/Extensions/ExtensionClientHelper.re
+++ b/test/editor/Extensions/ExtensionClientHelper.re
@@ -43,12 +43,13 @@ module Waiters = {
   };
 
   let createActivationWaiter = (extensionId, api: extHostApi) => {
-   api.createWaiterForMessage("MainThreadExtensionService", "$onDidActivateExtension", args =>
-          switch (args) {
-          | [`String(v), ..._] => String.equal(extensionId, v)
-          | _ => false
-          }
-  );
+    api.createWaiterForMessage(
+      "MainThreadExtensionService", "$onDidActivateExtension", args =>
+      switch (args) {
+      | [`String(v), ..._] => String.equal(extensionId, v)
+      | _ => false
+      }
+    );
   };
 };
 

--- a/test/editor/Extensions/ExtensionClientHelper.re
+++ b/test/editor/Extensions/ExtensionClientHelper.re
@@ -41,6 +41,15 @@ module Waiters = {
       }
     );
   };
+
+  let createActivationWaiter = (extensionId, api: extHostApi) => {
+   api.createWaiterForMessage("MainThreadExtensionService", "$onDidActivateExtension", args =>
+          switch (args) {
+          | [`String(v), ..._] => String.equal(extensionId, v)
+          | _ => false
+          }
+  );
+  };
 };
 
 let withExtensionClient = (f: extHostApi => unit) => {

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -19,6 +19,33 @@ module JsonInformationMessageFormat = {
 };
 
 describe("Extension Client", ({describe, _}) => {
+  describe("activation", ({test, _}) => {
+   test("activates by language", _ => {
+      withExtensionClient(api => {
+       let waitForActivationMessage = api |> Waiters.createMessageWaiter(s => String.equal(s, "Activated!"));
+
+        api.start();
+
+        api.send(ExtensionService.activateByEvent("onLanguage:testlang"));
+
+        waitForActivationMessage();
+      });
+    
+   });
+
+   test("activates by command", _ => {
+      withExtensionClient(api => {
+       let waitForActivationMessage = api |> Waiters.createMessageWaiter(s => String.equal(s, "Activated!"));
+
+        api.start();
+
+        api.send(ExtensionService.activateByEvent("onCommand:extension.activationTest"));
+
+        waitForActivationMessage();
+      });
+  });
+  });
+
   describe("commands", ({test, _}) =>
     test("executes simple command", _ =>
       withExtensionClient(api => {

--- a/test/editor/Extensions/ExtensionClientTest.re
+++ b/test/editor/Extensions/ExtensionClientTest.re
@@ -20,30 +20,37 @@ module JsonInformationMessageFormat = {
 
 describe("Extension Client", ({describe, _}) => {
   describe("activation", ({test, _}) => {
-   test("activates by language", _ => {
+    test("activates by language", _ =>
       withExtensionClient(api => {
-       let waitForActivationMessage = api |> Waiters.createMessageWaiter(s => String.equal(s, "Activated!"));
+        let waitForActivationMessage =
+          api
+          |> Waiters.createMessageWaiter(s => String.equal(s, "Activated!"));
 
         api.start();
 
         api.send(ExtensionService.activateByEvent("onLanguage:testlang"));
 
         waitForActivationMessage();
-      });
-    
-   });
+      })
+    );
 
-   test("activates by command", _ => {
+    test("activates by command", _ =>
       withExtensionClient(api => {
-       let waitForActivationMessage = api |> Waiters.createMessageWaiter(s => String.equal(s, "Activated!"));
+        let waitForActivationMessage =
+          api
+          |> Waiters.createMessageWaiter(s => String.equal(s, "Activated!"));
 
         api.start();
 
-        api.send(ExtensionService.activateByEvent("onCommand:extension.activationTest"));
+        api.send(
+          ExtensionService.activateByEvent(
+            "onCommand:extension.activationTest",
+          ),
+        );
 
         waitForActivationMessage();
-      });
-  });
+      })
+    );
   });
 
   describe("commands", ({test, _}) =>

--- a/test/test_extensions/oni-activation-events-tests/extension.js
+++ b/test/test_extensions/oni-activation-events-tests/extension.js
@@ -1,0 +1,21 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	vscode.window.showInformationMessage('Activated!');
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/test_extensions/oni-activation-events-tests/package.json
+++ b/test/test_extensions/oni-activation-events-tests/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "helloworld-minimal-sample",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": [
+		"onLanguage:testlang",
+		"onCommand:extension.helloWorld"
+	],
+	"main": "./extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.helloWorld",
+				"title": "Hello World"
+			}
+		]
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}

--- a/test/test_extensions/oni-activation-events-tests/package.json
+++ b/test/test_extensions/oni-activation-events-tests/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "helloworld-minimal-sample",
+	"name": "oni-activation-events-test",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
 	"publisher": "vscode-samples",
@@ -9,13 +9,13 @@
 	},
 	"activationEvents": [
 		"onLanguage:testlang",
-		"onCommand:extension.helloWorld"
+		"onCommand:extension.activationTest"
 	],
 	"main": "./extension.js",
 	"contributes": {
 		"commands": [
 			{
-				"command": "extension.helloWorld",
+				"command": "extension.activationTest",
 				"title": "Hello World"
 			}
 		]


### PR DESCRIPTION
Add test cases that validate activation events can be sent from the Onivim front-end to the VSCode extension process (and that the VSCode extension gets activated correctly)