### PR TITLE
Fix #374 - Change editorLineNumber default to 'on'

### DIFF
--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -35,7 +35,7 @@ let default = {
   editorMinimapEnabled: true,
   editorMinimapShowSlider: true,
   editorMinimapMaxColumn: Constants.default.minimapMaxColumn,
-  editorLineNumbers: Relative,
+  editorLineNumbers: On,
   editorInsertSpaces: false,
   editorIndentSize: 4,
   editorTabSize: 4,

--- a/src/editor/Model/EditorLayout.re
+++ b/src/editor/Model/EditorLayout.re
@@ -28,12 +28,14 @@ let getLayout =
       ~bufferLineCount: int,
       (),
     ) => {
-  let lineNumberWidthInPixels = showLineNumbers ?
-    LineNumber.getLineNumberPixelWidth(
-      ~lines=bufferLineCount,
-      ~fontPixelWidth=characterWidth,
-      (),
-    ) : 0.0;
+  let lineNumberWidthInPixels =
+    showLineNumbers
+      ? LineNumber.getLineNumberPixelWidth(
+          ~lines=bufferLineCount,
+          ~fontPixelWidth=characterWidth,
+          (),
+        )
+      : 0.0;
 
   let minimapPadding =
     isMinimapShown ? float_of_int(Constants.default.minimapPadding) : 0.0;

--- a/src/editor/Model/EditorLayout.re
+++ b/src/editor/Model/EditorLayout.re
@@ -18,6 +18,7 @@ type t = {
 
 let getLayout =
     (
+      ~showLineNumbers=true,
       ~maxMinimapCharacters=120,
       ~pixelWidth: float,
       ~pixelHeight: float,
@@ -27,12 +28,12 @@ let getLayout =
       ~bufferLineCount: int,
       (),
     ) => {
-  let lineNumberWidthInPixels =
+  let lineNumberWidthInPixels = showLineNumbers ?
     LineNumber.getLineNumberPixelWidth(
       ~lines=bufferLineCount,
       ~fontPixelWidth=characterWidth,
       (),
-    );
+    ) : 0.0;
 
   let minimapPadding =
     isMinimapShown ? float_of_int(Constants.default.minimapPadding) : 0.0;

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -203,17 +203,19 @@ let createElement =
     let bufferId = Buffer.getId(buffer);
     let lineCount = Buffer.getNumberOfLines(buffer);
 
-    let showLineNumbers  =
+    let showLineNumbers =
       Configuration.getValue(
         c => c.editorLineNumbers != LineNumber.Off,
         state.configuration,
       );
-    let lineNumberWidth = showLineNumbers ? 
-      LineNumber.getLineNumberPixelWidth(
-        ~lines=lineCount,
-        ~fontPixelWidth=state.editorFont.measuredWidth,
-        (),
-      ) : 0.0;
+    let lineNumberWidth =
+      showLineNumbers
+        ? LineNumber.getLineNumberPixelWidth(
+            ~lines=lineCount,
+            ~fontPixelWidth=state.editorFont.measuredWidth,
+            (),
+          )
+        : 0.0;
 
     let fontHeight = state.editorFont.measuredHeight;
     let fontWidth = state.editorFont.measuredWidth;
@@ -705,7 +707,7 @@ let createElement =
                     },
                   (),
                 );
-              }
+              };
 
               let renderIndentGuides =
                 Configuration.getValue(

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -203,12 +203,17 @@ let createElement =
     let bufferId = Buffer.getId(buffer);
     let lineCount = Buffer.getNumberOfLines(buffer);
 
-    let lineNumberWidth =
+    let showLineNumbers  =
+      Configuration.getValue(
+        c => c.editorLineNumbers != LineNumber.Off,
+        state.configuration,
+      );
+    let lineNumberWidth = showLineNumbers ? 
       LineNumber.getLineNumberPixelWidth(
         ~lines=lineCount,
         ~fontPixelWidth=state.editorFont.measuredWidth,
         (),
-      );
+      ) : 0.0;
 
     let fontHeight = state.editorFont.measuredHeight;
     let fontWidth = state.editorFont.measuredWidth;
@@ -293,6 +298,7 @@ let createElement =
 
     let layout =
       EditorLayout.getLayout(
+        ~showLineNumbers,
         ~maxMinimapCharacters=
           Configuration.getValue(
             c => c.editorMinimapMaxColumn,
@@ -663,41 +669,43 @@ let createElement =
               );
 
               /* Draw background for line numbers */
-              Shapes.drawRect(
-                ~transform,
-                ~x=0.,
-                ~y=0.,
-                ~width=lineNumberWidth,
-                ~height=float_of_int(height),
-                ~color=theme.colors.editorLineNumberBackground,
-                (),
-              );
+              if (showLineNumbers) {
+                Shapes.drawRect(
+                  ~transform,
+                  ~x=0.,
+                  ~y=0.,
+                  ~width=lineNumberWidth,
+                  ~height=float_of_int(height),
+                  ~color=theme.colors.editorLineNumberBackground,
+                  (),
+                );
 
-              FlatList.render(
-                ~scrollY,
-                ~rowHeight,
-                ~height=float_of_int(height),
-                ~count,
-                ~render=
-                  (item, offset) => {
-                    let _ =
-                      renderLineNumber(
-                        fontWidth,
-                        item,
-                        lineNumberWidth,
-                        theme,
-                        Configuration.getValue(
-                          c => c.editorLineNumbers,
-                          state.configuration,
-                        ),
-                        cursorLine,
-                        offset,
-                        transform,
-                      );
-                    ();
-                  },
-                (),
-              );
+                FlatList.render(
+                  ~scrollY,
+                  ~rowHeight,
+                  ~height=float_of_int(height),
+                  ~count,
+                  ~render=
+                    (item, offset) => {
+                      let _ =
+                        renderLineNumber(
+                          fontWidth,
+                          item,
+                          lineNumberWidth,
+                          theme,
+                          Configuration.getValue(
+                            c => c.editorLineNumbers,
+                            state.configuration,
+                          ),
+                          cursorLine,
+                          offset,
+                          transform,
+                        );
+                      ();
+                    },
+                  (),
+                );
+              }
 
               let renderIndentGuides =
                 Configuration.getValue(


### PR DESCRIPTION
__Issue:__ The `editor.lineNumber` default of `Relative` is confusing, especially if you've never encountered it in Vim before. Even Vim doesn't default to this setting. It's an opinionated remnant of my config.

__Fix:__ Change the default to `On` which is more in-line with other editors. In addition, I noticed `off` wasn't being picked up - so I added a fix for that as well.

Fixes #374 