### PR TITLE
Configuration: Additional settings for minimal UI

### DIFF
--- a/assets/configuration/configuration.json
+++ b/assets/configuration/configuration.json
@@ -1,8 +1,6 @@
 {
   "editor.minimap.enabled": true,
-  "editor.minimap.showSlider": true,
   "editor.insertSpaces": false,
   "editor.indentSize": 4,
   "editor.tabSize": 4,
-  "files.exclude": ["node_modules", "_esy"]
 }

--- a/assets/configuration/configuration.json
+++ b/assets/configuration/configuration.json
@@ -1,8 +1,6 @@
 {
-  "editor.lineNumbers": "relative",
   "editor.minimap.enabled": true,
   "editor.minimap.showSlider": true,
-  "workbench.iconTheme": "vs-seti",
   "editor.insertSpaces": false,
   "editor.indentSize": 4,
   "editor.tabSize": 4,

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -118,12 +118,24 @@ let configurationParsers: list(configurationTuple) = [
   ),
   ("files.exclude", (s, v) => {...s, filesExclude: parseStringList(v)}),
   (
+    "workbench.activityBar.visible",
+    (s, v) => {...s, workbenchActivityBarVisible: parseBool(v)},
+  ),
+  (
     "workbench.iconTheme",
     (s, v) => {...s, workbenchIconTheme: parseString(v)},
   ),
   (
     "workbench.editor.showTabs",
     (s, v) => {...s, workbenchEditorShowTabs: parseBool(v)},
+  ),
+  (
+    "workbench.sideBar.visible",
+    (s, v) => {...s, workbenchActivityBarVisible: parseBool(v)},
+  ),
+  (
+    "workbench.statusBar.visible",
+    (s, v) => {...s, workbenchStatusBarVisible: parseBool(v)},
   ),
 ];
 

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -131,7 +131,7 @@ let configurationParsers: list(configurationTuple) = [
   ),
   (
     "workbench.sideBar.visible",
-    (s, v) => {...s, workbenchActivityBarVisible: parseBool(v)},
+    (s, v) => {...s, workbenchSideBarVisible: parseBool(v)},
   ),
   (
     "workbench.statusBar.visible",

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -24,7 +24,10 @@ type t = {
   editorHighlightActiveIndentGuide: bool,
   editorRenderIndentGuides: bool,
   editorRenderWhitespace,
+  workbenchActivityBarVisible: bool,
+  workbenchSideBarVisible: bool,
   workbenchEditorShowTabs: bool,
+  workbenchStatusBarVisible: bool,
   workbenchIconTheme: string,
   filesExclude: list(string),
 };
@@ -42,7 +45,10 @@ let default = {
   editorRenderIndentGuides: true,
   editorHighlightActiveIndentGuide: true,
   editorRenderWhitespace: All,
+  workbenchActivityBarVisible: true,
   workbenchEditorShowTabs: true,
+  workbenchSideBarVisible: true,
+  workbenchStatusBarVisible: true,
   workbenchIconTheme: "vs-seti",
   filesExclude: ["node_modules", "_esy"],
 };

--- a/src/editor/Model/Selectors.re
+++ b/src/editor/Model/Selectors.re
@@ -60,10 +60,10 @@ let getActiveBuffer = (state: State.t) => {
 
 let getActiveConfigurationValue = (state: State.t, f) => {
   switch (getActiveBuffer(state)) {
-  | None => Configuration.getValue(f, state.configuration);
-  | Some(buffer) => 
+  | None => Configuration.getValue(f, state.configuration)
+  | Some(buffer) =>
     let fileType =
       LanguageInfo.getLanguageFromBuffer(state.languageInfo, buffer);
-      Configuration.getValue(~fileType, f, state.configuration);
-  }
+    Configuration.getValue(~fileType, f, state.configuration);
+  };
 };

--- a/src/editor/Model/Selectors.re
+++ b/src/editor/Model/Selectors.re
@@ -57,3 +57,13 @@ let getActiveBuffer = (state: State.t) => {
   | None => None
   };
 };
+
+let getActiveConfigurationValue = (state: State.t, f) => {
+  switch (getActiveBuffer(state)) {
+  | None => Configuration.getValue(f, state.configuration);
+  | Some(buffer) => 
+    let fileType =
+      LanguageInfo.getLanguageFromBuffer(state.languageInfo, buffer);
+      Configuration.getValue(~fileType, f, state.configuration);
+  }
+};

--- a/src/editor/Model/WindowManager.re
+++ b/src/editor/Model/WindowManager.re
@@ -139,12 +139,12 @@ let findDockItem = (id, layout: t) =>
   };
 
 let addDockItem = (~id, layout: t) => {
-  switch (List.exists(item => item.id == id, layout.leftDock)) {
-  | true => layout
-  | false =>  switch(findDockItem(id, layout)) {
-    | None => layout
-    | Some(dock) =>
-    { ...layout, leftDock: layout.leftDock @ [dock]}
-  }
-  }
+  List.exists(item => item.id == id, layout.leftDock)
+    ? layout
+    : (
+      switch (findDockItem(id, layout)) {
+      | None => layout
+      | Some(dock) => {...layout, leftDock: layout.leftDock @ [dock]}
+      }
+    );
 };

