### PR TITLE
fix(bug fix): cursor movement scrolls viewport

### DIFF
--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -258,7 +258,7 @@ let reduce = (view, action, metrics: EditorMetrics.t) =>
   | CursorMove(b) => {
       /* If the cursor moved, make sure we're snapping to the top line */
       /* This fixes a bug where, if the user scrolls, the cursor and topline are out of sync */
-      ...scrollToLine(view, Index.toInt1(view.lastTopLine), metrics),
+      ...scrollToLine(view, Index.toInt0(view.lastTopLine), metrics),
       cursorPosition: b,
     }
   | SelectionChanged(selection) => {...view, selection}


### PR DESCRIPTION
__Issue:__ When moving the cursor, the viewport would scroll.

__Defect:__ The index being used to store the last `topLine` in `Editor` is 0-based, but we were converting it to 1-based whenever the cursor moved - this would increment it by 1.

__Fix:__ Use `Index.toInt0` to use a zero-based index.