### PR TITLE
Packaging: - Windows: Include vendored ripgrep / node binaries

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -7,8 +7,9 @@ console.log("Bin folder: " + curBin);
 console.log("Working directory: " + process.cwd());
 
 const rootDirectory = process.cwd();
-const releaseDirectory = path.join(process.cwd(), "_release");
+const releaseDirectory = path.join(process.cwd(), "_release2");
 
+const textmateServiceSourceDirectory = path.join(rootDirectory, "src", "textmate_service");
 const extensionsSourceDirectory = path.join(process.cwd(), "extensions");
 // const extensionsDestDirectory = path.join(platformReleaseDirectory, "extensions");
 
@@ -29,7 +30,6 @@ const shell = (cmd) => {
 };
 
 const getRipgrepPath = () => {
-
     const rg = "ripgrep-v0.10.0";
 
     if (process.platform == "darwin") {
@@ -38,6 +38,18 @@ const getRipgrepPath = () => {
         return path.join(rootDirectory, "vendor", rg, "windows", "rg.exe");
     } else {
         return path.join(rootDirectory, "vendor", rg, "linux", "rg");
+    }
+}
+
+const getNodePath = () => {
+    const nodeDir = "node-v10.15.1";
+
+    if (process.platform == "darwin") {
+        return path.join(rootDirectory, "vendor", nodeDir, "osx", "node");
+    } else if (process.platform == "win32") {
+        return path.join(rootDirectory, "vendor", nodeDir, "win-x64", "node.exe");
+    } else {
+        return path.join(rootDirectory, "vendor", nodeDir, "linux-x64", "node");
     }
 }
 
@@ -124,10 +136,13 @@ if (process.platform == "darwin") {
 } else {
   const platformReleaseDirectory = path.join(releaseDirectory, process.platform);
   const extensionsDestDirectory = path.join(platformReleaseDirectory, "extensions");
+  const textmateServiceDestDirectory = path.join(platformReleaseDirectory, "textmate_service");
   fs.mkdirpSync(platformReleaseDirectory);
 
   copy(getRipgrepPath(), path.join(platformReleaseDirectory, process.platform == "win32" ? "rg.exe" : "rg"));
+  copy(getNodePath(), path.join(platformReleaseDirectory, process.platform == "win32" ? "node.exe" : "node"));
   fs.copySync(curBin, platformReleaseDirectory, { deference: true});
   fs.copySync(extensionsSourceDirectory, extensionsDestDirectory, {deference: true});
+  fs.copySync(textmateServiceSourceDirectory, textmateServiceDestDirectory, {deference: true});
   fs.removeSync(path.join(platformReleaseDirectory, "setup.json"));
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -28,6 +28,19 @@ const shell = (cmd) => {
     console.log(`[shell - output]: ${out.toString("utf8")}`);
 };
 
+const getRipgrepPath = () => {
+
+    const rg = "ripgrep-v0.10.0";
+
+    if (process.platform == "darwin") {
+        return path.join(rootDirectory, "vendor", rg, "mac", "rg");
+    } else if (process.platform == "win32") {
+        return path.join(rootDirectory, "vendor", rg, "windows", "rg.exe");
+    } else {
+        return path.join(rootDirectory, "vendor", rg, "linux", "rg");
+    }
+}
+
 if (process.platform == "darwin") {
 
   const executables = [
@@ -68,6 +81,8 @@ if (process.platform == "darwin") {
   copy(curBin, binaryDirectory);
   copy(extensionsSourceDirectory, extensionsDestDirectory);
 
+  copy(getRipgrepPath(), path.join(binaryDirectory, "rg"));
+
   // Copy icon
   copy(iconSourcePath, path.join(resourcesDirectory, "Onivim2.icns"));
 
@@ -105,11 +120,14 @@ if (process.platform == "darwin") {
     ]
   };
   fs.writeFileSync(dmgJsonPath, JSON.stringify(dmgJson));
+  fs.removeSync(path.join(binaryDirectory, "setup.json"));
 } else {
   const platformReleaseDirectory = path.join(releaseDirectory, process.platform);
   const extensionsDestDirectory = path.join(platformReleaseDirectory, "extensions");
   fs.mkdirpSync(platformReleaseDirectory);
 
+  copy(getRipgrepPath(), path.join(platformReleaseDirectory, process.platform == "win32" ? "rg.exe" : "rg"));
   fs.copySync(curBin, platformReleaseDirectory, { deference: true});
   fs.copySync(extensionsSourceDirectory, extensionsDestDirectory, {deference: true});
+  fs.removeSync(path.join(platformReleaseDirectory, "setup.json"));
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -7,7 +7,7 @@ console.log("Bin folder: " + curBin);
 console.log("Working directory: " + process.cwd());
 
 const rootDirectory = process.cwd();
-const releaseDirectory = path.join(process.cwd(), "_release2");
+const releaseDirectory = path.join(process.cwd(), "_release");
 
 const textmateServiceSourceDirectory = path.join(rootDirectory, "src", "textmate_service");
 const extensionsSourceDirectory = path.join(process.cwd(), "extensions");

--- a/scripts/windows/BuildSetupTemplate.js
+++ b/scripts/windows/BuildSetupTemplate.js
@@ -32,7 +32,7 @@ if (process.env["APPVEYOR"]) {
 
 const valuesToReplace = {
     AppName: prodName,
-    AppExecutableName: `${prodName}.exe`,
+    AppExecutableName: `Oni2.exe`,
     AppSetupExecutableName: `${prodName}-${version}-${buildFolderPrefix}win`,
     Version: version,
     SourcePath: path.join(__dirname, "..", "..", "_release", `win32`, "*"),

--- a/scripts/windows/setup.template.iss
+++ b/scripts/windows/setup.template.iss
@@ -33,7 +33,7 @@ Name: "addToRightClickMenu"; Description: "Add {{AppName}} to the right click me
 Name: "{group}\{{AppName}}"; Filename: "{app}\{{AppExecutableName}}"
 
 [Run]
-Filename: "{app}\{{AppName}}"; Flags: postinstall skipifsilent nowait
+Filename: "{app}\{{AppExecutableName}}"; Flags: postinstall skipifsilent nowait
 
 [Code]
 function NeedsAddPath(Param: string): boolean;

--- a/src/editor/Core/Setup.re
+++ b/src/editor/Core/Setup.re
@@ -24,38 +24,37 @@ type t = {
 let version = "0.2.0";
 
 let default = () => {
-
   let execDir = Revery.Environment.getExecutingDirectory();
 
   switch (Revery.Environment.os) {
   | Revery.Environment.Windows => {
-    nodePath: execDir ++ "node.exe",
-    textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
-    bundledExtensionsPath: execDir ++ "extensions",
-    developmentExtensionsPath: None,
-    extensionHostPath: "",
-    rgPath: execDir ++ "rg.exe",
-    version
-  }
+      nodePath: execDir ++ "node.exe",
+      textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
+      bundledExtensionsPath: execDir ++ "extensions",
+      developmentExtensionsPath: None,
+      extensionHostPath: "",
+      rgPath: execDir ++ "rg.exe",
+      version,
+    }
   | Revery.Environment.Mac => {
-    nodePath: execDir ++ "node",
-    textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
-    bundledExtensionsPath: execDir ++ "extensions",
-    developmentExtensionsPath: None,
-    extensionHostPath: "",
-    rgPath: execDir ++ "rg",
-    version
-  }
+      nodePath: execDir ++ "node",
+      textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
+      bundledExtensionsPath: execDir ++ "extensions",
+      developmentExtensionsPath: None,
+      extensionHostPath: "",
+      rgPath: execDir ++ "rg",
+      version,
+    }
   | _ => {
-    nodePath: execDir ++ "node",
-    textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
-    bundledExtensionsPath: execDir ++ "extensions",
-    developmentExtensionsPath: None,
-    extensionHostPath: "",
-    rgPath: execDir ++ "rg",
-    version
-  }
-  }
+      nodePath: execDir ++ "node",
+      textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
+      bundledExtensionsPath: execDir ++ "extensions",
+      developmentExtensionsPath: None,
+      extensionHostPath: "",
+      rgPath: execDir ++ "rg",
+      version,
+    }
+  };
 };
 
 let ofString = str => Yojson.Safe.from_string(str) |> of_yojson_exn;
@@ -63,11 +62,12 @@ let ofString = str => Yojson.Safe.from_string(str) |> of_yojson_exn;
 let ofFile = filePath => Yojson.Safe.from_file(filePath) |> of_yojson_exn;
 
 let init = () => {
-  let setupJsonPath = Revery.Environment.getExecutingDirectory() ++ "setup.json";
+  let setupJsonPath =
+    Revery.Environment.getExecutingDirectory() ++ "setup.json";
 
   if (Sys.file_exists(setupJsonPath)) {
-    ofFile(setupJsonPath)
+    ofFile(setupJsonPath);
   } else {
     default();
-  }
-}
+  };
+};

--- a/src/editor/Core/Setup.re
+++ b/src/editor/Core/Setup.re
@@ -21,9 +21,53 @@ type t = {
   version: [@default "Unknown"] string,
 };
 
+let version = "0.2.0";
+
+let default = () => {
+
+  let execDir = Revery.Environment.getExecutingDirectory();
+
+  switch (Revery.Environment.os) {
+  | Revery.Environment.Windows => {
+    nodePath: execDir ++ "node.exe",
+    textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
+    bundledExtensionsPath: execDir ++ "extensions",
+    developmentExtensionsPath: None,
+    extensionHostPath: "",
+    rgPath: execDir ++ "rg.exe",
+    version
+  }
+  | Revery.Environment.Mac => {
+    nodePath: execDir ++ "node",
+    textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
+    bundledExtensionsPath: execDir ++ "extensions",
+    developmentExtensionsPath: None,
+    extensionHostPath: "",
+    rgPath: execDir ++ "rg",
+    version
+  }
+  | _ => {
+    nodePath: execDir ++ "node",
+    textmateServicePath: execDir ++ "textmate_service/lib/src/index.js",
+    bundledExtensionsPath: execDir ++ "extensions",
+    developmentExtensionsPath: None,
+    extensionHostPath: "",
+    rgPath: execDir ++ "rg",
+    version
+  }
+  }
+};
+
 let ofString = str => Yojson.Safe.from_string(str) |> of_yojson_exn;
 
 let ofFile = filePath => Yojson.Safe.from_file(filePath) |> of_yojson_exn;
 
-let init = () =>
-  Revery.Environment.getExecutingDirectory() ++ "setup.json" |> ofFile;
+let init = () => {
+  let setupJsonPath = Revery.Environment.getExecutingDirectory() ++ "setup.json";
+
+  if (Sys.file_exists(setupJsonPath)) {
+    ofFile(setupJsonPath)
+  } else {
+    default();
+  }
+}


### PR DESCRIPTION
__Issue:__ When running Onivim 2 locally in the build environment, we drop a `setup.json` file that points to where various dependencies are, like: `node`, `rg`, the textmate service `index.js`, and the bundled extensions. However, in a packaged environment, we just have these dependencies local to the binary (the exact relation is dependent on the platform) - so we don't want to just package a `setup.json` from the build environment and try and load things from build-environment paths.

__Fix:__ In the case a `setup.json` isn't present (aka, a packaged environment), point to executable-relative reference directories, and don't include `setup.json` in the package. In addition, include the missing vendored dependencies (`node`, `rg`, textmate service, and bundled extensions) in the package.
