### PR TITLE
Fix #533 - Incorrect quotes in AppRun

### DIFF
--- a/scripts/linux/AppRun
+++ b/scripts/linux/AppRun
@@ -1,6 +1,6 @@
 #!/bin/sh
 HERE=$(dirname $(readlink -f "${0}"))
-export PATH="${HERE}/usr/bin":$PATH
-export LD_LIBRARY_PATH="${HERE}/usr/lib/":$LD_LIBRARY_PATH
+export PATH="${HERE}/usr/bin:$PATH"
+export LD_LIBRARY_PATH="${HERE}/usr/lib/:$LD_LIBRARY_PATH"
 ${HERE}/usr/bin/Oni2 $@
 


### PR DESCRIPTION
The `export` statements in our bash scripts were incorrectly quoted, which could cause problems in some shells when running Onivim 2 via the `AppRun` file (as an `.AppImage`).