### PR TITLE
ignore more keys to ignore on the vim side

### DIFF
--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -323,6 +323,8 @@ let start = (getState: unit => Model.State.t, getClipboardText) => {
       /* TODO: Fix these keypaths in libvim to not be blocking */
       =>
         if (!String.equal(key, "<S-SHIFT>")
+            && !String.equal(key, "<A-SHIFT>")
+            && !String.equal(key, "<D-SHIFT>")
             && !String.equal(key, "<D->")
             && !String.equal(key, "<D-S->")
             && !String.equal(key, "<C->")


### PR DESCRIPTION
I could reproduce `alt-shift` and `win-shift`. Not sure if there are more keys, I'll open more PRs if I find some.

fixes #415 