### PR TITLE
Packaging - Windows Codesigning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,9 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - powershell: ls /
-    displayName: 'Which program files?'
-  - powershell: ls 'C:/Program Files (x86)'
+  - powershell: ls 'C:/Program Files (x86)/Windows Kits'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: 'dir C:/Program Files (x86)'
+  - script: dir 'C:/Program Files (x86)'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - powershell: ls 'C:/Program Files (x86)/Windows Kits'
+  - powershell: ls 'C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,8 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
+  - script: signtool.exe /help
+    displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: 'C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe' /help
+  - powershell: ./scripts/windows/verify-signtool.ps1
     displayName: 'Validate signtool path'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe /help
+  - script: "C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" /help
     displayName: 'Validate signtool path'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - powershell: &'C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe' /help
+  - script: C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe /help
     displayName: 'Validate signtool path'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - powershell: ls 'C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe'
+  - powershell: ls 'C:/Program Files (x86)/Windows Kits/8.1/bin'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: "C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" /help
+  - script: 'C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe' /help
     displayName: 'Validate signtool path'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,8 +91,8 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - powershell: ls 'C:/Program Files (x86)/Windows Kits/8.1/bin'
-    displayName: 'Is signtool in path?'
+  - powershell: &'C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe' /help
+    displayName: 'Validate signtool path'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: C:/cert/signtool.exe /help
+  - script: 'dir C:/Program Files (x86)'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,9 +91,9 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: dir 'C:/'
+  - powershell: ls /
     displayName: 'Which program files?'
-  - script: dir 'C:/Program Files (x86)'
+  - powershell: ls 'C:/Program Files (x86)'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,8 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
+  - script: dir 'C:/'
+    displayName: 'Which program files?'
   - script: dir 'C:/Program Files (x86)'
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - script: signtool.exe /help
+  - script: C:/cert/signtool.exe /help
     displayName: 'Is signtool in path?'
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml

--- a/scripts/windows/publish.ps1
+++ b/scripts/windows/publish.ps1
@@ -1,6 +1,23 @@
 $SHORT_COMMIT_ID_UNTRIMMED = (git rev-parse --short HEAD) | Out-String
 $SHORT_COMMIT_ID = $SHORT_COMMIT_ID_UNTRIMMED.Trim()
 
+function CodeSign {
+    Param ([string]$path)
+
+    Write-Host "Signing $path with certificate $env:CODESIGN_CERTIFICATE"
+
+    &"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" sign /tr http://timestamp.digicert.com /fd sha256 /td sha256 /f $env:CODESIGN_CERTIFICATE /p $env:CODESIGN_PASSWORD $path
+}
+
+if (Test-Path env:CODESIGN_CERTIFICATE) {
+    Write-Host "Code signing enabled."
+
+    CodeSign("_release/win32/Oni2.exe")
+    CodeSign("_release/win32/Oni2_editor.exe")
+    CodeSign("_release/win32/rg.exe")
+    CodeSign("_release/win32/node.exe")
+}
+
 mkdir -p _publish
 
 Compress-Archive -Path _release/win32 -DestinationPath _publish/Onivim2-$SHORT_COMMIT_ID.zip
@@ -9,4 +26,9 @@ esy create-win-setup
 
 npm install -g innosetup-compiler
 innosetup-compiler _release/setup.iss --O=_publish
+
+if (Test-Path env:CODESIGN_CERTIFICATE) {
+    CodeSign("_publish/Onivim2-0.2.0-win.exe");
+}
+
 mv _publish/Onivim2-0.2.0-win.exe _publish/Onivim2-$SHORT_COMMIT_ID-x64.exe

--- a/scripts/windows/verify-signtool.ps1
+++ b/scripts/windows/verify-signtool.ps1
@@ -1,0 +1,1 @@
+&"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" /help

--- a/scripts/windows/verify-signtool.ps1
+++ b/scripts/windows/verify-signtool.ps1
@@ -1,1 +1,1 @@
-&"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" /help
+&"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" sign /?


### PR DESCRIPTION
This change sets up infra for codesigning using `signtool.exe` - just needs `CODESIGN_CERTIFICATE` and `CODESIGN_PASSWORD` specified via the environment.