### PR TITLE
[Windows] File Associations

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "468fdcaeef1b198b1ba9a046d0f837ca",
+  "checksum": "930a8caf6f38937994a8f59c59b2344c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -445,14 +445,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.14@d41d8cd9": {
-      "id": "lodash@4.17.14@d41d8cd9",
+    "lodash@4.17.15@d41d8cd9": {
+      "id": "lodash@4.17.15@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.14",
+      "version": "4.17.15",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#sha1:b447f6670a0455bbfeedd11392eff330ea097548"
         ]
       },
       "overrides": [],
@@ -800,7 +800,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.15@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@e3edecdd"
       ]
     },
@@ -956,7 +956,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cmdliner@opam:1.0.2@8ab0598a",
@@ -1017,32 +1017,30 @@
         "@opam/dune@opam:1.7.3@72aad784"
       ]
     },
-    "@opam/topkg@opam:1.0.0@61f4ccf9": {
-      "id": "@opam/topkg@opam:1.0.0@61f4ccf9",
+    "@opam/topkg@opam:1.0.1@a42c631e": {
+      "id": "@opam/topkg@opam:1.0.1@a42c631e",
       "name": "@opam/topkg",
-      "version": "opam:1.0.0",
+      "version": "opam:1.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/e3/e3d76bda06bf68cb5853caf6627da603#md5:e3d76bda06bf68cb5853caf6627da603",
-          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz#md5:e3d76bda06bf68cb5853caf6627da603"
+          "archive:https://opam.ocaml.org/cache/md5/16/16b90e066d8972a5ef59655e7c28b3e9#md5:16b90e066d8972a5ef59655e7c28b3e9",
+          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz#md5:16b90e066d8972a5ef59655e7c28b3e9"
         ],
         "opam": {
           "name": "topkg",
-          "version": "1.0.0",
-          "path": "bench.esy.lock/opam/topkg.1.0.0"
+          "version": "1.0.1",
+          "path": "bench.esy.lock/opam/topkg.1.0.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
       ]
     },
     "@opam/stdio@opam:v0.11.0@3b11cb88": {
@@ -1156,7 +1154,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1207,7 +1205,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -1246,20 +1244,20 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.8.0@189fc0d4": {
-      "id": "@opam/ppxlib@opam:0.8.0@189fc0d4",
+    "@opam/ppxlib@opam:0.8.1@67aec471": {
+      "id": "@opam/ppxlib@opam:0.8.1@67aec471",
       "name": "@opam/ppxlib",
-      "version": "opam:0.8.0",
+      "version": "opam:0.8.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/9b/9b1cfe1ae58d7ad851ed5618c1bf64a0#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0",
-          "archive:https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0"
+          "archive:https://opam.ocaml.org/cache/sha256/a5/a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.8.0",
-          "path": "bench.esy.lock/opam/ppxlib.0.8.0"
+          "version": "0.8.1",
+          "path": "bench.esy.lock/opam/ppxlib.0.8.1"
         }
       },
       "overrides": [],
@@ -1378,14 +1376,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -2021,7 +2019,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bigarray@opam:base@b03491b0",
@@ -2049,7 +2047,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2221,7 +2219,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2543,7 +2541,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",

--- a/bench.esy.lock/opam/ppxlib.0.8.1/opam
+++ b/bench.esy.lock/opam/ppxlib.0.8.1/opam
@@ -11,16 +11,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
   "ocaml"                   {>= "4.04.1"}
-  "base"                    {>= "v0.11.0" & < "v0.13"}
+  "base"                    {>= "v0.11.0"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.3.1"}
   "ppx_derivers"            {>= "1.0"}
-  "stdio"                   {>= "v0.11.0" & < "v0.13"}
+  "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}
 ]
 synopsis: "Base library and tools for ppx rewriters"
@@ -37,6 +37,9 @@ A comprehensive toolbox for ppx development. It features:
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz"
-  checksum: "md5=9b1cfe1ae58d7ad851ed5618c1bf64a0"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz"
+  checksum: [
+    "sha256=a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
+    "sha512=74bf4a0811f4fa73969149efc7f98620bf1c1ef7322edb8de82e02e25b61e005945887ea865b462bfb638d7d0e574706da190ca9416643f4464a89262ae7ae12"
+  ]
 }

