### PR TITLE
Bugfix - Regression: Scroll not working

### DIFF
--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -13,7 +13,7 @@ let editorSurfaceMinimalState = () => {
   let _ =
     React.RenderedElement.render(
       rootNode,
-      <EditorSurface editor=simpleEditor state=simpleState />,
+      <EditorSurface editor=simpleEditor state=simpleState metrics />,
     );
   ();
 };
@@ -22,7 +22,7 @@ let editorSurfaceThousandLineState = () => {
   let _ =
     React.RenderedElement.render(
       rootNode,
-      <EditorSurface editor=simpleEditor state=thousandLineState />,
+      <EditorSurface editor=simpleEditor state=thousandLineState metrics />,
     );
   ();
 };
@@ -31,7 +31,11 @@ let editorSurfaceHundredThousandLineState = () => {
   let _ =
     React.RenderedElement.render(
       rootNode,
-      <EditorSurface editor=simpleEditor state=hundredThousandLineState />,
+      <EditorSurface
+        editor=simpleEditor
+        state=hundredThousandLineState
+        metrics
+      />,
     );
   ();
 };
@@ -46,7 +50,7 @@ let setupSurfaceThousandLineLayout = () => {
   let container = Container.create(rootNode);
   Container.update(
     container,
-    <EditorSurface editor=simpleEditor state=thousandLineState />,
+    <EditorSurface editor=simpleEditor state=thousandLineState metrics />,
   )
   |> ignore;
 

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -1,6 +1,8 @@
 open Oni_Core;
 open Oni_Model;
 
+let metrics = EditorMetrics.create();
+
 /* Create a state with some editor size */
 let simpleState =
   Reducer.reduce(

--- a/src/editor/Extensions/ExtensionHostClient.re
+++ b/src/editor/Extensions/ExtensionHostClient.re
@@ -179,5 +179,6 @@ let send =
 
 let close = (v: t) => {
   v.send(ExtensionHostProtocol.MessageType.terminate, `Assoc([]));
+  Rpc.stop(v.rpc);
   Unix.kill(v.process.pid, Sys.sigkill);
 };

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -19,10 +19,7 @@ type t = {
    */
   maxLineLength: int,
   viewLines: int,
-  size: EditorSize.t,
   cursorPosition: Position.t,
-  lineHeight: float,
-  characterWidth: float,
   selection: VisualRange.t,
 };
 
@@ -43,10 +40,7 @@ let create = (~bufferId=0, ()) => {
      * We need an initial editor size, otherwise we'll immediately scroll the view
      * if a buffer loads prior to our first render.
      */
-    size: EditorSize.create(~pixelWidth=1000, ~pixelHeight=1000, ()),
     cursorPosition: Position.createFromZeroBasedIndices(0, 0),
-    lineHeight: 1.,
-    characterWidth: 1.,
     selection: VisualRange.create(),
   };
   ret;
@@ -65,25 +59,25 @@ type scrollbarMetrics = {
 /*   pixelHeight: int, */
 /* }; */
 
-let getVisibleView = (view: t) =>
-  int_of_float(float_of_int(view.size.pixelWidth) /. view.lineHeight);
+let getVisibleView = (metrics: EditorMetrics.t) =>
+  int_of_float(float_of_int(metrics.pixelHeight) /. metrics.lineHeight);
 
-let getTotalSizeInPixels = (view: t) =>
-  int_of_float(float_of_int(view.viewLines) *. view.lineHeight);
+let getTotalSizeInPixels = (view: t, metrics: EditorMetrics.t) =>
+  int_of_float(float_of_int(view.viewLines) *. metrics.lineHeight);
 
-let getCursorPixelLine = (view: t) =>
+let getCursorPixelLine = (view: t, metrics: EditorMetrics.t) =>
   float_of_int(Index.toZeroBasedInt(view.cursorPosition.line))
-  *. view.lineHeight;
+  *. metrics.lineHeight;
 
-let getCursorPixelColumn = (view: t) =>
+let getCursorPixelColumn = (view: t, metrics: EditorMetrics.t) =>
   float_of_int(Index.toZeroBasedInt(view.cursorPosition.character))
-  *. view.characterWidth;
+  *. metrics.characterWidth;
 
-let getVerticalScrollbarMetrics = (view: t, scrollBarHeight: int) => {
+let getVerticalScrollbarMetrics = (view: t, scrollBarHeight: int, metrics: EditorMetrics.t) => {
   let totalViewSizeInPixels =
-    float_of_int(getTotalSizeInPixels(view) + view.size.pixelHeight);
+    float_of_int(getTotalSizeInPixels(view, metrics) + metrics.pixelHeight);
   let thumbPercentage =
-    float_of_int(view.size.pixelHeight) /. totalViewSizeInPixels;
+    float_of_int(metrics.pixelHeight) /. totalViewSizeInPixels;
   let thumbSize =
     int_of_float(thumbPercentage *. float_of_int(scrollBarHeight));
 
@@ -93,9 +87,9 @@ let getVerticalScrollbarMetrics = (view: t, scrollBarHeight: int) => {
   {thumbSize, thumbOffset, visible: true};
 };
 
-let getHorizontalScrollbarMetrics = (view: t, availableWidth: int) => {
+let getHorizontalScrollbarMetrics = (view: t, availableWidth: int, metrics: EditorMetrics.t) => {
   let totalViewWidthInPixels =
-    float_of_int(view.maxLineLength) *. view.characterWidth;
+    float_of_int(view.maxLineLength) *. metrics.characterWidth;
   let availableWidthF = float_of_int(availableWidth);
 
   totalViewWidthInPixels <= availableWidthF
@@ -111,18 +105,18 @@ let getHorizontalScrollbarMetrics = (view: t, availableWidth: int) => {
     };
 };
 
-let scrollTo = (view: t, newScrollY) => {
+let scrollTo = (view: t, newScrollY, metrics: EditorMetrics.t) => {
   let newScrollY = max(0., newScrollY);
   let availableScroll =
-    max(float_of_int(view.viewLines - 1), 0.) *. view.lineHeight;
+    max(float_of_int(view.viewLines - 1), 0.) *. metrics.lineHeight;
   let newScrollY = min(newScrollY, availableScroll);
 
   let scrollPercentage =
-    newScrollY /. (availableScroll -. float_of_int(view.size.pixelHeight));
+    newScrollY /. (availableScroll -. float_of_int(metrics.pixelHeight));
   let minimapLineSize =
     Constants.default.minimapCharacterWidth
     + Constants.default.minimapCharacterHeight;
-  let linesInMinimap = view.size.pixelHeight / minimapLineSize;
+  let linesInMinimap = metrics.pixelHeight / minimapLineSize;
   let availableMinimapScroll =
     max(view.viewLines - linesInMinimap, 0) * minimapLineSize;
   let newMinimapScroll =
@@ -131,17 +125,17 @@ let scrollTo = (view: t, newScrollY) => {
   {...view, minimapScrollY: newMinimapScroll, scrollY: newScrollY};
 };
 
-let scrollToHorizontal = (view: t, newScrollX) => {
+let scrollToHorizontal = (view: t, newScrollX, metrics: EditorMetrics.t) => {
   let newScrollX = max(0., newScrollX);
 
   let layout =
     EditorLayout.getLayout(
       ~maxMinimapCharacters=view.minimapMaxColumnWidth,
-      ~pixelWidth=float_of_int(view.size.pixelWidth),
-      ~pixelHeight=float_of_int(view.size.pixelHeight),
+      ~pixelWidth=float_of_int(metrics.pixelWidth),
+      ~pixelHeight=float_of_int(metrics.pixelHeight),
       ~isMinimapShown=true,
-      ~characterWidth=view.characterWidth,
-      ~characterHeight=view.lineHeight,
+      ~characterWidth=metrics.characterWidth,
+      ~characterHeight=metrics.lineHeight,
       ~bufferLineCount=view.viewLines,
       (),
     );
@@ -150,98 +144,98 @@ let scrollToHorizontal = (view: t, newScrollX) => {
     max(
       0.,
       float_of_int(view.maxLineLength)
-      *. view.characterWidth
+      *. metrics.characterWidth
       -. layout.bufferWidthInPixels,
     );
   let scrollX = min(newScrollX, availableScroll);
   {...view, scrollX};
 };
 
-let scroll = (view: t, scrollDeltaY) => {
+let scroll = (view: t, scrollDeltaY, metrics) => {
   let newScrollY = view.scrollY +. scrollDeltaY;
-  scrollTo(view, newScrollY);
+  scrollTo(view, newScrollY, metrics);
 };
 
 /* Scroll so that the cursor is at the TOP of the view */
-let scrollToCursorTop = (view: t) => {
-  let scrollPosition = getCursorPixelLine(view);
-  scrollTo(view, scrollPosition);
+let scrollToCursorTop = (view: t, metrics) => {
+  let scrollPosition = getCursorPixelLine(view, metrics);
+  scrollTo(view, scrollPosition, metrics);
 };
 
 /* Scroll so that the cursor is at the BOTTOM of the view */
-let scrollToCursorBottom = (view: t) => {
-  let cursorPixelPosition = getCursorPixelLine(view);
+let scrollToCursorBottom = (view: t, metrics: EditorMetrics.t) => {
+  let cursorPixelPosition = getCursorPixelLine(view, metrics);
   let scrollPosition =
     cursorPixelPosition
-    -. (float_of_int(view.size.pixelHeight) -. view.lineHeight);
-  scrollTo(view, scrollPosition);
+    -. (float_of_int(metrics.pixelHeight) -. metrics.lineHeight);
+  scrollTo(view, scrollPosition, metrics);
 };
 
 /* Scroll so that the cursor is at the LEFT of the view */
-let scrollToCursorLeft = (view: t) => {
-  let cursorPixelColumn = getCursorPixelColumn(view);
+let scrollToCursorLeft = (view: t, metrics) => {
+  let cursorPixelColumn = getCursorPixelColumn(view, metrics);
 
   let scrollPosition = cursorPixelColumn;
-  scrollToHorizontal(view, scrollPosition);
+  scrollToHorizontal(view, scrollPosition, metrics);
 };
 
 /* Scroll so that the cursor is at the RIGHT of the view */
-let scrollToCursorRight = (view: t, availableWidth) => {
-  let cursorPixelColumn = getCursorPixelColumn(view);
+let scrollToCursorRight = (view: t, availableWidth, metrics) => {
+  let cursorPixelColumn = getCursorPixelColumn(view, metrics);
 
   let scrollPosition =
-    cursorPixelColumn -. availableWidth +. view.characterWidth;
-  scrollToHorizontal(view, scrollPosition);
+    cursorPixelColumn -. availableWidth +. metrics.characterWidth;
+  scrollToHorizontal(view, scrollPosition, metrics);
 };
 
-let scrollToCursor = (view: t) => {
+let scrollToCursor = (view: t, metrics: EditorMetrics.t) => {
   let scrollPosition =
-    getCursorPixelLine(view)
-    -. float_of_int(view.size.pixelHeight / 2)
-    +. view.lineHeight
+    getCursorPixelLine(view, metrics)
+    -. float_of_int(metrics.pixelHeight / 2)
+    +. metrics.lineHeight
     /. 2.;
 
-  scrollTo(view, scrollPosition);
+  scrollTo(view, scrollPosition, metrics);
 };
 
-let snapToCursorPosition = (view: t) => {
-  let cursorPixelPositionY = getCursorPixelLine(view);
+let snapToCursorPosition = (view: t, metrics: EditorMetrics.t) => {
+  let cursorPixelPositionY = getCursorPixelLine(view, metrics);
   let scrollY = view.scrollY;
 
   let view =
     if (cursorPixelPositionY < scrollY) {
-      scrollToCursorTop(view);
+      scrollToCursorTop(view, metrics);
     } else if (cursorPixelPositionY > scrollY
-               +. float_of_int(view.size.pixelHeight)
-               -. view.lineHeight) {
-      scrollToCursorBottom(view);
+               +. float_of_int(metrics.pixelHeight)
+               -. metrics.lineHeight) {
+      scrollToCursorBottom(view, metrics);
     } else {
       view;
     };
 
   let layout =
     EditorLayout.getLayout(
-      ~pixelWidth=float_of_int(view.size.pixelWidth),
-      ~pixelHeight=float_of_int(view.size.pixelHeight),
+      ~pixelWidth=float_of_int(metrics.pixelWidth),
+      ~pixelHeight=float_of_int(metrics.pixelHeight),
       ~isMinimapShown=true,
-      ~characterWidth=view.characterWidth,
-      ~characterHeight=view.lineHeight,
+      ~characterWidth=metrics.characterWidth,
+      ~characterHeight=metrics.lineHeight,
       ~bufferLineCount=view.viewLines,
       (),
     );
 
-  let cursorPixelPositionX = getCursorPixelColumn(view);
+  let cursorPixelPositionX = getCursorPixelColumn(view, metrics);
   let scrollX = view.scrollX;
 
   let availableWidth = layout.bufferWidthInPixels;
 
   let view =
     if (cursorPixelPositionX < scrollX) {
-      scrollToCursorLeft(view);
+      scrollToCursorLeft(view, metrics);
     } else if (cursorPixelPositionX >= scrollX
                +. layout.bufferWidthInPixels
-               -. view.characterWidth) {
-      scrollToCursorRight(view, availableWidth);
+               -. metrics.characterWidth) {
+      scrollToCursorRight(view, availableWidth, metrics);
     } else {
       view;
     };
@@ -254,30 +248,30 @@ type cursorLocation =
   | Middle
   | Bottom;
 
-let getTopVisibleLine = view =>
-  int_of_float(view.scrollY /. view.lineHeight) + 1;
+let getTopVisibleLine = (view, metrics: EditorMetrics.t) =>
+  int_of_float(view.scrollY /. metrics.lineHeight) + 1;
 
-let getBottomVisibleLine = view => {
+let getBottomVisibleLine = (view, metrics: EditorMetrics.t) => {
   let absoluteBottomLine =
     int_of_float(
-      (view.scrollY +. float_of_int(view.size.pixelHeight)) /. view.lineHeight,
+      (view.scrollY +. float_of_int(metrics.pixelHeight)) /. metrics.lineHeight,
     );
   absoluteBottomLine > view.viewLines ? view.viewLines : absoluteBottomLine;
 };
 
-let moveCursorToPosition = (~moveCursor, view, position) =>
+let moveCursorToPosition = (~moveCursor, view, position, metrics) =>
   switch (position) {
   | Top =>
-    let line = getTopVisibleLine(view);
+    let line = getTopVisibleLine(view, metrics);
     moveCursor(~column=0, ~line);
     view;
   | Middle =>
-    let topLine = getTopVisibleLine(view);
-    let bottomLine = getBottomVisibleLine(view);
+    let topLine = getTopVisibleLine(view, metrics);
+    let bottomLine = getBottomVisibleLine(view, metrics);
     moveCursor(~column=0, ~line=(bottomLine + topLine) / 2);
     view;
   | Bottom =>
-    let line = getBottomVisibleLine(view);
+    let line = getBottomVisibleLine(view, metrics);
     moveCursor(~column=0, ~line);
     view;
   };
@@ -312,26 +306,20 @@ let recalculate = (view: t, buffer: option(Buffer.t)) =>
   | None => view
   };
 
-let reduce = (view, action) =>
+let reduce = (view, action, metrics: EditorMetrics.t) =>
   switch (action) {
-  | CursorMove(b) => snapToCursorPosition({...view, cursorPosition: b})
+  | CursorMove(b) => snapToCursorPosition({...view, cursorPosition: b}, metrics)
   | SelectionChanged(selection) => {...view, selection}
-  | SetEditorSize(size) => {...view, size}
   | RecalculateEditorView(buffer) => recalculate(view, buffer)
-  | EditorScroll(scrollY) => scroll(view, scrollY)
-  | EditorScrollToCursorTop => scrollToCursorTop(view)
-  | EditorScrollToCursorBottom => scrollToCursorBottom(view)
-  | EditorScrollToCursorCentered => scrollToCursor(view)
+  | EditorScroll(scrollY) => scroll(view, scrollY, metrics)
+  | EditorScrollToCursorTop => scrollToCursorTop(view, metrics)
+  | EditorScrollToCursorBottom => scrollToCursorBottom(view, metrics)
+  | EditorScrollToCursorCentered => scrollToCursor(view, metrics)
   | EditorMoveCursorToTop(moveCursor) =>
-    moveCursorToPosition(~moveCursor, view, Top)
+    moveCursorToPosition(~moveCursor, view, Top, metrics)
   | EditorMoveCursorToMiddle(moveCursor) =>
-    moveCursorToPosition(~moveCursor, view, Middle)
-  | SetEditorFont({measuredHeight, measuredWidth, _}) => {
-      ...view,
-      lineHeight: measuredHeight,
-      characterWidth: measuredWidth,
-    }
+    moveCursorToPosition(~moveCursor, view, Middle, metrics)
   | EditorMoveCursorToBottom(moveCursor) =>
-    moveCursorToPosition(~moveCursor, view, Bottom)
+    moveCursorToPosition(~moveCursor, view, Bottom, metrics)
   | _ => view
   };

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -73,7 +73,8 @@ let getCursorPixelColumn = (view: t, metrics: EditorMetrics.t) =>
   float_of_int(Index.toZeroBasedInt(view.cursorPosition.character))
   *. metrics.characterWidth;
 
-let getVerticalScrollbarMetrics = (view: t, scrollBarHeight: int, metrics: EditorMetrics.t) => {
+let getVerticalScrollbarMetrics =
+    (view: t, scrollBarHeight: int, metrics: EditorMetrics.t) => {
   let totalViewSizeInPixels =
     float_of_int(getTotalSizeInPixels(view, metrics) + metrics.pixelHeight);
   let thumbPercentage =
@@ -87,7 +88,8 @@ let getVerticalScrollbarMetrics = (view: t, scrollBarHeight: int, metrics: Edito
   {thumbSize, thumbOffset, visible: true};
 };
 
-let getHorizontalScrollbarMetrics = (view: t, availableWidth: int, metrics: EditorMetrics.t) => {
+let getHorizontalScrollbarMetrics =
+    (view: t, availableWidth: int, metrics: EditorMetrics.t) => {
   let totalViewWidthInPixels =
     float_of_int(view.maxLineLength) *. metrics.characterWidth;
   let availableWidthF = float_of_int(availableWidth);
@@ -254,7 +256,8 @@ let getTopVisibleLine = (view, metrics: EditorMetrics.t) =>
 let getBottomVisibleLine = (view, metrics: EditorMetrics.t) => {
   let absoluteBottomLine =
     int_of_float(
-      (view.scrollY +. float_of_int(metrics.pixelHeight)) /. metrics.lineHeight,
+      (view.scrollY +. float_of_int(metrics.pixelHeight))
+      /. metrics.lineHeight,
     );
   absoluteBottomLine > view.viewLines ? view.viewLines : absoluteBottomLine;
 };
@@ -308,7 +311,8 @@ let recalculate = (view: t, buffer: option(Buffer.t)) =>
 
 let reduce = (view, action, metrics: EditorMetrics.t) =>
   switch (action) {
-  | CursorMove(b) => snapToCursorPosition({...view, cursorPosition: b}, metrics)
+  | CursorMove(b) =>
+    snapToCursorPosition({...view, cursorPosition: b}, metrics)
   | SelectionChanged(selection) => {...view, selection}
   | RecalculateEditorView(buffer) => recalculate(view, buffer)
   | EditorScroll(scrollY) => scroll(view, scrollY, metrics)

--- a/src/editor/Model/EditorGroup.re
+++ b/src/editor/Model/EditorGroup.re
@@ -119,7 +119,6 @@ let removeEditorsForBuffer = (state, bufferId) => {
 };
 
 let reduce = (v: t, action: Actions.t) => {
-
   let metrics = EditorMetrics.reduce(v.metrics, action);
 
   let editors =

--- a/src/editor/Model/EditorMetrics.re
+++ b/src/editor/Model/EditorMetrics.re
@@ -4,8 +4,6 @@
   * Dimensions and measurements relating to an editor
  */
 
-open Oni_Core;
-open Oni_Core.Types;
 
 open Actions;
 

--- a/src/editor/Model/EditorMetrics.re
+++ b/src/editor/Model/EditorMetrics.re
@@ -4,7 +4,6 @@
   * Dimensions and measurements relating to an editor
  */
 
-
 open Actions;
 
 type t = {

--- a/src/editor/Model/EditorMetrics.re
+++ b/src/editor/Model/EditorMetrics.re
@@ -1,0 +1,38 @@
+/*
+  * EditorMetrics.re
+  *
+  * Dimensions and measurements relating to an editor
+ */
+
+open Oni_Core;
+open Oni_Core.Types;
+
+open Actions;
+
+type t = {
+  pixelWidth: int,
+  pixelHeight: int,
+  lineHeight: float,
+  characterWidth: float,
+};
+
+let create = () => {
+  {
+    pixelWidth: 1000,
+    pixelHeight: 1000,
+    lineHeight: 1.,
+    characterWidth: 1.,
+  };
+};
+
+let reduce = (v: t, action) => {
+    switch (action) {
+      | SetEditorSize({pixelWidth, pixelHeight}) => {...v, pixelWidth, pixelHeight }
+      | SetEditorFont({measuredHeight, measuredWidth, _}) => {
+        ...v,
+        lineHeight: measuredHeight,
+        characterWidth: measuredWidth,
+      }
+      | _ => v
+    };
+};

--- a/src/editor/Model/EditorMetrics.re
+++ b/src/editor/Model/EditorMetrics.re
@@ -17,22 +17,21 @@ type t = {
 };
 
 let create = () => {
-  {
-    pixelWidth: 1000,
-    pixelHeight: 1000,
-    lineHeight: 1.,
-    characterWidth: 1.,
-  };
+  {pixelWidth: 1000, pixelHeight: 1000, lineHeight: 1., characterWidth: 1.};
 };
 
 let reduce = (v: t, action) => {
-    switch (action) {
-      | SetEditorSize({pixelWidth, pixelHeight}) => {...v, pixelWidth, pixelHeight }
-      | SetEditorFont({measuredHeight, measuredWidth, _}) => {
-        ...v,
-        lineHeight: measuredHeight,
-        characterWidth: measuredWidth,
-      }
-      | _ => v
-    };
+  switch (action) {
+  | SetEditorSize({pixelWidth, pixelHeight}) => {
+      ...v,
+      pixelWidth,
+      pixelHeight,
+    }
+  | SetEditorFont({measuredHeight, measuredWidth, _}) => {
+      ...v,
+      lineHeight: measuredHeight,
+      characterWidth: measuredWidth,
+    }
+  | _ => v
+  };
 };

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -17,6 +17,7 @@ module Diagnostics = Diagnostics;
 module Editor = Editor;
 module EditorGroup = EditorGroup;
 module EditorLayout = EditorLayout;
+module EditorMetrics = EditorMetrics;
 module Filter = Filter;
 module IconTheme = IconTheme;
 module Indentation = Indentation;

--- a/src/editor/UI/EditorGroupView.re
+++ b/src/editor/UI/EditorGroupView.re
@@ -54,9 +54,11 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let style =
       editorViewStyle(theme.colors.background, theme.colors.foreground);
 
+    let metrics = state.editors.metrics;
+
     let editorView =
       switch (editor) {
-      | Some(v) => <EditorSurface editor=v state />
+      | Some(v) => <EditorSurface metrics editor=v state />
       | None => React.empty
       };
 

--- a/src/editor/UI/EditorHorizontalScrollbar.re
+++ b/src/editor/UI/EditorHorizontalScrollbar.re
@@ -18,12 +18,13 @@ let createElement =
       ~state: State.t,
       ~editor: Editor.t,
       ~width as totalWidth,
+      ~metrics,
       ~children as _,
       (),
     ) =>
   component(hooks => {
     let scrollMetrics =
-      Editor.getHorizontalScrollbarMetrics(editor, totalWidth);
+      Editor.getHorizontalScrollbarMetrics(editor, totalWidth, metrics);
 
     let scrollThumbStyle =
       Style.[

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -179,7 +179,14 @@ let renderTokens =
 
 let component = React.component("EditorSurface");
 
-let createElement = (~state: State.t, ~metrics:EditorMetrics.t, ~editor: Editor.t, ~children as _, ()) =>
+let createElement =
+    (
+      ~state: State.t,
+      ~metrics: EditorMetrics.t,
+      ~editor: Editor.t,
+      ~children as _,
+      (),
+    ) =>
   component(hooks => {
     let theme = state.theme;
 
@@ -402,8 +409,7 @@ let createElement = (~state: State.t, ~metrics:EditorMetrics.t, ~editor: Editor.
                      )
                   -. editor.scrollY,
                 ~height=fontHeight,
-                ~width=
-                  float_of_int(metrics.pixelWidth) -. lineNumberWidth,
+                ~width=float_of_int(metrics.pixelWidth) -. lineNumberWidth,
                 ~color=theme.colors.editorLineHighlightBackground,
                 (),
               );

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -179,7 +179,7 @@ let renderTokens =
 
 let component = React.component("EditorSurface");
 
-let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
+let createElement = (~state: State.t, ~metrics:EditorMetrics.t, ~editor: Editor.t, ~children as _, ()) =>
   component(hooks => {
     let theme = state.theme;
 
@@ -207,8 +207,8 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
     let iFontHeight = int_of_float(fontHeight +. 0.5);
     let indentation = IndentationSettings.default;
 
-    let topVisibleLine = Editor.getTopVisibleLine(editor);
-    let bottomVisibleLine = Editor.getBottomVisibleLine(editor);
+    let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
+    let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);
 
     let cursorLine = Index.toZeroBasedInt(editor.cursorPosition.line);
 
@@ -310,8 +310,8 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
     let layout =
       EditorLayout.getLayout(
         ~maxMinimapCharacters=state.configuration.editorMinimapMaxColumn,
-        ~pixelWidth=float_of_int(editor.size.pixelWidth),
-        ~pixelHeight=float_of_int(editor.size.pixelHeight),
+        ~pixelWidth=float_of_int(metrics.pixelWidth),
+        ~pixelHeight=float_of_int(metrics.pixelHeight),
         ~isMinimapShown=true,
         ~characterWidth=state.editorFont.measuredWidth,
         ~characterHeight=state.editorFont.measuredHeight,
@@ -387,8 +387,8 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
             style=bufferViewStyle
             render={(transform, _ctx) => {
               let count = lineCount;
-              let height = editor.size.pixelHeight;
-              let rowHeight = state.editorFont.measuredHeight;
+              let height = metrics.pixelHeight;
+              let rowHeight = metrics.lineHeight;
               let scrollY = editor.scrollY;
 
               /* Draw background for cursor line */
@@ -403,7 +403,7 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
                   -. editor.scrollY,
                 ~height=fontHeight,
                 ~width=
-                  float_of_int(editor.size.pixelWidth) -. lineNumberWidth,
+                  float_of_int(metrics.pixelWidth) -. lineNumberWidth,
                 ~color=theme.colors.editorLineHighlightBackground,
                 (),
               );
@@ -555,6 +555,7 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
             <EditorHorizontalScrollbar
               editor
               state
+              metrics
               width={int_of_float(layout.bufferWidthInPixels)}
             />
           </View>
@@ -564,8 +565,9 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
             state
             editor
             width={layout.minimapWidthInPixels}
-            height={editor.size.pixelHeight}
+            height={metrics.pixelHeight}
             count=lineCount
+            metrics
             getTokensForLine
           />
         </View>
@@ -573,8 +575,9 @@ let createElement = (~state: State.t, ~editor: Editor.t, ~children as _, ()) =>
           <EditorVerticalScrollbar
             state
             editor
-            height={editor.size.pixelHeight}
+            metrics
             width={Constants.default.scrollBarThickness}
+            height={metrics.pixelHeight}
           />
         </View>
       </View>,

--- a/src/editor/UI/EditorVerticalScrollbar.re
+++ b/src/editor/UI/EditorVerticalScrollbar.re
@@ -18,12 +18,13 @@ let createElement =
       ~editor: Editor.t,
       ~height as totalHeight,
       ~width as totalWidth,
+      ~metrics,
       ~children as _,
       (),
     ) =>
   component(hooks => {
     let scrollMetrics =
-      Editor.getVerticalScrollbarMetrics(editor, totalHeight);
+      Editor.getVerticalScrollbarMetrics(editor, totalHeight, metrics);
 
     let scrollThumbStyle =
       Style.[
@@ -38,12 +39,12 @@ let createElement =
     let cursorPixelY =
       float_of_int(Index.toZeroBasedInt(editor.cursorPosition.line))
       *. state.editorFont.measuredHeight;
-    let totalPixel = Editor.getTotalSizeInPixels(editor) |> float_of_int;
+    let totalPixel = Editor.getTotalSizeInPixels(editor, metrics) |> float_of_int;
 
     let cursorPosition =
       int_of_float(
         cursorPixelY
-        /. (totalPixel +. float_of_int(editor.size.pixelHeight))
+        /. (totalPixel +. float_of_int(metrics.pixelHeight))
         *. float_of_int(totalHeight),
       );
     let cursorSize = 2;

--- a/src/editor/UI/EditorVerticalScrollbar.re
+++ b/src/editor/UI/EditorVerticalScrollbar.re
@@ -39,7 +39,8 @@ let createElement =
     let cursorPixelY =
       float_of_int(Index.toZeroBasedInt(editor.cursorPosition.line))
       *. state.editorFont.measuredHeight;
-    let totalPixel = Editor.getTotalSizeInPixels(editor, metrics) |> float_of_int;
+    let totalPixel =
+      Editor.getTotalSizeInPixels(editor, metrics) |> float_of_int;
 
     let cursorPosition =
       int_of_float(

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -68,8 +68,8 @@ let component = React.component("Minimap");
 let absoluteStyle =
   Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
-let getMinimapSize = (view: Editor.t) => {
-  let currentViewSize = Editor.getVisibleView(view);
+let getMinimapSize = (view: Editor.t, metrics) => {
+  let currentViewSize = Editor.getVisibleView(metrics);
 
   view.viewLines < currentViewSize ? 0 : currentViewSize + 1;
 };
@@ -82,6 +82,7 @@ let createElement =
       ~height: int,
       ~count,
       ~getTokensForLine: int => list(BufferViewTokenizer.t),
+      ~metrics,
       ~children as _,
       (),
     ) =>
@@ -95,8 +96,8 @@ let createElement =
     let (isActive, setActive, hooks) = React.Hooks.state(false, hooks);
 
     let getScrollTo = (mouseY: float) => {
-      let totalHeight: int = Editor.getTotalSizeInPixels(editor);
-      let visibleHeight: int = editor.size.pixelHeight;
+      let totalHeight: int = Editor.getTotalSizeInPixels(editor, metrics);
+      let visibleHeight: int = metrics.pixelHeight;
       let offsetMouseY: int = int_of_float(mouseY) - Tab.tabHeight;
       float_of_int(offsetMouseY)
       /. float_of_int(visibleHeight)
@@ -123,7 +124,7 @@ let createElement =
                     Constants.default.minimapCharacterWidth
                     + Constants.default.minimapCharacterHeight;
                   let linesInMinimap =
-                    editor.size.pixelHeight / minimapLineSize;
+                    metrics.pixelHeight / minimapLineSize;
                   GlobalContext.current().editorScroll(
                     ~deltaY=
                       (startPosition -. scrollTo)
@@ -153,7 +154,7 @@ let createElement =
       let minimapLineSize =
         Constants.default.minimapCharacterWidth
         + Constants.default.minimapCharacterHeight;
-      let linesInMinimap = editor.size.pixelHeight / minimapLineSize;
+      let linesInMinimap = metrics.pixelHeight / minimapLineSize;
       GlobalContext.current().editorScroll(
         ~deltaY=scrollTo -. editor.scrollY -. float_of_int(linesInMinimap),
         (),
@@ -176,9 +177,9 @@ let createElement =
                 ~x=0.,
                 ~y=
                   rowHeight
-                  *. float_of_int(Editor.getTopVisibleLine(editor) - 1)
+                  *. float_of_int(Editor.getTopVisibleLine(editor, metrics) - 1)
                   -. scrollY,
-                ~height=rowHeight *. float_of_int(getMinimapSize(editor)),
+                ~height=rowHeight *. float_of_int(getMinimapSize(editor, metrics)),
                 ~width=float_of_int(width),
                 ~color=state.theme.colors.scrollbarSliderHoverBackground,
                 (),

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -123,8 +123,7 @@ let createElement =
                   let minimapLineSize =
                     Constants.default.minimapCharacterWidth
                     + Constants.default.minimapCharacterHeight;
-                  let linesInMinimap =
-                    metrics.pixelHeight / minimapLineSize;
+                  let linesInMinimap = metrics.pixelHeight / minimapLineSize;
                   GlobalContext.current().editorScroll(
                     ~deltaY=
                       (startPosition -. scrollTo)
@@ -177,9 +176,12 @@ let createElement =
                 ~x=0.,
                 ~y=
                   rowHeight
-                  *. float_of_int(Editor.getTopVisibleLine(editor, metrics) - 1)
+                  *. float_of_int(
+                       Editor.getTopVisibleLine(editor, metrics) - 1,
+                     )
                   -. scrollY,
-                ~height=rowHeight *. float_of_int(getMinimapSize(editor, metrics)),
+                ~height=
+                  rowHeight *. float_of_int(getMinimapSize(editor, metrics)),
                 ~width=float_of_int(width),
                 ~color=state.theme.colors.scrollbarSliderHoverBackground,
                 (),


### PR DESCRIPTION
__Issue:__ When the cursor moves outside the viewport, the viewport doesn't scroll - it's not usable to work with a document outside the viewport.

__Defect:__ This is a regression from #269 , the change to add an `EditorGroup`. The sizing information (editor pixel width / height, as well as character width / height) did not make it to individual `Editor` instances, and the `EditorGroup` was not leveraging it. Therefore, the `Editor`s had default settings for their metrics - a character width/height of 1, which made the viewport seem very large.

__Fix:__ It doesn't really make sense to store the metrics per-Editor, since all editors in an editor group will have the same metrics. Therefore, I've moved tracking these metrics to the `EditorGroup`, and I plumb the metrics through the reducer for `Editor` - so they are always available, as the reducer is called by `EditorGroup`, but doesn't need to be stored on the `Editor` instance.