### PR TITLE
Bugfix: Fix menu search logic for streaming results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ jobs:
     # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
 
   steps:
+  - script: sudo apt-get update
   - script: sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libegl1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev
   - script: '$(ONI2_NEOVIM_PATH) --version'
     displayName: 'Check neovim version'

--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -1,43 +1,59 @@
 open Revery;
 
-type doWork('p, 'c) = ('p, 'c) => ((bool, 'p, 'c));
-type mapFn('p, 'c) = ('p, 'c) => (('p, 'c));
+type doWork('p, 'c) = ('p, 'c) => (bool, 'p, 'c);
+type mapFn('p, 'c) = ('p, 'c) => ('p, 'c);
 
 type t('p, 'c) = {
-    f: doWork('p, 'c),
-    isComplete: bool,
-    pendingWork: 'p,
-    completedWork: 'c,
-    budget: Time.t,
+  f: doWork('p, 'c),
+  isComplete: bool,
+  pendingWork: 'p,
+  completedWork: 'c,
+  budget: Time.t,
 };
 
 let defaultBudget = Time.Milliseconds(1.);
 
 let isComplete = (v: t('p, 'c)) => v.isComplete;
 
-let create = (~budget=defaultBudget, ~f: doWork('p, 'c), ~initialCompletedWork: 'c, pendingWork: 'p) => {
-    { budget, f, completedWork: initialCompletedWork, pendingWork, isComplete: false }
+let create =
+    (
+      ~budget=defaultBudget,
+      ~f: doWork('p, 'c),
+      ~initialCompletedWork: 'c,
+      pendingWork: 'p,
+    ) => {
+  {
+    budget,
+    f,
+    completedWork: initialCompletedWork,
+    pendingWork,
+    isComplete: false,
+  };
 };
 
 let map = (~f: mapFn('p, 'c), v: t('p, 'c)) => {
-    let { pendingWork, completedWork, _ } = v;
-    let (pendingWork, completedWork) = f(pendingWork, completedWork);
-    { ...v, pendingWork, completedWork }
+  let {pendingWork, completedWork, _} = v;
+  let (pendingWork, completedWork) = f(pendingWork, completedWork);
+  {...v, pendingWork, completedWork};
 };
 
 let doWork = (v: t('p, 'c)) => {
-    let (isComplete, pendingWork, completedWork) = v.f(v.pendingWork, v.completedWork);
-    { ...v, isComplete, pendingWork, completedWork }
+  let (isComplete, pendingWork, completedWork) =
+    v.f(v.pendingWork, v.completedWork);
+  {...v, isComplete, pendingWork, completedWork};
 };
 
-let tick: t('p, 'c) => t('p, 'c) = (v: t('p, 'c)) => {
+let tick: t('p, 'c) => t('p, 'c) =
+  (v: t('p, 'c)) => {
     let budget = Time.to_float_seconds(v.budget);
     let startTime = Time.getTime() |> Time.to_float_seconds;
     let current = ref(v);
 
-    while (Time.to_float_seconds(Time.getTime()) -. startTime < budget && !current^.isComplete) {
-        current := doWork(v);
+    while (Time.to_float_seconds(Time.getTime())
+           -. startTime < budget
+           && !current^.isComplete) {
+      current := doWork(v);
     };
 
     current^;
-};
+  };

--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -1,0 +1,32 @@
+open Revery;
+
+type doWork('p, 'c) = ('p, 'c) => ((bool, 'p, 'c));
+
+type t('p, 'c) = {
+    f: doWork('p, 'c),
+    isComplete: bool,
+    pendingWork: 'p,
+    completedWork: 'c,
+    budget: Time.t,
+};
+
+let create = (~budget=Milliseconds(1.), ~f: doWork('p, 'c), ~initialCompletedWork: 'c, pendingWork: 'p) => {
+    { budget, f, completedWork: initialCompletedWork, pendingWork, isComplete: false }
+};
+
+let doWork = (v: t('p, 'c)) => {
+    let (isCompleted, pendingWork, completedWork) = v.doWork(v.pendingWork, v.completedWork);
+    { ...v, isCompleted, pendingWork, completedWork }
+}
+
+let tick: t('p, 'c) => t('p, 'c) = (v: t('p, 'c)) => {
+    let budget = Time.toSeconds(v.budget);
+    let startTime = Time.getTime() |> Time.toSeconds;
+    let current = ref(v);
+
+    while (Time.toSeconds(Time.getTime()) -. startTime < budget && !current^.isCompleted) {
+        current := doWork(v);
+    };
+
+    current^;
+}

--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -1,6 +1,7 @@
 open Revery;
 
 type doWork('p, 'c) = ('p, 'c) => ((bool, 'p, 'c));
+type mapFn('p, 'c) = ('p, 'c) => (('p, 'c));
 
 type t('p, 'c) = {
     f: doWork('p, 'c),
@@ -10,23 +11,33 @@ type t('p, 'c) = {
     budget: Time.t,
 };
 
-let create = (~budget=Milliseconds(1.), ~f: doWork('p, 'c), ~initialCompletedWork: 'c, pendingWork: 'p) => {
+let defaultBudget = Time.Milliseconds(1.);
+
+let isComplete = (v: t('p, 'c)) => v.isComplete;
+
+let create = (~budget=defaultBudget, ~f: doWork('p, 'c), ~initialCompletedWork: 'c, pendingWork: 'p) => {
     { budget, f, completedWork: initialCompletedWork, pendingWork, isComplete: false }
 };
 
+let map = (~f: mapFn('p, 'c), v: t('p, 'c)) => {
+    let { pendingWork, completedWork, _ } = v;
+    let (pendingWork, completedWork) = f(pendingWork, completedWork);
+    { ...v, pendingWork, completedWork }
+};
+
 let doWork = (v: t('p, 'c)) => {
-    let (isCompleted, pendingWork, completedWork) = v.doWork(v.pendingWork, v.completedWork);
-    { ...v, isCompleted, pendingWork, completedWork }
-}
+    let (isComplete, pendingWork, completedWork) = v.f(v.pendingWork, v.completedWork);
+    { ...v, isComplete, pendingWork, completedWork }
+};
 
 let tick: t('p, 'c) => t('p, 'c) = (v: t('p, 'c)) => {
-    let budget = Time.toSeconds(v.budget);
-    let startTime = Time.getTime() |> Time.toSeconds;
+    let budget = Time.to_float_seconds(v.budget);
+    let startTime = Time.getTime() |> Time.to_float_seconds;
     let current = ref(v);
 
-    while (Time.toSeconds(Time.getTime()) -. startTime < budget && !current^.isCompleted) {
+    while (Time.to_float_seconds(Time.getTime()) -. startTime < budget && !current^.isComplete) {
         current := doWork(v);
     };
 
     current^;
-}
+};

--- a/src/editor/Model/Menu.re
+++ b/src/editor/Model/Menu.re
@@ -2,6 +2,7 @@ type t = {
   searchQuery: string,
   isOpen: bool,
   commands: list(Actions.menuCommand),
+  filteredCommands: list(Actions.menuCommand),
   selectedItem: int,
   dispose: unit => unit,
 };
@@ -10,6 +11,7 @@ let create = () => {
   searchQuery: "",
   isOpen: false,
   commands: [],
+  filteredCommands: [],
   selectedItem: 0,
   dispose: () => (),
 };

--- a/src/editor/Store/MenuStoreConnector.re
+++ b/src/editor/Store/MenuStoreConnector.re
@@ -32,9 +32,6 @@ let start = () => {
       dispatch(action);
     });
 
-  let updateMenuCommands = (commands, state: Model.Menu.t) =>
-    List.append(state.commands, commands);
-
   let disposeMenuEffect = dispose =>
     Isolinear.Effect.create(~name="menu.dispose", dispose);
 
@@ -62,7 +59,7 @@ let start = () => {
         {
           ...state,
           searchQuery: query,
-          commands: Model.Filter.menu(query, state.commands),
+          filteredCommands: Model.Filter.menu(query, state.commands),
         },
         Isolinear.Effect.none,
       )
@@ -70,10 +67,17 @@ let start = () => {
         {...state, isOpen: true, commands: []},
         menuOpenEffect(menuConstructor),
       )
-    | MenuUpdate(update) => (
-        {...state, commands: updateMenuCommands(update, state)},
+    | MenuUpdate(update) => {
+		let commands = List.append(state.commands, update);
+		let filteredCommands = Model.Filter.menu(state.searchQuery, commands);
+
+		(
+        {...state, 
+				commands,
+				filteredCommands},
         Isolinear.Effect.none,
       )
+						}
     | MenuSetDispose(dispose) => (
         {...state, dispose},
         Isolinear.Effect.none,

--- a/src/editor/Store/MenuStoreConnector.re
+++ b/src/editor/Store/MenuStoreConnector.re
@@ -67,17 +67,11 @@ let start = () => {
         {...state, isOpen: true, commands: []},
         menuOpenEffect(menuConstructor),
       )
-    | MenuUpdate(update) => {
-		let commands = List.append(state.commands, update);
-		let filteredCommands = Model.Filter.menu(state.searchQuery, commands);
+    | MenuUpdate(update) =>
+      let commands = List.append(state.commands, update);
+      let filteredCommands = Model.Filter.menu(state.searchQuery, commands);
 
-		(
-        {...state, 
-				commands,
-				filteredCommands},
-        Isolinear.Effect.none,
-      )
-						}
+      ({...state, commands, filteredCommands}, Isolinear.Effect.none);
     | MenuSetDispose(dispose) => (
         {...state, dispose},
         Isolinear.Effect.none,

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -105,9 +105,9 @@ let createElement =
                 rowHeight=40
                 height={menuHeight - 50}
                 width=menuWidth
-                count={List.length(menu.commands)}
+                count={List.length(menu.filteredCommands)}
                 render={index => {
-                  let cmd = List.nth(menu.commands, index);
+                  let cmd = List.nth(menu.filteredCommands, index);
                   <MenuItem
                     onClick
                     theme


### PR DESCRIPTION
__Issue:__ When results are streamed in the QuickOpen menu, and a search query is typed, we can sometimes get unpredictable results.

There were two problems here:
1) We filter the `commands` with the query as they come in. The problem is, if we press `Backspace`, we won't get these results back. 
2) When `commands` come in via the `MenuUpdate` action, we weren't actually filtering them. So this meant that if you typed `foo` and `bar` came in after you typed the query - `bar` would show up erroneously in the results.

__Fix:__
1) Create a separate `commands` and `filteredCommands`. `commands` is the full set of unfiltered commands, whereas `filteredCommands` is `commands` with the search query filter applied.
2) Append the new commands to `commands` first, and then apply the filter on the aggregate.

The downside to this is that the `MenuUpdate` action and `MenuSearch` action are now more expensive - applying the menu filter on the full set for each keystroke is correct, but costs more runtime perf.

We should look at potentially debouncing this as a next step if we see a bottleneck (or offloading to a process / thread).

