### PR TITLE
fix (bug fix): vsp does not use current file

### DIFF
--- a/integration_test/RegressionVspEmpty.re
+++ b/integration_test/RegressionVspEmpty.re
@@ -1,0 +1,47 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(~name="RegressionVspEmpty", (_, wait, _) => {
+  wait(~name="Wait for split to be created 1", (state: State.t) => {
+    let splitCount =
+      state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
+    splitCount == 1;
+  });
+  
+  Vim.command("e test.txt");
+
+  /* :vsp with no arguments should create a second split w/ same buffer */
+  Vim.command("vsp");
+
+  wait(~name="Wait for split to be created", (state: State.t) => {
+    let splitCount =
+      state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
+
+    splitCount == 2;
+  });
+
+  /* Validate the editors all have same buffer id */
+  wait(~name="Wait for split to be created", (state: State.t) => {
+    let splits = WindowTree.getSplits(state.windowManager.windowTree);
+
+    let firstSplit = List.nth(splits, 0);
+    let secondSplit = List.nth(splits, 1);
+
+    let firstActiveEditor = 
+        Selectors.getEditorGroupById(state, firstSplit.editorGroupId)
+        |> Selectors.getActiveEditor;
+
+    let secondActiveEditor =
+        Selectors.getEditorGroupById(state, secondSplit.editorGroupId)
+        |> Selectors.getActiveEditor;
+
+    switch ((firstActiveEditor, secondActiveEditor)) {
+    | (Some(e1), Some(e2)) => {
+        print_endline ("e1 buffer id: " ++ string_of_int(e1.bufferId));
+        print_endline ("e2 buffer id: " ++ string_of_int(e2.bufferId));
+        e1.bufferId == e2.bufferId
+    }
+    | _ => false;
+    }
+  });
+});

--- a/integration_test/RegressionVspEmpty.re
+++ b/integration_test/RegressionVspEmpty.re
@@ -7,7 +7,7 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
       state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
     splitCount == 1;
   });
-  
+
   Vim.command("e test.txt");
 
   /* :vsp with no arguments should create a second split w/ same buffer */
@@ -27,21 +27,20 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
     let firstSplit = List.nth(splits, 0);
     let secondSplit = List.nth(splits, 1);
 
-    let firstActiveEditor = 
-        Selectors.getEditorGroupById(state, firstSplit.editorGroupId)
-        |> Selectors.getActiveEditor;
+    let firstActiveEditor =
+      Selectors.getEditorGroupById(state, firstSplit.editorGroupId)
+      |> Selectors.getActiveEditor;
 
     let secondActiveEditor =
-        Selectors.getEditorGroupById(state, secondSplit.editorGroupId)
-        |> Selectors.getActiveEditor;
+      Selectors.getEditorGroupById(state, secondSplit.editorGroupId)
+      |> Selectors.getActiveEditor;
 
-    switch ((firstActiveEditor, secondActiveEditor)) {
-    | (Some(e1), Some(e2)) => {
-        print_endline ("e1 buffer id: " ++ string_of_int(e1.bufferId));
-        print_endline ("e2 buffer id: " ++ string_of_int(e2.bufferId));
-        e1.bufferId == e2.bufferId
-    }
-    | _ => false;
-    }
+    switch (firstActiveEditor, secondActiveEditor) {
+    | (Some(e1), Some(e2)) =>
+      print_endline("e1 buffer id: " ++ string_of_int(e1.bufferId));
+      print_endline("e2 buffer id: " ++ string_of_int(e2.bufferId));
+      e1.bufferId == e2.bufferId;
+    | _ => false
+    };
   });
 });

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,6 +1,7 @@
 (executables
     (names InsertModeTest
            RegressionCommandLineNoCompletionTest
+           RegressionVspEmpty
            AddRemoveSplitTest
            TypingBatchedTest
            TypingUnbatchedTest
@@ -17,6 +18,7 @@
         run-tests.sh
         InsertModeTest.exe
         RegressionCommandLineNoCompletionTest.exe
+        RegressionVspEmpty.exe
         AddRemoveSplitTest.exe
         TypingBatchedTest.exe
         TypingUnbatchedTest.exe

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -115,16 +115,18 @@ let start = (getState: unit => Model.State.t) => {
   let _ =
     Vim.Window.onSplit((splitType, buf) => {
       /* If buf wasn't specified, use the filepath from the current buffer */
-      let buf = switch(buf) {
-      | "" => switch(Vim.Buffer.getFilename(Vim.Buffer.getCurrent())) {
-      | None => ""
-      | Some(v) => v
-      }
-      | v => v
-      };
+      let buf =
+        switch (buf) {
+        | "" =>
+          switch (Vim.Buffer.getFilename(Vim.Buffer.getCurrent())) {
+          | None => ""
+          | Some(v) => v
+          }
+        | v => v
+        };
 
       Log.info("Vim.Window.onSplit: " ++ buf);
-      
+
       let command =
         switch (splitType) {
         | Vim.Types.Vertical =>

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -114,7 +114,17 @@ let start = (getState: unit => Model.State.t) => {
 
   let _ =
     Vim.Window.onSplit((splitType, buf) => {
-      Log.info("Vim.Window.onSplit");
+      /* If buf wasn't specified, use the filepath from the current buffer */
+      let buf = switch(buf) {
+      | "" => switch(Vim.Buffer.getFilename(Vim.Buffer.getCurrent())) {
+      | None => ""
+      | Some(v) => v
+      }
+      | v => v
+      };
+
+      Log.info("Vim.Window.onSplit: " ++ buf);
+      
       let command =
         switch (splitType) {
         | Vim.Types.Vertical =>


### PR DESCRIPTION
When splitting, we should use the current buffer if no buffer was specified via `vsp` (same behavior as Vim)