### PR TITLE
Performance: Throttle syntax highlighting

### DIFF
--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -103,7 +103,10 @@ let configurationParsers: list(configurationTuple) = [
     (s, v) => {...s, editorInsertSpaces: parseBool(v)},
   ),
   ("editor.indentSize", (s, v) => {...s, editorIndentSize: parseInt(v)}),
-  ("editor.largeFileOptimizations", (s, v) => {...s, editorLargeFileOptimizations: parseBool(v)}),
+  (
+    "editor.largeFileOptimizations",
+    (s, v) => {...s, editorLargeFileOptimizations: parseBool(v)},
+  ),
   ("editor.tabSize", (s, v) => {...s, editorTabSize: parseInt(v)}),
   (
     "editor.highlightActiveIndentGuide",

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -103,6 +103,7 @@ let configurationParsers: list(configurationTuple) = [
     (s, v) => {...s, editorInsertSpaces: parseBool(v)},
   ),
   ("editor.indentSize", (s, v) => {...s, editorIndentSize: parseInt(v)}),
+  ("editor.largeFileOptimizations", (s, v) => {...s, editorLargeFileOptimizations: parseBool(v)}),
   ("editor.tabSize", (s, v) => {...s, editorTabSize: parseInt(v)}),
   (
     "editor.highlightActiveIndentGuide",

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -26,10 +26,8 @@ type t = {
   editorRenderIndentGuides: bool,
   editorRenderWhitespace,
   workbenchActivityBarVisible: bool,
-
   /* Onivim2 specific setting */
   workbenchSideBarVisible: bool,
-
   workbenchEditorShowTabs: bool,
   workbenchStatusBarVisible: bool,
   workbenchIconTheme: string,

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -26,7 +26,10 @@ type t = {
   editorRenderIndentGuides: bool,
   editorRenderWhitespace,
   workbenchActivityBarVisible: bool,
+
+  /* Onivim2 specific setting */
   workbenchSideBarVisible: bool,
+
   workbenchEditorShowTabs: bool,
   workbenchStatusBarVisible: bool,
   workbenchIconTheme: string,

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -13,6 +13,7 @@ type editorRenderWhitespace =
 [@deriving show({with_path: false})]
 type t = {
   editorDetectIndentation: bool,
+  editorLargeFileOptimizations: bool,
   editorLineNumbers: LineNumber.setting,
   editorMatchBrackets: bool,
   editorMinimapEnabled: bool,
@@ -34,6 +35,7 @@ type t = {
 
 let default = {
   editorDetectIndentation: true,
+  editorLargeFileOptimizations: true,
   editorMatchBrackets: true,
   editorMinimapEnabled: true,
   editorMinimapShowSlider: true,

--- a/src/editor/Core/Constants.re
+++ b/src/editor/Core/Constants.re
@@ -28,7 +28,6 @@ type t = {
    */
   maximumExplorerDepth: int,
   tabHeight: int,
-
   /*
    * The line count considered a 'large file' - if a file exceeds this limit,
    * some features like syntax highlighting will be disabled.

--- a/src/editor/Core/Constants.re
+++ b/src/editor/Core/Constants.re
@@ -28,6 +28,12 @@ type t = {
    */
   maximumExplorerDepth: int,
   tabHeight: int,
+
+  /*
+   * The line count considered a 'large file' - if a file exceeds this limit,
+   * some features like syntax highlighting will be disabled.
+   */
+  largeFileLineCountThreshold: int,
 };
 
 let default: t = {
@@ -39,4 +45,11 @@ let default: t = {
   minimapMaxColumn: 120,
   maximumExplorerDepth: 1,
   tabHeight: 35,
+
+  /*
+   * The threshold we set right now is artificially low,
+   * because our current textmate highlighting strategy is very slow.
+   * We'll switch to a native strategy, and bump this up.
+   */
+  largeFileLineCountThreshold: 1000,
 };

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -40,6 +40,7 @@ type t =
   | EditorScroll(float)
   | EditorScrollToLine(int)
   | EditorScrollToColumn(int)
+  | SyntaxHighlightClear(int)
   | SyntaxHighlightColorMap(ColorMap.t)
   | SyntaxHighlightTokens(TextmateClient.TokenizationResult.t)
   | OpenExplorer(string)

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -11,6 +11,7 @@ open Oni_Extensions;
 type t =
   | Init
   | Tick
+  | BufferDisableSyntaxHighlighting(int)
   | BufferEnter(Vim.BufferMetadata.t)
   | BufferUpdate(BufferUpdate.t)
   | BufferSaved(Vim.BufferMetadata.t)

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -11,6 +11,7 @@ type t = {
   metadata: Vim.BufferMetadata.t,
   lines: array(string),
   indentation: option(IndentationSettings.t),
+  syntaxHighlightingEnabled: bool,
 };
 
 let show = _ => "TODO";
@@ -19,6 +20,7 @@ let ofLines = (lines: array(string)) => {
   metadata: Vim.BufferMetadata.create(),
   lines,
   indentation: None,
+  syntaxHighlightingEnabled: true,
 };
 
 let empty = ofLines([||]);
@@ -27,6 +29,7 @@ let ofMetadata = (metadata: Vim.BufferMetadata.t) => {
   metadata,
   lines: [||],
   indentation: None,
+  syntaxHighlightingEnabled: true,
 };
 
 let getFilePath = (buffer: t) => buffer.metadata.filePath;
@@ -38,6 +41,12 @@ let getId = (buffer: t) => buffer.metadata.id;
 let getLine = (buffer: t, line: int) => buffer.lines[line];
 
 let isModified = (buffer: t) => buffer.metadata.modified;
+
+let isSyntaxHighlightingEnabled = (buffer: t) => buffer.syntaxHighlightingEnabled;
+let disableSyntaxHighlighting = (buffer: t) => {
+...buffer,
+syntaxHighlightingEnabled: false,
+};
 
 let getUri = (buffer: t) => {
   let getUriFromMetadata = (metadata: Vim.BufferMetadata.t) => {

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -42,10 +42,11 @@ let getLine = (buffer: t, line: int) => buffer.lines[line];
 
 let isModified = (buffer: t) => buffer.metadata.modified;
 
-let isSyntaxHighlightingEnabled = (buffer: t) => buffer.syntaxHighlightingEnabled;
+let isSyntaxHighlightingEnabled = (buffer: t) =>
+  buffer.syntaxHighlightingEnabled;
 let disableSyntaxHighlighting = (buffer: t) => {
-...buffer,
-syntaxHighlightingEnabled: false,
+  ...buffer,
+  syntaxHighlightingEnabled: false,
 };
 
 let getUri = (buffer: t) => {

--- a/src/editor/Model/Buffer.rei
+++ b/src/editor/Model/Buffer.rei
@@ -23,10 +23,12 @@ let getUri: t => Uri.t;
 let getId: t => int;
 let getNumberOfLines: t => int;
 let isModified: t => bool;
+let isSyntaxHighlightingEnabled: t => bool;
 
 let isIndentationSet: t => bool;
 let setIndentation: (IndentationSettings.t, t) => t;
 let getIndentation: t => option(IndentationSettings.t);
+let disableSyntaxHighlighting: t => t;
 
 let update: (t, BufferUpdate.t) => t;
 let updateMetadata: (Vim.BufferMetadata.t, t) => t;

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -33,34 +33,38 @@ let anyModified = (buffers: t) => {
   );
 };
 
+let ofBufferOpt = (f, buffer) => {
+  switch(buffer) {
+  | None => None
+  | Some(b) => Some(f(b));
+  }
+};
+
 let getBufferMetadata = (id, map) =>
   switch (getBuffer(id, map)) {
+  | None => None
   | Some(v) => Some(Buffer.getMetadata(v))
-  | None => None
   };
 
-let applyBufferUpdate = (bufferUpdate, buffer) =>
-  switch (buffer) {
-  | None => None
-  | Some(b) => Some(Buffer.update(b, bufferUpdate))
-  };
+let applyBufferUpdate = (bufferUpdate) => ofBufferOpt((buffer) => {
+    Buffer.update(buffer, bufferUpdate);
+});
 
-let updateMetadata = (metadata, buffer) => {
-  switch (buffer) {
-  | None => None
-  | Some(b) => Some(b |> Buffer.updateMetadata(metadata))
-  };
-};
+let updateMetadata = (metadata) => ofBufferOpt((buffer) => {
+  Buffer.updateMetadata(metadata, buffer);
+});
 
-let setIndentation = (indent, buffer) => {
-  switch (buffer) {
-  | None => None
-  | Some(b) => Some(Buffer.setIndentation(indent, b))
-  };
-};
+let setIndentation = (indent) => ofBufferOpt((buffer) => {
+  Buffer.setIndentation(indent, buffer);
+});
+
+let disableSyntaxHighlighting = ofBufferOpt((buffer) => {
+  Buffer.disableSyntaxHighlighting(buffer);
+});
 
 let reduce = (state: t, action: Actions.t) => {
   switch (action) {
+  | BufferDisableSyntaxHighlighting(id) => IntMap.update(id, disableSyntaxHighlighting, state);
   | BufferEnter(metadata) =>
     let f = buffer =>
       switch (buffer) {

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -34,10 +34,10 @@ let anyModified = (buffers: t) => {
 };
 
 let ofBufferOpt = (f, buffer) => {
-  switch(buffer) {
+  switch (buffer) {
   | None => None
-  | Some(b) => Some(f(b));
-  }
+  | Some(b) => Some(f(b))
+  };
 };
 
 let getBufferMetadata = (id, map) =>
@@ -46,25 +46,22 @@ let getBufferMetadata = (id, map) =>
   | Some(v) => Some(Buffer.getMetadata(v))
   };
 
-let applyBufferUpdate = (bufferUpdate) => ofBufferOpt((buffer) => {
-    Buffer.update(buffer, bufferUpdate);
-});
+let applyBufferUpdate = bufferUpdate =>
+  ofBufferOpt(buffer => Buffer.update(buffer, bufferUpdate));
 
-let updateMetadata = (metadata) => ofBufferOpt((buffer) => {
-  Buffer.updateMetadata(metadata, buffer);
-});
+let updateMetadata = metadata =>
+  ofBufferOpt(buffer => Buffer.updateMetadata(metadata, buffer));
 
-let setIndentation = (indent) => ofBufferOpt((buffer) => {
-  Buffer.setIndentation(indent, buffer);
-});
+let setIndentation = indent =>
+  ofBufferOpt(buffer => Buffer.setIndentation(indent, buffer));
 
-let disableSyntaxHighlighting = ofBufferOpt((buffer) => {
-  Buffer.disableSyntaxHighlighting(buffer);
-});
+let disableSyntaxHighlighting =
+  ofBufferOpt(buffer => Buffer.disableSyntaxHighlighting(buffer));
 
 let reduce = (state: t, action: Actions.t) => {
   switch (action) {
-  | BufferDisableSyntaxHighlighting(id) => IntMap.update(id, disableSyntaxHighlighting, state);
+  | BufferDisableSyntaxHighlighting(id) =>
+    IntMap.update(id, disableSyntaxHighlighting, state)
   | BufferEnter(metadata) =>
     let f = buffer =>
       switch (buffer) {

--- a/src/editor/Model/SyntaxHighlighting.re
+++ b/src/editor/Model/SyntaxHighlighting.re
@@ -130,7 +130,7 @@ let reduce: (t, Actions.t) => t =
     | SyntaxHighlightClear(bufferId) => {
       ...state,
       idToBufferSyntaxHighlights: IntMap.update(
-        tokens.bufferId,
+        bufferId,
         buffer => switch(buffer) {
         | None => None
         | Some(_) => None

--- a/src/editor/Model/SyntaxHighlighting.re
+++ b/src/editor/Model/SyntaxHighlighting.re
@@ -127,6 +127,17 @@ let reduce: (t, Actions.t) => t =
   (state, action) =>
     switch (action) {
     | SyntaxHighlightColorMap(colorMap) => {...state, colorMap}
+    | SyntaxHighlightClear(bufferId) => {
+      ...state,
+      idToBufferSyntaxHighlights: IntMap.update(
+        tokens.bufferId,
+        buffer => switch(buffer) {
+        | None => None
+        | Some(_) => None
+        },
+        state.idToBufferSyntaxHighlights,
+        ),
+      }
     | SyntaxHighlightTokens(tokens) => {
         ...state,
         idToBufferSyntaxHighlights:

--- a/src/editor/Model/SyntaxHighlighting.re
+++ b/src/editor/Model/SyntaxHighlighting.re
@@ -128,15 +128,17 @@ let reduce: (t, Actions.t) => t =
     switch (action) {
     | SyntaxHighlightColorMap(colorMap) => {...state, colorMap}
     | SyntaxHighlightClear(bufferId) => {
-      ...state,
-      idToBufferSyntaxHighlights: IntMap.update(
-        bufferId,
-        buffer => switch(buffer) {
-        | None => None
-        | Some(_) => None
-        },
-        state.idToBufferSyntaxHighlights,
-        ),
+        ...state,
+        idToBufferSyntaxHighlights:
+          IntMap.update(
+            bufferId,
+            buffer =>
+              switch (buffer) {
+              | None => None
+              | Some(_) => None
+              },
+            state.idToBufferSyntaxHighlights,
+          ),
       }
     | SyntaxHighlightTokens(tokens) => {
         ...state,

--- a/src/editor/Store/TextmateClientStoreConnector.re
+++ b/src/editor/Store/TextmateClientStoreConnector.re
@@ -48,16 +48,18 @@ let start = (languageInfo: Model.LanguageInfo.t, setup: Core.Setup.t) => {
       Extensions.TextmateClient.notifyBufferUpdate(tmClient, scope, bc)
     );
 
-  let clearHighlightsEffect = (buffer) => 
+  let clearHighlightsEffect = buffer =>
     Isolinear.Effect.create(~name="textmate.clearHighlights", () => {
       let bufferId = Model.Buffer.getId(buffer);
       if (Model.Buffer.isSyntaxHighlightingEnabled(buffer)) {
-        Log.debug("Disabling syntax highlighting for buffer: " ++ string_of_int(bufferId));
+        Log.debug(
+          "Disabling syntax highlighting for buffer: "
+          ++ string_of_int(bufferId),
+        );
         dispatch(BufferDisableSyntaxHighlighting(bufferId));
         dispatch(SyntaxHighlightClear(bufferId));
-      }
+      };
     });
-    
 
   let updater = (state: Model.State.t, action) => {
     let default = (state, Isolinear.Effect.none);
@@ -70,23 +72,34 @@ let start = (languageInfo: Model.LanguageInfo.t, setup: Core.Setup.t) => {
       switch (buffer) {
       | None => default
       | Some(buffer) =>
-        let largeFileOptimizations = Model.Selectors.getConfigurationValue(state, buffer, (c) => c.editorLargeFileOptimizations);
+        let largeFileOptimizations =
+          Model.Selectors.getConfigurationValue(state, buffer, c =>
+            c.editorLargeFileOptimizations
+          );
 
-        if ((!largeFileOptimizations || Model.Buffer.getNumberOfLines(buffer) < Core.Constants.default.largeFileLineCountThreshold) && Model.Buffer.isSyntaxHighlightingEnabled(buffer)) {
+        if ((
+              !largeFileOptimizations
+              || Model.Buffer.getNumberOfLines(buffer)
+              < Core.Constants.default.largeFileLineCountThreshold
+            )
+            && Model.Buffer.isSyntaxHighlightingEnabled(buffer)) {
           switch (Model.Buffer.getMetadata(buffer).filePath) {
           | None => default
           | Some(v) =>
             let extension = Path.extname(v);
             switch (
-              Model.LanguageInfo.getScopeFromExtension(languageInfo, extension)
+              Model.LanguageInfo.getScopeFromExtension(
+                languageInfo,
+                extension,
+              )
             ) {
             | None => default
             | Some(scope) => (state, notifyBufferUpdateEffect(scope, bc))
             };
-          }
+          };
         } else {
-          (state, clearHighlightsEffect(buffer))
-        }
+          (state, clearHighlightsEffect(buffer));
+        };
       };
 
     | _ => default

--- a/src/editor/Store/TextmateClientStoreConnector.re
+++ b/src/editor/Store/TextmateClientStoreConnector.re
@@ -62,13 +62,12 @@ let start = (languageInfo: Model.LanguageInfo.t, setup: Core.Setup.t) => {
       let bufferId = bc.id;
       let buffer = Model.Buffers.getBuffer(bufferId, state.buffers);
 
-
       switch (buffer) {
       | None => default
       | Some(buffer) =>
-        let largeFileOptimizations = Selectors.getConfigurationValue(state, buffer, (c) => c.editorLargeFileOptimizations);
+        let largeFileOptimizations = Model.Selectors.getConfigurationValue(state, buffer, (c) => c.editorLargeFileOptimizations);
 
-        if (!largeFileOptimizations || Buffer.getNumberOfLines(buffer) < Constants.default.largeFileLineCountThreshold) {
+        if (!largeFileOptimizations || Model.Buffer.getNumberOfLines(buffer) < Core.Constants.default.largeFileLineCountThreshold) {
           switch (Model.Buffer.getMetadata(buffer).filePath) {
           | None => default
           | Some(v) =>
@@ -81,7 +80,7 @@ let start = (languageInfo: Model.LanguageInfo.t, setup: Core.Setup.t) => {
             };
           }
         } else {
-          (state, clearHighlightsEffect(Buffer.getId(buffer)))
+          (state, clearHighlightsEffect(Model.Buffer.getId(buffer)))
         }
       };
 


### PR DESCRIPTION
Our current textmate syntax highlighting strategy, found [here]( https://github.com/onivim/oni2/tree/master/src/textmate_service/src) leaves a lot to be desired in terms of performance. It's not incremental, and is slow (doesn't use results of previous optimizations).

Rather than invest further in it, for now, I'm disabling it for 'large' files (which is a relatively small limit - 1000 lines or so). This is to ensure a fast and performant user experience - I don't want this work-in-progress feature to detract from user experience. 

Once we implement #161 - a native textmate highlight implementation - we'll bump that limit back up!

