### PR TITLE
Visual Mode Changes

### DIFF
--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -459,7 +459,8 @@ let createElement =
                           -. editor.scrollY,
                         ~height=fontHeight,
                         ~width=
-                          float_of_int(endOffset - startOffset) *. fontWidth,
+                          max(float_of_int(endOffset - startOffset), 1.0)
+                          *. fontWidth,
                         ~color=theme.colors.editorSelectionBackground,
                         (),
                       );


### PR DESCRIPTION
Always show at least one 1 char in visual mode. This doesn't change visual block mode as I don't think that works that way in terminal neovim (unless the `virtualedit` options are changed).

Before:
![image](https://user-images.githubusercontent.com/10038688/56772729-19225c80-67b3-11e9-8476-b6325fc2b661.png)

After:
![image](https://user-images.githubusercontent.com/10038688/56772780-4ff87280-67b3-11e9-894f-546769feb6ca.png)
