### PR TITLE
Add CLI file argument handling back

### DIFF
--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -37,7 +37,6 @@ let discoverExtensions = (setup: Core.Setup.t) => {
 
 let start =
     (
-      ~cliOptions: Core.Cli.t,
       ~setup: Core.Setup.t,
       ~executingDirectory,
       ~onStateChanged,
@@ -45,7 +44,6 @@ let start =
     ) => {
   /* TODO: Bring cliOptions back */
   ignore(executingDirectory);
-  ignore(cliOptions);
 
   let state = Model.State.create();
 
@@ -160,18 +158,21 @@ let start =
 
   setIconTheme("vs-seti");
 
-  let _ =
-    Tick.interval(
-      _ => {
-        dispatch(Model.Actions.Tick);
-
+  let runEffects = () => {
         let effects = accumulatedEffects^;
         accumulatedEffects := [];
 
         List.iter(e => Isolinear.Effect.run(e, dispatch), effects);
+  };
+
+  let _ =
+    Tick.interval(
+      _ => {
+        dispatch(Model.Actions.Tick);
+		runEffects();
       },
       Seconds(0.),
     );
 
-  dispatch;
+  (dispatch, runEffects);
 };

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -35,13 +35,7 @@ let discoverExtensions = (setup: Core.Setup.t) => {
   extensions;
 };
 
-let start =
-    (
-      ~setup: Core.Setup.t,
-      ~executingDirectory,
-      ~onStateChanged,
-      (),
-    ) => {
+let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => {
   /* TODO: Bring cliOptions back */
   ignore(executingDirectory);
 
@@ -159,17 +153,17 @@ let start =
   setIconTheme("vs-seti");
 
   let runEffects = () => {
-        let effects = accumulatedEffects^;
-        accumulatedEffects := [];
+    let effects = accumulatedEffects^;
+    accumulatedEffects := [];
 
-        List.iter(e => Isolinear.Effect.run(e, dispatch), effects);
+    List.iter(e => Isolinear.Effect.run(e, dispatch), effects);
   };
 
   let _ =
     Tick.interval(
       _ => {
         dispatch(Model.Actions.Tick);
-		runEffects();
+        runEffects();
       },
       Seconds(0.),
     );

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -124,9 +124,9 @@ let start = () => {
       );
 
   let openFileByPathEffect = filePath =>
-    Isolinear.Effect.create(~name="vim.openFileByPath", () => {
-      Vim.Buffer.openFile(filePath) |> ignore;
-    });
+    Isolinear.Effect.create(~name="vim.openFileByPath", () =>
+      Vim.Buffer.openFile(filePath) |> ignore
+    );
 
   /* let registerQuitHandlerEffect = */
   /*   Isolinear.Effect.createWithDispatch( */

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -102,7 +102,7 @@ let start = () => {
     Isolinear.Effect.create(~name="vim.init", () => {
       Vim.init();
       hasInitialized := true;
-      print_endline ("Vim initialized.");
+      print_endline("Vim initialized.");
     });
 
   /* TODO: Move to init */
@@ -126,9 +126,9 @@ let start = () => {
 
   let openFileByPathEffect = filePath =>
     Isolinear.Effect.create(~name="vim.openFileByPath", () => {
-      print_endline ("Opening file: " ++ filePath);
-      Vim.Buffer.openFile(filePath) |> ignore
-      print_endline ("Opening file complete!");
+      print_endline("Opening file: " ++ filePath);
+      Vim.Buffer.openFile(filePath) |> ignore;
+      print_endline("Opening file complete!");
     });
 
   /* let registerQuitHandlerEffect = */

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -102,6 +102,7 @@ let start = () => {
     Isolinear.Effect.create(~name="vim.init", () => {
       Vim.init();
       hasInitialized := true;
+      print_endline ("Vim initialized.");
     });
 
   /* TODO: Move to init */
@@ -124,9 +125,11 @@ let start = () => {
       );
 
   let openFileByPathEffect = filePath =>
-    Isolinear.Effect.create(~name="vim.openFileByPath", () =>
+    Isolinear.Effect.create(~name="vim.openFileByPath", () => {
+      print_endline ("Opening file: " ++ filePath);
       Vim.Buffer.openFile(filePath) |> ignore
-    );
+      print_endline ("Opening file complete!");
+    });
 
   /* let registerQuitHandlerEffect = */
   /*   Isolinear.Effect.createWithDispatch( */

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -102,7 +102,6 @@ let start = () => {
     Isolinear.Effect.create(~name="vim.init", () => {
       Vim.init();
       hasInitialized := true;
-      print_endline("Vim initialized.");
     });
 
   /* TODO: Move to init */
@@ -126,9 +125,7 @@ let start = () => {
 
   let openFileByPathEffect = filePath =>
     Isolinear.Effect.create(~name="vim.openFileByPath", () => {
-      print_endline("Opening file: " ++ filePath);
       Vim.Buffer.openFile(filePath) |> ignore;
-      print_endline("Opening file complete!");
     });
 
   /* let registerQuitHandlerEffect = */

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -57,9 +57,8 @@ let init = app => {
     update(<Root state />);
   };
 
-  let dispatch =
+  let (dispatch, runEffects) =
     Store.StoreThread.start(
-      ~cliOptions,
       ~setup,
       ~executingDirectory=Revery.Environment.getExecutingDirectory(),
       ~onStateChanged,
@@ -87,6 +86,12 @@ let init = app => {
   });
 
   dispatch(Model.Actions.Init);
+  runEffects();
+
+  List.iter((v) => {
+  	dispatch(Model.Actions.OpenFileByPath(v));
+	  print_endline("Opening: " ++ v);
+	}, cliOptions.filesToOpen);
 
   let setFont = (fontFamily, fontSize) => {
     let scaleFactor =

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -89,10 +89,7 @@ let init = app => {
   runEffects();
 
   List.iter(
-    v => {
-      dispatch(Model.Actions.OpenFileByPath(v));
-      print_endline("Opening: " ++ v);
-    },
+    v => dispatch(Model.Actions.OpenFileByPath(v)),
     cliOptions.filesToOpen,
   );
 

--- a/src/editor/bin/Oni2.re
+++ b/src/editor/bin/Oni2.re
@@ -88,10 +88,13 @@ let init = app => {
   dispatch(Model.Actions.Init);
   runEffects();
 
-  List.iter((v) => {
-  	dispatch(Model.Actions.OpenFileByPath(v));
-	  print_endline("Opening: " ++ v);
-	}, cliOptions.filesToOpen);
+  List.iter(
+    v => {
+      dispatch(Model.Actions.OpenFileByPath(v));
+      print_endline("Opening: " ++ v);
+    },
+    cliOptions.filesToOpen,
+  );
 
   let setFont = (fontFamily, fontSize) => {
     let scaleFactor =


### PR DESCRIPTION
In the transition from Neovim -> Libvim, our handling of command-line arguments was lost. This brings back opening files from the CLI. 

I'll bring back setting the current directory - want to wire up the change directory API to libvim so that the internals are connected (in other words - have libvim own the state of the current directory, and have methods to change directory, get the current directory, and know when the current directory has changed)