### PR TITLE
Editor Rulers (Part 2 - Pick up configuration setting and render)

### DIFF
--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -27,6 +27,7 @@ let getDefaultConfigString = configName =>
   "editor.renderIndentGuides": true,
   "editor.highlightActiveIndentGuide": true,
   "editor.renderWhitespace": "all",
+  "editor.rulers": [],
   "workbench.activityBar.visible": true,
   "workbench.editor.showTabs": true,
   "workbench.sideBar.visible": true,

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -34,6 +34,22 @@ let parseStringList = json => {
   };
 };
 
+let parseIntList = json => {
+  switch (json) {
+  | `List(items) =>
+    List.fold_left(
+      (accum, item) =>
+        switch (item) {
+        | `Int(v) => [v, ...accum]
+        | _ => accum
+        },
+      [],
+      items,
+    )
+  | _ => []
+  };
+};
+
 let parseLineNumberSetting = json =>
   switch (json) {
   | `String(v) =>
@@ -120,6 +136,7 @@ let configurationParsers: list(configurationTuple) = [
     "editor.renderWhitespace",
     (s, v) => {...s, editorRenderWhitespace: parseRenderWhitespace(v)},
   ),
+  ("editor.rulers", (s, v) => {...s, editorRulers: parseIntList(v)}),
   ("files.exclude", (s, v) => {...s, filesExclude: parseStringList(v)}),
   (
     "workbench.activityBar.visible",

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -25,6 +25,7 @@ type t = {
   editorHighlightActiveIndentGuide: bool,
   editorRenderIndentGuides: bool,
   editorRenderWhitespace,
+  editorRulers: list(int),
   workbenchActivityBarVisible: bool,
   /* Onivim2 specific setting */
   workbenchSideBarVisible: bool,
@@ -49,6 +50,7 @@ let default = {
   editorRenderIndentGuides: true,
   editorHighlightActiveIndentGuide: true,
   editorRenderWhitespace: All,
+  editorRulers: [],
   workbenchActivityBarVisible: true,
   workbenchEditorShowTabs: true,
   workbenchSideBarVisible: true,

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -205,6 +205,9 @@ let createElement =
     let bufferId = Buffer.getId(buffer);
     let lineCount = Buffer.getNumberOfLines(buffer);
 
+    let rulers =
+      Configuration.getValue(c => c.editorRulers, state.configuration);
+
     let showLineNumbers =
       Configuration.getValue(
         c => c.editorLineNumbers != LineNumber.Off,
@@ -546,6 +549,20 @@ let createElement =
                 ~color=theme.colors.editorLineHighlightBackground,
                 (),
               );
+
+              /* Draw configured rulers */
+              let renderRuler = ruler =>
+                Shapes.drawRect(
+                  ~transform,
+                  ~x=fst(bufferPositionToPixel(0, ruler)),
+                  ~y=0.0,
+                  ~height=float_of_int(metrics.pixelHeight),
+                  ~width=float_of_int(1),
+                  ~color=Color.rgba(0.78, 0.78, 0.78, 0.78),
+                  (),
+                );
+
+              List.iter(renderRuler, rulers);
 
               let renderRange = (~offset=0., ~color=Colors.black, r: Range.t) =>
                 {let halfOffset = offset /. 2.0

--- a/test/editor/Core/ConfigurationParserTests.re
+++ b/test/editor/Core/ConfigurationParserTests.re
@@ -113,4 +113,19 @@ describe("ConfigurationParser", ({test, describe, _}) => {
     | Error(_) => expect.bool(false).toBe(true)
     };
   });
+
+  test("list of numbers", ({expect}) => {
+    let configuration = {|
+      { "editor.rulers": [120, 80] }
+    |};
+
+    switch (ConfigurationParser.ofString(configuration)) {
+    | Ok(v) =>
+      expect.list(Configuration.getValue(c => c.editorRulers, v)).toEqual([
+        80,
+        120,
+      ])
+    | Error(_) => expect.bool(false).toBe(true)
+    };
+  });
 });


### PR DESCRIPTION
Given any rulers present in `editor.rulers` they will be rendered in the viewport. The color is currently hardcoded and will be fixed in part three of #460 

This pull request depends on the work done in #573, so be sure to merge that first.

![2019-08-03 19 54 49](https://user-images.githubusercontent.com/503025/62415348-c7e2fe00-b628-11e9-907b-44b24e2330f1.gif)
