### PR TITLE
Add resolution for delete key.

### DIFF
--- a/src/editor/bin_editor/Input.re
+++ b/src/editor/bin_editor/Input.re
@@ -69,6 +69,7 @@ let keyPressToCommand =
         | KEY_TAB => Some("TAB")
         | KEY_ENTER => Some("CR")
         | KEY_BACKSPACE => Some("C-h")
+        | KEY_DELETE => Some("DELETE")
         | KEY_LEFT => Some("LEFT")
         | KEY_RIGHT => Some("RIGHT")
         | KEY_DOWN => Some("DOWN")


### PR DESCRIPTION
Delete doesn't work for me (and some other people on Discord) at the moment, and adding a resolution here seems to work.

One thing I'm not 100% on is if I should be using `"DELETE"` here, or if I need some other representation? I.e, I see that `KEY_BACKSPACE` returns `Some("C-h")`, which is the terminal equivalent as far as I know.