### PR TITLE
refactor(dependency): reason-glfw -> 3.2.1027

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7645548a804064342bc68a738cd2ceb7",
+  "checksum": "1ce9eba8c330a2059e2b65fc3cb43a06",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -87,7 +87,7 @@
       "dependencies": [
         "reperf@1.4.0@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "reason-fontkit@github:revery-ui/reason-fontkit#f364c36@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -102,14 +102,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.11.1@d41d8cd9": {
-      "id": "resolve@1.11.1@d41d8cd9",
+    "resolve@1.12.0@d41d8cd9": {
+      "id": "resolve@1.12.0@d41d8cd9",
       "name": "resolve",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz#sha1:ea10d8110376982fef578df8fc30b9ac30a07a3e"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz#sha1:3fc644a35c84a48554609ff26ec52b66fa577df6"
         ]
       },
       "overrides": [],
@@ -211,7 +211,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.11.1@d41d8cd9" ],
+      "dependencies": [ "resolve@1.12.0@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -283,14 +283,14 @@
       ],
       "devDependencies": []
     },
-    "reason-glfw@3.2.1024@d41d8cd9": {
-      "id": "reason-glfw@3.2.1024@d41d8cd9",
+    "reason-glfw@3.2.1027@d41d8cd9": {
+      "id": "reason-glfw@3.2.1027@d41d8cd9",
       "name": "reason-glfw",
-      "version": "3.2.1024",
+      "version": "3.2.1027",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1024.tgz#sha1:6be601ab352e1842bab7f9ca9bbc4f27441cc106"
+          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1027.tgz#sha1:3f9b255e169b47aa581fb6e247c9cd8f96e16058"
         ]
       },
       "overrides": [],
@@ -335,7 +335,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7",
@@ -782,7 +782,7 @@
         "reperf@1.4.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",
-        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7645548a804064342bc68a738cd2ceb7",
+  "checksum": "1ce9eba8c330a2059e2b65fc3cb43a06",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -87,7 +87,7 @@
       "dependencies": [
         "reperf@1.4.0@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "reason-fontkit@github:revery-ui/reason-fontkit#f364c36@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -102,14 +102,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.11.1@d41d8cd9": {
-      "id": "resolve@1.11.1@d41d8cd9",
+    "resolve@1.12.0@d41d8cd9": {
+      "id": "resolve@1.12.0@d41d8cd9",
       "name": "resolve",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz#sha1:ea10d8110376982fef578df8fc30b9ac30a07a3e"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz#sha1:3fc644a35c84a48554609ff26ec52b66fa577df6"
         ]
       },
       "overrides": [],
@@ -211,7 +211,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.11.1@d41d8cd9" ],
+      "dependencies": [ "resolve@1.12.0@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -283,14 +283,14 @@
       ],
       "devDependencies": []
     },
-    "reason-glfw@3.2.1024@d41d8cd9": {
-      "id": "reason-glfw@3.2.1024@d41d8cd9",
+    "reason-glfw@3.2.1027@d41d8cd9": {
+      "id": "reason-glfw@3.2.1027@d41d8cd9",
       "name": "reason-glfw",
-      "version": "3.2.1024",
+      "version": "3.2.1027",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1024.tgz#sha1:6be601ab352e1842bab7f9ca9bbc4f27441cc106"
+          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1027.tgz#sha1:3f9b255e169b47aa581fb6e247c9cd8f96e16058"
         ]
       },
       "overrides": [],
@@ -335,7 +335,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7",
@@ -782,7 +782,7 @@
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",
-        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7645548a804064342bc68a738cd2ceb7",
+  "checksum": "1ce9eba8c330a2059e2b65fc3cb43a06",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -87,7 +87,7 @@
       "dependencies": [
         "reperf@1.4.0@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "reason-fontkit@github:revery-ui/reason-fontkit#f364c36@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -102,14 +102,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.11.1@d41d8cd9": {
-      "id": "resolve@1.11.1@d41d8cd9",
+    "resolve@1.12.0@d41d8cd9": {
+      "id": "resolve@1.12.0@d41d8cd9",
       "name": "resolve",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz#sha1:ea10d8110376982fef578df8fc30b9ac30a07a3e"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz#sha1:3fc644a35c84a48554609ff26ec52b66fa577df6"
         ]
       },
       "overrides": [],
