### PR TITLE
DX - OSX: Add scripts to create `oni2` symlink

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -54,6 +54,20 @@ npm run build
 - `esy '@bench' build`
 - `esy '@bench' run`
 
+## Release 
+
+To create a release build, run:
+- `esy create-release`
+
+### Windows
+
+### OSX
+
+Once you have a release build created, you can create an `oni2` symlink to point to your development environment.
+
+Run the following from the `oni2` directory:
+- `./scripts/osx/create-symlink.sh`
+
 # Building the Documentation Website
 
 From the `oni2` directory:
@@ -61,5 +75,3 @@ From the `oni2` directory:
 - `cd docs/website`
 - `npm install`
 - `npm start`
-
-T

--- a/scripts/osx/create-symlink.sh
+++ b/scripts/osx/create-symlink.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# From: https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+# Get actual directory of script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+SRC="$DIR/../../_release/run.sh"
+DEST=/usr/local/bin/oni2
+echo "Removing existing: $DEST"
+rm -f /usr/local/bin/oni2
+echo "Creating symlink from $DEST to $SRC"
+ln -s $SRC $DEST

--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# From: https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+# Get actual directory of script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+open "$DIR/Onivim2.App" --args "$@"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -10,6 +10,10 @@ console.log("Working directory: " + process.cwd());
 const rootDirectory = process.cwd();
 const releaseDirectory = path.join(process.cwd(), "_release");
 
+// Delete releaseDirectory, and remake
+fs.removeSync(releaseDirectory);
+fs.mkdirpSync(releaseDirectory);
+
 const textmateServiceSourceDirectory = path.join(rootDirectory, "src", "textmate_service");
 const extensionsSourceDirectory = path.join(process.cwd(), "extensions");
 // const extensionsDestDirectory = path.join(platformReleaseDirectory, "extensions");

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -118,6 +118,9 @@ if (process.platform == "linux") {
   // Copy bins over
   copy(curBin, binaryDirectory);
 
+  // Copy run helper script over
+  copy("scripts/osx/run.sh", "_release/run.sh");
+
   copy(extensionsSourceDirectory, resourcesDirectory);
   copy(textmateServiceSourceDirectory, resourcesDirectory);
   copy(camomilePath, resourcesDirectory);


### PR DESCRIPTION
When developing on Mac, it's helpful to be able to point an `oni2` symlink to the local release bundle for testing or usage. 

We don't have any automation for this today, so this adds a couple scripts to help out:
- `run.sh` - helper script to run the app / pass args
- `create-symlink.sh` - helper script to create an `oni2` symlink in `/usr/local/bin` that points to the local dev environment.

__TODO:__
- [x] Add docs in the development environment section