### PR TITLE
Fix #360 - Add a few additional keys to ignore on the Vim side

### DIFF
--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -175,7 +175,7 @@ let start = () => {
         if (!String.equal(key, "<S-SHIFT>")
             && !String.equal(key, "<C->")
             && !String.equal(key, "<A-C->")
-            && !String.equal(key, "<SHIFT>") 
+            && !String.equal(key, "<SHIFT>")
             && !String.equal(key, "<S-C->")) {
           Log.debug("VimStoreConnector - handling key: " ++ key);
           Vim.input(key);

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -174,7 +174,9 @@ let start = () => {
       =>
         if (!String.equal(key, "<S-SHIFT>")
             && !String.equal(key, "<C->")
-            && !String.equal(key, "<A-C->")) {
+            && !String.equal(key, "<A-C->")
+            && !String.equal(key, "<SHIFT>") 
+            && !String.equal(key, "<S-C->")) {
           Log.debug("VimStoreConnector - handling key: " ++ key);
           Vim.input(key);
           Log.debug("VimStoreConnector - handled key: " ++ key);


### PR DESCRIPTION
__Issue:__ Several keys aren't properly handled by `libvim` - we prune those out so we don't send them. This manifests in a few ways: 
- `<SHIFT>` gets interpreted literally, like in #360 
- `<S-C->` puts `libvim` in a blocking mode and crashes Onivim 2

__Fix:__ We should make `libvim` itself more robust in the face of these inputs - but for now, we'll sanitize these on the Onivim 2 side.

Fixes #360 