### PR TITLE
Fix type conflict.

### DIFF
--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -258,7 +258,7 @@ let reduce = (view, action, metrics: EditorMetrics.t) =>
   | CursorMove(b) => {
       /* If the cursor moved, make sure we're snapping to the top line */
       /* This fixes a bug where, if the user scrolls, the cursor and topline are out of sync */
-      ...scrollToLine(view, view.lastTopLine, metrics),
+      ...scrollToLine(view, Index.toInt1(view.lastTopLine), metrics),
       cursorPosition: b,
     }
   | SelectionChanged(selection) => {...view, selection}


### PR DESCRIPTION
Looks like the combination of #457 and #432 without the CI running between caused a type conflict.

As far as I know, this should be a 1 based index since its a line, so I've fixed that.