### PR TITLE
Splits (Rotation) - Part 1

### DIFF
--- a/src/editor/Core/Utility.re
+++ b/src/editor/Core/Utility.re
@@ -147,4 +147,13 @@ let trimTrailingSlash = (item: string) => {
 
 let executingDirectory = Revery.Environment.executingDirectory;
 
+/**
+ * Return the last element in a list.
+ */
+let rec last =
+  fun
+  | [] => None
+  | [x] => Some(x)
+  | [_, ...t] => last(t);
+
 external freeConsole: unit => unit = "win32_free_console";

--- a/src/editor/Core/Utility.re
+++ b/src/editor/Core/Utility.re
@@ -156,4 +156,13 @@ let rec last =
   | [x] => Some(x)
   | [_, ...t] => last(t);
 
+/**
+ * Return all but the last element in a list.
+ */
+let rec dropLast =
+  fun
+  | [] => []
+  | [_] => []
+  | [head, ...tail] => [head, ...dropLast(tail)];
+
 external freeConsole: unit => unit = "win32_free_console";

--- a/src/editor/Model/WindowTree.re
+++ b/src/editor/Model/WindowTree.re
@@ -1,3 +1,5 @@
+open Oni_Core;
+
 module WindowSplitId =
   Revery.UniqueId.Make({});
 
@@ -112,3 +114,53 @@ let rec removeSplit = (id, currentTree) =>
   | Leaf(_) as leaf => leaf
   | Empty => Empty
   };
+
+let rec rotate = (id, func, currenTree) => {
+  let findSplit = (id, children) => {
+    let predicate =
+      fun
+      | Leaf(split) => split.id == id
+      | _ => false;
+
+    List.exists(predicate, children);
+  };
+
+  switch (currenTree) {
+  | Parent(direction, children) =>
+    Parent(
+      direction,
+      List.map(
+        rotate(id, func),
+        findSplit(id, children) ? func(children) : children,
+      ),
+    )
+  | Leaf(_) as leaf => leaf
+  | Empty => Empty
+  };
+};
+
+let rotateForward = (id, currentTree) => {
+  let f =
+    fun
+    | [] => []
+    | [a] => [a]
+    | [a, b] => [b, a]
+    | l =>
+      switch (Utility.last(l)) {
+      | Some(x) => [x, ...Utility.dropLast(l)]
+      | None => []
+      };
+
+  rotate(id, f, currentTree);
+};
+
+let rotateBackward = (id, currentTree) => {
+  let f =
+    fun
+    | [] => []
+    | [a] => [a]
+    | [a, b] => [b, a]
+    | [head, ...tail] => tail @ [head];
+
+  rotate(id, f, currentTree);
+};

--- a/test/editor/Core/UtilityTests.re
+++ b/test/editor/Core/UtilityTests.re
@@ -1,0 +1,18 @@
+open TestFramework;
+
+module Utility = Oni_Core__Utility;
+open Utility;
+
+describe("last", ({test, _}) => {
+  test("empty", ({expect}) =>
+    expect.bool(last([]) == None).toBe(true)
+  );
+
+  test("one", ({expect}) =>
+    expect.bool(last([1]) == Some(1)).toBe(true)
+  );
+
+  test("many", ({expect}) =>
+    expect.bool(last([1, 2]) == Some(2)).toBe(true)
+  );
+});

--- a/test/editor/Core/UtilityTests.re
+++ b/test/editor/Core/UtilityTests.re
@@ -16,3 +16,18 @@ describe("last", ({test, _}) => {
     expect.bool(last([1, 2]) == Some(2)).toBe(true)
   );
 });
+
+describe("dropLast", ({test, _}) => {
+  test("empty", ({expect}) =>
+    expect.list(dropLast([])).toEqual([])
+  );
+
+  test("one", ({expect}) =>
+    expect.list(dropLast([1])).toEqual([])
+  );
+
+  test("many", ({expect}) => {
+    expect.list(dropLast([1, 2])).toEqual([1]);
+    expect.list(dropLast([1, 2, 3])).toEqual([1, 2]);
+  });
+});

--- a/test/editor/Model/WindowTreeTests.re
+++ b/test/editor/Model/WindowTreeTests.re
@@ -80,3 +80,161 @@ describe("WindowTreeTests", ({describe, _}) =>
     });
   })
 );
