### PR TITLE
Packaging: Minimize launcher deps

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -104,8 +104,6 @@ console.log(result.output.toString());
   // Copy icon
   copy(iconSourcePath, path.join(resourcesDirectory, "Onivim2.icns"));
 
-  shell(`dylibbundler -b -x "${path.join(binaryDirectory, "Oni2")}" -d "${libsDirectory}" -cd`);
-
   shell(`dylibbundler -b -x "${path.join(binaryDirectory, "Oni2_editor")}" -d "${libsEditorDirectory}" -cd`);
 
   const dmgPath = path.join(releaseDirectory, "Onivim2.dmg");

--- a/src/editor/bin_launcher/Oni2.re
+++ b/src/editor/bin_launcher/Oni2.re
@@ -20,6 +20,26 @@ let anonArg = _ => ();
 
 let () = Arg.parse(spec, anonArg, "Usage: ");
 
+type platform =
+  | Windows
+  | Mac
+  | Linux
+  | Unknown;
+
+let os =
+  switch (Sys.os_type) {
+  | "Win32" => Windows
+  | _ =>
+    let ic = Unix.open_process_in("uname");
+    let uname = input_line(ic);
+    let _ = close_in(ic);
+    switch (uname) {
+    | "Darwin" => Mac
+    | "Linux" => Linux
+    | _ => Unknown
+    };
+  };
+
 /* NOTE: This is duplicated from Revery's core utility
  * This is the only method we use from Revery - this prevents us
  * from needing to bring in the full set of Revery's dependencies

--- a/src/editor/bin_launcher/Oni2.re
+++ b/src/editor/bin_launcher/Oni2.re
@@ -20,10 +20,46 @@ let anonArg = _ => ();
 
 let () = Arg.parse(spec, anonArg, "Usage: ");
 
+/* NOTE: This is duplicated from Revery's core utility
+ * This is the only method we use from Revery - this prevents us
+ * from needing to bring in the full set of Revery's dependencies
+ * just for this one method.
+ */
+let executingDirectory = {
+  let dir =
+    switch (os) {
+    /* The default strategy of preferring Sys.executable_name seems to only work
+     * reliably on Mac.  On Linux, it will return the symlink source instead of
+     * the symlink destination - this causes problems when trying to load assets
+     * relative to the binary location when symlinked.
+     */
+    | Mac =>
+      switch (
+        String.rindex_opt(Sys.executable_name, '/'),
+        String.rindex_opt(Sys.executable_name, '\\'),
+      ) {
+      | (Some(v1), Some(v2)) =>
+        String.sub(Sys.executable_name, 0, max(v1, v2))
+      | (None, Some(v)) => String.sub(Sys.executable_name, 0, v)
+      | (Some(v), None) => String.sub(Sys.executable_name, 0, v)
+      | _ => Sys.executable_name
+      }
+    | _ => Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep
+    };
+
+  /* Check if there is a trailing slash. If not, we need to add one. */
+
+  let len = String.length(dir);
+  switch (dir.[len - 1]) {
+  | '/' => dir
+  | '\\' => dir
+  | _ => dir ++ Filename.dir_sep
+  };
+};
+
 let executable = Sys.win32 ? "Oni2_editor.exe" : "Oni2_editor";
 
 let startProcess = (stdio, stdout, stderr) => {
-  let executingDirectory = Oni_Core.Utility.executingDirectory;
   Unix.create_process(
     executingDirectory ++ executable,
     Sys.argv,

--- a/src/editor/bin_launcher/dune
+++ b/src/editor/bin_launcher/dune
@@ -4,5 +4,5 @@
     (name Oni2)
     (package Oni2)
     (public_name Oni2)
-    (libraries unix Oni2.core)
+    (libraries unix)
 )


### PR DESCRIPTION
Onivim 2 has two processes - a launcher process (Oni2) and the actual editor process (Oni2_editor). This split is primarily for Windows, to detach from the console process, but we use them on all platforms for consistency (there is relatively low overhead for the launcher process on Linux/MacOS).

However, we were bringing in some heavyweight dependencies - Revery needs various graphics libraries, and the launcher was dependent on Oni_Core (which was dependent on Revery). This would necessitate packaging deps for both Oni2/Oni2_editor.

This vendors a little bit of code from Revery (just the env stuff we need from the launcher), so that we don't need to bundle the dependencies twice