### PR TITLE
Refactoring: Extract colorization logic from BufferViewTokenizer

### DIFF
--- a/bench/lib/BufferViewTokenizerBench.re
+++ b/bench/lib/BufferViewTokenizerBench.re
@@ -1,21 +1,24 @@
 open Oni_Core;
-open Oni_Extensions;
 open Oni_Model;
 open BenchFramework;
+open Revery;
 
 let giantString = String.make(1000, 'a');
-
-let theme = Theme.create();
-let noTokens: list(ColorizedToken.t) = [];
-let colorMap = ColorMap.create();
 
 let options = Reperf.Options.create(~iterations=1000, ());
 
 let setup = () => ();
 
+let indentationSettings = IndentationSettings.default;
+let simpleColorizer = _ => (Colors.black, Colors.white);
+
 let tokenizeLine = () => {
   let _ =
-    BufferViewTokenizer.tokenize(giantString, theme, noTokens, colorMap);
+    BufferViewTokenizer.tokenize(
+      giantString,
+      indentationSettings,
+      simpleColorizer,
+    );
   ();
 };
 

--- a/src/editor/Model/BufferLineColorizer.re
+++ b/src/editor/Model/BufferLineColorizer.re
@@ -1,0 +1,75 @@
+/*
+ * BufferLineColorizer.re
+ */
+
+open Revery;
+
+open Oni_Core;
+open Oni_Core.Types;
+open Oni_Extensions;
+
+type tokenColor = (Color.t, Color.t);
+type t = int => tokenColor;
+
+let create =
+    (
+      length: int,
+      theme: Theme.t,
+      tokenColors: list(ColorizedToken.t),
+      colorMap: ColorMap.t,
+      selection: option(Range.t),
+      defaultBackgroundColor: Color.t,
+      selectionColor: Color.t,
+      matchingPair: option(int),
+    ) => {
+  let tokenColorArray: array(ColorizedToken.t) =
+    Array.make(length, ColorizedToken.default);
+
+  let rec f = (tokens: list(ColorizedToken.t), start) =>
+    switch (tokens) {
+    | [] => ()
+    | [hd, ...tail] =>
+      let pos = ref(start);
+      while (pos^ >= hd.index) {
+        tokenColorArray[pos^] = hd;
+        decr(pos);
+      };
+      f(tail, pos^);
+    };
+
+  let (selectionStart, selectionEnd) =
+    switch (selection) {
+    | Some(v) =>
+      let s = Index.toZeroBasedInt(v.startPosition.character);
+      let e = Index.toZeroBasedInt(v.endPosition.character);
+      e > s ? (s, e) : (e, s);
+    | None => ((-1), (-1))
+    };
+
+  let tokenColors = List.rev(tokenColors);
+
+  f(tokenColors, length - 1);
+
+  i => {
+    let colorIndex = tokenColorArray[i];
+
+    let matchingPair =
+      switch (matchingPair) {
+      | None => (-1)
+      | Some(v) => v
+      };
+
+    let backgroundColor =
+      i >= selectionStart && i < selectionEnd || i == matchingPair
+        ? selectionColor : defaultBackgroundColor;
+
+    let color =
+      ColorMap.get(
+        colorMap,
+        colorIndex.foregroundColor,
+        theme.colors.editorForeground,
+        theme.colors.editorBackground,
+      );
+    (backgroundColor, color);
+  };
+};