--- a/bench.esy.lock/opam/topkg.1.0.1/opam
+++ b/bench.esy.lock/opam/topkg.1.0.1/opam
@@ -8,10 +8,9 @@ dev-repo: "git+http://erratique.ch/repos/topkg.git"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 tags: ["packaging" "ocamlbuild" "org:erratique"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.6.1"}
-  "ocamlbuild"
-  "result" ]
+  "ocamlbuild" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name
@@ -44,6 +43,6 @@ Topkg-care is distributed under the ISC license it depends on
 [webbrowser]: http://erratique.ch/software/webbrowser
 """
 url {
-src: "http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz"
-checksum: "md5=e3d76bda06bf68cb5853caf6627da603"
+archive: "http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz"
+checksum: "16b90e066d8972a5ef59655e7c28b3e9"
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "468fdcaeef1b198b1ba9a046d0f837ca",
+  "checksum": "930a8caf6f38937994a8f59c59b2344c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -445,14 +445,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.14@d41d8cd9": {
-      "id": "lodash@4.17.14@d41d8cd9",
+    "lodash@4.17.15@d41d8cd9": {
+      "id": "lodash@4.17.15@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.14",
+      "version": "4.17.15",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#sha1:b447f6670a0455bbfeedd11392eff330ea097548"
         ]
       },
       "overrides": [],
@@ -800,7 +800,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.15@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@e3edecdd"
       ]
     },
@@ -956,7 +956,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cmdliner@opam:1.0.2@8ab0598a",
@@ -1017,32 +1017,30 @@
         "@opam/dune@opam:1.7.3@72aad784"
       ]
     },
-    "@opam/topkg@opam:1.0.0@61f4ccf9": {
-      "id": "@opam/topkg@opam:1.0.0@61f4ccf9",
+    "@opam/topkg@opam:1.0.1@a42c631e": {
+      "id": "@opam/topkg@opam:1.0.1@a42c631e",
       "name": "@opam/topkg",
-      "version": "opam:1.0.0",
+      "version": "opam:1.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/e3/e3d76bda06bf68cb5853caf6627da603#md5:e3d76bda06bf68cb5853caf6627da603",
-          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz#md5:e3d76bda06bf68cb5853caf6627da603"
+          "archive:https://opam.ocaml.org/cache/md5/16/16b90e066d8972a5ef59655e7c28b3e9#md5:16b90e066d8972a5ef59655e7c28b3e9",
+          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz#md5:16b90e066d8972a5ef59655e7c28b3e9"
         ],
         "opam": {
           "name": "topkg",
-          "version": "1.0.0",
-          "path": "esy.lock/opam/topkg.1.0.0"
+          "version": "1.0.1",
+          "path": "esy.lock/opam/topkg.1.0.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
       ]
     },
     "@opam/stdio@opam:v0.11.0@3b11cb88": {
@@ -1156,7 +1154,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1207,7 +1205,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -1246,20 +1244,20 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.8.0@189fc0d4": {
-      "id": "@opam/ppxlib@opam:0.8.0@189fc0d4",
+    "@opam/ppxlib@opam:0.8.1@67aec471": {
+      "id": "@opam/ppxlib@opam:0.8.1@67aec471",
       "name": "@opam/ppxlib",
-      "version": "opam:0.8.0",
+      "version": "opam:0.8.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/9b/9b1cfe1ae58d7ad851ed5618c1bf64a0#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0",
-          "archive:https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0"
+          "archive:https://opam.ocaml.org/cache/sha256/a5/a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.8.0",
-          "path": "esy.lock/opam/ppxlib.0.8.0"
+          "version": "0.8.1",
+          "path": "esy.lock/opam/ppxlib.0.8.1"
         }
       },
       "overrides": [],
@@ -1378,14 +1376,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -2021,7 +2019,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bigarray@opam:base@b03491b0",
@@ -2049,7 +2047,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2221,7 +2219,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2543,7 +2541,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",

--- a/esy.lock/opam/ppxlib.0.8.1/opam
+++ b/esy.lock/opam/ppxlib.0.8.1/opam
@@ -11,16 +11,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
   "ocaml"                   {>= "4.04.1"}
-  "base"                    {>= "v0.11.0" & < "v0.13"}
+  "base"                    {>= "v0.11.0"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.3.1"}
   "ppx_derivers"            {>= "1.0"}
-  "stdio"                   {>= "v0.11.0" & < "v0.13"}
+  "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}
 ]
 synopsis: "Base library and tools for ppx rewriters"
@@ -37,6 +37,9 @@ A comprehensive toolbox for ppx development. It features:
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz"
-  checksum: "md5=9b1cfe1ae58d7ad851ed5618c1bf64a0"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz"
+  checksum: [
+    "sha256=a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
+    "sha512=74bf4a0811f4fa73969149efc7f98620bf1c1ef7322edb8de82e02e25b61e005945887ea865b462bfb638d7d0e574706da190ca9416643f4464a89262ae7ae12"
+  ]
 }

--- a/esy.lock/opam/topkg.1.0.1/opam
+++ b/esy.lock/opam/topkg.1.0.1/opam
@@ -8,10 +8,9 @@ dev-repo: "git+http://erratique.ch/repos/topkg.git"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 tags: ["packaging" "ocamlbuild" "org:erratique"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.6.1"}
-  "ocamlbuild"
-  "result" ]
+  "ocamlbuild" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name
@@ -44,6 +43,6 @@ Topkg-care is distributed under the ISC license it depends on
 [webbrowser]: http://erratique.ch/software/webbrowser
 """
 url {
-src: "http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz"
-checksum: "md5=e3d76bda06bf68cb5853caf6627da603"
+archive: "http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz"
+checksum: "16b90e066d8972a5ef59655e7c28b3e9"
 }

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "468fdcaeef1b198b1ba9a046d0f837ca",
+  "checksum": "930a8caf6f38937994a8f59c59b2344c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -445,14 +445,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.14@d41d8cd9": {
-      "id": "lodash@4.17.14@d41d8cd9",
+    "lodash@4.17.15@d41d8cd9": {
+      "id": "lodash@4.17.15@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.14",
+      "version": "4.17.15",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#sha1:b447f6670a0455bbfeedd11392eff330ea097548"
         ]
       },
       "overrides": [],
