### PR TITLE
Remove duplicate default config

### DIFF
--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -10,7 +10,6 @@ let getDefaultConfigString = configName =>
     Some(
       {|
 {
-  "editor.minimap.enabled": true,
   "editor.insertSpaces": false,
   "editor.indentSize": 4,
   "editor.tabSize": 4,


### PR DESCRIPTION
Default config option: `"editor.minimap.enabled"` is duplicated in configuration.json


