### PR TITLE
Bugfix - Regression: Editor not showing correct buffer title

### DIFF
--- a/src/editor/UI/EditorGroupView.re
+++ b/src/editor/UI/EditorGroupView.re
@@ -53,7 +53,7 @@ let toUiTabs = (editorGroup: Model.EditorGroup.t, buffers: Model.Buffers.t) => {
     | None => None
     | Some(v) =>
       let (modified, title) =
-        Model.Buffers.getBuffer(id, buffers) |> getBufferMetadata;
+        Model.Buffers.getBuffer(v.bufferId, buffers) |> getBufferMetadata;
       let ret: Tabs.tabInfo = {
         title,
         modified,


### PR DESCRIPTION
Regression from #306 - we were using the editor id to look up the buffer, and get the title. However, the 'editor id' and 'buffer id' are not necessarily in sync.

__Fix:__ Get the `bufferId` from the editor and use that for resolving the buffer