### PR TITLE
Fix #552: Filter out rogue -psn argument

### DIFF
--- a/src/editor/bin_launcher/Oni2.re
+++ b/src/editor/bin_launcher/Oni2.re
@@ -21,7 +21,27 @@ let spec = [
 
 let anonArg = _ => ();
 
-let () = Arg.parse(spec, anonArg, "Usage: ");
+/* NOTE: On MacOS, when launching the app through GateKeeper,
+ * there is a legacy parameter parsed in: -psn_X_XXXXXX
+ * Apparently this is a legacy ProcessSerialNumber - more info here:
+ * http://mirror.informatimago.com/next/developer.apple.com/documentation/Carbon/Reference/Process_Manager/prmref_main/data_type_5.html#//apple_ref/doc/uid/TP30000208/C001951
+ * https://stackoverflow.com/questions/10242115/os-x-strange-psn-command-line-parameter-when-launched-from-finder
+ *
+ * We fail and show an error message if we get an unrecognized parameter, so we need to filter this out, otherwise we get a crash on first launch:
+ * https://github.com/onivim/oni2/issues/552
+ */
+let filterPsnArgument = args => {
+  let psnRegex = Str.regexp("^-psn.*");
+  let f = s => {
+    !Str.string_match(psnRegex, s, 0);
+  };
+
+  args |> Array.to_list |> List.filter(f) |> Array.of_list;
+};
+
+let args = Sys.argv |> filterPsnArgument;
+
+let () = Arg.parse_argv(args, spec, anonArg, "Usage: ");
 
 type platform =
   | Windows
@@ -85,7 +105,7 @@ let executable = Sys.win32 ? "Oni2_editor.exe" : "Oni2_editor";
 let startProcess = (stdio, stdout, stderr) => {
   Unix.create_process(
     executingDirectory ++ executable,
-    Sys.argv,
+    args,
     stdio,
     stdout,
     stderr,

--- a/src/editor/bin_launcher/Oni2.re
+++ b/src/editor/bin_launcher/Oni2.re
@@ -41,7 +41,17 @@ let filterPsnArgument = args => {
 
 let args = Sys.argv |> filterPsnArgument;
 
-let () = Arg.parse_argv(args, spec, anonArg, "Usage: ");
+let () = {
+  switch (Arg.parse_argv(args, spec, anonArg, "Usage: ")) {
+  | exception (Arg.Bad(err)) =>
+    prerr_endline(err);
+    exit(1);
+  | exception (Arg.Help(msg)) =>
+    print_endline(msg);
+    exit(0);
+  | _ => ()
+  };
+};
 
 type platform =
   | Windows

--- a/src/editor/bin_launcher/dune
+++ b/src/editor/bin_launcher/dune
@@ -4,5 +4,5 @@
     (name Oni2)
     (package Oni2)
     (public_name Oni2)
-    (libraries unix)
+    (libraries unix str)
 )


### PR DESCRIPTION
__TODO:__
- [x] Verify fix in GateKeeper (that there aren't any further blockers)
- [x] Fix the handling of effects in `Arg.parse_argv`