--- a/src/editor/Model/BufferLineColorizer.rei
+++ b/src/editor/Model/BufferLineColorizer.rei
@@ -1,0 +1,37 @@
+/*
+ * BufferViewColorizer.rei
+ */
+
+open Revery;
+open Oni_Core;
+open Oni_Extensions;
+
+/*
+ * Type [tokenColor] is a tuple of [(backgroundColor, foregroundColor)]
+ */
+type tokenColor = (Color.t, Color.t);
+
+/*
+ * Type [t] is a function of [(int) => tokenColor)].
+ *
+ */
+type t = int => tokenColor;
+
+/*
+ * [create] takes information about the line, like
+ * the syntax highlighting ([tokenColors]), the selection,
+ * and others - and consolidates it into a colorizer
+ * function [t].
+ */
+let create:
+  (
+    int,
+    Theme.t,
+    list(ColorizedToken.t),
+    ColorMap.t,
+    option(Range.t),
+    Color.t,
+    Color.t,
+    option(int)
+  ) =>
+  t;

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -119,7 +119,8 @@ let makeColorizer = (
 	colorMap: ColorMap.t,
 	selection: option(Range.t),
 	defaultBackgroundColor: Color.t,
-	selectionColor: Color.t
+	selectionColor: Color.t,
+	matchingPair: option(int),
 ) => {
     let tokenColorArray: array(ColorizedToken.t) =
       Array.make(length, ColorizedToken.default);
@@ -150,17 +151,31 @@ let makeColorizer = (
     f(tokenColors, length - 1);
 
 	(i) => {
-		if (i >= selectionStart && i <= selectionEnd) {
-			(Colors.black, Colors.white)
-		} else {
-			(Colors.white, Colors.black)
-		}
+
+
+	let colorIndex = tokenColorArray[i];
+
+	let matchingPair = switch(matchingPair) {
+	| None => -1
+	| Some(v) => v
+	};
+
+	let backgroundColor = 
+	i >= selectionStart && i < selectionEnd || i == matchingPair ? selectionColor : defaultBackgroundColor;
+
+	let color =
+		ColorMap.get(
+			colorMap,
+			colorIndex.foregroundColor,
+			theme.colors.editorForeground,
+			theme.colors.editorBackground,
+		);
+		(backgroundColor, color)
 	};
 
 };
 
 let colorEqual = (c1: Color.t, c2: Color.t) => {
- open Color;
  Float.equal(c1.r, c2.r) 
  && Float.equal(c1.g, c2.g)
  && Float.equal(c1.b, c2.b)

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -6,7 +6,6 @@ open Revery;
 
 open Oni_Core;
 open Oni_Core.Types;
-open Oni_Extensions;
 
 open CamomileLibrary;
 
@@ -106,69 +105,6 @@ let getCharacterPositionAndWidth =
   let width = i < len ? measure(Zed_utf8.get(str, i)) : 1;
 
   (totalOffset^, width);
-};
-
-let makeColorizer =
-    (
-      length: int,
-      theme: Theme.t,
-      tokenColors: list(ColorizedToken.t),
-      colorMap: ColorMap.t,
-      selection: option(Range.t),
-      defaultBackgroundColor: Color.t,
-      selectionColor: Color.t,
-      matchingPair: option(int),
-    ) => {
-  let tokenColorArray: array(ColorizedToken.t) =
-    Array.make(length, ColorizedToken.default);
-
-  let rec f = (tokens: list(ColorizedToken.t), start) =>
-    switch (tokens) {
-    | [] => ()
-    | [hd, ...tail] =>
-      let pos = ref(start);
-      while (pos^ >= hd.index) {
-        tokenColorArray[pos^] = hd;
-        decr(pos);
-      };
-      f(tail, pos^);
-    };
-
-  let (selectionStart, selectionEnd) =
-    switch (selection) {
-    | Some(v) =>
-      let s = Index.toZeroBasedInt(v.startPosition.character);
-      let e = Index.toZeroBasedInt(v.endPosition.character);
-      e > s ? (s, e) : (e, s);
-    | None => ((-1), (-1))
-    };
-
-  let tokenColors = List.rev(tokenColors);
-
-  f(tokenColors, length - 1);
-
-  i => {
-    let colorIndex = tokenColorArray[i];
-
-    let matchingPair =
-      switch (matchingPair) {
-      | None => (-1)
-      | Some(v) => v
-      };
-
-    let backgroundColor =
-      i >= selectionStart && i < selectionEnd || i == matchingPair
-        ? selectionColor : defaultBackgroundColor;
-
-    let color =
-      ColorMap.get(
-        colorMap,
-        colorIndex.foregroundColor,
-        theme.colors.editorForeground,
-        theme.colors.editorBackground,
-      );
-    (backgroundColor, color);
-  };
 };
 
 let colorEqual = (c1: Color.t, c2: Color.t) => {

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -9,6 +9,7 @@
 module Actions = Actions;
 module Buffer = Buffer;
 module Buffers = Buffers;
+module BufferLineColorizer = BufferLineColorizer;
 module BufferViewTokenizer = BufferViewTokenizer;
 module Commandline = Commandline;
 module CommandPalette = CommandPalette;

--- a/src/editor/Model/Oni_Model.re
+++ b/src/editor/Model/Oni_Model.re
@@ -23,6 +23,7 @@ module Indentation = Indentation;
 module LanguageInfo = LanguageInfo;
 module Menu = Menu;
 module Reducer = Reducer;
+module SearchHighlights = SearchHighlights;
 module Selection = Selection;
 module Selectors = Selectors;
 module StatusBarModel = StatusBarModel;

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -39,11 +39,11 @@ let start = () => {
             id,
             Core.Types.Position.create(
               OneBasedIndex(newPosition.line),
-              OneBasedIndex(newPosition.column + 1),
+              ZeroBasedIndex(newPosition.column),
             ),
             Core.Types.Position.create(
               OneBasedIndex(line),
-              OneBasedIndex(column + 1),
+              ZeroBasedIndex(column),
             ),
           ),
         )

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -39,11 +39,11 @@ let start = () => {
             id,
             Core.Types.Position.create(
               OneBasedIndex(newPosition.line),
-              OneBasedIndex(newPosition.column),
+              OneBasedIndex(newPosition.column + 1),
             ),
             Core.Types.Position.create(
               OneBasedIndex(line),
-              OneBasedIndex(column),
+              OneBasedIndex(column + 1),
             ),
           ),
         )

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -304,7 +304,7 @@ let createElement =
         };
 
       let colorizer =