@@ -800,7 +800,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.15@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@e3edecdd"
       ]
     },
@@ -956,7 +956,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cmdliner@opam:1.0.2@8ab0598a",
@@ -1017,32 +1017,30 @@
         "@opam/dune@opam:1.7.3@72aad784"
       ]
     },
-    "@opam/topkg@opam:1.0.0@61f4ccf9": {
-      "id": "@opam/topkg@opam:1.0.0@61f4ccf9",
+    "@opam/topkg@opam:1.0.1@a42c631e": {
+      "id": "@opam/topkg@opam:1.0.1@a42c631e",
       "name": "@opam/topkg",
-      "version": "opam:1.0.0",
+      "version": "opam:1.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/e3/e3d76bda06bf68cb5853caf6627da603#md5:e3d76bda06bf68cb5853caf6627da603",
-          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz#md5:e3d76bda06bf68cb5853caf6627da603"
+          "archive:https://opam.ocaml.org/cache/md5/16/16b90e066d8972a5ef59655e7c28b3e9#md5:16b90e066d8972a5ef59655e7c28b3e9",
+          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz#md5:16b90e066d8972a5ef59655e7c28b3e9"
         ],
         "opam": {
           "name": "topkg",
-          "version": "1.0.0",
-          "path": "integrationtest.esy.lock/opam/topkg.1.0.0"
+          "version": "1.0.1",
+          "path": "integrationtest.esy.lock/opam/topkg.1.0.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
       ]
     },
     "@opam/stdio@opam:v0.11.0@3b11cb88": {
@@ -1156,7 +1154,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1207,7 +1205,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -1246,20 +1244,20 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.8.0@189fc0d4": {
-      "id": "@opam/ppxlib@opam:0.8.0@189fc0d4",
+    "@opam/ppxlib@opam:0.8.1@67aec471": {
+      "id": "@opam/ppxlib@opam:0.8.1@67aec471",
       "name": "@opam/ppxlib",
-      "version": "opam:0.8.0",
+      "version": "opam:0.8.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/9b/9b1cfe1ae58d7ad851ed5618c1bf64a0#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0",
-          "archive:https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0"
+          "archive:https://opam.ocaml.org/cache/sha256/a5/a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.8.0",
-          "path": "integrationtest.esy.lock/opam/ppxlib.0.8.0"
+          "version": "0.8.1",
+          "path": "integrationtest.esy.lock/opam/ppxlib.0.8.1"
         }
       },
       "overrides": [],
@@ -1378,14 +1376,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -2022,7 +2020,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bigarray@opam:base@b03491b0",
@@ -2050,7 +2048,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2222,7 +2220,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2544,7 +2542,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",

--- a/integrationtest.esy.lock/opam/ppxlib.0.8.1/opam
+++ b/integrationtest.esy.lock/opam/ppxlib.0.8.1/opam
@@ -11,16 +11,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
   "ocaml"                   {>= "4.04.1"}
