### PR TITLE
Fix #510 - Part 3 - Enable 'hardened runtime' on OSX

### DIFF
--- a/scripts/osx/publish.sh
+++ b/scripts/osx/publish.sh
@@ -23,7 +23,7 @@ else
 	security find-identity -v
 
 	echo "Starting codesign..."
-	codesign --deep --force --verbose --sign "Outrun Labs, LLC" _release/Onivim2.App --options runtime
+	codesign --deep --force --verbose --sign "Outrun Labs, LLC" _release/Onivim2.App --options runtime --entitlements _release/entitlements.plist
 	echo "Onivim2.App codesign complete!"
 
 	# Validate

--- a/scripts/osx/publish.sh
+++ b/scripts/osx/publish.sh
@@ -23,7 +23,7 @@ else
 	security find-identity -v
 
 	echo "Starting codesign..."
-	codesign --deep --force --verbose --sign "Outrun Labs, LLC" _release/Onivim2.App
+	codesign --deep --force --verbose --sign "Outrun Labs, LLC" _release/Onivim2.App --options runtime
 	echo "Onivim2.App codesign complete!"
 
 	# Validate

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -95,7 +95,6 @@ if (process.platform == "linux") {
 
   fs.mkdirpSync(frameworksDirectory);
   fs.mkdirpSync(resourcesDirectory);
-
   fs.writeFileSync(plistFile, require("plist").build(plistContents));
 
   // Copy bins over
@@ -114,9 +113,18 @@ if (process.platform == "linux") {
 
   shell(`dylibbundler -b -x "${path.join(binaryDirectory, "Oni2_editor")}" -d "${frameworksDirectory}" -p "@executable_path/../Frameworks/" -cd`);
 
+  const entitlementsPath = path.join(releaseDirectory, "entitlements.plist");
+  const entitlementsContents = {
+      "com.apple.security.cs.allow-jit": true,
+      "com.apple.security.cs.allow-unsigned-executable-memory": true,
+      "com.apple.security.cs.disable-library-validation": true,
+  };
+  fs.writeFileSync(entitlementsPath, require("plist").build(entitlementsContents));
+
   const dmgPath = path.join(releaseDirectory, "Onivim2.dmg");
   const dmgJsonPath = path.join(releaseDirectory, "appdmg.json");
   const basePath = releaseDirectory;
+
 
   const dmgJson = {
     title: "Onivim 2",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -125,7 +125,6 @@ if (process.platform == "linux") {
   const dmgJsonPath = path.join(releaseDirectory, "appdmg.json");
   const basePath = releaseDirectory;
 
-
   const dmgJson = {
     title: "Onivim 2",
     background: path.join(imageSourceDirectory, "dmg-background.png"),


### PR DESCRIPTION
Enabling a [hardened runtime](https://developer.apple.com/documentation/security/hardened_runtime_entitlements) is a requirement for the notarization step, however, without any entitlements, the `node` process will not run (it relies on JIT'ing, which is blocked by default with the hardened runtime).

This change turns on hardened runtime for code-signing / notarization _and_ includes an `entitlements.plist` file to enable the set of entitlements needed to get node running.