### PR TITLE
Launch app in user directory on Linux and MacOS

### DIFF
--- a/src/editor/Core/Cli.re
+++ b/src/editor/Core/Cli.re
@@ -89,14 +89,16 @@ let parse = () => {
   /* Set the folder to be opened, based on 4 options:
        - If a folder(s) is given, use the first.
        - If no folders are given, but files are, use the dir of the first file.
-       - If no files or folders are given, use the home directory if available.
-       - If no files or folders are given, and no home directory, use workingDirectory.
-     */
+       - If no files or folders are given, and the path is, the root, "/", try and use the home directory
+       - If none of the other conditions are met, use the working directory
+   */
+
   let folder =
-    switch (directories, filesToOpen) {
-    | ([hd, ..._], _) => hd
-    | ([], [hd, ..._]) => Rench.Path.dirname(hd)
-    | ([], []) => homeOrWorkingDirectory
+    switch (directories, filesToOpen, workingDirectory) {
+    | ([hd, ..._], _, _) => hd
+    | ([], [hd, ..._], _) => Rench.Path.dirname(hd)
+    | ([], [], "/") => homeOrWorkingDirectory
+    | ([], [], workingDirectory) => workingDirectory
     };
 
   {folder, filesToOpen};

--- a/src/editor/Core/Cli.re
+++ b/src/editor/Core/Cli.re
@@ -80,15 +80,23 @@ let parse = () => {
   let directories = List.filter(isDirectory, absolutePaths);
   let filesToOpen = List.filter(p => !isDirectory(p), absolutePaths);
 
-  /* Set the folder to be opened, based on 3 options:
-     - If a folder(s) is given, use the first.
-     - If no folders are given, but files are, use the dir of the first file.
-     - If no files or folders are given, use the working directory. */
+  let homeOrWorkingDirectory =
+    switch (Sys.getenv_opt("HOME")) {
+    | Some(homePath) => homePath
+    | None => workingDirectory
+    };
+
+  /* Set the folder to be opened, based on 4 options:
+       - If a folder(s) is given, use the first.
+       - If no folders are given, but files are, use the dir of the first file.
+       - If no files or folders are given, use the home directory if available.
+       - If no files or folders are given, and no home directory, use workingDirectory.
+     */
   let folder =
     switch (directories, filesToOpen) {
     | ([hd, ..._], _) => hd
     | ([], [hd, ..._]) => Rench.Path.dirname(hd)
-    | ([], []) => workingDirectory
+    | ([], []) => homeOrWorkingDirectory
     };
 
   {folder, filesToOpen};

--- a/src/editor/Core/Cli.re
+++ b/src/editor/Core/Cli.re
@@ -87,11 +87,11 @@ let parse = () => {
     };
 
   /* Set the folder to be opened, based on 4 options:
-       - If a folder(s) is given, use the first.
-       - If no folders are given, but files are, use the dir of the first file.
-       - If no files or folders are given, and the path is, the root, "/", try and use the home directory
-       - If none of the other conditions are met, use the working directory
-   */
+         - If a folder(s) is given, use the first.
+         - If no folders are given, but files are, use the dir of the first file.
+         - If no files or folders are given, and the path is, the root, "/", try and use the home directory
+         - If none of the other conditions are met, use the working directory
+     */
 
   let folder =
     switch (directories, filesToOpen, workingDirectory) {


### PR DESCRIPTION
Problem: 
- When you open the app via the app icon, `Sys.getcwd`, which is used to find the `workingDirectory` returns `"/"` on MacOS.
   - I am not sure how this works on linux, but I am assuming its the same.

Possible Solution:

- Instead of defaulting to workingDirectory, this change looks for the `$HOME` env variable which is usually set on MacOS and Linux. It uses that as the default directory
- It only uses this directory if a file or directory was not passed in as an argument. 
- If the `$HOME` env var is not found, it will default to the working directory 

Re-submitting #578, on a different branch, more discussion are on that PR.

As @CrossR pointed out, one downside of this approach is that you would always have to explicitly call the folder you want to open. 

For example before this PR, if you are in the `~/code/revery` folder, and you type `oni` it would open the  `~/code/revery` folder. 

After this PR, you would have to type `oni .` to open the current directory.  Typing just `oni` would always open the `~/` folder.

One option around this is to check if the working directory is "/" before launch as with the code below. 

We would have to determine what the default behaviour should be. 

```reason
  let folder =
    switch (directories, filesToOpen, workingDirectory) {
    | ([hd, ..._], _, _) => hd
    | ([], [hd, ..._], _) => Rench.Path.dirname(hd)
    | ([], [], "/") => homeOrWorkingDirectory
    | ([], [], workingDirectory) => workingDirectory
    };
```