### PR TITLE
Perf: Remove sort flag from Ripgrep

### DIFF
--- a/src/editor/Core/Ripgrep.re
+++ b/src/editor/Core/Ripgrep.re
@@ -25,6 +25,6 @@ let process = (rgPath, args, callback) => {
    path, modified, created
  */
 let search = (path, query, callback) =>
-  process(path, [|"--files", "--sort", "accessed", "--", query|], callback);
+  process(path, [|"--files", "--", query|], callback);
 
 let make = path => {search: search(path)};


### PR DESCRIPTION
__Issue:__ In starting to investigate #304 , I noticed that the `--sort` flag for Ripgrep was actually slowing it down.

__Defect:__ In the documentation for the `--sort` flag (https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#common-options):
```
Force ripgrep to sort its output by file name. (This disables parallelism, so it might be slower.)
```

__Fix:__ Turn off the `--sort` flag for now to enable parallelism and speed up the ripgrep search

@Akin909 - was there any particular reason functionality-wise to have this `--sort` flag? If it was to implement a most-recently-used experience, we could potentially implement that outside of ripgrep. Let me know if you have any concerns with this change 👍 