### PR TITLE
Fix #139 - Don't render parts of lines that are offscreen

### DIFF
--- a/bench/lib/TokenizerBench.re
+++ b/bench/lib/TokenizerBench.re
@@ -28,12 +28,12 @@ let tokenizeWithoutSplits = () => {
 };
 
 let tokenizeWithSplitsSub = () => {
-  let _ = Tokenizer.tokenize(~startIndex=1, ~endIndex=100, ~f=splitEverything, giantString);
+  let _ = Tokenizer.tokenize(~startIndex=100, ~endIndex=200, ~f=splitEverything, giantString);
   ();
 };
 
 let tokenizeWithoutSplitsSub = () => {
-  let _ = Tokenizer.tokenize(~startIndex=1, ~endIndex=100, ~f=splitNothing, giantString);
+  let _ = Tokenizer.tokenize(~startIndex=100, ~endIndex=200, ~f=splitNothing, giantString);
   ();
 };
 
@@ -58,7 +58,7 @@ bench(
 );
 
 bench(
-  ~name="Tokenizer: Tokenize large line subset (1-100), high split count",
+  ~name="Tokenizer: Tokenize large line subset (100-200), high split count",
   ~options,
   ~setup,
   ~f=tokenizeWithoutSplitsSub,
@@ -66,7 +66,7 @@ bench(
 );
 
 bench(
-  ~name="Tokenizer: Tokenize large line subset (1-100), no splits",
+  ~name="Tokenizer: Tokenize large line subset (100-200), no splits",
   ~options,
   ~setup,
   ~f=tokenizeWithoutSplitsSub,

--- a/bench/lib/TokenizerBench.re
+++ b/bench/lib/TokenizerBench.re
@@ -1,7 +1,18 @@
 open Oni_Core;
 open BenchFramework;
 
-let giantString = String.make(1000, 'a');
+let createGiantString = (iter) => {
+ let rec f = (s, i) => {
+  switch (i > 0) {
+  | true => f(s ++ "this is a really\tlong_linewithsomelongtokens", i - 1)
+  | false => s
+  }
+  }
+  
+  f("", iter);
+};
+
+let giantString = createGiantString(50);
 
 let splitEverything = (_, _, _, _) => true;
 let splitNothing = (_, _, _, _) => false;
@@ -16,12 +27,22 @@ let tokenizeWithoutSplits = () => {
   ();
 };
 
-let options = Reperf.Options.create(~iterations=1000, ());
+let tokenizeWithSplitsSub = () => {
+  let _ = Tokenizer.tokenize(~startIndex=1, ~endIndex=100, ~f=splitEverything, giantString);
+  ();
+};
+
+let tokenizeWithoutSplitsSub = () => {
+  let _ = Tokenizer.tokenize(~startIndex=1, ~endIndex=100, ~f=splitNothing, giantString);
+  ();
+};
+
+let options = Reperf.Options.create(~iterations=100, ());
 
 let setup = () => ();
 
 bench(
-  ~name="Tokenizer: Tokenize large line, high split count",
+  ~name="Tokenizer: Tokenize large line entirely, high split count",
   ~options,
   ~setup,
   ~f=tokenizeWithSplits,
@@ -29,9 +50,25 @@ bench(
 );
 
 bench(
-  ~name="Tokenizer: Tokenize large line, no splits",
+  ~name="Tokenizer: Tokenize large line entirely, no splits",
   ~options,
   ~setup,
   ~f=tokenizeWithoutSplits,
+  (),
+);
+
+bench(
+  ~name="Tokenizer: Tokenize large line subset (1-100), high split count",
+  ~options,
+  ~setup,
+  ~f=tokenizeWithoutSplitsSub,
+  (),
+);
+
+bench(
+  ~name="Tokenizer: Tokenize large line subset (1-100), no splits",
+  ~options,
+  ~setup,
+  ~f=tokenizeWithoutSplitsSub,
   (),
 );

--- a/bench/lib/TokenizerBench.re
+++ b/bench/lib/TokenizerBench.re
@@ -1,14 +1,12 @@
 open Oni_Core;
 open BenchFramework;
 
-let createGiantString = (iter) => {
- let rec f = (s, i) => {
-  switch (i > 0) {
-  | true => f(s ++ "this is a really\tlong_linewithsomelongtokens", i - 1)
-  | false => s
-  }
-  }
-  
+let createGiantString = iter => {
+  let rec f = (s, i) => {
+    i > 0
+      ? f(s ++ "this is a really\tlong_linewithsomelongtokens", i - 1) : s;
+  };
+
   f("", iter);
 };
 
@@ -28,12 +26,24 @@ let tokenizeWithoutSplits = () => {
 };
 
 let tokenizeWithSplitsSub = () => {
-  let _ = Tokenizer.tokenize(~startIndex=100, ~endIndex=200, ~f=splitEverything, giantString);
+  let _ =
+    Tokenizer.tokenize(
+      ~startIndex=100,
+      ~endIndex=200,
+      ~f=splitEverything,
+      giantString,
+    );
   ();
 };
 
 let tokenizeWithoutSplitsSub = () => {
-  let _ = Tokenizer.tokenize(~startIndex=100, ~endIndex=200, ~f=splitNothing, giantString);
+  let _ =
+    Tokenizer.tokenize(
+      ~startIndex=100,
+      ~endIndex=200,
+      ~f=splitNothing,
+      giantString,
+    );
   ();
 };
 

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -64,8 +64,6 @@ let _getNextBreak = (s: string, start: int, max: int, f: splitFunc) => {
 let defaultMeasure: measureFunc = _ => 1;
 
 let tokenize = (~startIndex=0, ~endIndex=-1, ~f: splitFunc, ~measure=defaultMeasure, s: string) => {
-  let startIndex = 0;
-
   let len = Zed_utf8.length(s)
   let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
   

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -63,14 +63,34 @@ let _getNextBreak = (s: string, start: int, max: int, f: splitFunc) => {
 
 let defaultMeasure: measureFunc = _ => 1;
 
+let getOffsetFromStart = (~measure, ~idx, s) => {
+
+  if (idx <= 0) {
+    0
+  } else {
+  
+    let offset = ref(0);
+    let i = ref(0);
+
+    while (i^ < idx) {
+      offset := offset^ + measure(Zed_utf8.get(s, i^));
+      incr(i);
+    }
+    
+    offset^;
+  }
+};
+
 let tokenize = (~startIndex=0, ~endIndex=-1, ~f: splitFunc, ~measure=defaultMeasure, s: string) => {
   let len = Zed_utf8.length(s)
   let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
+
   
+  let initialOffset = getOffsetFromStart(~measure, ~idx=startIndex, s);
   let idx = ref(startIndex);
   let tokens: ref(list(TextRun.t)) = ref([]);
 
-  let offset = ref(0);
+  let offset = ref(initialOffset);
 
   while (idx^ < maxIndex) {
     let startToken = idx^;

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -63,29 +63,32 @@ let _getNextBreak = (s: string, start: int, max: int, f: splitFunc) => {
 
 let defaultMeasure: measureFunc = _ => 1;
 
-let getOffsetFromStart = (~measure, ~idx, s) => {
-
+let getOffsetFromStart = (~measure, ~idx, s) =>
   if (idx <= 0) {
-    0
+    0;
   } else {
-  
     let offset = ref(0);
     let i = ref(0);
 
     while (i^ < idx) {
       offset := offset^ + measure(Zed_utf8.get(s, i^));
       incr(i);
-    }
-    
-    offset^;
-  }
-};
+    };
 
-let tokenize = (~startIndex=0, ~endIndex=-1, ~f: splitFunc, ~measure=defaultMeasure, s: string) => {
-  let len = Zed_utf8.length(s)
+    offset^;
+  };
+
+let tokenize =
+    (
+      ~startIndex=0,
+      ~endIndex=(-1),
+      ~f: splitFunc,
+      ~measure=defaultMeasure,
+      s: string,
+    ) => {
+  let len = Zed_utf8.length(s);
   let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
 
-  
   let initialOffset = getOffsetFromStart(~measure, ~idx=startIndex, s);
   let idx = ref(startIndex);
   let tokens: ref(list(TextRun.t)) = ref([]);

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -63,9 +63,12 @@ let _getNextBreak = (s: string, start: int, max: int, f: splitFunc) => {
 
 let defaultMeasure: measureFunc = _ => 1;
 
-let tokenize = (~f: splitFunc, ~measure=defaultMeasure, s: string) => {
+let tokenize = (~startIndex=0, ~endIndex=-1, ~f: splitFunc, ~measure=defaultMeasure, s: string) => {
   let startIndex = 0;
-  let maxIndex = Zed_utf8.length(s);
+
+  let len = Zed_utf8.length(s)
+  let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
+  
   let idx = ref(startIndex);
   let tokens: ref(list(TextRun.t)) = ref([]);
 

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -87,38 +87,43 @@ let tokenize =
       s: string,
     ) => {
   let len = Zed_utf8.length(s);
-  let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
 
-  let initialOffset = getOffsetFromStart(~measure, ~idx=startIndex, s);
-  let idx = ref(startIndex);
-  let tokens: ref(list(TextRun.t)) = ref([]);
+  if (len == 0 || startIndex >= len) {
+    []
+  } else {
+    let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
 
-  let offset = ref(initialOffset);
+    let initialOffset = getOffsetFromStart(~measure, ~idx=startIndex, s);
+    let idx = ref(startIndex);
+    let tokens: ref(list(TextRun.t)) = ref([]);
 
-  while (idx^ < maxIndex) {
-    let startToken = idx^;
-    let startOffset = offset^;
-    let endToken = _getNextBreak(s, startToken, maxIndex, f) + 1;
+    let offset = ref(initialOffset);
 
-    let text = Zed_utf8.sub(s, startToken, endToken - startToken);
-    let endOffset =
-      startOffset
-      + Zed_utf8.fold((char, prev) => prev + measure(char), text, 0);
+    while (idx^ < maxIndex) {
+      let startToken = idx^;
+      let startOffset = offset^;
+      let endToken = _getNextBreak(s, startToken, maxIndex, f) + 1;
 
-    let textRun =
-      TextRun.create(
-        ~text,
-        ~startIndex=ZeroBasedIndex(startToken),
-        ~endIndex=ZeroBasedIndex(endToken),
-        ~startPosition=ZeroBasedIndex(startOffset),
-        ~endPosition=ZeroBasedIndex(endOffset),
-        (),
-      );
+      let text = Zed_utf8.sub(s, startToken, endToken - startToken);
+      let endOffset =
+        startOffset
+        + Zed_utf8.fold((char, prev) => prev + measure(char), text, 0);
 
-    tokens := [textRun, ...tokens^];
-    idx := endToken;
-    offset := endOffset;
-  };
+      let textRun =
+        TextRun.create(
+          ~text,
+          ~startIndex=ZeroBasedIndex(startToken),
+          ~endIndex=ZeroBasedIndex(endToken),
+          ~startPosition=ZeroBasedIndex(startOffset),
+          ~endPosition=ZeroBasedIndex(endOffset),
+          (),
+        );
 
-  tokens^ |> List.rev;
+      tokens := [textRun, ...tokens^];
+      idx := endToken;
+      offset := endOffset;
+    };
+
+    tokens^ |> List.rev;
+  }
 };

--- a/src/editor/Core/Tokenizer.re
+++ b/src/editor/Core/Tokenizer.re
@@ -89,7 +89,7 @@ let tokenize =
   let len = Zed_utf8.length(s);
 
   if (len == 0 || startIndex >= len) {
-    []
+    [];
   } else {
     let maxIndex = endIndex < 0 || endIndex > len ? len : endIndex;
 
@@ -125,5 +125,5 @@ let tokenize =
     };
 
     tokens^ |> List.rev;
-  }
+  };
 };

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -114,8 +114,11 @@ let colorEqual = (c1: Color.t, c2: Color.t) => {
   && Float.equal(c1.a, c2.a);
 };
 
-let tokenize: (string, IndentationSettings.t, colorizer) => list(t) =
-  (s, indentationSettings, colorizer) => {
+let tokenize =
+  (~startIndex=0, ~endIndex=-1, s, indentationSettings, colorizer) => {
+    print_endline("STARTINDEX: " ++ string_of_int(startIndex) ++ " ENDINDEX: " 
+      ++ string_of_int(endIndex) ++ " s length: " 
+      ++ string_of_int(Zed_utf8.length(s)));
     let split = (i0, c0, i1, c1) => {
       let (bg1, fg1) = colorizer(i0);
       let (bg2, fg2) = colorizer(i1);
@@ -128,7 +131,7 @@ let tokenize: (string, IndentationSettings.t, colorizer) => list(t) =
       || UChar.eq(c1, tab);
     };
 
-    Tokenizer.tokenize(~f=split, ~measure=measure(indentationSettings), s)
+    Tokenizer.tokenize(~startIndex, ~endIndex, ~f=split, ~measure=measure(indentationSettings), s)
     |> List.filter(filterRuns)
     |> List.map(textRunToToken(colorizer));
   };

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -116,14 +116,6 @@ let colorEqual = (c1: Color.t, c2: Color.t) => {
 
 let tokenize =
     (~startIndex=0, ~endIndex=(-1), s, indentationSettings, colorizer) => {
-  print_endline(
-    "STARTINDEX: "
-    ++ string_of_int(startIndex)
-    ++ " ENDINDEX: "
-    ++ string_of_int(endIndex)
-    ++ " s length: "
-    ++ string_of_int(Zed_utf8.length(s)),
-  );
   let split = (i0, c0, i1, c1) => {
     let (bg1, fg1) = colorizer(i0);
     let (bg2, fg2) = colorizer(i1);

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -128,7 +128,7 @@ let tokenize: (string, IndentationSettings.t, colorizer) => list(t) =
       || UChar.eq(c1, tab);
     };
 
-    Tokenizer.tokenize(~startIndex=1, ~endIndex=100, ~f=split, ~measure=measure(indentationSettings), s)
+    Tokenizer.tokenize(~f=split, ~measure=measure(indentationSettings), s)
     |> List.filter(filterRuns)
     |> List.map(textRunToToken(colorizer));
   };

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -128,7 +128,7 @@ let tokenize: (string, IndentationSettings.t, colorizer) => list(t) =
       || UChar.eq(c1, tab);
     };
 
-    Tokenizer.tokenize(~f=split, ~measure=measure(indentationSettings), s)
+    Tokenizer.tokenize(~startIndex=1, ~endIndex=100, ~f=split, ~measure=measure(indentationSettings), s)
     |> List.filter(filterRuns)
     |> List.map(textRunToToken(colorizer));
   };

--- a/src/editor/Model/BufferViewTokenizer.re
+++ b/src/editor/Model/BufferViewTokenizer.re
@@ -115,23 +115,34 @@ let colorEqual = (c1: Color.t, c2: Color.t) => {
 };
 
 let tokenize =
-  (~startIndex=0, ~endIndex=-1, s, indentationSettings, colorizer) => {
-    print_endline("STARTINDEX: " ++ string_of_int(startIndex) ++ " ENDINDEX: " 
-      ++ string_of_int(endIndex) ++ " s length: " 
-      ++ string_of_int(Zed_utf8.length(s)));
-    let split = (i0, c0, i1, c1) => {
-      let (bg1, fg1) = colorizer(i0);
-      let (bg2, fg2) = colorizer(i1);
+    (~startIndex=0, ~endIndex=(-1), s, indentationSettings, colorizer) => {
+  print_endline(
+    "STARTINDEX: "
+    ++ string_of_int(startIndex)
+    ++ " ENDINDEX: "
+    ++ string_of_int(endIndex)
+    ++ " s length: "
+    ++ string_of_int(Zed_utf8.length(s)),
+  );
+  let split = (i0, c0, i1, c1) => {
+    let (bg1, fg1) = colorizer(i0);
+    let (bg2, fg2) = colorizer(i1);
 
-      !colorEqual(bg1, bg2)
-      || !colorEqual(fg1, fg2)
-      || _isWhitespace(c0) != _isWhitespace(c1)
-      /* Always split on tabs */
-      || UChar.eq(c0, tab)
-      || UChar.eq(c1, tab);
-    };
-
-    Tokenizer.tokenize(~startIndex, ~endIndex, ~f=split, ~measure=measure(indentationSettings), s)
-    |> List.filter(filterRuns)
-    |> List.map(textRunToToken(colorizer));
+    !colorEqual(bg1, bg2)
+    || !colorEqual(fg1, fg2)
+    || _isWhitespace(c0) != _isWhitespace(c1)
+    /* Always split on tabs */
+    || UChar.eq(c0, tab)
+    || UChar.eq(c1, tab);
   };
+
+  Tokenizer.tokenize(
+    ~startIndex,
+    ~endIndex,
+    ~f=split,
+    ~measure=measure(indentationSettings),
+    s,
+  )
+  |> List.filter(filterRuns)
+  |> List.map(textRunToToken(colorizer));
+};

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -177,9 +177,6 @@ type cursorLocation =
   | Bottom;
 
 let getLeftVisibleColumn = (view, metrics: EditorMetrics.t) => {
-  print_endline(
-    "metrics.characterWidth: " ++ string_of_float(metrics.characterWidth),
-  );
   int_of_float(view.scrollX /. metrics.characterWidth);
 };
 

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -177,9 +177,11 @@ type cursorLocation =
   | Bottom;
 
 let getLeftVisibleColumn = (view, metrics: EditorMetrics.t) => {
-  print_endline ("metrics.characterWidth: " ++ string_of_float(metrics.characterWidth));
+  print_endline(
+    "metrics.characterWidth: " ++ string_of_float(metrics.characterWidth),
+  );
   int_of_float(view.scrollX /. metrics.characterWidth);
-  }
+};
 
 let getTopVisibleLine = (view, metrics: EditorMetrics.t) =>
   int_of_float(view.scrollY /. metrics.lineHeight) + 1;

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -176,6 +176,11 @@ type cursorLocation =
   | Middle
   | Bottom;
 
+let getLeftVisibleColumn = (view, metrics: EditorMetrics.t) => {
+  print_endline ("metrics.characterWidth: " ++ string_of_float(metrics.characterWidth));
+  int_of_float(view.scrollX /. metrics.characterWidth);
+  }
+
 let getTopVisibleLine = (view, metrics: EditorMetrics.t) =>
   int_of_float(view.scrollY /. metrics.lineHeight) + 1;
 

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -307,7 +307,7 @@ let createElement =
         (),
       );
 
-    let getTokensForLine = (~selection=None, i) => {
+    let getTokensForLine = (~selection=None, startIndex, endIndex, i) => {
       let line = Buffer.getLine(buffer, i);
       let tokenColors =
         SyntaxHighlighting.getTokensForLine(
@@ -355,8 +355,8 @@ let createElement =
         );
 
       BufferViewTokenizer.tokenize(
-        ~startIndex=leftVisibleColumn,
-        ~endIndex=leftVisibleColumn + layout.bufferWidthInCharacters,
+        ~startIndex,
+        ~endIndex,
         line,
         IndentationSettings.default,
         colorizer,
@@ -459,7 +459,7 @@ let createElement =
               count=lineCount
               diagnostics
               metrics
-              getTokensForLine
+              getTokensForLine=getTokensForLine(0, layout.bufferWidthInCharacters)
               selection=selectionRanges
             />
           </View>
@@ -625,7 +625,7 @@ let createElement =
                         }
                       };
                     let tokens =
-                      getTokensForLine(~selection=selectionRange, item);
+                      getTokensForLine(~selection=selectionRange, leftVisibleColumn, leftVisibleColumn + layout.bufferWidthInCharacters, item);
 
                     let _ =
                       renderTokens(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -220,6 +220,7 @@ let createElement =
       | None => IndentationSettings.default
       };
 
+    let leftVisibleColumn = Editor.getLeftVisibleColumn(editor, metrics);
     let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
     let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);
 
@@ -283,6 +284,29 @@ let createElement =
 
     let searchHighlights =
       Selectors.getSearchHighlights(state, editor.bufferId);
+    
+    let isMinimapShown =
+      Configuration.getValue(
+        c => c.editorMinimapEnabled,
+        state.configuration,
+      );
+
+    let layout =
+      EditorLayout.getLayout(
+        ~maxMinimapCharacters=
+          Configuration.getValue(
+            c => c.editorMinimapMaxColumn,
+            state.configuration,
+          ),
+        ~pixelWidth=float_of_int(metrics.pixelWidth),
+        ~pixelHeight=float_of_int(metrics.pixelHeight),
+        ~isMinimapShown,
+        ~characterWidth=state.editorFont.measuredWidth,
+        ~characterHeight=state.editorFont.measuredHeight,
+        ~bufferLineCount=lineCount,
+        (),
+      );
+
 
     let getTokensForLine = (~selection=None, i) => {
       let line = Buffer.getLine(buffer, i);
@@ -332,6 +356,8 @@ let createElement =
         );
 
       BufferViewTokenizer.tokenize(
+        ~startIndex=leftVisibleColumn,
+        ~endIndex=(leftVisibleColumn + layout.bufferWidthInCharacters),
         line,
         IndentationSettings.default,
         colorizer,
@@ -354,28 +380,6 @@ let createElement =
         (),
       );
     };
-
-    let isMinimapShown =
-      Configuration.getValue(
-        c => c.editorMinimapEnabled,
-        state.configuration,
-      );
-
-    let layout =
-      EditorLayout.getLayout(
-        ~maxMinimapCharacters=
-          Configuration.getValue(
-            c => c.editorMinimapMaxColumn,
-            state.configuration,
-          ),
-        ~pixelWidth=float_of_int(metrics.pixelWidth),
-        ~pixelHeight=float_of_int(metrics.pixelHeight),
-        ~isMinimapShown,
-        ~characterWidth=state.editorFont.measuredWidth,
-        ~characterHeight=state.editorFont.measuredHeight,
-        ~bufferLineCount=lineCount,
-        (),
-      );
 
     let bufferPixelWidth =
       layout.lineNumberWidthInPixels +. layout.bufferWidthInPixels;

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -285,7 +285,6 @@ let createElement =
     let searchHighlights =
       Selectors.getSearchHighlights(state, editor.bufferId);
 
-<<<<<<< HEAD
     let isMinimapShown =
       Configuration.getValue(
         c => c.editorMinimapEnabled,

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -459,7 +459,10 @@ let createElement =
               count=lineCount
               diagnostics
               metrics
-              getTokensForLine=getTokensForLine(0, layout.bufferWidthInCharacters)
+              getTokensForLine={getTokensForLine(
+                0,
+                layout.bufferWidthInCharacters,
+              )}
               selection=selectionRanges
             />
           </View>
@@ -625,7 +628,12 @@ let createElement =
                         }
                       };
                     let tokens =
-                      getTokensForLine(~selection=selectionRange, leftVisibleColumn, leftVisibleColumn + layout.bufferWidthInCharacters, item);
+                      getTokensForLine(
+                        ~selection=selectionRange,
+                        leftVisibleColumn,
+                        leftVisibleColumn + layout.bufferWidthInCharacters,
+                        item,
+                      );
 
                     let _ =
                       renderTokens(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -284,7 +284,7 @@ let createElement =
 
     let searchHighlights =
       Selectors.getSearchHighlights(state, editor.bufferId);
-    
+
     let isMinimapShown =
       Configuration.getValue(
         c => c.editorMinimapEnabled,
@@ -306,7 +306,6 @@ let createElement =
         ~bufferLineCount=lineCount,
         (),
       );
-
 
     let getTokensForLine = (~selection=None, i) => {
       let line = Buffer.getLine(buffer, i);
@@ -357,7 +356,7 @@ let createElement =
 
       BufferViewTokenizer.tokenize(
         ~startIndex=leftVisibleColumn,
-        ~endIndex=(leftVisibleColumn + layout.bufferWidthInCharacters),
+        ~endIndex=leftVisibleColumn + layout.bufferWidthInCharacters,
         line,
         IndentationSettings.default,
         colorizer,

--- a/test/editor/Model/TokenizerTests.re
+++ b/test/editor/Model/TokenizerTests.re
@@ -55,6 +55,42 @@ let validateTokens =
 describe("Tokenizer", ({test, describe, _}) => {
   describe("start / end indices", ({test, _}) => {
     test(
+      "empty string returns nothing",
+      ({expect}) => {
+      let measure = _ => 1;
+
+      let result =
+        Tokenizer.tokenize(
+          ~startIndex=1,
+          ~endIndex=3,
+          ~f=noSplit,
+          ~measure,
+          "",
+        );
+
+      let runs = [];
+
+      validateTokens(expect, result, runs);
+    });
+    test(
+      "start index past string",
+      ({expect}) => {
+      let measure = _ => 1;
+
+      let result =
+        Tokenizer.tokenize(
+          ~startIndex=5,
+          ~endIndex=8,
+          ~f=noSplit,
+          ~measure,
+          "abc",
+        );
+
+      let runs = [];
+
+      validateTokens(expect, result, runs);
+    });
+    test(
       "only part of token is produced when start / end index is specified",
       ({expect}) => {
       let measure = _ => 1;

--- a/test/editor/Model/TokenizerTests.re
+++ b/test/editor/Model/TokenizerTests.re
@@ -54,9 +54,7 @@ let validateTokens =
 
 describe("Tokenizer", ({test, describe, _}) => {
   describe("start / end indices", ({test, _}) => {
-    test(
-      "empty string returns nothing",
-      ({expect}) => {
+    test("empty string returns nothing", ({expect}) => {
       let measure = _ => 1;
 
       let result =
@@ -72,9 +70,7 @@ describe("Tokenizer", ({test, describe, _}) => {
 
       validateTokens(expect, result, runs);
     });
-    test(
-      "start index past string",
-      ({expect}) => {
+    test("start index past string", ({expect}) => {
       let measure = _ => 1;
 
       let result =

--- a/test/editor/Model/TokenizerTests.re
+++ b/test/editor/Model/TokenizerTests.re
@@ -54,13 +54,20 @@ let validateTokens =
 
 describe("Tokenizer", ({test, describe, _}) => {
   describe("start / end indices", ({test, _}) => {
-    test("only part of token is produced when start / end index is specified", ({expect}) => {
+    test(
+      "only part of token is produced when start / end index is specified",
+      ({expect}) => {
+      let measure = _ => 1;
 
-      let measure = (_) => 1;
+      let result =
+        Tokenizer.tokenize(
+          ~startIndex=1,
+          ~endIndex=3,
+          ~f=noSplit,
+          ~measure,
+          "abcd",
+        );
 
-      let result = 
-        Tokenizer.tokenize(~startIndex=1, ~endIndex=3, ~f=noSplit, ~measure, "abcd");
-      
       let runs = [
         TextRun.create(
           ~text="bc",
@@ -75,13 +82,18 @@ describe("Tokenizer", ({test, describe, _}) => {
       validateTokens(expect, result, runs);
     });
     test("offset prior to tokenize is handled", ({expect}) => {
-
       // Pretend 'b' is actually 2 characters wide
       let measure = thickB;
 
-      let result = 
-        Tokenizer.tokenize(~startIndex=2, ~endIndex=4, ~f=noSplit, ~measure, "bbbcd");
-      
+      let result =
+        Tokenizer.tokenize(
+          ~startIndex=2,
+          ~endIndex=4,
+          ~f=noSplit,
+          ~measure,
+          "bbbcd",
+        );
+
       let runs = [
         TextRun.create(
           ~text="bc",
@@ -96,7 +108,7 @@ describe("Tokenizer", ({test, describe, _}) => {
       validateTokens(expect, result, runs);
     });
   });
-  
+
   describe("character measurement", ({test, _}) =>
     test("wide b", ({expect}) => {
       let str = "abab";


### PR DESCRIPTION
__Issue:__ When there are long lines on a file, even the parts that are offscreen are being rendered - this is wasteful and can incur a tangible performance penalty on rendering as described in #139 

__Defect:__ We just tokenize the entire line, even parts that are offscreen.

__Fix:__ Only tokenize + render the part of the line that is on-screen.