### PR TITLE
Performance - Startup: Limit initial population of FileExplorer to 1 level

### DIFF
--- a/src/editor/Core/Constants.re
+++ b/src/editor/Core/Constants.re
@@ -37,6 +37,6 @@ let default: t = {
   minimapLineSpacing: 1,
   scrollBarThickness: 15,
   minimapMaxColumn: 120,
-  maximumExplorerDepth: 10,
+  maximumExplorerDepth: 1,
   tabHeight: 35,
 };


### PR DESCRIPTION
__Issue:__ When opening Oni2 in some folders, the startup time would be quite long (ie, opening the root directory of the drive).

__Fix:__ The population logic was traversing up to 5 levels deep, which is expensive in a big folder. Since we only show a single level for now, we can restrict to a single level for the initial load. Verified that expanded later worked as expected.