### PR TITLE
Bugfix: Crash - exception on 'List.hd' call

### DIFF
--- a/src/editor/Neovim/NeovimApi.re
+++ b/src/editor/Neovim/NeovimApi.re
@@ -136,7 +136,6 @@ let make = (msgpack: MsgpackTransport.t) => {
 
   let requestSync: requestSyncFunction =
     (methodName: string, args: M.t) => {
-      prerr_endline("requestSync: " ++ methodName ++ " | " ++ M.show(args));
       let requestId = getNextId();
 
       let request =


### PR DESCRIPTION
__Issue:__ There was an intermittent crash on `List.hd` in the `NeovimApi` method, here:
https://github.com/onivim/oni2/blob/69dc89dc4c596c45055ac4c479f17baecd48a038/src/editor/Neovim/NeovimApi.re#L164

The curious aspect of this is that there is a check that we received a message, and that check passed, but when we want to actually find the response message for the request we sent - there would be no message present. We assume there is with the call to `List.hd`, so that crashes and burns.

__Defect:__ The condition in the `Utility.wait` is actually incorrect - it's only checking to see if _any message_ came back from Neovim, when actually, we need to check if _any message matching our requestId__ came in. The crash is occurring when a _different message_ comes in (perhaps from a 'fire and forget call'), and erroneously flags the wait as completed - and then when we go to examine the message, we haven't found it.

__Fix:__ 
- Update the wait condition to wait for the actual response (ie, a `responseId` matching our `requestId`).
- Use the mutex helper when accessing the `getQueuedMessages`

If the condition actually fails in the future (due to a timeout, or an actual error) - show a more detailed error message.