### PR TITLE
Fix #375 - Cursor should be pointer in treeview

### DIFF
--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -92,7 +92,7 @@ let itemRenderer =
     | FileSystemNode({displayName, _}) => displayName
     };
 
-  <Clickable onClick={() => onClick(id)}>
+  <Clickable onClick={() => onClick(id)} style=Style.[cursor(Revery.MouseCursors.pointer)]>
     <View style=itemStyles>
       <Text text=indentStr style=textStyles />
       <FontIcon

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -92,7 +92,9 @@ let itemRenderer =
     | FileSystemNode({displayName, _}) => displayName
     };
 
-  <Clickable onClick={() => onClick(id)} style=Style.[cursor(Revery.MouseCursors.pointer)]>
+  <Clickable
+    onClick={() => onClick(id)}
+    style=Style.[cursor(Revery.MouseCursors.pointer)]>
     <View style=itemStyles>
       <Text text=indentStr style=textStyles />
       <FontIcon


### PR DESCRIPTION
__Issue:__  Mouse doesn't switch to a pointer over explorer, so it doesn't feel like the items are clickable.

__Defect:__ There seems to be a bug with `Clickable` where the `cursor(MouseCursors.pointer)` style isn't being set correctly when merging. We should revisit the `Style.merge` concept as part of https://github.com/revery-ui/revery/issues/489

__Fix:__ Set the `cursor(MouseCursors.pointer)` explicitly on the ItemRenderer, in lieu of the longer term fixes in https://github.com/revery-ui/revery/issues/489

Fixes #375 