--- a/src/editor/Model/WindowManager.re
+++ b/src/editor/Model/WindowManager.re
@@ -137,3 +137,14 @@ let findDockItem = (id, layout: t) =>
   | Some(_) as item => item
   | None => None
   };
+
+let addDockItem = (~id, layout: t) => {
+  switch (List.exists(item => item.id == id, layout.leftDock)) {
+  | true => layout
+  | false =>  switch(findDockItem(id, layout)) {
+    | None => layout
+    | Some(dock) =>
+    { ...layout, leftDock: layout.leftDock @ [dock]}
+  }
+  }
+};

--- a/src/editor/Store/WindowsStoreConnector.re
+++ b/src/editor/Store/WindowsStoreConnector.re
@@ -67,20 +67,28 @@ let start = getState => {
 
   let synchronizeConfiguration = (configuration: Core.Configuration.t) =>
     Isolinear.Effect.create(~name="windows.syncConfig", () => {
-      let activityBarVisible = Core.Configuration.getValue((c) => c.workbenchActivityBarVisible, configuration); 
-      let sideBarVisible = Core.Configuration.getValue((c) => c.workbenchSideBarVisible, configuration);
+      let activityBarVisible =
+        Core.Configuration.getValue(
+          c => c.workbenchActivityBarVisible,
+          configuration,
+        );
+      let sideBarVisible =
+        Core.Configuration.getValue(
+          c => c.workbenchSideBarVisible,
+          configuration,
+        );
 
       if (activityBarVisible) {
         dispatch(AddDockItem(MainDock));
       } else {
         dispatch(RemoveDockItem(MainDock));
-      }
-      
+      };
+
       if (sideBarVisible) {
         dispatch(AddDockItem(ExplorerDock));
       } else {
         dispatch(RemoveDockItem(ExplorerDock));
-      }
+      };
     });
 
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
@@ -109,9 +117,9 @@ let start = getState => {
         windowManager: WindowManager.removeDockItem(~id, s.windowManager),
       }
     | AddDockItem(id) => {
-      ...s,
-      windowManager: WindowManager.addDockItem(~id, s.windowManager),
-    }
+        ...s,
+        windowManager: WindowManager.addDockItem(~id, s.windowManager),
+      }
     | WindowSetActive(splitId, _) => {
         ...s,
         windowManager: {

--- a/src/editor/Store/WindowsStoreConnector.re
+++ b/src/editor/Store/WindowsStoreConnector.re
@@ -65,6 +65,24 @@ let start = getState => {
       dispatch(AddSplit(Vertical, editor));
     });
 
+  let synchronizeConfiguration = (configuration: Core.Configuration.t) =>
+    Isolinear.Effect.create(~name="windows.syncConfig", () => {
+      let activityBarVisible = Core.Configuration.getValue((c) => c.workbenchActivityBarVisible, configuration); 
+      let sideBarVisible = Core.Configuration.getValue((c) => c.workbenchSideBarVisible, configuration);
+
+      if (activityBarVisible) {
+        dispatch(AddDockItem(MainDock));
+      } else {
+        dispatch(RemoveDockItem(MainDock));
+      }
+      
+      if (sideBarVisible) {
+        dispatch(AddDockItem(ExplorerDock));
+      } else {
+        dispatch(RemoveDockItem(ExplorerDock));
+      }
+    });
+
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
     | RegisterDockItem(dock) =>
@@ -90,17 +108,10 @@ let start = getState => {
         ...s,
         windowManager: WindowManager.removeDockItem(~id, s.windowManager),
       }
-    | AddDockItem(id) =>
-      switch (WindowManager.findDockItem(id, s.windowManager)) {
-      | Some(dock) => {
-          ...s,
-          windowManager: {
-            ...s.windowManager,
-            leftDock: s.windowManager.leftDock @ [dock],
-          },
-        }
-      | None => s
-      }
+    | AddDockItem(id) => {
+      ...s,
+      windowManager: WindowManager.addDockItem(~id, s.windowManager),
+    }
     | WindowSetActive(splitId, _) => {
         ...s,
         windowManager: {
@@ -166,6 +177,7 @@ let start = getState => {
       let effect =
         switch (action) {
         | Init => initializeDefaultViewEffect(state)
+        | ConfigurationSet(c) => synchronizeConfiguration(c)
         | ViewCloseEditor(_) =>
           if (List.length(
                 WindowTree.getSplits(state.windowManager.windowTree),

--- a/src/editor/UI/EditorView.re
+++ b/src/editor/UI/EditorView.re
@@ -55,7 +55,10 @@ let createElement = (~state: State.t, ~children as _, ()) =>
               ~order=1,
               ~width=50,
               ~id=MainDock,
-              ~component=splitFactory(state => <Dock state />),
+              ~component=splitFactory(state => {
+                    let activityBarVisible = Selectors.getActiveConfigurationValue(state, (c) => c.workbenchActivityBarVisible);
+                    activityBarVisible ? <Dock state /> : React.empty;
+                    }),
               (),
             );
 
@@ -68,7 +71,10 @@ let createElement = (~state: State.t, ~children as _, ()) =>
               ~order=2,
               ~width=225,
               ~id=ExplorerDock,
-              ~component=splitFactory(state => <FileExplorerView state />),
+              ~component=splitFactory(state => {
+                  let sideBarVisible = Selectors.getActiveConfigurationValue(state, (c) => c.workbenchSideBarVisible);
+                  sideBarVisible ? <FileExplorerView state /> : React.empty;
+              }),
               (),
             );
 

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -24,7 +24,7 @@ let rootStyle = (background, foreground) =>
     alignItems(`Center),
   ];
 
-let surfaceStyle = (statusBarHeight) =>
+let surfaceStyle = statusBarHeight =>
   Style.[
     position(`Absolute),
     top(0),
@@ -33,7 +33,7 @@ let surfaceStyle = (statusBarHeight) =>
     bottom(statusBarHeight),
   ];
 
-let statusBarStyle = (statusBarHeight) =>
+let statusBarStyle = statusBarHeight =>
   Style.[
     backgroundColor(Color.hex("#21252b")),
     position(`Absolute),
@@ -50,24 +50,30 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let theme = state.theme;
     let style = rootStyle(theme.colors.background, theme.colors.foreground);
 
-
-    let statusBarVisible = Selectors.getActiveConfigurationValue(state, (c) => c.workbenchStatusBarVisible);
+    let statusBarVisible =
+      Selectors.getActiveConfigurationValue(state, c =>
+        c.workbenchStatusBarVisible
+      );
     let statusBarHeight = statusBarVisible ? 25 : 0;
-    let statusBar = statusBarVisible ? 
-        <View style=statusBarStyle(statusBarHeight)>
-          <StatusBar height=statusBarHeight state />
-        </View> : React.empty;
+    let statusBar =
+      statusBarVisible
+        ? <View style={statusBarStyle(statusBarHeight)}>
+            <StatusBar height=statusBarHeight state />
+          </View>
+        : React.empty;
 
     (
       hooks,
       <View style>
-        <View style=surfaceStyle(statusBarHeight)> <EditorView state /> </View>
+        <View style={surfaceStyle(statusBarHeight)}>
+          <EditorView state />
+        </View>
         <Overlay>
           <CommandlineView theme command={state.commandline} />
           <WildmenuView theme wildmenu={state.wildmenu} />
           <MenuView theme menu={state.menu} font={state.uiFont} />
         </Overlay>
-        {statusBar}
+        statusBar
       </View>,
     );
   });

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -11,8 +11,6 @@ open Oni_Model;
 
 let component = React.component("Root");
 
-let statusBarHeight = 25;
-
 let rootStyle = (background, foreground) =>
   Style.[
     backgroundColor(background),
@@ -26,7 +24,7 @@ let rootStyle = (background, foreground) =>
     alignItems(`Center),
   ];
 
-let surfaceStyle =
+let surfaceStyle = (statusBarHeight) =>
   Style.[
     position(`Absolute),
     top(0),
@@ -35,7 +33,7 @@ let surfaceStyle =
     bottom(statusBarHeight),
   ];
 
-let statusBarStyle =
+let statusBarStyle = (statusBarHeight) =>
   Style.[
     backgroundColor(Color.hex("#21252b")),
     position(`Absolute),
@@ -52,18 +50,24 @@ let createElement = (~state: State.t, ~children as _, ()) =>
     let theme = state.theme;
     let style = rootStyle(theme.colors.background, theme.colors.foreground);
 
+
+    let statusBarVisible = Selectors.getActiveConfigurationValue(state, (c) => c.workbenchStatusBarVisible);
+    let statusBarHeight = statusBarVisible ? 25 : 0;
+    let statusBar = statusBarVisible ? 
+        <View style=statusBarStyle(statusBarHeight)>
+          <StatusBar height=statusBarHeight state />
+        </View> : React.empty;
+
     (
       hooks,
       <View style>
-        <View style=surfaceStyle> <EditorView state /> </View>
+        <View style=surfaceStyle(statusBarHeight)> <EditorView state /> </View>
         <Overlay>
           <CommandlineView theme command={state.commandline} />
           <WildmenuView theme wildmenu={state.wildmenu} />
           <MenuView theme menu={state.menu} font={state.uiFont} />
         </Overlay>
-        <View style=statusBarStyle>
-          <StatusBar height=statusBarHeight state />
-        </View>
+        {statusBar}
       </View>,
     );
   });


### PR DESCRIPTION
This change adds the following configuration settings:

- `workbench.statusBar.visible` (bool)
- `workbench.activityBar.visible` (bool)
- `workbench.sideBar.visible` (bool)

Together with the existing `workbench.editor.showTabs` and `editor.minimap.enabled` setting, it can provide a more minimal UI experience:
![settings](https://user-images.githubusercontent.com/13532591/61314185-e3d54b80-a7b0-11e9-9619-f476926f9026.gif)
