### PR TITLE
Bugfix: Fast typing while searching can give out-of-order characters

### DIFF
--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="AddRemoveSplitTest", (dispatch, wait) => {
+runTest(~name="AddRemoveSplitTest", (dispatch, wait, _) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.windowManager.windowTree |> WindowTree.getSplits |> List.length;

--- a/integration_test/InsertModeTest.re
+++ b/integration_test/InsertModeTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="InsertMode test", (dispatch, wait) => {
+runTest(~name="InsertMode test", (dispatch, wait, _) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     state.mode == Vim.Types.Normal
   );

--- a/integration_test/RegressionCommandLineNoCompletionTest.re
+++ b/integration_test/RegressionCommandLineNoCompletionTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="Regression: Command line no completions", (dispatch, wait) => {
+runTest(~name="Regression: Command line no completions", (dispatch, wait, _) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     state.mode == Vim.Types.Normal
   );

--- a/integration_test/TypingBatchedTest.re
+++ b/integration_test/TypingBatchedTest.re
@@ -1,0 +1,34 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(
+  ~name="InsertMode test - effects batched to runEffects",
+  (dispatch, wait, runEffects) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  dispatch(KeyboardInput("i"));
+
+  wait(~name="Mode switches to insert", (state: State.t) =>
+    state.mode == Vim.Types.Insert
+  );
+
+  /* Simulate multiple events getting dispatched before running effects */
+
+  dispatch(KeyboardInput("A"));
+  dispatch(KeyboardInput("B"));
+  dispatch(KeyboardInput("C"));
+
+  runEffects();
+
+  wait(~name="Buffer shows ABC", (state: State.t) =>
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => false
+    | Some(buf) =>
+      let line = Buffer.getLine(buf, 0);
+      Log.info("Current line is: |" ++ line ++ "|");
+      String.equal(line, "ABC");
+    }
+  );
+});

--- a/integration_test/TypingUnbatchedTest.re
+++ b/integration_test/TypingUnbatchedTest.re
@@ -1,0 +1,37 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(
+  ~name="InsertMode test - effects batched to runEffects",
+  (dispatch, wait, runEffects) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  dispatch(KeyboardInput("i"));
+
+  wait(~name="Mode switches to insert", (state: State.t) =>
+    state.mode == Vim.Types.Insert
+  );
+
+  /* Simulate multiple events getting dispatched before running effects */
+
+  dispatch(KeyboardInput("A"));
+  runEffects();
+
+  dispatch(KeyboardInput("B"));
+  runEffects();
+
+  dispatch(KeyboardInput("C"));
+  runEffects();
+
+  wait(~name="Buffer shows ABC", (state: State.t) =>
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => false
+    | Some(buf) =>
+      let line = Buffer.getLine(buf, 0);
+      Log.info("Current line is: |" ++ line ++ "|");
+      String.equal(line, "ABC");
+    }
+  );
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -2,6 +2,8 @@
     (names InsertModeTest
            RegressionCommandLineNoCompletionTest
            AddRemoveSplitTest
+           TypingBatchedTest
+           TypingUnbatchedTest
     )
     (libraries
         libvim
@@ -16,4 +18,6 @@
         InsertModeTest.exe
         RegressionCommandLineNoCompletionTest.exe
         AddRemoveSplitTest.exe
+        TypingBatchedTest.exe
+        TypingUnbatchedTest.exe
         ))

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -4,10 +4,12 @@ module Store = Oni_Store;
 module Log = Core.Log;
 
 type dispatchFunction = Model.Actions.t => unit;
+type runEffectsFunction = unit => unit;
 type waiter = Model.State.t => bool;
 type waitForState = (~name: string, waiter) => unit;
 
-type testCallback = (dispatchFunction, waitForState) => unit;
+type testCallback =
+  (dispatchFunction, waitForState, runEffectsFunction) => unit;
 
 let runTest = (~name="AnonymousTest", test: testCallback) => {
   Printexc.record_backtrace(true);
@@ -62,7 +64,6 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
 
   let wrappedDispatch = action => {
     dispatch(action);
-    runEffects();
   };
 
   let waitForState = (~name, waiter) => {
@@ -92,7 +93,7 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
   };
 
   Log.info("--- Starting test: " ++ name);
-  test(wrappedDispatch, waitForState);
+  test(wrappedDispatch, waitForState, wrappedRunEffects);
   Log.info("--- TEST COMPLETE: " ++ name);
 
   dispatch(Model.Actions.Quit(true));

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -165,7 +165,7 @@ let start = (~setup: Core.Setup.t, ~executingDirectory, ~onStateChanged, ()) => 
     let effects = accumulatedEffects^;
     accumulatedEffects := [];
 
-    List.iter(e => Isolinear.Effect.run(e, dispatch), effects);
+    List.iter(e => Isolinear.Effect.run(e, dispatch), List.rev(effects));
   };
 
   let _ =


### PR DESCRIPTION
__Issue:__ When typing very quickly during an operation that takes more than a frame, the typing events can get out of order. This is visible when opening a very large file and searching for something like `/abc`.

__Defect:__ Ideally, we wouldn't have any slow operations that take time in this way - but this exposed a defect in the way we handle input events. When multiple input events come in, and we haven't flushed them via 'runEffects', they'll get executed in _reverse order_ - this is a very frustrating experience!

__Fix:__ As we append the list items in the events linked list in reverse, we need to reverse again when we flush events to get the correct order.