-        BufferViewTokenizer.makeColorizer(
+        BufferLineColorizer.create(
           Zed_utf8.length(line),
           state.theme,
           tokenColors,

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -290,6 +290,16 @@ let createElement =
           ? theme.colors.editorLineHighlightBackground
           : theme.colors.editorBackground;
 
+	   let matchingPairIndex = switch(Selectors.getMatchingPairs(state, editor.bufferId)) {
+	   | None => None
+	   | Some(v) => if (Index.toInt0(v.startPos.line) == i) {
+	   	Some(Index.toInt0(v.startPos.character))
+	   } else if(Index.toInt0(v.endPos.line) == i) {
+	   	Some(Index.toInt0(v.endPos.character))
+	   } else {
+	   	None
+	   }
+	   };
 
 	  let colorizer = BufferViewTokenizer.makeColorizer(
 	  	Zed_utf8.length(line),
@@ -298,7 +308,8 @@ let createElement =
 		state.syntaxHighlighting.colorMap,
 		selection,
 		defaultBackground,
-		theme.colors.editorSelectionBackground
+		theme.colors.editorSelectionBackground,
+		matchingPairIndex,
 	  );
 
       BufferViewTokenizer.tokenize(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -290,15 +290,21 @@ let createElement =
           ? theme.colors.editorLineHighlightBackground
           : theme.colors.editorBackground;
 
+
+	  let colorizer = BufferViewTokenizer.makeColorizer(
+	  	Zed_utf8.length(line),
+		state.theme,
+		tokenColors,
+		state.syntaxHighlighting.colorMap,
+		selection,
+		defaultBackground,
+		theme.colors.editorSelectionBackground
+	  );
+
       BufferViewTokenizer.tokenize(
         line,
-        state.theme,
-        tokenColors,
-        state.syntaxHighlighting.colorMap,
         IndentationSettings.default,
-        selection,
-        defaultBackground,
-        theme.colors.editorSelectionBackground,
+        colorizer
       );
     };
 

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -290,32 +290,35 @@ let createElement =
           ? theme.colors.editorLineHighlightBackground
           : theme.colors.editorBackground;
 
-	   let matchingPairIndex = switch(Selectors.getMatchingPairs(state, editor.bufferId)) {
-	   | None => None
-	   | Some(v) => if (Index.toInt0(v.startPos.line) == i) {
-	   	Some(Index.toInt0(v.startPos.character))
-	   } else if(Index.toInt0(v.endPos.line) == i) {
-	   	Some(Index.toInt0(v.endPos.character))
-	   } else {
-	   	None
-	   }
-	   };
+      let matchingPairIndex =
+        switch (Selectors.getMatchingPairs(state, editor.bufferId)) {
+        | None => None
+        | Some(v) =>
+          if (Index.toInt0(v.startPos.line) == i) {
+            Some(Index.toInt0(v.startPos.character));
+          } else if (Index.toInt0(v.endPos.line) == i) {
+            Some(Index.toInt0(v.endPos.character));
+          } else {
+            None;
+          }
+        };
 
-	  let colorizer = BufferViewTokenizer.makeColorizer(
-	  	Zed_utf8.length(line),
-		state.theme,
-		tokenColors,
-		state.syntaxHighlighting.colorMap,
-		selection,
-		defaultBackground,
-		theme.colors.editorSelectionBackground,
-		matchingPairIndex,
-	  );
+      let colorizer =
+        BufferViewTokenizer.makeColorizer(
+          Zed_utf8.length(line),
+          state.theme,
+          tokenColors,
+          state.syntaxHighlighting.colorMap,
+          selection,
+          defaultBackground,
+          theme.colors.editorSelectionBackground,
+          matchingPairIndex,
+        );
 
       BufferViewTokenizer.tokenize(
         line,
         IndentationSettings.default,
-        colorizer
+        colorizer,
       );
     };
 

--- a/test/editor/Model/BufferViewTokenizerTests.re
+++ b/test/editor/Model/BufferViewTokenizerTests.re
@@ -1,31 +1,20 @@
 open Revery;
 open Oni_Core;
 open Oni_Model;
-open Oni_Extensions;
 open TestFramework;
 
 open Helpers;
 
 let theme = Theme.create();
 
-let tokenColors = [];
-let colorMap = ColorMap.create();
-
 let indentation = IndentationSettings.default;
+
+let basicColorizer = _ => (Colors.black, Colors.white);
 
 describe("BufferViewTokenizer", ({describe, test, _}) => {
   test("empty string", ({expect}) => {
     let result =
-      BufferViewTokenizer.tokenize(
-        "",
-        theme,
-        tokenColors,
-        colorMap,
-        indentation,
-        None,
-        Colors.white,
-        Colors.black,
-      );
+      BufferViewTokenizer.tokenize("", indentation, basicColorizer);
     expect.int(List.length(result)).toBe(0);
   });
 
@@ -34,16 +23,7 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
       let indentation =
         IndentationSettings.create(~mode=Tabs, ~size=2, ~tabSize=4, ());
       let result =
-        BufferViewTokenizer.tokenize(
-          "\tabc",
-          theme,
-          tokenColors,
-          colorMap,
-          indentation,
-          None,
-          Colors.white,
-          Colors.black,
-        );
+        BufferViewTokenizer.tokenize("\tabc", indentation, basicColorizer);
 
       let expectedTokens: list(BufferViewTokenizer.t) = [
         {
@@ -70,31 +50,13 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
 
   test("string with only whitespace", ({expect}) => {
     let result =
-      BufferViewTokenizer.tokenize(
-        "   \t",
-        theme,
-        tokenColors,
-        colorMap,
-        indentation,
-        None,
-        Colors.white,
-        Colors.black,
-      );
+      BufferViewTokenizer.tokenize("   \t", indentation, basicColorizer);
     expect.int(List.length(result)).toBe(2);
   });
 
   test("single word token", ({expect}) => {
     let result =
-      BufferViewTokenizer.tokenize(
-        "testWord",
-        theme,
-        tokenColors,
-        colorMap,
-        indentation,
-        None,
-        Colors.white,
-        Colors.black,
-      );
+      BufferViewTokenizer.tokenize("testWord", indentation, basicColorizer);
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
       {
@@ -114,13 +76,8 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
     let result =
       BufferViewTokenizer.tokenize(
         "  testWord  ",
-        theme,
-        tokenColors,
-        colorMap,
         indentation,
-        None,
-        Colors.white,
-        Colors.black,
+        basicColorizer,
       );
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
@@ -155,16 +112,7 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
 
   test("single letter token, no spaces", ({expect}) => {
     let result =
-      BufferViewTokenizer.tokenize(
-        "a",
-        theme,
-        tokenColors,
-        colorMap,
-        indentation,
-        None,
-        Colors.white,
-        Colors.black,
-      );
+      BufferViewTokenizer.tokenize("a", indentation, basicColorizer);
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
       {
@@ -181,20 +129,14 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
   });
 
   test("respects tokenColor breaks", ({expect}) => {
-    let tokenColors = [
-      ColorizedToken.create(0, 0),
-      ColorizedToken.create(1, 0),
-    ];
+    let differentColorTokenizer = i =>
+      i > 0 ? (Colors.green, Colors.yellow) : (Colors.black, Colors.white);
+
     let result =
       BufferViewTokenizer.tokenize(
         "ab",
-        theme,
-        tokenColors,
-        colorMap,
         indentation,
-        None,
-        Colors.white,
-        Colors.black,
+        differentColorTokenizer,
       );
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
@@ -221,16 +163,7 @@ describe("BufferViewTokenizer", ({describe, test, _}) => {
 
   test("multiple tokens", ({expect}) => {
     let result =
-      BufferViewTokenizer.tokenize(
-        " a btest ",
-        theme,
-        tokenColors,
-        colorMap,
-        indentation,
-        None,
-        Colors.white,
-        Colors.black,
-      );
+      BufferViewTokenizer.tokenize(" a btest ", indentation, basicColorizer);
 
     let expectedTokens: list(BufferViewTokenizer.t) = [
       {


### PR DESCRIPTION
We use a module called `BufferViewTokenizer` to split up tokens in the editor surface for rendering. We batch up tokens that have common properties (same foreground / background color).

Much of the logic for that 'batching' was baked-in to the BufferViewTokenizer - it accounted for syntax highlighting, and selection ranges, but we need to generalize it further to enable visualizations for things like matching bracket pairs and search highlights.

To accomodate this, I'm generalizing the colorizer into a separate method that takes an index `i` and returns  `(backgroundColor, foregroundColor)` tuple. This colorizer handles all the details of things that impact background / foreground color. This means the `BufferViewTokenizer` doesn't need to know details about selection, theme, or anything else - it's encapsulated by the `colorizer` function passed in.