### PR TITLE
Bugfix: ':q' doesn't work as expected

### DIFF
--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -61,7 +61,8 @@ type t =
   | RemoveSplit(int)
   | OpenConfigFile(string)
   | QuickOpen
-  | Quit
+  | QuitBuffer(Vim.Buffer.t, bool)
+  | Quit(bool)
   | RegisterQuitCleanup(unit => unit)
   | SearchClearMatchingPair(int)
   | SearchSetMatchingPair(int, Position.t, Position.t)

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -35,6 +35,8 @@ let getId = (buffer: t) => buffer.metadata.id;
 
 let getLine = (buffer: t, line: int) => buffer.lines[line];
 
+let isModified = (buffer: t) => buffer.metadata.modified;
+
 let getUri = (buffer: t) => {
   let getUriFromMetadata = (metadata: Vim.BufferMetadata.t) => {
     switch (metadata.filePath) {

--- a/src/editor/Model/Buffer.rei
+++ b/src/editor/Model/Buffer.rei
@@ -20,8 +20,8 @@ let getLineLength: (t, int) => int;
 let getMetadata: t => Vim.BufferMetadata.t;
 let getUri: t => Uri.t;
 let getId: t => int;
-
 let getNumberOfLines: t => int;
+let isModified: t => bool;
 
 let isIndentationSet: t => bool;
 let setIndentation: (IndentationSettings.t, t) => t;

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -26,9 +26,11 @@ let log = (m: t) =>
 let getBuffer = (id, map) => IntMap.find_opt(id, map);
 
 let anyModified = (buffers: t) => {
-  IntMap.fold((_key, v, prev) => {
-    Buffer.isModified(v) || prev
-  }, buffers, false);
+  IntMap.fold(
+    (_key, v, prev) => Buffer.isModified(v) || prev,
+    buffers,
+    false,
+  );
 };
 
 let getBufferMetadata = (id, map) =>

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -26,7 +26,7 @@ let log = (m: t) =>
 let getBuffer = (id, map) => IntMap.find_opt(id, map);
 
 let anyModified = (buffers: t) => {
-  IntMap.fold_left((_key, v, prev) => {
+  IntMap.fold((_key, v, prev) => {
     Buffer.isModified(v) || prev
   }, buffers, false);
 };

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -25,6 +25,12 @@ let log = (m: t) =>
 
 let getBuffer = (id, map) => IntMap.find_opt(id, map);
 
+let anyModified = (buffers: t) => {
+  IntMap.fold_left((_key, v, prev) => {
+    Buffer.isModified(v) || prev
+  }, buffers, false);
+};
+
 let getBufferMetadata = (id, map) =>
   switch (getBuffer(id, map)) {
   | Some(v) => Some(Buffer.getMetadata(v))

--- a/src/editor/Store/LifecycleStoreConnector.re
+++ b/src/editor/Store/LifecycleStoreConnector.re
@@ -11,21 +11,54 @@ module Core = Oni_Core;
 module Model = Oni_Model;
 
 let start = () => {
-  let quitEffect = handlers =>
+  let (stream, dispatch) = Isolinear.Stream.create();
+  
+  let quitAllEffect = (state: Model.State.t, force) => {
+    let handlers = state.lifecycle.onQuitFunctions;
+
+    let anyModified = Model.Buffers.anyModified(state.buffers);
+    let canClose = force || !anyModified;
+
     Isolinear.Effect.create(~name="lifecycle.quit", () => {
-      List.iter(h => h(), handlers);
-      App.quit(0);
+      if (canClose) {
+        List.iter(h => h(), handlers);
+        App.quit(0);
+      }
     });
+    };
+
+  let quitBufferEffect = (state: Model.State.t, buffer: Vim.Buffer.t, force) => {
+    Isolinear.Effect.create(~name="lifecycle.quitBuffer", () => {
+    let editorGroup = Model.Selectors.getActiveEditorGroup(state);
+    switch (Model.Selectors.getActiveEditor(editorGroup)) {
+    | None => ()
+    | Some(editor) => {
+      let bufferMeta = Vim.BufferMetadata.ofBuffer(buffer);
+      if (editor.bufferId == bufferMeta.id) {
+
+        if (force || !bufferMeta.modified) {
+          dispatch(Model.Actions.ViewCloseEditor(editor.editorId));
+        }
+      }
+    }
+    }
+
+    });
+  };
 
   let updater = (state: Model.State.t, action) => {
     switch (action) {
-    | Model.Actions.Quit => (
+    | Model.Actions.QuitBuffer(buffer, force) => (
         state,
-        quitEffect(state.lifecycle.onQuitFunctions),
+        quitBufferEffect(state, buffer, force),
+      )
+    | Model.Actions.Quit(force) => (
+        state,
+        quitAllEffect(state, force),
       )
     | _ => (state, Isolinear.Effect.none)
     };
   };
 
-  updater;
+  (updater, stream);
 };

--- a/src/editor/Store/LifecycleStoreConnector.re
+++ b/src/editor/Store/LifecycleStoreConnector.re
@@ -12,37 +12,34 @@ module Model = Oni_Model;
 
 let start = () => {
   let (stream, dispatch) = Isolinear.Stream.create();
-  
+
   let quitAllEffect = (state: Model.State.t, force) => {
     let handlers = state.lifecycle.onQuitFunctions;
 
     let anyModified = Model.Buffers.anyModified(state.buffers);
     let canClose = force || !anyModified;
 
-    Isolinear.Effect.create(~name="lifecycle.quit", () => {
+    Isolinear.Effect.create(~name="lifecycle.quit", () =>
       if (canClose) {
         List.iter(h => h(), handlers);
         App.quit(0);
       }
-    });
-    };
+    );
+  };
 
   let quitBufferEffect = (state: Model.State.t, buffer: Vim.Buffer.t, force) => {
     Isolinear.Effect.create(~name="lifecycle.quitBuffer", () => {
-    let editorGroup = Model.Selectors.getActiveEditorGroup(state);
-    switch (Model.Selectors.getActiveEditor(editorGroup)) {
-    | None => ()
-    | Some(editor) => {
-      let bufferMeta = Vim.BufferMetadata.ofBuffer(buffer);
-      if (editor.bufferId == bufferMeta.id) {
-
-        if (force || !bufferMeta.modified) {
-          dispatch(Model.Actions.ViewCloseEditor(editor.editorId));
-        }
-      }
-    }
-    }
-
+      let editorGroup = Model.Selectors.getActiveEditorGroup(state);
+      switch (Model.Selectors.getActiveEditor(editorGroup)) {
+      | None => ()
+      | Some(editor) =>
+        let bufferMeta = Vim.BufferMetadata.ofBuffer(buffer);
+        if (editor.bufferId == bufferMeta.id) {
+          if (force || !bufferMeta.modified) {
+            dispatch(Model.Actions.ViewCloseEditor(editor.editorId));
+          };
+        };
+      };
     });
   };
 
@@ -52,10 +49,7 @@ let start = () => {
         state,
         quitBufferEffect(state, buffer, force),
       )
-    | Model.Actions.Quit(force) => (
-        state,
-        quitAllEffect(state, force),
-      )
+    | Model.Actions.Quit(force) => (state, quitAllEffect(state, force))
     | _ => (state, Isolinear.Effect.none)
     };
   };

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -71,7 +71,7 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
   let (fileExplorerUpdater, explorerStream) =
     FileExplorerStoreConnector.start();
 
-  let lifecycleUpdater = LifecycleStoreConnector.start();
+  let (lifecycleUpdater, lifecycleStream) = LifecycleStoreConnector.start();
   let indentationUpdater = IndentationStoreConnector.start();
 
   let (storeDispatch, storeStream) =
@@ -124,6 +124,7 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
   /* Isolinear.Stream.connect(dispatch, extHostStream); */
   Isolinear.Stream.connect(dispatch, menuStream);
   Isolinear.Stream.connect(dispatch, explorerStream);
+  Isolinear.Stream.connect(dispatch, lifecycleStream);
 
   dispatch(Model.Actions.SetLanguageInfo(languageInfo));
 

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -53,6 +53,14 @@ let start = () => {
     });
 
   let _ =
+    Vim.onQuit((quitType, force) => {
+     switch (quitType) {
+     | QuitAll => dispatch(Quit(force))
+     | QuitOne(buf) => dispatch(QuitBuffer(buf, force))
+     }
+    });
+
+  let _ =
     Vim.Visual.onRangeChanged(vr => {
       open Vim.Range;
       open Vim.VisualRange;

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -53,12 +53,12 @@ let start = () => {
     });
 
   let _ =
-    Vim.onQuit((quitType, force) => {
-     switch (quitType) {
-     | QuitAll => dispatch(Quit(force))
-     | QuitOne(buf) => dispatch(QuitBuffer(buf, force))
-     }
-    });
+    Vim.onQuit((quitType, force) =>
+      switch (quitType) {
+      | QuitAll => dispatch(Quit(force))
+      | QuitOne(buf) => dispatch(QuitBuffer(buf, force))
+      }
+    );
 
   let _ =
     Vim.Visual.onRangeChanged(vr => {


### PR DESCRIPTION
__Issue__: `:q` and family isn't behaving as expected - `:q` should close the current 'tab', and `:qall` should close everything.

__Defect__: We haven't hooked up the new quit handlers from libvim / reason-libvim.

__Fix:__: Hook up the quit handler.