### PR TITLE
Change the indent size in the tree explorer

### DIFF
--- a/docs/docs/using-onivim/configuration.md
+++ b/docs/docs/using-onivim/configuration.md
@@ -35,3 +35,5 @@ Onivim's configuration is designed to be mostly compatible with [VSCode's User S
 - `editor.insertSpaces` __(_bool_ default: `true`)__ - When `true`, the Onivim will use spaces for indentation as opposed to tabs.
 
 - `editor.rulers` __(_list of int_ default: `[]`)__ - Render vertical rulers at given columns.
+
+- `workbench.tree.indent` __(_int_ default: `2`)__ - Indentation of the tree explorer.

--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -31,7 +31,7 @@ let getDefaultConfigString = configName =>
   "workbench.iconTheme": "vs-seti",
   "workbench.sideBar.visible": true,
   "workbench.statusBar.visible": true,
-  "explorer.indentSize": 4,
+  "explorer.indentSize": 2,
 }
 |},
     )

--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -31,7 +31,7 @@ let getDefaultConfigString = configName =>
   "workbench.iconTheme": "vs-seti",
   "workbench.sideBar.visible": true,
   "workbench.statusBar.visible": true,
-  "workbench.tree.indent": 2,
+  "workbench.tree.indent": 2
 }
 |},
     )

--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -30,7 +30,8 @@ let getDefaultConfigString = configName =>
   "workbench.editor.showTabs": true,
   "workbench.iconTheme": "vs-seti",
   "workbench.sideBar.visible": true,
-  "workbench.statusBar.visible": true
+  "workbench.statusBar.visible": true,
+  "explorer.indentSize": 4,
 }
 |},
     )

--- a/src/editor/Core/ConfigurationDefaults.re
+++ b/src/editor/Core/ConfigurationDefaults.re
@@ -31,7 +31,7 @@ let getDefaultConfigString = configName =>
   "workbench.iconTheme": "vs-seti",
   "workbench.sideBar.visible": true,
   "workbench.statusBar.visible": true,
-  "explorer.indentSize": 2,
+  "workbench.tree.indent": 2,
 }
 |},
     )

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -164,7 +164,7 @@ let configurationParsers: list(configurationTuple) = [
   ),
   (
     "workbench.tree.indent",
-    (s, v) => {...s, workbenchTreeIndent: parseInt(v)}
+    (s, v) => {...s, workbenchTreeIndent: parseInt(v)},
   ),
 ];
 

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -166,6 +166,7 @@ let configurationParsers: list(configurationTuple) = [
     "workbench.tree.indent",
     (s, v) => {...s, workbenchTreeIndent: parseInt(v)},
   ),
+  (
     "editor.zenMode.singleFile",
     (s, v) => {...s, zenModeSingleFile: parseBool(v)},
   ),

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -162,6 +162,10 @@ let configurationParsers: list(configurationTuple) = [
     "editor.zenMode.hideTabs",
     (s, v) => {...s, zenModeHideTabs: parseBool(v)},
   ),
+  (
+    "explorer.indentSize",
+    (s, v) => {...s, explorerIndentSize: parseInt(v)}
+  ),
 ];
 
 let keyToParser: Hashtbl.t(string, parseFunction) =

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -163,8 +163,8 @@ let configurationParsers: list(configurationTuple) = [
     (s, v) => {...s, zenModeHideTabs: parseBool(v)},
   ),
   (
-    "explorer.indentSize",
-    (s, v) => {...s, explorerIndentSize: parseInt(v)}
+    "workbench.tree.indent",
+    (s, v) => {...s, workbenchTreeIndent: parseInt(v)}
   ),
 ];
 

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -34,6 +34,7 @@ type t = {
   workbenchIconTheme: string,
   filesExclude: list(string),
   zenModeHideTabs: bool,
+  explorerIndentSize: int,
 };
 
 let default = {
@@ -58,4 +59,5 @@ let default = {
   workbenchIconTheme: "vs-seti",
   filesExclude: ["node_modules", "_esy"],
   zenModeHideTabs: true,
+  explorerIndentSize: 2,
 };

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -34,7 +34,7 @@ type t = {
   workbenchIconTheme: string,
   filesExclude: list(string),
   zenModeHideTabs: bool,
-  explorerIndentSize: int,
+  workbenchTreeIndent: int,
 };
 
 let default = {
@@ -59,5 +59,5 @@ let default = {
   workbenchIconTheme: "vs-seti",
   filesExclude: ["node_modules", "_esy"],
   zenModeHideTabs: true,
-  explorerIndentSize: 2,
+  workbenchTreeIndent: 2,
 };

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -67,9 +67,12 @@ let itemRenderer =
       backgroundColor(bgColor),
     ];
 
+  let explorerIndent =
+    Core.Configuration.getValue(
+      c => c.workbenchTreeIndent,
+      state.configuration,
+    );
 
-  let explorerIndent = Core.Configuration.getValue(c => c.workbenchTreeIndent, state.configuration)
-  
   let indentStr = String.make(indent * explorerIndent, ' ');
 
   let icon =

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -67,7 +67,6 @@ let itemRenderer =
       backgroundColor(bgColor),
     ];
 
-  Core.Log.info("Indent"++string_of_int(indent))
 
   let explorerIndent = Core.Configuration.getValue(c => c.workbenchTreeIndent, state.configuration)
   

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -1,4 +1,5 @@
 open Oni_Model;
+
 open UiTree;
 open Revery.UI;
 open Revery.UI.Components;
@@ -66,7 +67,10 @@ let itemRenderer =
       backgroundColor(bgColor),
     ];
 
-  let explorerIndent = Core.Configuration.getValue(c => c.explorerIndentSize, state.configuration)
+  Core.Log.info("Indent"++string_of_int(indent))
+
+  let explorerIndent = Core.Configuration.getValue(c => c.workbenchTreeIndent, state.configuration)
+  
   let indentStr = String.make(indent * explorerIndent, ' ');
 
   let icon =

--- a/src/editor/UI/TreeView.re
+++ b/src/editor/UI/TreeView.re
@@ -47,6 +47,7 @@ let itemRenderer =
       ~itemSize,
       ~foregroundColor,
       ~backgroundColor,
+      ~state: State.t,
       {data, status, id}: itemContent,
     ) => {
   let isOpen =
@@ -65,7 +66,8 @@ let itemRenderer =
       backgroundColor(bgColor),
     ];
 
-  let indentStr = String.make(indent * 2, ' ');
+  let explorerIndent = Core.Configuration.getValue(c => c.explorerIndentSize, state.configuration)
+  let indentStr = String.make(indent * explorerIndent, ' ');
 
   let icon =
     switch (data) {
@@ -140,6 +142,7 @@ let createElement =
         ~itemSize,
         ~backgroundColor,
         ~foregroundColor,
+        ~state,
       );
 
     (


### PR DESCRIPTION
#### New entry in the configuration

Added a new entry to handle the intent size of tree explorer
```json
{
"explorer.indentSize": 4
}
```

Before this, the indent size was hardcoded (2) and the tree explorer could look too narrowed for some users.

The `itemRenderer` (`TreeView.re`) now receives the state so it can get the explorer indent size from the configuration and it simply uses it instead of the old hardcoded value.
