### PR TITLE
Theming: Add sideBar theme colors

### DIFF
--- a/src/editor/Core/Constants.re
+++ b/src/editor/Core/Constants.re
@@ -27,6 +27,7 @@ type t = {
    * when initially populating the file explorer
    */
   maximumExplorerDepth: int,
+  tabHeight: int,
 };
 
 let default: t = {
@@ -37,4 +38,5 @@ let default: t = {
   scrollBarThickness: 15,
   minimapMaxColumn: 120,
   maximumExplorerDepth: 10,
+  tabHeight: 35,
 };

--- a/src/editor/Core/Theme.re
+++ b/src/editor/Core/Theme.re
@@ -41,11 +41,15 @@ module EditorColors = {
     statusBarForeground: Color.t,
     statusBarBackground: Color.t,
     scrollbarSliderHoverBackground: Color.t,
+    sideBarBackground: Color.t,
+    sideBarForeground: Color.t,
   };
 
   let default: t = {
     background: Color.hex("#282C35"),
     foreground: Color.hex("#ECEFF4"),
+    sideBarBackground: Color.hex("#21252b"),
+    sideBarForeground: Color.hex("#ECEFF4"),
     editorBackground: Color.hex("#2F3440"),
     editorForeground: Color.hex("#DCDCDC"),
     editorLineHighlightBackground: Color.hex("#495162"),

--- a/src/editor/UI/EditorLayoutView.re
+++ b/src/editor/UI/EditorLayoutView.re
@@ -6,6 +6,7 @@
  */
 open Revery;
 open UI;
+open Oni_Core;
 open Oni_Model;
 open WindowManager;
 
@@ -26,13 +27,18 @@ let splitStyle = (split: split) =>
     }
   );
 
