### PR TITLE
Editor Rulers (Part 1 - Add a Configuration Setting)

### DIFF
--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -27,6 +27,7 @@ let getDefaultConfigString = configName =>
   "editor.renderIndentGuides": true,
   "editor.highlightActiveIndentGuide": true,
   "editor.renderWhitespace": "all",
+  "editor.rulers": [],
   "workbench.activityBar.visible": true,
   "workbench.editor.showTabs": true,
   "workbench.sideBar.visible": true,

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -34,6 +34,22 @@ let parseStringList = json => {
   };
 };
 
+let parseIntList = json => {
+  switch (json) {
+  | `List(items) =>
+    List.fold_left(
+      (accum, item) =>
+        switch (item) {
+        | `Int(v) => [v, ...accum]
+        | _ => accum
+        },
+      [],
+      items,
+    )
+  | _ => []
+  };
+};
+
 let parseLineNumberSetting = json =>
   switch (json) {
   | `String(v) =>
@@ -120,6 +136,7 @@ let configurationParsers: list(configurationTuple) = [
     "editor.renderWhitespace",
     (s, v) => {...s, editorRenderWhitespace: parseRenderWhitespace(v)},
   ),
+  ("editor.rulers", (s, v) => {...s, editorRulers: parseIntList(v)}),
   ("files.exclude", (s, v) => {...s, filesExclude: parseStringList(v)}),
   (
     "workbench.activityBar.visible",

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -25,6 +25,7 @@ type t = {
   editorHighlightActiveIndentGuide: bool,
   editorRenderIndentGuides: bool,
   editorRenderWhitespace,
+  editorRulers: list(int),
   workbenchActivityBarVisible: bool,
   /* Onivim2 specific setting */
   workbenchSideBarVisible: bool,
@@ -49,6 +50,7 @@ let default = {
   editorRenderIndentGuides: true,
   editorHighlightActiveIndentGuide: true,
   editorRenderWhitespace: All,
+  editorRulers: [],
   workbenchActivityBarVisible: true,
   workbenchEditorShowTabs: true,
   workbenchSideBarVisible: true,

--- a/test/editor/Core/ConfigurationParserTests.re
+++ b/test/editor/Core/ConfigurationParserTests.re
@@ -113,4 +113,19 @@ describe("ConfigurationParser", ({test, describe, _}) => {
     | Error(_) => expect.bool(false).toBe(true)
     };
   });
+
+  test("list of numbers", ({expect}) => {
+    let configuration = {|
+      { "editor.rulers": [120, 80] }
+    |};
+
+    switch (ConfigurationParser.ofString(configuration)) {
+    | Ok(v) =>
+      expect.list(Configuration.getValue(c => c.editorRulers, v)).toEqual([
+        80,
+        120,
+      ])
+    | Error(_) => expect.bool(false).toBe(true)
+    };
+  });
 });


### PR DESCRIPTION
This is my first attempt at tackling part one of #460. I'm totally new to Reason and the project in general so any feedback is much appreciated.

A few questions that arose as I implemented this:

- Is the preferred way to run the tests using `npm test`?

- When I finished the implementation I ran `npm run format`. It threw an error (containing a diff) on me. Rerunning the command did not throw and error and terminated successfully. Is that expected?

- I tried to add a test case for parsing a list of integers. I noticed that the parsed values come back flipped. I assume it's due to the fact that we do ` [v, ...accum]` instead of ` [...accum, v]`. I didn't want to change this behaviour as I had a feeling it might be due to performance reasons. Is that the case?