### PR TITLE
Fix #519 - Scroll movements don't work

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7408a948a779f9682b4ad67e0948f62d",
+  "checksum": "b8338f8a1b23bea7fdebc8efc2f78c38",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+    "revery@github:revery-ui/revery#b473741@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#b473741@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f932c5",
+      "version": "github:revery-ui/revery#b473741",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f932c5" ]
+        "source": [ "github:revery-ui/revery#b473741" ]
       },
       "overrides": [],
       "dependencies": [
@@ -792,7 +792,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+        "revery@github:revery-ui/revery#b473741@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#b1b554f@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7408a948a779f9682b4ad67e0948f62d",
+  "checksum": "b8338f8a1b23bea7fdebc8efc2f78c38",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+    "revery@github:revery-ui/revery#b473741@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#b473741@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f932c5",
+      "version": "github:revery-ui/revery#b473741",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f932c5" ]
+        "source": [ "github:revery-ui/revery#b473741" ]
       },
       "overrides": [],
       "dependencies": [
@@ -792,7 +792,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+        "revery@github:revery-ui/revery#b473741@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#b1b554f@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7408a948a779f9682b4ad67e0948f62d",
+  "checksum": "b8338f8a1b23bea7fdebc8efc2f78c38",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+    "revery@github:revery-ui/revery#b473741@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#b473741@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f932c5",
+      "version": "github:revery-ui/revery#b473741",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f932c5" ]
+        "source": [ "github:revery-ui/revery#b473741" ]
       },
       "overrides": [],
       "dependencies": [
@@ -792,7 +792,7 @@
       },
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+        "revery@github:revery-ui/revery#b473741@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#b1b554f@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "pesy": "0.4.1",
     "@opam/ocaml-migrate-parsetree": "1.3.1",
     "@opam/ppx_tools_versioned": "5.2.2",
-    "revery": "github:revery-ui/revery#3f932c5",
+    "revery": "github:revery-ui/revery#b473741",
     "reason-libvim": "github:onivim/reason-libvim#b1b554f",
     "reason-fontkit": "github:revery-ui/reason-fontkit#f364c36",
     "@opam/ocamlfind": "1.8.0",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7408a948a779f9682b4ad67e0948f62d",
+  "checksum": "b8338f8a1b23bea7fdebc8efc2f78c38",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -75,13 +75,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f932c5@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+    "revery@github:revery-ui/revery#b473741@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#b473741@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f932c5",
+      "version": "github:revery-ui/revery#b473741",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f932c5" ]
+        "source": [ "github:revery-ui/revery#b473741" ]
       },
       "overrides": [],
       "dependencies": [
@@ -792,7 +792,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f932c5@d41d8cd9",
+        "revery@github:revery-ui/revery#b473741@d41d8cd9",
         "rench@1.7.1@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#b1b554f@d41d8cd9",


### PR DESCRIPTION
Fixes #519 

There were several issues with our scroll events - described by `libvim` PRs:
https://github.com/onivim/libvim/pull/158
https://github.com/onivim/libvim/pull/157
https://github.com/onivim/libvim/pull/156

These are now in `master` - however, there was one remaining issue - the `<c-f>` key wasn't working as expected. It turns out there was a Revery bug causing it to resolve to the wrong key - https://github.com/revery-ui/revery/pull/533

This picks up that last Revery fix, so this should be last fix needed to unblock the scroll events described by #519 .