### PR TITLE
Packaging - OSX: Fix hang on OSX when codesigning

### DIFF
--- a/scripts/osx/publish.sh
+++ b/scripts/osx/publish.sh
@@ -14,7 +14,9 @@ else
 	security default-keychain -s build.keychain
 	security unlock-keychain -p p@ssword1 build.keychain
 
-	security import certificate.p12 -k build.keychain -P $CODESIGN_PASSWORD
+	security import certificate.p12 -k build.keychain -P $CODESIGN_PASSWORD -T /usr/bin/codesign
+	
+	security set-key-partition-list -S apple-tool:,apple: -s -k p@ssword1 build.keychain
 
 	echo "Checking identities..."
 


### PR DESCRIPTION
__Issue:__ CI machines would hang when getting to the `codesign` step of the build process.

__Defect:__ It seems calling `codesign` was triggering the UI to prompt for a password.

__Fix:__ Researching a few places... I found we needed a couple additions:
- Using the `-A` or `-T` parameter for importing the certificate
- Using `set-key-partition-list`

Found a reference here: https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p and in the TravisCI docs: https://docs.travis-ci.com/user/common-build-problems/#mac-macos-sierra-1012-code-signing-errors