### PR TITLE
Windows: Use x64 install mode

### DIFF
--- a/scripts/windows/setup.template.iss
+++ b/scripts/windows/setup.template.iss
@@ -20,6 +20,8 @@ WizardImageFile={{WizardImageFilePath}}
 WizardImageStretch=no
 WizardSmallImageFile={{WizardSmallImageFilePath}}
 ChangesAssociations=yes
+ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64
 
 [Files]
 Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs


### PR DESCRIPTION
__Issue:__ Our setup / install program for Windows installs Onivim 2 by default in `\Program Files (x86)`, which isn't correct - our windows builds are all x64 today.

__Fix:__ Run InnoSetup in x64 install mode, documented here http://www.jrsoftware.org/ishelp/index.php?topic=32vs64bitinstalls
