### PR TITLE
fix(dependency): revery -> 3f932c5

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "930a8caf6f38937994a8f59c59b2344c",
+  "checksum": "9fa8af4eadd183a0d2b6773638825b3d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f80eafe@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f80eafe",
+      "version": "github:revery-ui/revery#3f932c5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f80eafe" ]
+        "source": [ "github:revery-ui/revery#3f932c5" ]
       },
       "overrides": [],
       "dependencies": [
@@ -779,7 +779,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "930a8caf6f38937994a8f59c59b2344c",
+  "checksum": "9fa8af4eadd183a0d2b6773638825b3d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f80eafe@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f80eafe",
+      "version": "github:revery-ui/revery#3f932c5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f80eafe" ]
+        "source": [ "github:revery-ui/revery#3f932c5" ]
       },
       "overrides": [],
       "dependencies": [
@@ -779,7 +779,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "930a8caf6f38937994a8f59c59b2344c",
+  "checksum": "9fa8af4eadd183a0d2b6773638825b3d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f80eafe@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f80eafe",
+      "version": "github:revery-ui/revery#3f932c5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f80eafe" ]
+        "source": [ "github:revery-ui/revery#3f932c5" ]
       },
       "overrides": [],
       "dependencies": [
@@ -779,7 +779,7 @@
       },
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
-        "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "pesy": "0.4.1",
     "@opam/ocaml-migrate-parsetree": "1.3.1",
     "@opam/ppx_tools_versioned": "5.2.2",
-    "revery": "github:revery-ui/revery#f80eafe",
+    "revery": "github:revery-ui/revery#3f932c5",
     "reason-libvim": "github:onivim/reason-libvim#3fab519"
   },
   "devDependencies": {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "930a8caf6f38937994a8f59c59b2344c",
+  "checksum": "9fa8af4eadd183a0d2b6773638825b3d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f80eafe@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f80eafe",
+      "version": "github:revery-ui/revery#3f932c5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f80eafe" ]
+        "source": [ "github:revery-ui/revery#3f932c5" ]
       },
       "overrides": [],
       "dependencies": [
@@ -779,7 +779,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "revery@github:revery-ui/revery#f80eafe@d41d8cd9",
+        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",


### PR DESCRIPTION
This upgrades Revery to pick up a few commits, including a fix for #461 , as well as a new API to unblock #457 / #442 