### PR TITLE
add CopyActiveFilepathToClipboard action

### DIFF
--- a/integration_test/CopyActiveFilepathToClipboardTest.re
+++ b/integration_test/CopyActiveFilepathToClipboardTest.re
@@ -1,0 +1,24 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(
+  ~name=
+    "CopyActiveFilepathToClipboard writes the active buffer's file path to the clipboard",
+  (dispatch, wait, runEffects) => {
+    setClipboard(Some("def"));
+    dispatch(CopyActiveFilepathToClipboard);
+    runEffects();
+
+    wait(~name="clipboard contains file path", (state: State.t) =>
+      switch (Selectors.getActiveBuffer(state)) {
+      | Some(buffer) =>
+        switch (getClipboard(), Buffer.getFilePath(buffer)) {
+        | (Some(textInClipBoard), Some(filname)) =>
+          String.equal(textInClipBoard, filname)
+        | _ => false
+        }
+      | _ => false
+      }
+    );
+  },
+);

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -3,6 +3,7 @@
            ClipboardPasteMultiLineTest
            ClipboardPasteSingleLineTest
            ClipboardPasteEmptyTest
+           CopyActiveFilepathToClipboardTest
            SearchShowClearHighlightsTest
            RegressionCommandLineNoCompletionTest
            RegressionVspEmptyInitialBufferTest
@@ -25,6 +26,7 @@
         ClipboardPasteMultiLineTest.exe
         ClipboardPasteSingleLineTest.exe
         ClipboardPasteEmptyTest.exe
+        CopyActiveFilepathToClipboardTest.exe
         RegressionCommandLineNoCompletionTest.exe
         RegressionVspEmptyInitialBufferTest.exe
         RegressionVspEmptyExistingBufferTest.exe

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -14,6 +14,7 @@ type testCallback =
 let _currentClipboard: ref(option(string)) = ref(None);
 
 let setClipboard = v => _currentClipboard := v;
+let getClipboard = () => _currentClipboard^;
 
 let runTest = (~name="AnonymousTest", test: testCallback) => {
   Printexc.record_backtrace(true);
@@ -37,6 +38,7 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
     Store.StoreThread.start(
       ~setup,
       ~getClipboardText=() => _currentClipboard^,
+      ~setClipboardText=text => setClipboard(Some(text)),
       ~executingDirectory=Revery.Environment.getExecutingDirectory(),
       ~onStateChanged,
       ~cliOptions=None,

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -79,6 +79,7 @@ type t =
   | ViewCloseEditor(int)
   | ViewSetActiveEditor(int)
   | ToggleZenMode
+  | CopyActiveFilepathToClipboard
   | Noop
 and editor = {
   editorId: int,

--- a/src/editor/Model/CommandPalette.re
+++ b/src/editor/Model/CommandPalette.re
@@ -54,6 +54,12 @@ let create = setItems => {
       command: () => Actions.Command("view.rotateBackward"),
       icon: None,
     },
+    {
+      category: Some("Editor"),
+      name: "Copy Active Filepath To Clipboard",
+      command: () => Actions.CopyActiveFilepathToClipboard,
+      icon: None,
+    },
   ];
 
   setItems(commands);

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -41,6 +41,7 @@ let start =
       ~executingDirectory,
       ~onStateChanged,
       ~getClipboardText,
+      ~setClipboardText,
       ~cliOptions: option(Oni_Core.Cli.t),
       (),
     ) => {
@@ -58,7 +59,7 @@ let start =
 
   let commandUpdater = CommandStoreConnector.start(getState);
   let (vimUpdater, vimStream) =
-    VimStoreConnector.start(getState, getClipboardText);
+    VimStoreConnector.start(getState, getClipboardText, setClipboardText);
 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);

--- a/src/editor/bin_editor/Oni2_editor.re
+++ b/src/editor/bin_editor/Oni2_editor.re
@@ -67,6 +67,8 @@ let init = app => {
       ~setup,
       ~getClipboardText=
         () => Reglfw.Glfw.glfwGetClipboardString(w.glfwWindow),
+      ~setClipboardText=
+        text => Reglfw.Glfw.glfwSetClipboardString(w.glfwWindow, text),
       ~executingDirectory=Core.Utility.executingDirectory,
       ~onStateChanged,
       ~cliOptions=Some(cliOptions),


### PR DESCRIPTION
I'm currently using atom and this is one of my most used commands. Whenever I work on a test and I want to run that test only I use that command to the the path of the file I'm currently editing. Or basically if I want to do anything on the terminal with the file I use this.

I hope this is useful for other's as well.