### PR TITLE
Bugfix: Indent line guides not rendering correctly

### DIFF
--- a/src/editor/Store/IndentationStoreConnector.re
+++ b/src/editor/Store/IndentationStoreConnector.re
@@ -51,18 +51,19 @@ let start = () => {
                   defaultInsertSpaces,
                 );
 
-              let size = switch (guess.mode) {
-              | Tabs => 
+              let size =
+                switch (guess.mode) {
+                | Tabs =>
                   Configuration.getValue(
                     c => c.editorTabSize,
                     state.configuration,
                   )
-              | Spaces => guess.size
-              };
+                | Spaces => guess.size
+                };
 
               IndentationSettings.create(
                 ~mode=guess.mode,
-                ~size=size,
+                ~size,
                 ~tabSize=size,
                 (),
               );

--- a/src/editor/Store/IndentationStoreConnector.re
+++ b/src/editor/Store/IndentationStoreConnector.re
@@ -51,14 +51,19 @@ let start = () => {
                   defaultInsertSpaces,
                 );
 
-              IndentationSettings.create(
-                ~mode=guess.mode,
-                ~size=guess.size,
-                ~tabSize=
+              let size = switch (guess.mode) {
+              | Tabs => 
                   Configuration.getValue(
                     c => c.editorTabSize,
                     state.configuration,
-                  ),
+                  )
+              | Spaces => guess.size
+              };
+
+              IndentationSettings.create(
+                ~mode=guess.mode,
+                ~size=size,
+                ~tabSize=size,
                 (),
               );
             } else {

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -212,10 +212,11 @@ let createElement =
     let fontWidth = state.editorFont.measuredWidth;
 
     let iFontHeight = int_of_float(fontHeight +. 0.5);
-    let indentation = switch(Buffer.getIndentation(buffer)) {
-    | Some(v) => v
-    | None => IndentationSettings.default
-    };
+    let indentation =
+      switch (Buffer.getIndentation(buffer)) {
+      | Some(v) => v
+      | None => IndentationSettings.default
+      };
 
     let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
     let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);
@@ -620,8 +621,6 @@ let createElement =
                   c => c.editorHighlightActiveIndentGuide,
                   state.configuration,
                 );
-
-              print_endline ("Indentation: " ++ string_of_int(indentation.size) ++ " | " ++ string_of_int(indentation.tabSize));
 
               if (renderIndentGuides) {
                 switch (activeBuffer) {

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -212,7 +212,10 @@ let createElement =
     let fontWidth = state.editorFont.measuredWidth;
 
     let iFontHeight = int_of_float(fontHeight +. 0.5);
-    let indentation = IndentationSettings.default;
+    let indentation = switch(Buffer.getIndentation(buffer)) {
+    | Some(v) => v
+    | None => IndentationSettings.default
+    };
 
     let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
     let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -621,6 +621,8 @@ let createElement =
                   state.configuration,
                 );
 
+              print_endline ("Indentation: " ++ string_of_int(indentation.size) ++ " | " ++ string_of_int(indentation.tabSize));
+
               if (renderIndentGuides) {
                 switch (activeBuffer) {
                 | None => ()


### PR DESCRIPTION
__Issue:__ For files with 2-spaces-per-indent-level, the indent line guides are still rendering at 4 spaces.