### PR TITLE
Documentation: add a link to MOTIVATION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The goal of this project is to build an editor that doesn't exist today - the _s
 
 - __VimL compatibility__ - we may not support all features of VimL plugins / configuration.
 
+### See also
+
+See also the document about motivations, software architecture, the model for sustainability and risks : https://github.com/onivim/oni2/blob/master/docs/MOTIVATION.md
+
 ## Documentation
 
 Coming soon!


### PR DESCRIPTION
Hi !

In the README.md , I believe it could be cool to add a link to the file https://github.com/onivim/oni2/blob/master/docs/MOTIVATION.md

Actually there is no link into the README.md, therefore probably a reader could not read this very important document. Often a reader doesn't check the Github tree to see if under the folder doc there is a such important document !

Thanks in advance ;-)