### PR TITLE
Bugfix: ':sav' command not handled properly

### DIFF
--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -26,6 +26,12 @@ let start = (getState: unit => Model.State.t) => {
     );
 
   let _ =
+    Vim.Buffer.onFilenameChanged(meta => {
+      Log.info("Buffer metadata changed: " ++ string_of_int(meta.id));
+      dispatch(Model.Actions.BufferEnter(meta));
+    });
+
+  let _ =
     Vim.Cursor.onMoved(newPosition => {
       let cursorPos =
         Core.Types.Position.createFromOneBasedIndices(


### PR DESCRIPTION
__Issue:__ The `:sav` command wasn't being handled properly by the UI. When the `:sav` command is executed, the buffer stays the same (same id), but the associated file changes. We don't reflect this in the UI, so it was confusing, and worse, the filetype wouldn't be picked up.

__Defect:__ An `onFilenameChanged` event was added to `reason-libvim` but we weren't using it here.

__Fix:__ Hook the `onFilenameChanged` event and dispatch a buffer enter in response.