### PR TITLE
Bugfix: Clicking on buffer tab doesn't select buffer

### DIFF
--- a/src/editor/Model/EditorGroup.re
+++ b/src/editor/Model/EditorGroup.re
@@ -164,12 +164,11 @@ let reduce = (v: t, action: Actions.t) => {
     let (newState, activeEditorId) = getOrCreateEditorForBuffer(v, id);
     {...newState, activeEditorId: Some(activeEditorId)};
   | ViewCloseEditor(id) => removeEditorById(v, id)
-  | ViewSetActiveEditor(id) => {
-        switch (IntMap.find_opt(id, v.editors)) {
-        | None => v
-        | Some(_) => { ...v, activeEditorId: Some(id) }
-        }
-}
+  | ViewSetActiveEditor(id) =>
+    switch (IntMap.find_opt(id, v.editors)) {
+    | None => v
+    | Some(_) => {...v, activeEditorId: Some(id)}
+    }
   | _ => v
   };
 };

--- a/src/editor/Model/EditorGroup.re
+++ b/src/editor/Model/EditorGroup.re
@@ -164,6 +164,12 @@ let reduce = (v: t, action: Actions.t) => {
     let (newState, activeEditorId) = getOrCreateEditorForBuffer(v, id);
     {...newState, activeEditorId: Some(activeEditorId)};
   | ViewCloseEditor(id) => removeEditorById(v, id)
+  | ViewSetActiveEditor(id) => {
+        switch (IntMap.find_opt(id, v.editors)) {
+        | None => v
+        | Some(_) => { ...v, activeEditorId: Some(id) }
+        }
+}
   | _ => v
   };
 };


### PR DESCRIPTION
__Issue:__ Clicking on the buffer tab doesn't do anything

__Defect:__ We were dispatching a `ViewSetActiveEditor` command, but never handling it

__Fix:__ Handle the `ViewSetActiveEditor` in the `Editor` reducer, and actually set the `activeEditor` state if applicable