### PR TITLE
Bugfix - NodeProcess: Only log stderr when debug logging is activated

### DIFF
--- a/src/editor/Extensions/ExtensionHostClient.re
+++ b/src/editor/Extensions/ExtensionHostClient.re
@@ -130,7 +130,6 @@ let start =
     switch (n.method, n.params) {
     | ("host/msg", json) =>
       open Protocol.Notification;
-      print_endline("JSON: " ++ Yojson.Safe.to_string(json));
       switch (parse(json)) {
       | Request(req) => handleMessage(req.reqId, req.payload)
       | Reply(_) => ()

--- a/src/editor/Extensions/ExtensionHostClient.re
+++ b/src/editor/Extensions/ExtensionHostClient.re
@@ -129,15 +129,16 @@ let start =
   let onNotification = (n: Notification.t, _) => {
     switch (n.method, n.params) {
     | ("host/msg", json) =>
-      open Protocol.Notification;
-      switch (parse(json)) {
-      | Request(req) => handleMessage(req.reqId, req.payload)
-      | Reply(_) => ()
-      | Ack(_) => ()
-      | Error => ()
-      | Ready => _sendInitData()
-      | Initialized => _handleInitialization()
-      };
+      Protocol.Notification.(
+        switch (parse(json)) {
+        | Request(req) => handleMessage(req.reqId, req.payload)
+        | Reply(_) => ()
+        | Ack(_) => ()
+        | Error => ()
+        | Ready => _sendInitData()
+        | Initialized => _handleInitialization()
+        }
+      )
 
     | _ =>
       print_endline("[Extension Host Client] Unknown message: " ++ n.method)

--- a/src/editor/Extensions/NodeProcess.re
+++ b/src/editor/Extensions/NodeProcess.re
@@ -10,11 +10,13 @@ type t = {
   pid: int,
   stdout: in_channel,
   stdin: out_channel,
+  stderr: out_channel,
 };
 
-let start = (~args=[], ~env=[], setup: Setup.t, scriptPath: string) => {
+let start = (~args=[], ~env=[], ~passThroughStderr=false, setup: Setup.t, scriptPath: string) => {
   let (pstdin, stdin) = Unix.pipe();
   let (stdout, pstdout) = Unix.pipe();
+  let (stderr, pstderr) = Unix.pipe();
 
   let args = [setup.nodePath, scriptPath, ...args] |> Array.of_list;
 
@@ -27,14 +29,16 @@ let start = (~args=[], ~env=[], setup: Setup.t, scriptPath: string) => {
       env,
       pstdin,
       pstdout,
-      Unix.stderr,
+      passThroughStderr ? Unix.stderr : pstderr,
     );
 
   let in_channel = Unix.in_channel_of_descr(stdout);
   let out_channel = Unix.out_channel_of_descr(stdin);
+  let err_channel = Unix.out_channel_of_descr(stderr);
 
   Unix.close(pstdout);
   Unix.close(pstdin);
+  Unix.close(pstderr);
 
-  {pid, stdin: out_channel, stdout: in_channel};
+  {pid, stdin: out_channel, stdout: in_channel, stderr: err_channel};
 };

--- a/src/editor/Extensions/NodeProcess.re
+++ b/src/editor/Extensions/NodeProcess.re
@@ -40,23 +40,25 @@ let start = (~args=[], ~env=[], setup: Setup.t, scriptPath: string) => {
   let err_channel = Unix.in_channel_of_descr(stderr);
   let out_channel = Unix.out_channel_of_descr(stdin);
 
-  let logPrefix = "[" ++ string_of_int(pid) ++ "|" ++ Rench.Path.filename(scriptPath) ++ "]: ";
+  let logPrefix =
+    "["
+    ++ string_of_int(pid)
+    ++ "|"
+    ++ Rench.Path.filename(scriptPath)
+    ++ "]: ";
 
-    let _ =
+  let _ =
     Thread.create(
       () => {
-          let shouldClose = ref(false);
-          while(!shouldClose^) {
+        let shouldClose = ref(false);
+        while (! shouldClose^) {
           Thread.wait_read(stderr);
 
           switch (input_line(err_channel)) {
-          | exception End_of_file => shouldClose := true;
-          | v => switch (Log.isDebugLoggingEnabled) {
-            | true => Log.debug(logPrefix ++ v)
-            | false => ()
-          }
-          }
-          }
+          | exception End_of_file => shouldClose := true
+          | v => Log.isDebugLoggingEnabled ? Log.debug(logPrefix ++ v) : ()
+          };
+        };
       },
       (),
     );

--- a/src/editor/Extensions/NodeProcess.re
+++ b/src/editor/Extensions/NodeProcess.re
@@ -9,11 +9,11 @@ open Oni_Core;
 type t = {
   pid: int,
   stdout: in_channel,
+  stderr: in_channel,
   stdin: out_channel,
-  stderr: out_channel,
 };
 
-let start = (~args=[], ~env=[], ~passThroughStderr=false, setup: Setup.t, scriptPath: string) => {
+let start = (~args=[], ~env=[], setup: Setup.t, scriptPath: string) => {
   let (pstdin, stdin) = Unix.pipe();
   let (stdout, pstdout) = Unix.pipe();
   let (stderr, pstderr) = Unix.pipe();
@@ -29,16 +29,37 @@ let start = (~args=[], ~env=[], ~passThroughStderr=false, setup: Setup.t, script
       env,
       pstdin,
       pstdout,
-      passThroughStderr ? Unix.stderr : pstderr,
+      pstderr,
     );
 
-  let in_channel = Unix.in_channel_of_descr(stdout);
-  let out_channel = Unix.out_channel_of_descr(stdin);
-  let err_channel = Unix.out_channel_of_descr(stderr);
-
   Unix.close(pstdout);
-  Unix.close(pstdin);
   Unix.close(pstderr);
+  Unix.close(pstdin);
+
+  let in_channel = Unix.in_channel_of_descr(stdout);
+  let err_channel = Unix.in_channel_of_descr(stderr);
+  let out_channel = Unix.out_channel_of_descr(stdin);
+
+  let logPrefix = "[" ++ string_of_int(pid) ++ "|" ++ Rench.Path.filename(scriptPath) ++ "]: ";
+
+    let _ =
+    Thread.create(
+      () => {
+          let shouldClose = ref(false);
+          while(!shouldClose^) {
+          Thread.wait_read(stderr);
+
+          switch (input_line(err_channel)) {
+          | exception End_of_file => shouldClose := true;
+          | v => switch (Log.isDebugLoggingEnabled) {
+            | true => Log.debug(logPrefix ++ v)
+            | false => ()
+          }
+          }
+          }
+      },
+      (),
+    );
 
   {pid, stdin: out_channel, stdout: in_channel, stderr: err_channel};
 };


### PR DESCRIPTION
This is the remaining fix for #206 - we'll suppress `stderr` piping and only log it when debug logging is enabled.

We could potentially abstract / move this to `reason-jsonrpc` 🤔 