### PR TITLE
Refactoring: Move initial view setup to store

### DIFF
--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -5,8 +5,7 @@ runTest(~name="AddRemoveSplitTest", (dispatch, wait) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
-
-    splitCount == 1;
+      splitCount == 1;
   });
 
   dispatch(Command("view.splitVertical"));

--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -5,7 +5,7 @@ runTest(~name="AddRemoveSplitTest", (dispatch, wait) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
-      splitCount == 1;
+    splitCount == 1;
   });
 
   dispatch(Command("view.splitVertical"));

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -58,7 +58,7 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
         (),
       ),
     ),
-  )
+  );
 
   let wrappedDispatch = action => {
     dispatch(action);

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -58,12 +58,7 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
         (),
       ),
     ),
-  ) /* TODO: Move this to a shared place... */;
-
-  let editorGroupId = currentState^.editorGroups.activeId;
-
-  let editor = Model.WindowTree.createSplit(~editorGroupId, ());
-  dispatch(AddSplit(Vertical, editor));
+  )
 
   let wrappedDispatch = action => {
     dispatch(action);

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -73,7 +73,7 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
 
   let (lifecycleUpdater, lifecycleStream) = LifecycleStoreConnector.start();
   let indentationUpdater = IndentationStoreConnector.start();
-  let (windowUpdater, windowStream) = WindowsStoreConnector.start();
+  let (windowUpdater, windowStream) = WindowsStoreConnector.start(getState);
 
   let (storeDispatch, storeStream) =
     Isolinear.Store.create(

--- a/src/editor/Store/WindowsStoreConnector.re
+++ b/src/editor/Store/WindowsStoreConnector.re
@@ -9,13 +9,62 @@ module Model = Oni_Model;
 
 open Model;
 
-let start = () => {
+let start = (getState) => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
   let quitEffect =
     Isolinear.Effect.create(~name="windows.quitEffect", () =>
       dispatch(Model.Actions.Quit(false))
     );
+
+  /**
+     We wrap each split component as we have to have a type signature
+     that matches unit => React.syntheticElement this is because
+     in the WindowManager module we cannot pass a reference of state
+     in the type signature e.g. State.t => React.syntheticElement because
+     this would cause a circular reference.
+
+     Alternatives are type parameters but this invloves a lot of unrelated
+     type params being added everywhere. ?Functors is another route
+   */
+  let splitFactory = (fn, ()) => {
+    let state = getState();
+    fn(state);
+  };
+
+  let initializeDefaultViewEffect = (state: State.t) =>
+    Isolinear.Effect.create(~name="windows.init", () => {
+          open WindowManager;
+          open WindowTree;
+          open Oni_UI;
+
+          let dock =
+            registerDock(
+              ~order=1,
+              ~width=50,
+              ~id=MainDock,
+              ~component=splitFactory(state => <Dock state />),
+              (),
+            );
+
+          let editorGroupId = state.editorGroups.activeId;
+
+          let editor = createSplit(~editorGroupId, ());
+
+          let explorer =
+            registerDock(
+              ~order=2,
+              ~width=225,
+              ~id=ExplorerDock,
+              ~component=splitFactory(state => <FileExplorerView state />),
+              (),
+            );
+
+          dispatch(RegisterDockItem(dock));
+          dispatch(RegisterDockItem(explorer));
+          Core.Log.info("!!! Adding split!");
+          dispatch(AddSplit(Vertical, editor));
+    });
 
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
@@ -65,7 +114,8 @@ let start = () => {
         windowManager:
           WindowManager.setTreeSize(width, height, s.windowManager),
       }
-    | AddSplit(direction, split) => {
+    | AddSplit(direction, split) => 
+    {
         ...s,
         windowManager: {
           ...s.windowManager,
@@ -117,6 +167,7 @@ let start = () => {
 
       let effect =
         switch (action) {
+        | Init => initializeDefaultViewEffect(state)
         | ViewCloseEditor(_) =>
           if (List.length(
                 WindowTree.getSplits(state.windowManager.windowTree),

--- a/src/editor/Store/WindowsStoreConnector.re
+++ b/src/editor/Store/WindowsStoreConnector.re
@@ -9,7 +9,7 @@ module Model = Oni_Model;
 
 open Model;
 
-let start = (getState) => {
+let start = getState => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
   let quitEffect =
@@ -34,36 +34,35 @@ let start = (getState) => {
 
   let initializeDefaultViewEffect = (state: State.t) =>
     Isolinear.Effect.create(~name="windows.init", () => {
-          open WindowManager;
-          open WindowTree;
-          open Oni_UI;
+      open WindowManager;
+      open WindowTree;
+      open Oni_UI;
 
-          let dock =
-            registerDock(
-              ~order=1,
-              ~width=50,
-              ~id=MainDock,
-              ~component=splitFactory(state => <Dock state />),
-              (),
-            );
+      let dock =
+        registerDock(
+          ~order=1,
+          ~width=50,
+          ~id=MainDock,
+          ~component=splitFactory(state => <Dock state />),
+          (),
+        );
 
-          let editorGroupId = state.editorGroups.activeId;
+      let editorGroupId = state.editorGroups.activeId;
 
-          let editor = createSplit(~editorGroupId, ());
+      let editor = createSplit(~editorGroupId, ());
 
-          let explorer =
-            registerDock(
-              ~order=2,
-              ~width=225,
-              ~id=ExplorerDock,
-              ~component=splitFactory(state => <FileExplorerView state />),
-              (),
-            );
+      let explorer =
+        registerDock(
+          ~order=2,
+          ~width=225,
+          ~id=ExplorerDock,
+          ~component=splitFactory(state => <FileExplorerView state />),
+          (),
+        );
 
-          dispatch(RegisterDockItem(dock));
-          dispatch(RegisterDockItem(explorer));
-          Core.Log.info("!!! Adding split!");
-          dispatch(AddSplit(Vertical, editor));
+      dispatch(RegisterDockItem(dock));
+      dispatch(RegisterDockItem(explorer));
+      dispatch(AddSplit(Vertical, editor));
     });
 
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
@@ -114,8 +113,7 @@ let start = (getState) => {
         windowManager:
           WindowManager.setTreeSize(width, height, s.windowManager),
       }
-    | AddSplit(direction, split) => 
-    {
+    | AddSplit(direction, split) => {
         ...s,
         windowManager: {
           ...s.windowManager,

--- a/src/editor/Store/dune
+++ b/src/editor/Store/dune
@@ -10,6 +10,7 @@
         Oni2.core
         Oni2.model
         Oni2.extensions
+        Oni2.ui
         isolinear
         libvim
     )

--- a/src/editor/UI/EditorView.re
+++ b/src/editor/UI/EditorView.re
@@ -24,62 +24,9 @@ let editorViewStyle = (background, foreground) =>
     flexDirection(`Column),
   ];
 
-/**
-   We wrap each split component as we have to have a type signature
-   that matches unit => React.syntheticElement this is because
-   in the WindowManager module we cannot pass a reference of state
-   in the type signature e.g. State.t => React.syntheticElement because
-   this would cause a circular reference.
-
-   Alternatives are type parameters but this invloves a lot of unrelated
-   type params being added everywhere. ?Functors is another route
- */
-let splitFactory = (fn, ()) => {
-  let state = GlobalContext.current().getState();
-  fn(state);
-};
-
 let createElement = (~state: State.t, ~children as _, ()) =>
   component(hooks => {
     let theme = state.theme;
-    let hooks =
-      React.Hooks.effect(
-        OnMount,
-        () => {
-          open WindowManager;
-          open WindowTree;
-
-          let dispatch = GlobalContext.current().dispatch;
-          let dock =
-            registerDock(
-              ~order=1,
-              ~width=50,
-              ~id=MainDock,
-              ~component=splitFactory(state => <Dock state />),
-              (),
-            );
-
-          let editorGroupId = state.editorGroups.activeId;
-
-          let editor = createSplit(~editorGroupId, ());
-
-          let explorer =
-            registerDock(
-              ~order=2,
-              ~width=225,
-              ~id=ExplorerDock,
-              ~component=splitFactory(state => <FileExplorerView state />),
-              (),
-            );
-
-          dispatch(RegisterDockItem(dock));
-          dispatch(RegisterDockItem(explorer));
-          dispatch(AddSplit(Vertical, editor));
-          None;
-        },
-        hooks,
-      );
-
     let style =
       editorViewStyle(theme.colors.background, theme.colors.foreground);
 

--- a/src/editor/UI/Oni_UI.re
+++ b/src/editor/UI/Oni_UI.re
@@ -4,6 +4,8 @@
  * Top-level module for Oni_UI. This determines the public-facing API for this module.
  */
 
+module Dock = Dock;
 module GlobalContext = GlobalContext;
 module EditorSurface = EditorSurface;
+module FileExplorerView = FileExplorerView;
 module Root = Root;


### PR DESCRIPTION
The current design of window management relies on the UI to be instantiated to set up the initial splits - this hurts testability and means duplicated logic in our integration tests to simulate the 'real' environment.

(This was hit while setting up the `workbench.activityBar.visible` and `workbench.sideBar.visible`, it's a prepatory refactoring to enable those configuration options).