### PR TITLE
Bugfix: Duplicate contents on buffer save

### DIFF
--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -10,11 +10,15 @@ module Index = {
     | OneBasedIndex(n) => n - 1
     };
 
+  let toInt0 = toZeroBasedInt;
+
   let toOneBasedInt = (pos: t) =>
     switch (pos) {
     | ZeroBasedIndex(n) => n + 1
     | OneBasedIndex(n) => n
     };
+
+  let toInt1 = toOneBasedInt;
 };
 
 module EditorSize = {
@@ -124,6 +128,17 @@ module BufferUpdate = {
       id,
       startLine: Index.ZeroBasedIndex(startLine),
       endLine: Index.ZeroBasedIndex(endLine),
+      lines,
+      version,
+    };
+    ret;
+  };
+  let createFromOneBasedIndices =
+      (~id=0, ~startLine: int, ~endLine: int, ~lines, ~version, ()) => {
+    let ret: t = {
+      id,
+      startLine: Index.OneBasedIndex(startLine),
+      endLine: Index.OneBasedIndex(endLine),
       lines,
       version,
     };

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -93,33 +93,30 @@ let applyUpdate = (lines: array(string), update: BufferUpdate.t) => {
 };
 
 let update = (buf: t, update: BufferUpdate.t) => {
-    let endLine = Index.toInt0(update.endLine);
-
+  let endLine = Index.toInt0(update.endLine);
 
   if (update.version > buf.metadata.version) {
-
-  /***
-     When a buffer is first attached it emits an update with
-     a startLine of 0 and endLine of -1 in this case we should
-     update the buffer's version but set the content of the buffer
-     rather than update it, which would result in duplication
-   */
-   if (endLine < 0) {
+    /***
+       When a buffer is first attached it emits an update with
+       a startLine of 0 and endLine of -1 in this case we should
+       update the buffer's version but set the content of the buffer
+       rather than update it, which would result in duplication
+     */
+    if (endLine < 0) {
       {
-      metadata: {
-        ...buf.metadata,
-        version: update.version
-      },
-      lines: update.lines,
-    }
-
-   } else {
-    let metadata = {...buf.metadata, version: update.version};
-    {metadata, lines: applyUpdate(buf.lines, update)};
-   }
-   } else {
-        buf
-    }
+        metadata: {
+          ...buf.metadata,
+          version: update.version,
+        },
+        lines: update.lines,
+      };
+    } else {
+      let metadata = {...buf.metadata, version: update.version};
+      {metadata, lines: applyUpdate(buf.lines, update)};
+    };
+  } else {
+    buf;
+  };
 };
 
 let updateMetadata = (metadata: Vim.BufferMetadata.t, buf: t) => {

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -93,25 +93,33 @@ let applyUpdate = (lines: array(string), update: BufferUpdate.t) => {
 };
 
 let update = (buf: t, update: BufferUpdate.t) => {
-  switch (update) {
+    let endLine = Index.toInt0(update.endLine);
+
+
+  if (update.version > buf.metadata.version) {
+
   /***
      When a buffer is first attached it emits an update with
      a startLine of 0 and endLine of -1 in this case we should
      update the buffer's version but set the content of the buffer
      rather than update it, which would result in duplication
    */
-  | {startLine: ZeroBasedIndex(0), endLine: ZeroBasedIndex((-1)), version, _} => {
+   if (endLine < 0) {
+      {
       metadata: {
         ...buf.metadata,
-        version,
+        version: update.version
       },
       lines: update.lines,
     }
-  | {version, _} when version > buf.metadata.version =>
+
+   } else {
     let metadata = {...buf.metadata, version: update.version};
     {metadata, lines: applyUpdate(buf.lines, update)};
-  | _ => buf
-  };
+   }
+   } else {
+        buf
+    }
 };
 
 let updateMetadata = (metadata: Vim.BufferMetadata.t, buf: t) => {

--- a/test/editor/Model/BufferTests.re
+++ b/test/editor/Model/BufferTests.re
@@ -36,6 +36,22 @@ describe("Buffer", ({describe, _}) =>
       validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
     });
 
+    test("BufEnter update does not duplicate content, 1-based indices", ({expect}) => {
+prerr_endline ("=== STARTING TEST ==");
+      let buffer = Buffer.ofLines([|"a", "d", "e", "f", "c"|]);
+      let update =
+        BufferUpdate.createFromOneBasedIndices(
+          ~startLine=1,
+          ~endLine=-1,
+          ~lines=[|"a", "d", "e", "f", "c"|],
+          ~version=2,
+          (),
+        );
+      let updatedBuffer = Buffer.update(buffer, update);
+      validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
+prerr_endline ("=== ENDING TEST ==");
+    });
+
     test("update single line", ({expect}) => {
       let buffer = Buffer.ofLines([|"a"|]);
       let update =

--- a/test/editor/Model/BufferTests.re
+++ b/test/editor/Model/BufferTests.re
@@ -39,7 +39,6 @@ describe("Buffer", ({describe, _}) =>
     test(
       "BufEnter update does not duplicate content, 1-based indices",
       ({expect}) => {
-      prerr_endline("=== STARTING TEST ==");
       let buffer = Buffer.ofLines([|"a", "d", "e", "f", "c"|]);
       let update =
         BufferUpdate.createFromOneBasedIndices(
@@ -51,7 +50,6 @@ describe("Buffer", ({describe, _}) =>
         );
       let updatedBuffer = Buffer.update(buffer, update);
       validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
-      prerr_endline("=== ENDING TEST ==");
     });
 
     test("update single line", ({expect}) => {

--- a/test/editor/Model/BufferTests.re
+++ b/test/editor/Model/BufferTests.re
@@ -36,8 +36,10 @@ describe("Buffer", ({describe, _}) =>
       validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
     });
 
-    test("BufEnter update does not duplicate content, 1-based indices", ({expect}) => {
-prerr_endline ("=== STARTING TEST ==");
+    test(
+      "BufEnter update does not duplicate content, 1-based indices",
+      ({expect}) => {
+      prerr_endline("=== STARTING TEST ==");
       let buffer = Buffer.ofLines([|"a", "d", "e", "f", "c"|]);
       let update =
         BufferUpdate.createFromOneBasedIndices(
@@ -49,7 +51,7 @@ prerr_endline ("=== STARTING TEST ==");
         );
       let updatedBuffer = Buffer.update(buffer, update);
       validateBuffer(expect, updatedBuffer, [|"a", "d", "e", "f", "c"|]);
-prerr_endline ("=== ENDING TEST ==");
+      prerr_endline("=== ENDING TEST ==");
     });
 
     test("update single line", ({expect}) => {


### PR DESCRIPTION
__Issue:__ When saving or re-opening a file with `:e!`, the buffer contents get duplicated in the window. A simple repro is to open a file, and then:
- `e!`
- `G`
- `zz`

__Defect:__ When saving or re-opening, we get a 'full' buffer update - this comes in as the `endLine` being `-1`. However, because of the conversion - the new `libvim` approach uses one-based indices, whereas the previous approach uses zero-based indices - a bug was exposed in applying the buffer updates.

__Fix:__ Don't pattern match on `ZeroBasedIndex`, instead, convert the index to the desired base (0 or 1) and then work with it. The buffer updates use zero based indices, so we convert that, and check if the endline is less than 0. Added a test to cover this case.