-  "base"                    {>= "v0.11.0" & < "v0.13"}
+  "base"                    {>= "v0.11.0"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.3.1"}
   "ppx_derivers"            {>= "1.0"}
-  "stdio"                   {>= "v0.11.0" & < "v0.13"}
+  "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}
 ]
 synopsis: "Base library and tools for ppx rewriters"
@@ -37,6 +37,9 @@ A comprehensive toolbox for ppx development. It features:
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz"
-  checksum: "md5=9b1cfe1ae58d7ad851ed5618c1bf64a0"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz"
+  checksum: [
+    "sha256=a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
+    "sha512=74bf4a0811f4fa73969149efc7f98620bf1c1ef7322edb8de82e02e25b61e005945887ea865b462bfb638d7d0e574706da190ca9416643f4464a89262ae7ae12"
+  ]
 }

--- a/integrationtest.esy.lock/opam/topkg.1.0.1/opam
+++ b/integrationtest.esy.lock/opam/topkg.1.0.1/opam
@@ -8,10 +8,9 @@ dev-repo: "git+http://erratique.ch/repos/topkg.git"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 tags: ["packaging" "ocamlbuild" "org:erratique"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.6.1"}
-  "ocamlbuild"
-  "result" ]
+  "ocamlbuild" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name
@@ -44,6 +43,6 @@ Topkg-care is distributed under the ISC license it depends on
 [webbrowser]: http://erratique.ch/software/webbrowser
 """
 url {
-src: "http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz"
-checksum: "md5=e3d76bda06bf68cb5853caf6627da603"
+archive: "http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz"
+checksum: "16b90e066d8972a5ef59655e7c28b3e9"
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
         ]
       },
       {
+        "name": "Javascript source",
+        "role": "Editor",
+        "ext": [
+          ".js",
+          ".es6",
+          ".mjs",
+          ".pac"
+        ]
+      },
+      {
         "name": "JSON",
         "role": "Editor",
         "ext": [

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
         "name": "C++ source",
         "role": "Editor",
         "ext": [
-          ".cpp",
-          ".cc",
-          ".cxx",
-          ".hpp",
-          ".hh",
-          ".hxx",
-          ".h",
-          ".ino",
-          ".inl",
-          ".ipp"
+          "cpp",
+          "cc",
+          "cxx",
+          "hpp",
+          "hh",
+          "hxx",
+          "h",
+          "ino",
+          "inl",
+          "ipp"
         ]
       },
       {
@@ -42,126 +42,126 @@
         "name": "HTML document",
         "role": "Editor",
         "ext": [
-          ".html",
-          ".htm",
-          ".shtml",
-          ".xhtml",
-          ".mdoc",
-          ".jsp",
-          ".asp",
-          ".aspx",
-          ".jshtm",
-          ".volt",
-          ".ejs",
-          ".rhtml"
+          "html",
+          "htm",
+          "shtml",
+          "xhtml",
+          "mdoc",
+          "jsp",
+          "asp",
+          "aspx",
+          "jshtm",
+          "volt",
+          "ejs",
+          "rhtml"
         ]
       },
       {
         "name": "Java source",
         "role": "Editor",
         "ext": [
-          ".java",
-          ".jav"
+          "java",
+          "jav"
         ]
       },
       {
         "name": "Javascript source",
         "role": "Editor",
         "ext": [
-          ".js",
-          ".es6",
-          ".mjs",
-          ".pac"
+          "js",
+          "es6",
+          "mjs",
+          "pac"
         ]
       },
       {
         "name": "JSON",
         "role": "Editor",
         "ext": [
-          ".json",
-          ".bowerrc",
-          ".jshintrc",
-          ".jscsrc",
-          ".eslintrc",
-          ".swcrc",
-          ".webmanifest",
-          ".js.map",
-          ".css.map"
+          "json",
+          "bowerrc",
+          "jshintrc",
+          "jscsrc",
+          "eslintrc",
+          "swcrc",
+          "webmanifest",
+          "js.map",
+          "css.map"
         ]
       },
       {
         "name": "JSON with Comments",
         "role": "Editor",
         "ext": [
-          ".hintrc",
-          ".babelrc",
-          ".jsonc"
+          "hintrc",
+          "babelrc",
+          "jsonc"
         ]
       },
       {
         "name": "Markdown Source",
         "role": "Editor",
         "ext": [
-          ".md",
-          ".mkd",
-          ".mdwn",
-          ".mdown",
-          ".markdown",
-          ".markdn",
-          ".mdtxt",
-          ".mdtext",
-          ".workbook"
+          "md",
+          "mkd",
+          "mdwn",
+          "mdown",
+          "markdown",
+          "markdn",
+          "mdtxt",
+          "mdtext",
+          "workbook"
         ]
       },
       {
         "name": "Python Source",
         "role": "Editor",
         "ext": [
-          ".py",
-          ".rpy",
-          ".pyw",
-          ".cpy",
-          ".gyp",
-          ".gypi",
-          ".snakefile",
-          ".smk",
-          ".pyi",
-          ".ipy"
+          "py",
+          "rpy",
+          "pyw",
+          "cpy",
+          "gyp",
+          "gypi",
+          "snakefile",
+          "smk",
+          "pyi",
+          "ipy"
         ]
       },
       {
         "name": "Shell source",
         "role": "Editor",
         "ext": [
-          ".sh",
-          ".bash",
-          ".bashrc",
-          ".bash_aliases",
-          ".bash_profile",
-          ".bash_login",
-          ".ebuild",
-          ".install",
-          ".profile",
-          ".bash_logout",
-          ".zsh",
-          ".zshrc",
-          ".zprofile",
-          ".zlogin",
-          ".zlogout",
-          ".zshenv",
-          ".zsh-theme",
-          ".ksh"
+          "sh",
+          "bash",
+          "bashrc",
+          "bash_aliases",
+          "bash_profile",
+          "bash_login",
+          "ebuild",
+          "install",
+          "profile",
+          "bash_logout",
+          "zsh",
+          "zshrc",
+          "zprofile",
+          "zlogin",
+          "zlogout",
+          "zshenv",
+          "zsh-theme",
+          "ksh"
         ]
       },
       {
         "name": "Typescript",
         "role": "Editor",
-        "ext": ".ts"
+        "ext": "ts"
       },
       {
         "name": "Typescript React",
         "role": "Editor",
-        "ext": ".tsx"
+        "ext": "tsx"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,150 @@
     ]
   },
   "build": {
-  "productName": "Onivim2",
-  "fileAssociations": []
+    "productName": "Onivim2",
+    "fileAssociations": [
+      {
+        "name": "C source",
+        "role": "Editor",
+        "ext": "c"
+      },
+      {
+        "name": "C++ source",
+        "role": "Editor",
+        "ext": [
+          ".cpp",
+          ".cc",
+          ".cxx",
+          ".hpp",
+          ".hh",
+          ".hxx",
+          ".h",
+          ".ino",
+          ".inl",
+          ".ipp"
+        ]
+      },
+      {
+        "name": "Cascading style sheet",
+        "role": "Editor",
+        "ext": "css"
+      },
+      {
+        "name": "HTML document",
+        "role": "Editor",
+        "ext": [
+          ".html",
+          ".htm",
+          ".shtml",
+          ".xhtml",
+          ".mdoc",
+          ".jsp",
+          ".asp",
+          ".aspx",
+          ".jshtm",
+          ".volt",
+          ".ejs",
+          ".rhtml"
+        ]
+      },
+      {
+        "name": "Java source",
+        "role": "Editor",
+        "ext": [
+          ".java",
+          ".jav"
+        ]
+      },
+      {
+        "name": "JSON",
+        "role": "Editor",
+        "ext": [
+          ".json",
+          ".bowerrc",
+          ".jshintrc",
+          ".jscsrc",
+          ".eslintrc",
+          ".swcrc",
+          ".webmanifest",
+          ".js.map",
+          ".css.map"
+        ]
+      },
+      {
+        "name": "JSON with Comments",
+        "role": "Editor",
+        "ext": [
+          ".hintrc",
+          ".babelrc",
+          ".jsonc"
+        ]
+      },
+      {
+        "name": "Markdown Source",
+        "role": "Editor",
+        "ext": [
+          ".md",
+          ".mkd",
+          ".mdwn",
+          ".mdown",
+          ".markdown",
+          ".markdn",
+          ".mdtxt",
+          ".mdtext",
+          ".workbook"
+        ]
+      },
+      {
+        "name": "Python Source",
+        "role": "Editor",
+        "ext": [
+          ".py",
+          ".rpy",
+          ".pyw",
+          ".cpy",
+          ".gyp",
+          ".gypi",
+          ".snakefile",
+          ".smk",
+          ".pyi",
+          ".ipy"
+        ]
+      },
+      {
+        "name": "Shell source",
+        "role": "Editor",
+        "ext": [
+          ".sh",
+          ".bash",
+          ".bashrc",
+          ".bash_aliases",
+          ".bash_profile",
+          ".bash_login",
+          ".ebuild",
+          ".install",
+          ".profile",
+          ".bash_logout",
+          ".zsh",
+          ".zshrc",
+          ".zprofile",
+          ".zlogin",
+          ".zlogout",
+          ".zshenv",
+          ".zsh-theme",
+          ".ksh"
+        ]
+      },
+      {
+        "name": "Typescript",
+        "role": "Editor",
+        "ext": ".ts"
+      },
+      {
+        "name": "Typescript React",
+        "role": "Editor",
+        "ext": ".tsx"
+      }
+    ]
   },
   "scripts": {
     "bootstrap": "esy node ./scripts/bootstrap.js #{@opam/camomile.install}",
@@ -24,9 +166,8 @@
   "dependencies": {
     "ocaml": "~4.7.0",
     "@esy-ocaml/reason": "3.4.0",
-    "isolinear": "*",
     "@opam/ocamlbuild": "*",
-    "revery": "*", 
+    "revery": "*",
     "@opam/dune": "*",
     "@opam/lwt": "*",
     "@opam/camomile": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,153 +15,161 @@
       {
         "name": "C source",
         "role": "Editor",
-        "ext": "c"
+        "ext": [
+          ".c"
+        ]
       },
       {
         "name": "C++ source",
         "role": "Editor",
         "ext": [
-          "cpp",
-          "cc",
-          "cxx",
-          "hpp",
-          "hh",
-          "hxx",
-          "h",
-          "ino",
-          "inl",
-          "ipp"
+          ".cpp",
+          ".cc",
+          ".cxx",
+          ".hpp",
+          ".hh",
+          ".hxx",
+          ".h",
+          ".ino",
+          ".inl",
+          ".ipp"
         ]
       },
       {
         "name": "Cascading style sheet",
         "role": "Editor",
-        "ext": "css"
+        "ext": [
+          ".css"
+        ]
       },
       {
         "name": "HTML document",
         "role": "Editor",
         "ext": [
-          "html",
-          "htm",
-          "shtml",
-          "xhtml",
-          "mdoc",
-          "jsp",
-          "asp",
-          "aspx",
-          "jshtm",
-          "volt",
-          "ejs",
-          "rhtml"
+          ".html",
+          ".htm",
+          ".shtml",
+          ".xhtml",
+          ".mdoc",
+          ".jsp",
+          ".asp",
+          ".aspx",
+          ".jshtm",
+          ".volt",
+          ".ejs",
+          ".rhtml"
         ]
       },
       {
         "name": "Java source",
         "role": "Editor",
         "ext": [
-          "java",
-          "jav"
+          ".java",
+          ".jav"
         ]
       },
       {
         "name": "Javascript source",
         "role": "Editor",
         "ext": [
-          "js",
-          "es6",
-          "mjs",
-          "pac"
+          ".js",
+          ".es6",
+          ".mjs",
+          ".pac"
         ]
       },
       {
         "name": "JSON",
         "role": "Editor",
         "ext": [
-          "json",
-          "bowerrc",
-          "jshintrc",
-          "jscsrc",
-          "eslintrc",
-          "swcrc",
-          "webmanifest",
-          "js.map",
-          "css.map"
+          ".json",
+          ".bowerrc",
+          ".jshintrc",
+          ".jscsrc",
+          ".eslintrc",
+          ".swcrc",
+          ".webmanifest",
+          ".js.map",
+          ".css.map"
         ]
       },
       {
         "name": "JSON with Comments",
         "role": "Editor",
         "ext": [
-          "hintrc",
-          "babelrc",
-          "jsonc"
+          ".hintrc",
+          ".babelrc",
+          ".jsonc"
         ]
       },
       {
         "name": "Markdown Source",
         "role": "Editor",
         "ext": [
-          "md",
-          "mkd",
-          "mdwn",
-          "mdown",
-          "markdown",
-          "markdn",
-          "mdtxt",
-          "mdtext",
-          "workbook"
+          ".md",
+          ".mkd",
+          ".mdwn",
+          ".mdown",
+          ".markdown",
+          ".markdn",
+          ".mdtxt",
+          ".mdtext",
+          ".workbook"
         ]
       },
       {
         "name": "Python Source",
         "role": "Editor",
         "ext": [
-          "py",
-          "rpy",
-          "pyw",
-          "cpy",
-          "gyp",
-          "gypi",
-          "snakefile",
-          "smk",
-          "pyi",
-          "ipy"
+          ".py",
+          ".rpy",
+          ".pyw",
+          ".cpy",
+          ".gyp",
+          ".gypi",
+          ".snakefile",
+          ".smk",
+          ".pyi",
+          ".ipy"
         ]
       },
       {
         "name": "Shell source",
         "role": "Editor",
         "ext": [
-          "sh",
-          "bash",
-          "bashrc",
-          "bash_aliases",
-          "bash_profile",
-          "bash_login",
-          "ebuild",
-          "install",
-          "profile",
-          "bash_logout",
-          "zsh",
-          "zshrc",
-          "zprofile",
-          "zlogin",
-          "zlogout",
-          "zshenv",
-          "zsh-theme",
-          "ksh"
+          ".sh",
+          ".bash",
+          ".bashrc",
+          ".bash_aliases",
+          ".bash_profile",
+          ".bash_login",
+          ".ebuild",
+          ".install",
+          ".profile",
+          ".bash_logout",
+          ".zsh",
+          ".zshrc",
+          ".zprofile",
+          ".zlogin",
+          ".zlogout",
+          ".zshenv",
+          ".zsh-theme",
+          ".ksh"
         ]
       },
       {
         "name": "Typescript",
         "role": "Editor",
-        "ext": "ts"
+        "ext": [
+          ".ts"
+        ]
       },
       {
         "name": "Typescript React",
         "role": "Editor",
-        "ext": "tsx"
+        "ext": [
+          ".tsx"
+        ]
       }
     ]
   },

--- a/scripts/windows/BuildSetupTemplate.js
+++ b/scripts/windows/BuildSetupTemplate.js
@@ -51,6 +51,12 @@ Root: HKCU; Subkey: "SOFTWARE\\Classes\\*\\shell\\${prodName}\\command"; ValueTy
 `
 
 function getFileRegKey(ext, desc) {
+
+    // Check that an actual extension was given, make it one if not.
+    if (ext[0] !== '.') {
+        ext = `.${ext}`
+    }
+
     return `
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}${ext}"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
@@ -67,13 +73,9 @@ _.keys(valuesToReplace).forEach(key => {
 let allFilesToAddRegKeysFor = ""
 
 packageMeta.build.fileAssociations.forEach(association => {
-    if (Array.isArray(association.ext)) {
-        association.ext.forEach(extension => {
-            allFilesToAddRegKeysFor += getFileRegKey(`.${extension}`, association.name)
-        })
-    } else {
-        allFilesToAddRegKeysFor += getFileRegKey(`.${association.ext}`, association.name)
-    }
+    association.ext.forEach(extension => {
+        allFilesToAddRegKeysFor += getFileRegKey(extension, association.name)
+    })
 })
 
 allFilesToAddRegKeysFor += addToEnv

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "468fdcaeef1b198b1ba9a046d0f837ca",
+  "checksum": "930a8caf6f38937994a8f59c59b2344c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -445,14 +445,14 @@
       "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
       "devDependencies": []
     },
-    "lodash@4.17.14@d41d8cd9": {
-      "id": "lodash@4.17.14@d41d8cd9",
+    "lodash@4.17.15@d41d8cd9": {
+      "id": "lodash@4.17.15@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.14",
+      "version": "4.17.15",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz#sha1:9ce487ae66c96254fe20b599f21b6816028078ba"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#sha1:b447f6670a0455bbfeedd11392eff330ea097548"
         ]
       },
       "overrides": [],
@@ -800,7 +800,7 @@
       "devDependencies": [
         "shelljs@0.8.3@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "plist@3.0.1@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "lodash@4.17.14@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
+        "lodash@4.17.15@d41d8cd9", "innosetup-compiler@5.5.9@d41d8cd9",
         "fs-extra@7.0.1@d41d8cd9", "@opam/merlin@opam:3.2.2@e3edecdd"
       ]
     },
@@ -956,7 +956,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/cmdliner@opam:1.0.2@8ab0598a",
@@ -1017,32 +1017,30 @@
         "@opam/dune@opam:1.7.3@72aad784"
       ]
     },
-    "@opam/topkg@opam:1.0.0@61f4ccf9": {
-      "id": "@opam/topkg@opam:1.0.0@61f4ccf9",
+    "@opam/topkg@opam:1.0.1@a42c631e": {
+      "id": "@opam/topkg@opam:1.0.1@a42c631e",
       "name": "@opam/topkg",
-      "version": "opam:1.0.0",
+      "version": "opam:1.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/e3/e3d76bda06bf68cb5853caf6627da603#md5:e3d76bda06bf68cb5853caf6627da603",
-          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz#md5:e3d76bda06bf68cb5853caf6627da603"
+          "archive:https://opam.ocaml.org/cache/md5/16/16b90e066d8972a5ef59655e7c28b3e9#md5:16b90e066d8972a5ef59655e7c28b3e9",
+          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz#md5:16b90e066d8972a5ef59655e7c28b3e9"
         ],
         "opam": {
           "name": "topkg",
-          "version": "1.0.0",
-          "path": "test.esy.lock/opam/topkg.1.0.0"
+          "version": "1.0.1",
+          "path": "test.esy.lock/opam/topkg.1.0.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
       ]
     },
     "@opam/stdio@opam:v0.11.0@3b11cb88": {
@@ -1156,7 +1154,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1207,7 +1205,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -1246,20 +1244,20 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.8.0@189fc0d4": {
-      "id": "@opam/ppxlib@opam:0.8.0@189fc0d4",
+    "@opam/ppxlib@opam:0.8.1@67aec471": {
+      "id": "@opam/ppxlib@opam:0.8.1@67aec471",
       "name": "@opam/ppxlib",
-      "version": "opam:0.8.0",
+      "version": "opam:0.8.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/9b/9b1cfe1ae58d7ad851ed5618c1bf64a0#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0",
-          "archive:https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz#md5:9b1cfe1ae58d7ad851ed5618c1bf64a0"
+          "archive:https://opam.ocaml.org/cache/sha256/a5/a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz#sha256:a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.8.0",
-          "path": "test.esy.lock/opam/ppxlib.0.8.0"
+          "version": "0.8.1",
+          "path": "test.esy.lock/opam/ppxlib.0.8.1"
         }
       },
       "overrides": [],
@@ -1378,14 +1376,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.0@189fc0d4",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.8.1@67aec471",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@73570fbd",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -2021,7 +2019,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bigarray@opam:base@b03491b0",
@@ -2049,7 +2047,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2221,7 +2219,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/result@opam:1.4@6fb665c3",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
@@ -2543,7 +2541,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",

--- a/test.esy.lock/opam/ppxlib.0.8.1/opam
+++ b/test.esy.lock/opam/ppxlib.0.8.1/opam
@@ -11,16 +11,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
   "ocaml"                   {>= "4.04.1"}
-  "base"                    {>= "v0.11.0" & < "v0.13"}
+  "base"                    {>= "v0.11.0"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.3.1"}
   "ppx_derivers"            {>= "1.0"}
-  "stdio"                   {>= "v0.11.0" & < "v0.13"}
+  "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}
 ]
 synopsis: "Base library and tools for ppx rewriters"
@@ -37,6 +37,9 @@ A comprehensive toolbox for ppx development. It features:
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz"
-  checksum: "md5=9b1cfe1ae58d7ad851ed5618c1bf64a0"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.8.1/ppxlib-0.8.1.tbz"
+  checksum: [
+    "sha256=a5cb79ee83bba80304b65bc47f2985382bef89668b1b46f9ffb3734c2f2f7521"
+    "sha512=74bf4a0811f4fa73969149efc7f98620bf1c1ef7322edb8de82e02e25b61e005945887ea865b462bfb638d7d0e574706da190ca9416643f4464a89262ae7ae12"
+  ]
 }

--- a/test.esy.lock/opam/topkg.1.0.1/opam
+++ b/test.esy.lock/opam/topkg.1.0.1/opam
@@ -8,10 +8,9 @@ dev-repo: "git+http://erratique.ch/repos/topkg.git"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 tags: ["packaging" "ocamlbuild" "org:erratique"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.6.1"}
-  "ocamlbuild"
-  "result" ]
+  "ocamlbuild" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name
@@ -44,6 +43,6 @@ Topkg-care is distributed under the ISC license it depends on
 [webbrowser]: http://erratique.ch/software/webbrowser
 """
 url {
-src: "http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz"
-checksum: "md5=e3d76bda06bf68cb5853caf6627da603"
+archive: "http://erratique.ch/software/topkg/releases/topkg-1.0.1.tbz"
+checksum: "16b90e066d8972a5ef59655e7c28b3e9"
 }


### PR DESCRIPTION
Fix #468.

This adds the file associations.

There was also a few other issues:

 - Reg keys were pointing at "Onivim2.exe" rather than "Oni2.exe" which meant it didn't work even with the associations.
 - Was pointing to the old app icon location (I couldn't see a real .ico file anywhere, so you may need to add one yourself @bryphe, since currently there is no App Icon).
 - The setup in Oni wasn't setup to deal with arrays of extensions very well, so I've swapped that.