### PR TITLE
Feature - Health checks: Add healthcheck for executing node

### DIFF
--- a/src/editor/Core/HealthCheck.re
+++ b/src/editor/Core/HealthCheck.re
@@ -20,6 +20,15 @@ let checks = [
     (setup: Setup.t) => Sys.file_exists(setup.nodePath),
   ),
   (
+    "Verify node executable can execute simple script",
+    (setup: Setup.t) => {
+      let ret = Rench.ChildProcess.spawnSync(setup.nodePath, [|"-e", "console.log(\"test\")"|]);
+      ret.stdout
+      |> String.trim
+      |> String.equal("test");
+    }
+  ),
+  (
     "Verify rg executable",
     (setup: Setup.t) => Sys.file_exists(setup.rgPath),
   ),

--- a/src/editor/Core/HealthCheck.re
+++ b/src/editor/Core/HealthCheck.re
@@ -22,11 +22,13 @@ let checks = [
   (
     "Verify node executable can execute simple script",
     (setup: Setup.t) => {
-      let ret = Rench.ChildProcess.spawnSync(setup.nodePath, [|"-e", "console.log(\"test\")"|]);
-      ret.stdout
-      |> String.trim
-      |> String.equal("test");
-    }
+      let ret =
+        Rench.ChildProcess.spawnSync(
+          setup.nodePath,
+          [|"-e", "console.log(\"test\")"|],
+        );
+      ret.stdout |> String.trim |> String.equal("test");
+    },
   ),
   (
     "Verify rg executable",


### PR DESCRIPTION
This adds a healthcheck to verify we can run the bundled `node` executable. This was an issue that came up while working on the signing / hardened runtime (the `node` executable stopped running) - so we should check and verify that it still works after the code-signing process.