### PR TITLE
Logging: Log unhandled exceptions to log file

### DIFF
--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -7,7 +7,7 @@
 let canPrint = ref(false);
 
 let enablePrinting = () => {
-  canPrint := true
+  canPrint := true;
 };
 
 let print = msg => canPrint^ ? print_endline(msg) : ();
@@ -50,14 +50,19 @@ let debug = msg => isDebugLoggingEnabled ? logCore("[DEBUG] " ++ msg) : ();
 
 let error = msg => logCore(~error=true, "[ERROR] " ++ msg);
 
-
-let () = switch(isDebugLoggingEnabled) {
-| false => ()
-| true => 
-  debug("Recording backtraces");
-  Printexc.record_backtrace(true);
-  Printexc.set_uncaught_exception_handler((e, bt) => {
-  error("Exception " ++ Printexc.to_string(e) ++ ":\n" ++ Printexc.raw_backtrace_to_string(bt));
-  flush_all();
-});
-}
+let () =
+  switch (isDebugLoggingEnabled) {
+  | false => ()
+  | true =>
+    debug("Recording backtraces");
+    Printexc.record_backtrace(true);
+    Printexc.set_uncaught_exception_handler((e, bt) => {
+      error(
+        "Exception "
+        ++ Printexc.to_string(e)
+        ++ ":\n"
+        ++ Printexc.raw_backtrace_to_string(bt),
+      );
+      flush_all();
+    });
+  };

--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -6,7 +6,9 @@
 
 let canPrint = ref(false);
 
-let enablePrinting = () => canPrint := true;
+let enablePrinting = () => {
+  canPrint := true
+};
 
 let print = msg => canPrint^ ? print_endline(msg) : ();
 
@@ -47,3 +49,15 @@ let info = msg => logCore("[INFO] " ++ msg);
 let debug = msg => isDebugLoggingEnabled ? logCore("[DEBUG] " ++ msg) : ();
 
 let error = msg => logCore(~error=true, "[ERROR] " ++ msg);
+
+
+let () = switch(isDebugLoggingEnabled) {
+| false => ()
+| true => 
+  debug("Recording backtraces");
+  Printexc.record_backtrace(true);
+  Printexc.set_uncaught_exception_handler((e, bt) => {
+  error("Exception " ++ Printexc.to_string(e) ++ ":\n" ++ Printexc.raw_backtrace_to_string(bt));
+  flush_all();
+});
+}

--- a/src/editor/bin_editor/Oni2_editor.re
+++ b/src/editor/bin_editor/Oni2_editor.re
@@ -16,14 +16,7 @@ module Model = Oni_Model;
 module Store = Oni_Store;
 module Log = Core.Log;
 
-/**
-   This allows a stack trace to be printed when exceptions occur
- */
-/* switch (Sys.getenv_opt("ONI2_DEBUG")) { */
-/* | Some(_) => Printexc.record_backtrace(true) |> ignore */
-/* | None => () */
-/* }; */
-Printexc.record_backtrace(true);
+exception BadNewsBears;
 
 let () = Log.debug("Starting Onivim 2.");
 
@@ -46,6 +39,8 @@ let init = app => {
   Log.debug("Startup: Parsing CLI options");
   let cliOptions = Core.Cli.parse(setup);
   Log.debug("Startup: Parsing CLI options complete");
+
+let () = raise(BadNewsBears);
 
   Log.debug("Startup: Changing folder to: " ++ cliOptions.folder);
   Sys.chdir(cliOptions.folder);

--- a/src/editor/bin_editor/Oni2_editor.re
+++ b/src/editor/bin_editor/Oni2_editor.re
@@ -16,8 +16,6 @@ module Model = Oni_Model;
 module Store = Oni_Store;
 module Log = Core.Log;
 
-exception BadNewsBears;
-
 let () = Log.debug("Starting Onivim 2.");
 
 /* The 'main' function for our app */
@@ -39,8 +37,6 @@ let init = app => {
   Log.debug("Startup: Parsing CLI options");
   let cliOptions = Core.Cli.parse(setup);
   Log.debug("Startup: Parsing CLI options complete");
-
-let () = raise(BadNewsBears);
 
   Log.debug("Startup: Changing folder to: " ++ cliOptions.folder);
   Sys.chdir(cliOptions.folder);


### PR DESCRIPTION
__Issue:__ When there is an unhandled exception, it doesn't get logged to the log file specified by the `ONI2_LOG_FILE` environment variable.

__Fix:__ Add an unhandled-exception handler that ensures the exception details get flushed.