### PR TITLE
Dependency: revery -> 0.22.0

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "74175a193dcc57f01922034747a6123d",
+  "checksum": "8aab97539ba2b00b1a8a8b3624aace48",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "universalify@0.1.2@d41d8cd9": {
@@ -16,14 +16,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "revery@0.20.0@d41d8cd9": {
-      "id": "revery@0.20.0@d41d8cd9",
+    "revery@0.22.0@d41d8cd9": {
+      "id": "revery@0.22.0@d41d8cd9",
       "name": "revery",
-      "version": "0.20.0",
+      "version": "0.22.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/revery/-/revery-0.20.0.tgz#sha1:c6984ce9b73f7a016e0a390f22347b56f25849e5"
+          "archive:https://registry.npmjs.org/revery/-/revery-0.22.0.tgz#sha1:2a6d17e5a8f5e0e3959606ce82af6e23a32df3e8"
         ]
       },
       "overrides": [],
@@ -446,7 +446,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "revery@0.20.0@d41d8cd9", "reperf@1.4.0@d41d8cd9",
+        "revery@0.22.0@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@8.10869.12001@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "74175a193dcc57f01922034747a6123d",
+  "checksum": "8aab97539ba2b00b1a8a8b3624aace48",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "universalify@0.1.2@d41d8cd9": {
@@ -16,14 +16,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "revery@0.20.0@d41d8cd9": {
-      "id": "revery@0.20.0@d41d8cd9",
+    "revery@0.22.0@d41d8cd9": {
+      "id": "revery@0.22.0@d41d8cd9",
       "name": "revery",
-      "version": "0.20.0",
+      "version": "0.22.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/revery/-/revery-0.20.0.tgz#sha1:c6984ce9b73f7a016e0a390f22347b56f25849e5"
+          "archive:https://registry.npmjs.org/revery/-/revery-0.22.0.tgz#sha1:2a6d17e5a8f5e0e3959606ce82af6e23a32df3e8"
         ]
       },
       "overrides": [],
@@ -446,7 +446,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@0.20.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
+        "revery@0.22.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@8.10869.12001@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@esy-ocaml/reason": "3.4.0",
     "isolinear": "*",
     "@opam/ocamlbuild": "*",
-    "revery": "0.20.0",
+    "revery": "0.22.0",
     "@opam/dune": "*",
     "@opam/lwt": "*",
     "@opam/camomile": "^1.0.1",

--- a/src/editor/UI/Dock.re
+++ b/src/editor/UI/Dock.re
@@ -1,5 +1,5 @@
 open Revery;
-open Revery_UI;
+open Revery.UI;
 open Revery.UI.Components;
 
 open Oni_Model;

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -1,6 +1,6 @@
 open Oni_Model;
 open UiTree;
-open Revery_UI;
+open Revery.UI;
 open Revery.UI.Components;
 
 module Core = Oni_Core;

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "74175a193dcc57f01922034747a6123d",
+  "checksum": "8aab97539ba2b00b1a8a8b3624aace48",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "universalify@0.1.2@d41d8cd9": {
@@ -16,14 +16,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "revery@0.20.0@d41d8cd9": {
-      "id": "revery@0.20.0@d41d8cd9",
+    "revery@0.22.0@d41d8cd9": {
+      "id": "revery@0.22.0@d41d8cd9",
       "name": "revery",
-      "version": "0.20.0",
+      "version": "0.22.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/revery/-/revery-0.20.0.tgz#sha1:c6984ce9b73f7a016e0a390f22347b56f25849e5"
+          "archive:https://registry.npmjs.org/revery/-/revery-0.22.0.tgz#sha1:2a6d17e5a8f5e0e3959606ce82af6e23a32df3e8"
         ]
       },
       "overrides": [],
@@ -446,7 +446,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "revery@0.20.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
+        "revery@0.22.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@8.10869.12001@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",


### PR DESCRIPTION
When testing #377 with a local `link:` resolution to Revery, I noticed this wasn't upgraded to the latest Revery (so there were a few minor fixes needed). Figured it was a good time to upgrade to latest.