### PR TITLE
Releasing click stops scrolling

### DIFF
--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -100,28 +100,27 @@ let createElement =
         () => {
           let isCaptured = isActive;
           let startPosition = editor.scrollY;
-
-          Mouse.setCapture(
-            ~onMouseMove=
-              evt =>
-                if (isCaptured) {
-                  let scrollTo = getScrollTo(evt.mouseY);
-                  let minimapLineSize =
-                    Constants.default.minimapCharacterWidth
-                    + Constants.default.minimapCharacterHeight;
-                  let linesInMinimap = metrics.pixelHeight / minimapLineSize;
-                  GlobalContext.current().editorScroll(
-                    ~deltaY=
-                      (startPosition -. scrollTo)
-                      *. (-1.)
-                      -. float_of_int(linesInMinimap),
-                    (),
-                  );
-                },
-            ~onMouseUp=_evt => scrollComplete(),
-            (),
-          );
-
+          if (isCaptured) {
+            Mouse.setCapture(
+              ~onMouseMove=
+                evt => {
+                    let scrollTo = getScrollTo(evt.mouseY);
+                    let minimapLineSize =
+                      Constants.default.minimapCharacterWidth
+                      + Constants.default.minimapCharacterHeight;
+                    let linesInMinimap = metrics.pixelHeight / minimapLineSize;
+                    GlobalContext.current().editorScroll(
+                      ~deltaY=
+                        (startPosition -. scrollTo)
+                        *. (-1.)
+                        -. float_of_int(linesInMinimap),
+                      (),
+                    );
+                  },
+              ~onMouseUp=_evt => scrollComplete(),
+              (),
+            );
+          }
           Some(
             () =>
               if (isCaptured) {

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -104,23 +104,23 @@ let createElement =
             Mouse.setCapture(
               ~onMouseMove=
                 evt => {
-                    let scrollTo = getScrollTo(evt.mouseY);
-                    let minimapLineSize =
-                      Constants.default.minimapCharacterWidth
-                      + Constants.default.minimapCharacterHeight;
-                    let linesInMinimap = metrics.pixelHeight / minimapLineSize;
-                    GlobalContext.current().editorScroll(
-                      ~deltaY=
-                        (startPosition -. scrollTo)
-                        *. (-1.)
-                        -. float_of_int(linesInMinimap),
-                      (),
-                    );
-                  },
+                  let scrollTo = getScrollTo(evt.mouseY);
+                  let minimapLineSize =
+                    Constants.default.minimapCharacterWidth
+                    + Constants.default.minimapCharacterHeight;
+                  let linesInMinimap = metrics.pixelHeight / minimapLineSize;
+                  GlobalContext.current().editorScroll(
+                    ~deltaY=
+                      (startPosition -. scrollTo)
+                      *. (-1.)
+                      -. float_of_int(linesInMinimap),
+                    (),
+                  );
+                },
               ~onMouseUp=_evt => scrollComplete(),
               (),
             );
-          }
+          };
           Some(
             () =>
               if (isCaptured) {


### PR DESCRIPTION
This is a fix for one part of #250

> Right now, you have to click once to start a dragging behavior. To end the dragging behavior, you need to click a second time.
