### PR TITLE
MIT Commit Helper Tool / Time-delay license clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ __Anyone who has contributed financially to the project__ - via BountySource, Pa
 
 Alternatively, you can contribute to the project through [Patreon](https://www.patreon.com/onivim), which helps us with ongoing costs.
 
-#### 'Time-Bomb' Dual License
+#### 'Time-Delay' Dual License
 
 Because of the support we've received from open source communities, we've decided to __dual-license the code after 18 months__ - every commit, starting with [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), as it was committed to `master` on __4/18/2019__ that means it would be dual-licensed with __MIT License__ on __10/18/2020__. 
 
-Any external contributions to the project from outside Outrun Labs, LLC will not be subject to this 'time-bomb' delay - they'll be dual-licensed immediately under the MIT License.
+For convenience, we will maintain an [oni2-mit](https://github.com/onivim/oni2-mit) repo containing the MIT-licensed code. The first commit to that repo will be on __July 2, 2020__.
+
+Any external contributions to the project from outside Outrun Labs, LLC will not be subject to this 'time-delay' - they'll be dual-licensed immediately under the MIT License.
 
 We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities by having our work eventually end up in the open, and ensuring that external contributions are always open source.
 

--- a/scripts/get-mit-commit.js
+++ b/scripts/get-mit-commit.js
@@ -9,6 +9,8 @@ const cp = require("child_process");
 const date = new Date();
 const eighteenMonthsAgo = new Date(date.setMonth(date.getMonth() - 18));
 
+console.log(eighteenMonthsAgo.toString());
+
 const month = eighteenMonthsAgo.toLocaleString('en-us', { month: 'short' });
 const day = eighteenMonthsAgo.getDate();
 const year = eighteenMonthsAgo.getFullYear();

--- a/scripts/get-mit-commit.js
+++ b/scripts/get-mit-commit.js
@@ -1,19 +1,57 @@
-/* get-mit-commit.js
- *
- * We are dual-licensing MIT commits 18 months after they hit master
- * This script gets the commit ID for the latest MIT commit
- */
-
-const cp = require("child_process");
-
-const date = new Date();
-const eighteenMonthsAgo = new Date(date.setMonth(date.getMonth() - 18));
-
-console.log(eighteenMonthsAgo.toString());
-
-const month = eighteenMonthsAgo.toLocaleString('en-us', { month: 'short' });
-const day = eighteenMonthsAgo.getDate();
-const year = eighteenMonthsAgo.getFullYear();
-
-const ret = cp.execSync(`git rev-list -1 --before="${month} ${day} ${year}" master`).toString("utf-8");
-console.log(ret.trim());
+/* get-mit-commit.js
+
+
+ *
+
+
+ * We are dual-licensing MIT commits 18 months after they hit master
+
+
+ * This script gets the commit ID for the latest MIT commit
+
+
+ */
+
+
+
+
+
+const cp = require("child_process");
+
+
+
+
+
+const date = new Date();
+
+
+const eighteenMonthsAgo = new Date(date.setMonth(date.getMonth() - 18));
+
+
+
+
+
+console.log(eighteenMonthsAgo.toString());
+
+
+
+
+
+const month = eighteenMonthsAgo.toLocaleString('en-us', { month: 'short' });
+
+
+const day = eighteenMonthsAgo.getDate();
+
+
+const year = eighteenMonthsAgo.getFullYear();
+
+
+
+
+
+const ret = cp.execSync(`git rev-list -1 --before="${month} ${day} ${year}" master`).toString("utf-8");
+
+
+console.log(ret.trim());
+
+

--- a/scripts/get-mit-commit.js
+++ b/scripts/get-mit-commit.js
@@ -1,0 +1,17 @@
+/* get-mit-commit.js
+ *
+ * We are dual-licensing MIT commits 18 months after they hit master
+ * This script gets the commit ID for the latest MIT commit
+ */
+
+const cp = require("child_process");
+
+const date = new Date();
+const eighteenMonthsAgo = new Date(date.setMonth(date.getMonth() - 18));
+
+const month = eighteenMonthsAgo.toLocaleString('en-us', { month: 'short' });
+const day = eighteenMonthsAgo.getDate();
+const year = eighteenMonthsAgo.getFullYear();
+
+const ret = cp.execSync(`git rev-list -1 --before="${month} ${day} ${year}" master`).toString("utf-8");
+console.log(ret.trim());


### PR DESCRIPTION
Even though it is early, I thought that adding a placeholder repo [`oni2-mit`](https://github.com/onivim/oni2-mit) which contains our MIT licensed code would help clarify how the dual-licensing will work.

I also added a script that gets the current MIT licensed commit (18 months back). We'll hook up an Azure Pipeline job to sync the MIT repo daily.