### PR TITLE
add zenModeSingleFile

### DIFF
--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -39,6 +39,7 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
       ~getClipboardText=() => _currentClipboard^,
       ~executingDirectory=Revery.Environment.getExecutingDirectory(),
       ~onStateChanged,
+      ~cliOptions=None,
       (),
     );
 

--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -25,6 +25,7 @@ let getDefaultConfigString = configName =>
   "editor.rulers": [],
   "editor.tabSize": 4,
   "editor.zenMode.hideTabs": true,
+  "editor.zenMode.singleFile": true,
   "files.exclude": ["_esy", "node_modules"],
   "workbench.activityBar.visible": true,
   "workbench.editor.showTabs": true,

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -162,6 +162,10 @@ let configurationParsers: list(configurationTuple) = [
     "editor.zenMode.hideTabs",
     (s, v) => {...s, zenModeHideTabs: parseBool(v)},
   ),
+  (
+    "editor.zenMode.singleFile",
+    (s, v) => {...s, zenModeSingleFile: parseBool(v)},
+  ),
 ];
 
 let keyToParser: Hashtbl.t(string, parseFunction) =

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -34,6 +34,7 @@ type t = {
   workbenchIconTheme: string,
   filesExclude: list(string),
   zenModeHideTabs: bool,
+  zenModeSingleFile: bool,
 };
 
 let default = {
@@ -58,4 +59,5 @@ let default = {
   workbenchIconTheme: "vs-seti",
   filesExclude: ["node_modules", "_esy"],
   zenModeHideTabs: true,
+  zenModeSingleFile: true,
 };

--- a/src/editor/Store/ConfigurationStoreConnector.re
+++ b/src/editor/Store/ConfigurationStoreConnector.re
@@ -7,7 +7,7 @@
 open Oni_Core;
 open Oni_Model;
 
-let start = (~cliOptions: Cli.t) => {
+let start = (~cliOptions: option(Cli.t)) => {
   let configurationFileName = "configuration.json";
   let reloadConfigOnWritePost = (~configPath, dispatch) => {
     let _ =
@@ -34,12 +34,17 @@ let start = (~cliOptions: Cli.t) => {
         | Ok(v) =>
           dispatch(Actions.ConfigurationSet(v));
 
-          let zenModeSingleFile =
-            Configuration.getValue(c => c.zenModeSingleFile, v);
+          switch (cliOptions) {
+          | Some(cliOptions) =>
+            let zenModeSingleFile =
+              Configuration.getValue(c => c.zenModeSingleFile, v);
 
-          if (zenModeSingleFile && List.length(cliOptions.filesToOpen) == 1) {
-            dispatch(Actions.ToggleZenMode);
+            if (zenModeSingleFile && List.length(cliOptions.filesToOpen) == 1) {
+              dispatch(Actions.ToggleZenMode);
+            };
+          | None => ()
           };
+
         | Error(err) => Log.error("Error loading configuration file: " ++ err)
         }
       | Error(err) => Log.error("Error loading configuration file: " ++ err)

--- a/src/editor/Store/ConfigurationStoreConnector.re
+++ b/src/editor/Store/ConfigurationStoreConnector.re
@@ -7,7 +7,7 @@
 open Oni_Core;
 open Oni_Model;
 
-let start = () => {
+let start = (~cliOptions: Cli.t) => {
   let configurationFileName = "configuration.json";
   let reloadConfigOnWritePost = (~configPath, dispatch) => {
     let _ =
@@ -31,7 +31,15 @@ let start = () => {
       switch (configPath) {
       | Ok(configPathAsString) =>
         switch (ConfigurationParser.ofFile(configPathAsString)) {
-        | Ok(v) => dispatch(Actions.ConfigurationSet(v))
+        | Ok(v) =>
+          dispatch(Actions.ConfigurationSet(v));
+
+          let zenModeSingleFile =
+            Configuration.getValue(c => c.zenModeSingleFile, v);
+
+          if (zenModeSingleFile && List.length(cliOptions.filesToOpen) == 1) {
+            dispatch(Actions.ToggleZenMode);
+          };
         | Error(err) => Log.error("Error loading configuration file: " ++ err)
         }
       | Error(err) => Log.error("Error loading configuration file: " ++ err)

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -41,7 +41,7 @@ let start =
       ~executingDirectory,
       ~onStateChanged,
       ~getClipboardText,
-      ~cliOptions,
+      ~cliOptions: option(Oni_Core.Cli.t),
       (),
     ) => {
   ignore(executingDirectory);

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -41,6 +41,7 @@ let start =
       ~executingDirectory,
       ~onStateChanged,
       ~getClipboardText,
+      ~cliOptions,
       (),
     ) => {
   ignore(executingDirectory);
@@ -71,7 +72,7 @@ let start =
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 
-  let configurationUpdater = ConfigurationStoreConnector.start();
+  let configurationUpdater = ConfigurationStoreConnector.start(~cliOptions);
 
   let ripgrep = Core.Ripgrep.make(setup.rgPath);
   let quickOpenUpdater = QuickOpenStoreConnector.start(ripgrep);

--- a/src/editor/bin_editor/Oni2_editor.re
+++ b/src/editor/bin_editor/Oni2_editor.re
@@ -69,6 +69,7 @@ let init = app => {
         () => Reglfw.Glfw.glfwGetClipboardString(w.glfwWindow),
       ~executingDirectory=Core.Utility.executingDirectory,
       ~onStateChanged,
+      ~cliOptions,
       (),
     );
   Log.debug("Startup: StoreThread started!");

--- a/src/editor/bin_editor/Oni2_editor.re
+++ b/src/editor/bin_editor/Oni2_editor.re
@@ -69,7 +69,7 @@ let init = app => {
         () => Reglfw.Glfw.glfwGetClipboardString(w.glfwWindow),
       ~executingDirectory=Core.Utility.executingDirectory,
       ~onStateChanged,
-      ~cliOptions,
+      ~cliOptions=Some(cliOptions),
       (),
     );
   Log.debug("Startup: StoreThread started!");


### PR DESCRIPTION
Fixes #495 

I've been pretty much following the instructions from the issue. There are a couple of things I'd like to fix, but I'm not sure how:

* opening Oni like that still loads a folder, so using the file switcher is possible and one can open more files which does not disable zen mode, that may be confusing.
* when starting Oni with one file, disabling zen mode and then changing the config file will re-enable zen mode every time since the `reloadConfigurationEffect` runs every time the configuration changes

Let me know what you think.