### PR TITLE
Setup window movement commands

### DIFF
--- a/src/editor/Store/CommandStoreConnector.re
+++ b/src/editor/Store/CommandStoreConnector.re
@@ -61,7 +61,6 @@ let start = _ => {
   };
 
   let windowMoveEffect = (state: State.t, direction, _) => {
-    Log.info("WINDOW MOVE EFFECT");
     Isolinear.Effect.createWithDispatch(~name="window.move", dispatch => {
       let windowId = WindowManager.move(direction, state.windowManager);
       let maybeEditorGroupId =

--- a/src/editor/Store/CommandStoreConnector.re
+++ b/src/editor/Store/CommandStoreConnector.re
@@ -60,6 +60,24 @@ let start = _ => {
     });
   };
 
+  let windowMoveEffect = (state: State.t, direction, _) => {
+    Log.info("WINDOW MOVE EFFECT");
+    Isolinear.Effect.createWithDispatch(~name="window.move", dispatch => {
+      let windowId = WindowManager.move(direction, state.windowManager);
+      let maybeEditorGroupId =
+        WindowTree.getEditorGroupIdFromSplitId(
+          windowId,
+          state.windowManager.windowTree,
+        );
+
+      switch (maybeEditorGroupId) {
+      | Some(editorGroupId) =>
+        dispatch(WindowSetActive(windowId, editorGroupId))
+      | None => ()
+      };
+    });
+  };
+
   let commands = [
     (
       "commandPalette.open",
@@ -113,6 +131,10 @@ let start = _ => {
     ("wildmenu.next", _ => singleActionEffect(WildmenuNext)),
     ("wildmenu.previous", _ => singleActionEffect(WildmenuPrevious)),
     ("explorer.toggle", state => toggleExplorerEffect(state)),
+    ("window.moveLeft", state => windowMoveEffect(state, Left)),
+    ("window.moveRight", state => windowMoveEffect(state, Right)),
+    ("window.moveUp", state => windowMoveEffect(state, Up)),
+    ("window.moveDown", state => windowMoveEffect(state, Down)),
   ];
 
   let commandMap =


### PR DESCRIPTION
Add the ability to setup keybindings for moving between windows. I've tested this by setting defaults since we're not currently reading the `keybindings.json` file.

Solves https://github.com/onivim/oni2/issues/565.