### PR TITLE
Fix #414 - Cursor split display

### DIFF
--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -14,6 +14,7 @@ let editorSurfaceMinimalState = () => {
     React.RenderedElement.render(
       rootNode,
       <EditorSurface
+        isActiveSplit=true
         editorGroupId
         editor=simpleEditor
         state=simpleState
@@ -28,6 +29,7 @@ let editorSurfaceThousandLineState = () => {
     React.RenderedElement.render(
       rootNode,
       <EditorSurface
+        isActiveSplit=true
         editorGroupId
         editor=simpleEditor
         state=thousandLineState
@@ -42,6 +44,7 @@ let editorSurfaceThousandLineStateWithIndents = () => {
     React.RenderedElement.render(
       rootNode,
       <EditorSurface
+        isActiveSplit=true
         editorGroupId
         editor=simpleEditor
         state=thousandLineStateWithIndents
@@ -56,6 +59,7 @@ let editorSurfaceHundredThousandLineState = () => {
     React.RenderedElement.render(
       rootNode,
       <EditorSurface
+        isActiveSplit=true
         editorGroupId
         editor=simpleEditor
         state=hundredThousandLineState
@@ -76,6 +80,7 @@ let setupSurfaceThousandLineLayout = () => {
   Container.update(
     container,
     <EditorSurface
+      isActiveSplit=true
       editorGroupId
       editor=simpleEditor
       state=thousandLineState

--- a/src/editor/UI/EditorGroupView.re
+++ b/src/editor/UI/EditorGroupView.re
@@ -111,7 +111,14 @@ let createElement =
 
         let editorView =
           switch (editor) {
-          | Some(v) => <EditorSurface isActiveSplit=isActive editorGroupId metrics editor=v state />
+          | Some(v) =>
+            <EditorSurface
+              isActiveSplit=isActive
+              editorGroupId
+              metrics
+              editor=v
+              state
+            />
           | None => React.empty
           };
         switch (

--- a/src/editor/UI/EditorGroupView.re
+++ b/src/editor/UI/EditorGroupView.re
@@ -111,7 +111,7 @@ let createElement =
 
         let editorView =
           switch (editor) {
-          | Some(v) => <EditorSurface editorGroupId metrics editor=v state />
+          | Some(v) => <EditorSurface isActiveSplit=isActive editorGroupId metrics editor=v state />
           | None => React.empty
           };
         switch (

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -183,6 +183,7 @@ let component = React.component("EditorSurface");
 let createElement =
     (
       ~state: State.t,
+      ~isActiveSplit: bool,
       ~editorGroupId: int,
       ~metrics: EditorMetrics.t,
       ~editor: Editor.t,
@@ -255,11 +256,17 @@ let createElement =
       (x, y);
     };
 
+    let fullCursorWidth = cursorCharacterWidth * int_of_float(fontWidth);
+
     let cursorWidth =
-      switch (state.mode) {
-      | Insert => 2
-      | _ => cursorCharacterWidth * int_of_float(fontWidth)
+      switch ((state.mode, isActiveSplit)) {
+      | (Insert, true) => 2
+      | _ => fullCursorWidth
       };
+
+
+    let cursorOpacity = isActiveSplit ? 0.5 : 0.25;
+      
 
     let cursorStyle =
       Style.[
@@ -285,7 +292,7 @@ let createElement =
         ),
         height(iFontHeight),
         width(cursorWidth),
-        opacity(0.5),
+        opacity(cursorOpacity),
         backgroundColor(Colors.white),
       ];
 

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -259,14 +259,12 @@ let createElement =
     let fullCursorWidth = cursorCharacterWidth * int_of_float(fontWidth);
 
     let cursorWidth =
-      switch ((state.mode, isActiveSplit)) {
+      switch (state.mode, isActiveSplit) {
       | (Insert, true) => 2
       | _ => fullCursorWidth
       };
 
-
     let cursorOpacity = isActiveSplit ? 0.5 : 0.25;
-      
 
     let cursorStyle =
       Style.[


### PR DESCRIPTION
__Issue:__ When window splits are open, and you switch to insert mode (ie, via `i`, `a`, etc), cursors on _all splits_ change to insert mode. This is unexpected and visually jarring - which file am I editing?

__Defect:__ The current mode is 'global' to the UI - the cursor style is a function of that current global mode - so all cursors would pick that up. 

__Fix:__ For now - only adjust the cursor style for the 'active' editor group. 

Fixes #414 