### PR TITLE
Release - Disable extension host for July builds

### DIFF
--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -54,12 +54,12 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);
 
-  /* 
-    For our July builds, we won't be including the extension host -
-    but we'll bring this back as we start implementing those features!
-  */
+  /*
+     For our July builds, we won't be including the extension host -
+     but we'll bring this back as we start implementing those features!
+   */
   /* let (extHostUpdater, extHostStream) =
-    ExtensionClientStoreConnector.start(extensions, setup); */
+     ExtensionClientStoreConnector.start(extensions, setup); */
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -36,7 +36,6 @@ let discoverExtensions = (setup: Core.Setup.t) => {
 };
 
 let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => {
-  /* TODO: Bring cliOptions back */
   ignore(executingDirectory);
 
   let state = Model.State.create();
@@ -55,8 +54,12 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);
 
-  let (extHostUpdater, extHostStream) =
-    ExtensionClientStoreConnector.start(extensions, setup);
+  /* 
+    For our July builds, we won't be including the extension host -
+    but we'll bring this back as we start implementing those features!
+  */
+  /* let (extHostUpdater, extHostStream) =
+    ExtensionClientStoreConnector.start(extensions, setup); */
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 
@@ -79,7 +82,7 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
           Isolinear.Updater.ofReducer(Model.Reducer.reduce),
           vimUpdater,
           textmateUpdater,
-          extHostUpdater,
+          /* extHostUpdater, */
           menuHostUpdater,
           quickOpenUpdater,
           configurationUpdater,
@@ -118,7 +121,7 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
   Isolinear.Stream.connect(dispatch, vimStream);
   Isolinear.Stream.connect(dispatch, editorEventStream);
   Isolinear.Stream.connect(dispatch, textmateStream);
-  Isolinear.Stream.connect(dispatch, extHostStream);
+  /* Isolinear.Stream.connect(dispatch, extHostStream); */
   Isolinear.Stream.connect(dispatch, menuStream);
   Isolinear.Stream.connect(dispatch, explorerStream);
 


### PR DESCRIPTION
In `master`, we are currently spinning up the Node extension host process, and even sending buffer updates to it - but it is not being used (we haven't implemented a subset of the protocol for language services, yet!). So for our July builds, I'll turn this off, since it is not adding any functionality, and it is hasn't been thoroughly tested.

We still are shipping a vendored `node` binary because, at the moment, our textmate highlighting comes from JS. 

The plan for our Aug - Oct work is to switch that textmate highlighting strategy to native, and use `node` to host the extension host process. (So shipping the vendored `node` isn't wasted work - we'll need it to host the extension host process anyway, even with the textmate highlighting is moved to a native strategy)