### PR TITLE
Add error handling to Explorer

### DIFF
--- a/src/editor/Core/Constants.re
+++ b/src/editor/Core/Constants.re
@@ -36,5 +36,5 @@ let default: t = {
   minimapLineSpacing: 1,
   scrollBarThickness: 15,
   minimapMaxColumn: 120,
-  maximumExplorerDepth: 5,
+  maximumExplorerDepth: 10,
 };

--- a/src/editor/Core/Constants.re
+++ b/src/editor/Core/Constants.re
@@ -36,5 +36,5 @@ let default: t = {
   minimapLineSpacing: 1,
   scrollBarThickness: 15,
   minimapMaxColumn: 120,
-  maximumExplorerDepth: 10,
+  maximumExplorerDepth: 5,
 };

--- a/src/editor/Model/FileExplorer.re
+++ b/src/editor/Model/FileExplorer.re
@@ -63,7 +63,7 @@ let handleError = (~defaultValue, func) => {
     Lwt.return(defaultValue);
   | Failure(e) =>
     Log.error(e);
-    Lwt.return([]);
+    Lwt.return(defaultValue);
   };
 };
 

--- a/src/editor/UI/FileExplorerView.re
+++ b/src/editor/UI/FileExplorerView.re
@@ -45,11 +45,10 @@ let createElement = (~children as _, ~state: State.t, ()) =>
 
     (
       hooks,
-      <TreeView
-        state
-        onNodeClick
-        title="Explorer"
-        tree={state.fileExplorer.directory}
-      />,
+      switch (state.fileExplorer.directory) {
+      | Empty => React.empty
+      | Node(_, _) as tree =>
+        <TreeView state onNodeClick title="Explorer" tree />
+      },
     );
   });


### PR DESCRIPTION
This PR adds some error handling to the calls to get the folders and files for the file explorer, if an error is encountered trying to resolve subdirs we abort returning an empty children list and log the error. This allows the function to populate as much as possible.