### PR TITLE
fix(bug fix): Crash if directory passed that doesn't exist

### DIFF
--- a/src/editor/bin_editor/Oni2_editor.re
+++ b/src/editor/bin_editor/Oni2_editor.re
@@ -41,7 +41,10 @@ let init = app => {
   Log.debug("Startup: Parsing CLI options");
 
   Log.debug("Startup: Changing folder to: " ++ cliOptions.folder);
-  Sys.chdir(cliOptions.folder);
+  switch (Sys.chdir(cliOptions.folder)) {
+  | exception (Sys_error(msg)) => Log.debug("Folder does not exist: " ++ msg)
+  | v => v
+  };
 
   PreflightChecks.run();
 


### PR DESCRIPTION
If given a directory that doesn't exist as a command line argument, ie, `oni2 /some/fake/directory`, Onivim 2 will crash on startup. This handles that case, as it should be non-fatal.

Once we have a message UI, we should communicate this to the user as well.