### PR TITLE
Change command modifier for MacOS to Cmd

### DIFF
--- a/assets/configuration/keybindings.json
+++ b/assets/configuration/keybindings.json
@@ -1,10 +1,14 @@
 {
     "bindings": [
         { "key": "<C-P>", "command": "quickOpen.open", "when": [["editorTextFocus"]] },
+        { "key": "<D-P>", "command": "quickOpen.open", "when": [["editorTextFocus"]] },
         { "key": "<S-C-P>", "command": "commandPalette.open", "when": [["editorTextFocus"]] },
+        { "key": "<D-S-P>", "command": "commandPalette.open", "when": [["editorTextFocus"]] },
         { "key": "<ESC>", "command": "menu.close", "when": [["menuFocus"]] },
         { "key": "<C-N>", "command": "menu.next", "when": [["menuFocus"], ["textInputFocus"]] },
         { "key": "<C-P>", "command": "menu.previous", "when": [["menuFocus"], ["textInputFocus"]] },
+        { "key": "<D-N>", "command": "menu.next", "when": [["menuFocus"], ["textInputFocus"]] },
+        { "key": "<D-P>", "command": "menu.previous", "when": [["menuFocus"], ["textInputFocus"]] },
         { "key": "<CR>", "command": "menu.select", "when": [["menuFocus"], ["textInputFocus"]] }
     ]
 }

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -42,12 +42,15 @@ let charToCommand = (codepoint: int, mods: Modifier.t) => {
 };
 
 let keyPressToCommand =
-    ({shiftKey, altKey, ctrlKey, superKey, key, _}: Events.keyEvent, os: Revery_Core.Environment.os) => {
-
-  let commandKeyPressed = switch(os) {
-  | Mac => superKey
-  | _ => ctrlKey
-  }
+    (
+      {shiftKey, altKey, ctrlKey, superKey, key, _}: Events.keyEvent,
+      os: Revery_Core.Environment.os,
+    ) => {
+  let commandKeyPressed =
+    switch (os) {
+    | Mac => superKey
+    | _ => ctrlKey
+    };
 
   let keyString =
     commandKeyPressed

--- a/src/editor/bin/Input.re
+++ b/src/editor/bin/Input.re
@@ -42,9 +42,15 @@ let charToCommand = (codepoint: int, mods: Modifier.t) => {
 };
 
 let keyPressToCommand =
-    ({shiftKey, altKey, ctrlKey, superKey, key, _}: Events.keyEvent) => {
+    ({shiftKey, altKey, ctrlKey, superKey, key, _}: Events.keyEvent, os: Revery_Core.Environment.os) => {
+
+  let commandKeyPressed = switch(os) {
+  | Mac => superKey
+  | _ => ctrlKey
+  }
+
   let keyString =
-    ctrlKey
+    commandKeyPressed
       ? /**
         TODO:
         Revery's toString method returns lower case

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -153,7 +153,7 @@ let init = app => {
     };
 
   Event.subscribe(w.onKeyDown, keyEvent =>
-    Input.keyPressToCommand(keyEvent) |> keyEventListener
+    Input.keyPressToCommand(keyEvent, Revery_Core.Environment.os) |> keyEventListener
   )
   |> ignore;
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -153,7 +153,8 @@ let init = app => {
     };
 
   Event.subscribe(w.onKeyDown, keyEvent =>
-    Input.keyPressToCommand(keyEvent, Revery_Core.Environment.os) |> keyEventListener
+    Input.keyPressToCommand(keyEvent, Revery_Core.Environment.os)
+    |> keyEventListener
   )
   |> ignore;
 


### PR DESCRIPTION
This addresses https://github.com/onivim/oni2/issues/263

I had a hard time writing test cases for this, mainly because I didn't really know how to create a Key-Event object to pass to the corresponding method. Since the rest of `Input` isn't tested so far, I assume, others had similar issues?

I'd be happy for feedback either way, since this is my first contact with real world Reason.