-let getDockStyle = ({width, _}: dock) => {
+let getDockStyle = ({width, _}: dock, theme: Theme.t) => {
   let w =
     switch (width) {
     | Some(w) => w
     | None => 10
     };
-  Style.[width(w), top(0), bottom(0)];
+  Style.[
+    width(w),
+    top(0),
+    bottom(0),
+    backgroundColor(theme.colors.sideBarBackground),
+  ];
 };
 
 let renderDock = (dockItems: list(dock), state: State.t) =>
@@ -40,7 +46,9 @@ let renderDock = (dockItems: list(dock), state: State.t) =>
   |> List.fold_left(
        (accum, item) =>
          [
-           <View style={getDockStyle(item)}> {item.component()} </View>,
+           <View style={getDockStyle(item, state.theme)}>
+             {item.component()}
+           </View>,
            <WindowHandle direction=Vertical theme={state.theme} />,
            ...accum,
          ],

--- a/src/editor/UI/EditorView.re
+++ b/src/editor/UI/EditorView.re
@@ -71,7 +71,7 @@ let createElement = (~state: State.t, ~children as _, ()) =>
           let explorer =
             registerDock(
               ~order=2,
-              ~width=250,
+              ~width=225,
               ~id=ExplorerDock,
               ~component=splitFactory(state => <FileExplorerView state />),
               (),

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -84,7 +84,8 @@ let createElement =
     let getScrollTo = (mouseY: float) => {
       let totalHeight: int = Editor.getTotalSizeInPixels(editor, metrics);
       let visibleHeight: int = metrics.pixelHeight;
-      let offsetMouseY: int = int_of_float(mouseY) - Tab.tabHeight;
+      let offsetMouseY: int =
+        int_of_float(mouseY) - Constants.default.tabHeight;
       float_of_int(offsetMouseY)
       /. float_of_int(visibleHeight)
       *. float_of_int(totalHeight);

--- a/src/editor/UI/Tab.re
+++ b/src/editor/UI/Tab.re
@@ -12,7 +12,6 @@ module Model = Oni_Model;
 
 type tabAction = unit => unit;
 
-let tabHeight = 35;
 let minWidth_ = 125;
 let proportion = p => float_of_int(minWidth_) *. p |> int_of_float;
 
@@ -60,7 +59,7 @@ let createElement =
         borderTop(~color=borderColor, ~width=2),
         borderBottom(~color=theme.colors.editorBackground, ~width=2),
         opacity(opacityValue),
-        height(tabHeight),
+        height(Constants.default.tabHeight),
         minWidth(minWidth_),
         flexDirection(`Row),
         justifyContent(`Center),
@@ -83,7 +82,7 @@ let createElement =
     let iconContainerStyle =
       Style.[
         width(32),
-        height(tabHeight),
+        height(Constants.default.tabHeight),
         alignItems(`Center),
         justifyContent(`Center),
       ];

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -49,8 +49,6 @@ let itemRenderer =
       ~backgroundColor,
       {data, status, id}: itemContent,
     ) => {
-  open Revery;
-
   let isOpen =
     switch (status) {
     | Open => true

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -9,7 +9,13 @@ let component = React.component("TreeView");
 
 let itemStyles = Style.[flexDirection(`Row), marginVertical(5)];
 
-let containerStyles = Style.[paddingLeft(16), paddingVertical(8), overflow(`Hidden), flexGrow(1)];
+let containerStyles =
+  Style.[
+    paddingLeft(16),
+    paddingVertical(8),
+    overflow(`Hidden),
+    flexGrow(1),
+  ];
 
 let titleStyles = (fgColor, bgColor, font) =>
   Style.[

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -9,18 +9,23 @@ let component = React.component("TreeView");
 
 let itemStyles = Style.[flexDirection(`Row), marginVertical(5)];
 
-let containerStyles = Style.[padding(20), overflow(`Hidden), flexGrow(1)];
+let containerStyles = Style.[paddingLeft(16), paddingVertical(8), overflow(`Hidden), flexGrow(1)];
 
-let titleStyles = font =>
-  Style.[padding(5), fontSize(14), fontFamily(font)];
+let titleStyles = (fgColor, bgColor, font) =>
+  Style.[
+    fontSize(14),
+    fontFamily(font),
+    backgroundColor(bgColor),
+    color(fgColor),
+  ];
 
 let headingStyles = (theme: Core.Theme.t) =>
   Style.[
     flexDirection(`Row),
     justifyContent(`Center),
     alignItems(`Center),
-    backgroundColor(theme.colors.editorBackground),
-    paddingTop(5),
+    backgroundColor(theme.colors.sideBarBackground),
+    height(Core.Constants.default.tabHeight),
   ];
 
 let toIcon = (~character, ~color) =>
@@ -34,6 +39,8 @@ let itemRenderer =
       ~primaryRootIcon,
       ~secondaryRootIcon,
       ~itemSize,
+      ~foregroundColor,
+      ~backgroundColor,
       {data, status, id}: itemContent,
     ) => {
   open Revery;
@@ -44,15 +51,22 @@ let itemRenderer =
     | Closed => false
     };
 
+  let bgColor = backgroundColor;
+
   let textStyles =
-    Style.[fontSize(itemSize), fontFamily(font), color(Colors.white)];
+    Style.[
+      fontSize(itemSize),
+      fontFamily(font),
+      color(foregroundColor),
+      backgroundColor(bgColor),
+    ];
 
   let indentStr = String.make(indent * 2, ' ');
 
   let icon =
     switch (data) {
     | FileSystemNode({icon, secondaryIcon, _}) =>
-      let makeIcon = toIcon(~color=Colors.white);
+      let makeIcon = toIcon(~color=foregroundColor);
       switch (icon, secondaryIcon, isOpen) {
       | (Some(_), Some(secondary), true) => secondary
       | (Some(primary), Some(_), false) => primary
@@ -81,7 +95,7 @@ let itemRenderer =
         fontFamily
         color={icon.fontColor}
         icon={icon.fontCharacter}
-        backgroundColor=Colors.transparentWhite
+        backgroundColor
       />
       <Text text=label style=Style.[marginLeft(10), ...textStyles] />
     </View>
@@ -108,6 +122,9 @@ let createElement =
       UiTree.updateNode(id, tree, ())
       |> (({updated, tree, _}) => onNodeClick(updated, tree));
 
+    let backgroundColor = state.theme.colors.sideBarBackground;
+    let foregroundColor = state.theme.colors.sideBarForeground;
+
     let nodeRenderer =
       itemRenderer(
         ~onClick,
@@ -115,13 +132,18 @@ let createElement =
         ~secondaryRootIcon,
         ~font,
         ~itemSize,
+        ~backgroundColor,
+        ~foregroundColor,
       );
 
     (
       hooks,
       <View style=Style.[flexGrow(1)]>
         <View style={headingStyles(theme)}>
-          <Text text=title style={titleStyles(font)} />
+          <Text
+            text=title
+            style={titleStyles(foregroundColor, backgroundColor, font)}
+          />
         </View>
         <ScrollView style=containerStyles>
           <Tree tree nodeRenderer />


### PR DESCRIPTION
This adds the `sideBar.background` and `sideBar.foreground` theme colors - building on the file explorer by @Akin909 👍 

![image](https://user-images.githubusercontent.com/13532591/57342391-a50d8000-70f3-11e9-933a-1b16b21eebdf.png)

- Some minor fit-and-finish tweaks (use backgroundColor/foregroundColor on all the text elements, so we get gamma corrected text). 
- Update header to be the same color as the sidebar.
- Factor tabHeight to constant, reuse for sidebar header