### PR TITLE
fix(docs): Fix `npm install` typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ esy build
 
 ```sh
 cd src/textmate_service
-node install
+npm install
 npm run build
 ```
 


### PR DESCRIPTION
I'm assuming this should be `npm install` instead of `node install`