### PR TITLE
#510 - Part 2 - Move extensions, textmate service, and camomile to Resources

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -75,8 +75,6 @@ if (process.platform == "linux") {
   const resourcesDirectory = path.join(contentsDirectory, "Resources");
   const binaryDirectory = path.join(contentsDirectory, "MacOS");
   const libsDirectory = path.join(contentsDirectory, "libs");
-  const extensionsDestDirectory = path.join(contentsDirectory, "extensions");
-  const textmateServiceDestDirectory = path.join(contentsDirectory, "textmate_service");
 
   const imageSourceDirectory = path.join(rootDirectory, "assets", "images");
   const iconSourcePath = path.join(imageSourceDirectory, "Onivim2.icns");
@@ -96,17 +94,15 @@ if (process.platform == "linux") {
   };
 
   fs.mkdirpSync(libsDirectory);
-  fs.mkdirpSync(extensionsDestDirectory);
-  fs.mkdirpSync(textmateServiceDestDirectory);
   fs.mkdirpSync(resourcesDirectory);
 
   fs.writeFileSync(plistFile, require("plist").build(plistContents));
 
   // Copy bins over
   copy(curBin, binaryDirectory);
-  copy(extensionsSourceDirectory, contentsDirectory);
-  copy(textmateServiceSourceDirectory, contentsDirectory);
-  copy(camomilePath, contentsDirectory);
+  copy(extensionsSourceDirectory, resourcesDirectory);
+  copy(textmateServiceSourceDirectory, resourcesDirectory);
+  copy(camomilePath, resourcesDirectory);
   copy(getRipgrepPath(), path.join(binaryDirectory, "rg"));
   copy(getNodePath(), path.join(binaryDirectory, "node"));
   

--- a/src/editor/Core/Setup.re
+++ b/src/editor/Core/Setup.re
@@ -42,9 +42,9 @@ let default = () => {
     }
   | Revery.Environment.Mac => {
       nodePath: execDir ++ "node",
-      camomilePath: execDir ++ "../camomile",
-      textmateServicePath: execDir ++ "../textmate_service/lib/src/index.js",
-      bundledExtensionsPath: execDir ++ "../extensions",
+      camomilePath: execDir ++ "../Resources/camomile",
+      textmateServicePath: execDir ++ "../Resources/textmate_service/lib/src/index.js",
+      bundledExtensionsPath: execDir ++ "../Resources/extensions",
       developmentExtensionsPath: None,
       extensionHostPath: "",
       rgPath: execDir ++ "rg",

--- a/src/editor/Core/Setup.re
+++ b/src/editor/Core/Setup.re
@@ -43,7 +43,8 @@ let default = () => {
   | Revery.Environment.Mac => {
       nodePath: execDir ++ "node",
       camomilePath: execDir ++ "../Resources/camomile",
-      textmateServicePath: execDir ++ "../Resources/textmate_service/lib/src/index.js",
+      textmateServicePath:
+        execDir ++ "../Resources/textmate_service/lib/src/index.js",
       bundledExtensionsPath: execDir ++ "../Resources/extensions",
       developmentExtensionsPath: None,
       extensionHostPath: "",


### PR DESCRIPTION
This was another egregious bundle fail - we had extensions, textmate service, and camomile as siblings to `MacOS` which isn't what the bundle format expects. These should all live in `Onivim2.App\Contents\Resources` instead of directly in `Onivim2.App\Contents`