### PR TITLE
#510 - Part 1 - Move `dyllibs` to `Frameworks` folder

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -74,7 +74,7 @@ if (process.platform == "linux") {
   const contentsDirectory = path.join(appDirectory, "Contents");
   const resourcesDirectory = path.join(contentsDirectory, "Resources");
   const binaryDirectory = path.join(contentsDirectory, "MacOS");
-  const libsDirectory = path.join(contentsDirectory, "libs");
+  const frameworksDirectory = path.join(contentsDirectory, "Frameworks");
   const extensionsDestDirectory = path.join(contentsDirectory, "extensions");
   const textmateServiceDestDirectory = path.join(contentsDirectory, "textmate_service");
 
@@ -95,7 +95,7 @@ if (process.platform == "linux") {
       NSHighResolutionCapable: true,
   };
 
-  fs.mkdirpSync(libsDirectory);
+  fs.mkdirpSync(frameworksDirectory);
   fs.mkdirpSync(extensionsDestDirectory);
   fs.mkdirpSync(textmateServiceDestDirectory);
   fs.mkdirpSync(resourcesDirectory);
@@ -116,7 +116,7 @@ if (process.platform == "linux") {
   // Copy icon
   copy(iconSourcePath, path.join(resourcesDirectory, "Onivim2.icns"));
 
-  shell(`dylibbundler -b -x "${path.join(binaryDirectory, "Oni2_editor")}" -d "${libsDirectory}" -cd`);
+  shell(`dylibbundler -b -x "${path.join(binaryDirectory, "Oni2_editor")}" -d "${frameworksDirectory}" -cd`);
 
   const dmgPath = path.join(releaseDirectory, "Onivim2.dmg");
   const dmgJsonPath = path.join(releaseDirectory, "appdmg.json");


### PR DESCRIPTION
The MacOS code-signing infrastructure expects a certain anatomy to the `MacOS` folder. We're making a few egregious errors - (which causes issues with signing, and then notarization. This is the first and simplest - we were putting our `dyllibs` in a `libs` folder instead of the `Frameworks` folder. This just moves the dyllibs to the proper folder. The `macdyllibbundler` tool takes care of mapping the `rpaths` for `Oni2_editor` to the new location.