### PR TITLE
fix(bug fix): Moving cursor does not reset view after scrolling

### DIFF
--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -241,7 +241,12 @@ let recalculate = (view: t, buffer: option(Buffer.t)) =>
 
 let reduce = (view, action, metrics: EditorMetrics.t) =>
   switch (action) {
-  | CursorMove(b) => {...view, cursorPosition: b}
+  | CursorMove(b) => {
+      /* If the cursor moved, make sure we're snapping to the top line */
+      /* This fixes a bug where, if the user scrolls, the cursor and topline are out of sync */
+      ...scrollToLine(view, view.lastTopLine, metrics), 
+      cursorPosition: b
+  }
   | SelectionChanged(selection) => {...view, selection}
   | RecalculateEditorView(buffer) => recalculate(view, buffer)
   | EditorScroll(scrollY) => scroll(view, scrollY, metrics)

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -244,9 +244,9 @@ let reduce = (view, action, metrics: EditorMetrics.t) =>
   | CursorMove(b) => {
       /* If the cursor moved, make sure we're snapping to the top line */
       /* This fixes a bug where, if the user scrolls, the cursor and topline are out of sync */
-      ...scrollToLine(view, view.lastTopLine, metrics), 
-      cursorPosition: b
-  }
+      ...scrollToLine(view, view.lastTopLine, metrics),
+      cursorPosition: b,
+    }
   | SelectionChanged(selection) => {...view, selection}
   | RecalculateEditorView(buffer) => recalculate(view, buffer)
   | EditorScroll(scrollY) => scroll(view, scrollY, metrics)


### PR DESCRIPTION
__Issue:__ When scrolling manually with the mouse, and moving the cursor, the view does not reset - this is confusing because the cursor is being manipulated off-screen.

__Fix:__ When the cursor moves, reset the scroll to reflect the current topline / editor view.