### PR TITLE
Dependency: reason-libvim -> 8.10869.16001

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "775e98074ad09cfa9c5551c0e977a97a",
+  "checksum": "9b01cacdc654751953adab458d884b26",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -245,14 +245,14 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@8.10869.15001@d41d8cd9": {
-      "id": "reason-libvim@8.10869.15001@d41d8cd9",
+    "reason-libvim@8.10869.16001@d41d8cd9": {
+      "id": "reason-libvim@8.10869.16001@d41d8cd9",
       "name": "reason-libvim",
-      "version": "8.10869.15001",
+      "version": "8.10869.16001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-libvim/-/reason-libvim-8.10869.15001.tgz#sha1:0109b1b06f4230c1a5381f6ab31a0f2714a74dfc"
+          "archive:https://registry.npmjs.org/reason-libvim/-/reason-libvim-8.10869.16001.tgz#sha1:f0276bca6089b2c8ff1d80c07c0a4262d8d30ac6"
         ]
       },
       "overrides": [],
@@ -446,14 +446,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.11@d41d8cd9": {
-      "id": "lodash@4.17.11@d41d8cd9",
+    "lodash@4.17.14@d41d8cd9": {
+      "id": "lodash@4.17.14@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.11",
+      "version": "4.17.14",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#sha1:b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
         ]
       },
       "overrides": [],
@@ -783,7 +783,7 @@
         "revery@0.24.0@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@8.10869.15001@d41d8cd9",
+        "reason-libvim@8.10869.16001@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
@@ -800,7 +800,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.11@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@829ee6dd"
       ]
     },

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "775e98074ad09cfa9c5551c0e977a97a",
+  "checksum": "9b01cacdc654751953adab458d884b26",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -245,14 +245,14 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@8.10869.15001@d41d8cd9": {
-      "id": "reason-libvim@8.10869.15001@d41d8cd9",
+    "reason-libvim@8.10869.16001@d41d8cd9": {
+      "id": "reason-libvim@8.10869.16001@d41d8cd9",
       "name": "reason-libvim",
-      "version": "8.10869.15001",
+      "version": "8.10869.16001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-libvim/-/reason-libvim-8.10869.15001.tgz#sha1:0109b1b06f4230c1a5381f6ab31a0f2714a74dfc"
+          "archive:https://registry.npmjs.org/reason-libvim/-/reason-libvim-8.10869.16001.tgz#sha1:f0276bca6089b2c8ff1d80c07c0a4262d8d30ac6"
         ]
       },
       "overrides": [],
@@ -446,14 +446,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.11@d41d8cd9": {
-      "id": "lodash@4.17.11@d41d8cd9",
+    "lodash@4.17.14@d41d8cd9": {
+      "id": "lodash@4.17.14@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.11",
+      "version": "4.17.14",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#sha1:b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
         ]
       },
       "overrides": [],
@@ -782,7 +782,7 @@
       "dependencies": [
         "revery@0.24.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@8.10869.15001@d41d8cd9",
+        "reason-libvim@8.10869.16001@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
@@ -799,7 +799,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.11@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@829ee6dd"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "reason-glfw": "^3.2.1022",
     "isolinear": "^2.0.0",
     "reasonFuzz": "*",
-    "reason-libvim": "8.10869.15001",
+    "reason-libvim": "8.10869.16001",
     "esy-macdylibbundler": "*"
   },
   "resolutions": {
@@ -53,7 +53,8 @@
     "rebez": "github:jchavarri/rebez#46cbc183",
     "reasonFuzz": "github:CrossR/reasonFuzz#63d4056",
     "pesy": "0.4.1",
-    "@opam/ocaml-migrate-parsetree": "1.3.1"
+    "@opam/ocaml-migrate-parsetree": "1.3.1",
+    "@opam/ppx_tools_versioned": "5.2.2"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "775e98074ad09cfa9c5551c0e977a97a",
+  "checksum": "9b01cacdc654751953adab458d884b26",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -245,14 +245,14 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@8.10869.15001@d41d8cd9": {
-      "id": "reason-libvim@8.10869.15001@d41d8cd9",
+    "reason-libvim@8.10869.16001@d41d8cd9": {
+      "id": "reason-libvim@8.10869.16001@d41d8cd9",
       "name": "reason-libvim",
-      "version": "8.10869.15001",
+      "version": "8.10869.16001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-libvim/-/reason-libvim-8.10869.15001.tgz#sha1:0109b1b06f4230c1a5381f6ab31a0f2714a74dfc"
+          "archive:https://registry.npmjs.org/reason-libvim/-/reason-libvim-8.10869.16001.tgz#sha1:f0276bca6089b2c8ff1d80c07c0a4262d8d30ac6"
         ]
       },
       "overrides": [],
@@ -446,14 +446,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.11@d41d8cd9": {
-      "id": "lodash@4.17.11@d41d8cd9",
+    "lodash@4.17.14@d41d8cd9": {
+      "id": "lodash@4.17.14@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.11",
+      "version": "4.17.14",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#sha1:b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
         ]
       },
       "overrides": [],
@@ -782,7 +782,7 @@
       "dependencies": [
         "revery@0.24.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@8.10869.15001@d41d8cd9",
+        "reason-libvim@8.10869.16001@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
@@ -799,7 +799,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.11@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@829ee6dd"
       ]
     },


### PR DESCRIPTION
This picks up a few crash fixes in `reason-libvim` - there were various crashes occurring while using the commandline in OSX / Linux (thanks @CrossR for finding these!):
- https://github.com/onivim/reason-libvim/pull/49
- https://github.com/onivim/reason-libvim/pull/50
