### PR TITLE
Use the basedir of a file when needed for folder selection.

### DIFF
--- a/src/editor/Core/Cli.re
+++ b/src/editor/Core/Cli.re
@@ -79,10 +79,15 @@ let parse = () => {
   let directories = List.filter(isDirectory, absolutePaths);
   let filesToOpen = List.filter(p => !isDirectory(p), absolutePaths);
 
+  /* Set the folder to be opened, based on 3 options:
+     - If a folder(s) is given, use the first.
+     - If no folders are given, but files are, use the dir of the first file.
+     - If no files or folders are given, use the working directory. */
   let folder =
-    switch (directories) {
-    | [] => workingDirectory
-    | [hd, ..._] => hd
+    switch (directories, filesToOpen) {
+    | ([hd, ..._], _) => hd
+    | ([], [hd, ..._]) => Rench.Path.dirname(hd)
+    | ([], []) => workingDirectory
     };
 
   {folder, filesToOpen};


### PR DESCRIPTION
Small thing that I noticed whilst testing.

I think technically this is different to Nvim/Vim default behaviour. However, it is also pretty jarring to do `esy run ~/my/new/file.re` but have the explorer show the Oni2 dir still.

We could alternatively follow the VSCode way of working where we just don't open anything when given a file, but not sure that is preferable either.