### PR TITLE
Fix #510 - Part 4 - Fix up Onivim2.App/Contents/MacOS directory

### DIFF
--- a/scripts/osx/validate-release.sh
+++ b/scripts/osx/validate-release.sh
@@ -15,7 +15,11 @@ ONI2_DEBUG=1 ./_unpacked/Onivim2.App/Contents/MacOS/Oni2 -f --checkhealth
 echo "** Validating DMG **"
 rm -rf _unpacked
 mkdir _unpacked
+echo " - Attaching dmg...."
 sudo hdiutil attach $SYSTEM_ARTIFACTSDIRECTORY/Release_Darwin/Onivim2-$SHORT_COMMIT_ID.dmg
+echo " - DMG attached! Copying..."
 cp -rf "/Volumes/Onivim 2"/*.App _unpacked
+echo " - Copy completed. Detaching DMG..."
 sudo hdiutil detach "/Volumes/Onivim 2"
+echo "DMG detached - running health check"
 ONI2_DEBUG=1 ./_unpacked/Onivim2.App/Contents/MacOS/Oni2 -f --checkhealth

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -102,11 +102,16 @@ if (process.platform == "linux") {
 
   // Copy bins over
   copy(curBin, binaryDirectory);
+  
   copy(extensionsSourceDirectory, resourcesDirectory);
   copy(textmateServiceSourceDirectory, resourcesDirectory);
   copy(camomilePath, resourcesDirectory);
   copy(getRipgrepPath(), path.join(binaryDirectory, "rg"));
   copy(getNodePath(), path.join(binaryDirectory, "node"));
+
+  // Remove setup.json prior to remapping bundled files,
+  // so it doesn't get symlinked.
+  fs.removeSync(path.join(binaryDirectory, "setup.json"));
 
   // We need to remap the binary files - we end up with font files, images, and configuration files in the bin folder
   // These should be in 'Resources' instead. Move everything that is _not_ a binary out, and symlink back in.
@@ -163,7 +168,6 @@ if (process.platform == "linux") {
     ]
   };
   fs.writeFileSync(dmgJsonPath, JSON.stringify(dmgJson));
-  fs.removeSync(path.join(binaryDirectory, "setup.json"));
 } else {
   const platformReleaseDirectory = path.join(releaseDirectory, process.platform);
   const extensionsDestDirectory = path.join(platformReleaseDirectory, "extensions");

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -120,8 +120,9 @@ if (process.platform == "linux") {
     const fileDest = path.join(resourcesDirectory, file);
     console.log(`Moving file from ${fileSrc} to ${fileDest}.`);
     fs.moveSync(fileSrc, fileDest);
-    console.log(`Symlinking ${fileDest} -> ${fileSrc}`);
-    fs.ensureSymlinkSrc(fileDest, fileSrc);
+    const symlinkDest = path.join("../Resources", file);
+    console.log(`Symlinking ${symlinkDest} -> ${fileSrc}`);
+    fs.ensureSymlink(symlinkDest, fileSrc);
   });
   
   fs.copySync(eulaFile, path.join(resourcesDirectory, "EULA.md"));

--- a/src/editor/Core/HealthCheck.re
+++ b/src/editor/Core/HealthCheck.re
@@ -33,7 +33,7 @@ let checks = [
   ),
   (
     "Verify bundled font exists",
-    (setup: Setup.t) =>
+    (_) =>
       Sys.file_exists(Utility.executingDirectory ++ "FiraCode-Regular.ttf"),
   ),
 ];

--- a/src/editor/Core/HealthCheck.re
+++ b/src/editor/Core/HealthCheck.re
@@ -33,7 +33,7 @@ let checks = [
   ),
   (
     "Verify bundled font exists",
-    (_) =>
+    _ =>
       Sys.file_exists(Utility.executingDirectory ++ "FiraCode-Regular.ttf"),
   ),
 ];

--- a/src/editor/Core/HealthCheck.re
+++ b/src/editor/Core/HealthCheck.re
@@ -31,6 +31,10 @@ let checks = [
     "Verify bundled extensions exists",
     (setup: Setup.t) => Sys.is_directory(setup.bundledExtensionsPath),
   ),
+  (
+    "Verify bundled font exists",
+    (setup: Setup.t) => Sys.file_exists("FiraCode-Regular.ttf"),
+  ),
 ];
 
 let run = () => {

--- a/src/editor/Core/HealthCheck.re
+++ b/src/editor/Core/HealthCheck.re
@@ -33,7 +33,8 @@ let checks = [
   ),
   (
     "Verify bundled font exists",
-    (setup: Setup.t) => Sys.file_exists("FiraCode-Regular.ttf"),
+    (setup: Setup.t) =>
+      Sys.file_exists(Utility.executingDirectory ++ "FiraCode-Regular.ttf"),
   ),
 ];
 


### PR DESCRIPTION
__Issue:__ There were several non-executable files, like fonts, images, and configuration in the binary folder. This is not allowed per the MacOS bundle format, and causes issues with signing / notarization.

__Fix:__ We'll store the files in `Resources` and symlink them, so that the executable can pretend they are local. This is the quickest fix, but longer term we may want to specify these locations via our `Setup` module.

