### PR TITLE
Bugfix - Regression: Escape doesn't close QuickOpen

### DIFF
--- a/src/editor/Store/CommandStoreConnector.re
+++ b/src/editor/Store/CommandStoreConnector.re
@@ -34,7 +34,14 @@ let start = () => {
         ]),
     ),
     ("quickOpen.open", _ => singleActionEffect(QuickOpen)),
-    ("menu.close", _ => multipleActionEffect([MenuClose, SetInputControlMode(EditorTextFocus)])),
+    (
+      "menu.close",
+      _ =>
+        multipleActionEffect([
+          MenuClose,
+          SetInputControlMode(EditorTextFocus),
+        ]),
+    ),
     (
       "menu.open",
       _ =>

--- a/src/editor/Store/CommandStoreConnector.re
+++ b/src/editor/Store/CommandStoreConnector.re
@@ -34,6 +34,7 @@ let start = () => {
         ]),
     ),
     ("quickOpen.open", _ => singleActionEffect(QuickOpen)),
+    ("menu.close", _ => multipleActionEffect([MenuClose, SetInputControlMode(EditorTextFocus)])),
     (
       "menu.open",
       _ =>


### PR DESCRIPTION
Missed the `menu.close` event in #278 - thanks @Akin909 for catching it (sorry about the regression!).