### PR TITLE
fix(bug fix): OSX app package opens in low resolution mode

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -91,7 +91,8 @@ if (process.platform == "linux") {
       CFBundleVersion: "0.01",
       CFBundlePackageType: "APPL",
       CFBundleSignature: "????",
-      CFBundleExecutable: "Oni2"
+      CFBundleExecutable: "Oni2",
+      NSHighResolutionCapable: true,
   };
 
   fs.mkdirpSync(libsDirectory);


### PR DESCRIPTION
The packaged OSX app had really blurry text - this only reproduced when running from the `Onivim2.App` bundle, and not when building from source.

It turns out there is this `Open In Low Resolution` setting that was checked by default:
![image](https://user-images.githubusercontent.com/13532591/62140581-19456300-b2a0-11e9-9baa-6dffd9778739.png)

Added `NSHighResolutionCapable: true` to our plist fixes it