@@ -211,7 +211,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.11.1@d41d8cd9" ],
+      "dependencies": [ "resolve@1.12.0@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -283,14 +283,14 @@
       ],
       "devDependencies": []
     },
-    "reason-glfw@3.2.1024@d41d8cd9": {
-      "id": "reason-glfw@3.2.1024@d41d8cd9",
+    "reason-glfw@3.2.1027@d41d8cd9": {
+      "id": "reason-glfw@3.2.1027@d41d8cd9",
       "name": "reason-glfw",
-      "version": "3.2.1024",
+      "version": "3.2.1027",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1024.tgz#sha1:6be601ab352e1842bab7f9ca9bbc4f27441cc106"
+          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1027.tgz#sha1:3f9b255e169b47aa581fb6e247c9cd8f96e16058"
         ]
       },
       "overrides": [],
@@ -335,7 +335,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7",
@@ -782,7 +782,7 @@
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",
-        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "@reason-native/rely": "1.3.1",
     "@opam/charInfo_width": "*",
     "reason-jsonrpc": "1.1.0",
-    "reason-glfw": "3.2.1024",
+    "reason-glfw": "3.2.1027",
     "isolinear": "^2.0.0",
     "reasonFuzz": "*",
     "reason-libvim": "8.10869.16004",
@@ -217,7 +217,9 @@
     "revery": "github:revery-ui/revery#3f932c5",
     "reason-libvim": "github:onivim/reason-libvim#3fab519",
     "reason-fontkit": "github:revery-ui/reason-fontkit#f364c36",
-    "@opam/ocamlfind": "1.8.0"
+    "@opam/ocamlfind": "1.8.0",
+    "@opam/biniou": "1.2.0",
+    "@opam/easy-format": "1.3.1"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7645548a804064342bc68a738cd2ceb7",
+  "checksum": "1ce9eba8c330a2059e2b65fc3cb43a06",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -87,7 +87,7 @@
       "dependencies": [
         "reperf@1.4.0@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "reason-fontkit@github:revery-ui/reason-fontkit#f364c36@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -102,14 +102,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.11.1@d41d8cd9": {
-      "id": "resolve@1.11.1@d41d8cd9",
+    "resolve@1.12.0@d41d8cd9": {
+      "id": "resolve@1.12.0@d41d8cd9",
       "name": "resolve",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz#sha1:ea10d8110376982fef578df8fc30b9ac30a07a3e"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz#sha1:3fc644a35c84a48554609ff26ec52b66fa577df6"
         ]
       },
       "overrides": [],
@@ -211,7 +211,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.11.1@d41d8cd9" ],
+      "dependencies": [ "resolve@1.12.0@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -283,14 +283,14 @@
       ],
       "devDependencies": []
     },
-    "reason-glfw@3.2.1024@d41d8cd9": {
-      "id": "reason-glfw@3.2.1024@d41d8cd9",
+    "reason-glfw@3.2.1027@d41d8cd9": {
+      "id": "reason-glfw@3.2.1027@d41d8cd9",
       "name": "reason-glfw",
-      "version": "3.2.1024",
+      "version": "3.2.1027",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1024.tgz#sha1:6be601ab352e1842bab7f9ca9bbc4f27441cc106"
+          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1027.tgz#sha1:3f9b255e169b47aa581fb6e247c9cd8f96e16058"
         ]
       },
       "overrides": [],
@@ -335,7 +335,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "reason-gl-matrix@0.9.9304@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7",
@@ -782,7 +782,7 @@
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#3fab519@d41d8cd9",
-        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1024@d41d8cd9",
+        "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",


### PR DESCRIPTION
This brings in the `glfwGetClipboardText` and `glfwSetClipboardText` APIs so we can start integrating them for #506 