+
+describe("rotateForward", ({test, _}) => {
+  test("simple tree", ({expect}) => {
+    let splitA = createSplit(~editorGroupId=1, ());
+    let splitB = createSplit(~editorGroupId=2, ());
+    let splitC = createSplit(~editorGroupId=3, ());
+    let tree =
+      WindowTree.empty
+      |> addSplit(Vertical, splitA)
+      |> addSplit(Vertical, splitB)
+      |> addSplit(Vertical, splitC);
+
+    expect.bool(
+      tree == Parent(Vertical, [Leaf(splitC), Leaf(splitB), Leaf(splitA)]),
+    ).
+      toBe(
+      true,
+    );
+
+    let newTree = rotateForward(splitC.id, tree);
+
+    expect.bool(
+      newTree
+      == Parent(Vertical, [Leaf(splitA), Leaf(splitC), Leaf(splitB)]),
+    ).
+      toBe(
+      true,
+    );
+  });
+
+  test("nested tree", ({expect}) => {
+    let splitA = createSplit(~editorGroupId=1, ());
+    let splitB = createSplit(~editorGroupId=2, ());
+    let splitC = createSplit(~editorGroupId=3, ());
+    let splitD = createSplit(~editorGroupId=4, ());
+    let tree =
+      WindowTree.empty
+      |> addSplit(Vertical, splitA)
+      |> addSplit(Horizontal, splitB, ~target=Some(splitA.id))
+      |> addSplit(Horizontal, splitC, ~target=Some(splitB.id))
+      |> addSplit(Vertical, splitD);
+
+    expect.bool(
+      tree
+      == Parent(
+           Vertical,
+           [
+             Leaf(splitD),
+             Parent(
+               Horizontal,
+               [Leaf(splitC), Leaf(splitB), Leaf(splitA)],
+             ),
+           ],
+         ),
+    ).
+      toBe(
+      true,
+    );
+
+    let newTree = rotateForward(splitA.id, tree);
+
+    expect.bool(
+      newTree
+      == Parent(
+           Vertical,
+           [
+             Leaf(splitD),
+             Parent(
+               Horizontal,
+               [Leaf(splitA), Leaf(splitC), Leaf(splitB)],
+             ),
+           ],
+         ),
+    ).
+      toBe(
+      true,
+    );
+  });
+});
+
+describe("rotateBackward", ({test, _}) => {
+  test("simple tree", ({expect}) => {
+    let splitA = createSplit(~editorGroupId=1, ());
+    let splitB = createSplit(~editorGroupId=2, ());
+    let splitC = createSplit(~editorGroupId=3, ());
+    let tree =
+      WindowTree.empty
+      |> addSplit(Vertical, splitA)
+      |> addSplit(Vertical, splitB)
+      |> addSplit(Vertical, splitC);
+
+    expect.bool(
+      tree == Parent(Vertical, [Leaf(splitC), Leaf(splitB), Leaf(splitA)]),
+    ).
+      toBe(
+      true,
+    );
+
+    let newTree = rotateBackward(splitC.id, tree);
+
+    expect.bool(
+      newTree
+      == Parent(Vertical, [Leaf(splitB), Leaf(splitA), Leaf(splitC)]),
+    ).
+      toBe(
+      true,
+    );
+  });
+
+  test("nested tree", ({expect}) => {
+    let splitA = createSplit(~editorGroupId=1, ());
+    let splitB = createSplit(~editorGroupId=2, ());
+    let splitC = createSplit(~editorGroupId=3, ());
+    let splitD = createSplit(~editorGroupId=4, ());
+    let tree =
+      WindowTree.empty
+      |> addSplit(Vertical, splitA)
+      |> addSplit(Horizontal, splitB, ~target=Some(splitA.id))
+      |> addSplit(Horizontal, splitC, ~target=Some(splitB.id))
+      |> addSplit(Vertical, splitD);
+
+    expect.bool(
+      tree
+      == Parent(
+           Vertical,
+           [
+             Leaf(splitD),
+             Parent(
+               Horizontal,
+               [Leaf(splitC), Leaf(splitB), Leaf(splitA)],
+             ),
+           ],
+         ),
+    ).
+      toBe(
+      true,
+    );
+
+    let newTree = rotateBackward(splitA.id, tree);
+
+    expect.bool(
+      newTree
+      == Parent(
+           Vertical,
+           [
+             Leaf(splitD),
+             Parent(
+               Horizontal,
+               [Leaf(splitB), Leaf(splitA), Leaf(splitC)],
+             ),
+           ],
+         ),
+    ).
+      toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
This was a lot more challenging than I initially thought. I had to wrap my head around the `WindowTree` and the type `t` and the data structure it represents. Thinking about the problem from a functional perspective didn't help. 🙂

In #439, I said you can't rotate a split that is adjacent a Parent. While this is true, I could not come up with a good reason for why we shouldn't allow it. So the implementation allow it.

I've added two functions to the `WindowTree`:

- **rotateForward** - Given an id and the current tree, it will rotate all splits, confined within the same `Parent`, one step to the right, for the matching split. If no matching split is found, it returns the current tree.

- **rotateBackward** - Given an id and the current tree, it will rotate all splits, confined within the same `Parent`, one step to the left, for the matching split. If no matching split is found, it returns the current tree.

I can honestly say, that performance has not been a priority. Any suggestions regarding performance or the code in general is much appreciated. ❤️

This solves Part 1 of #439. 