### PR TITLE
Documentation: Fix create-release instructions

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -57,7 +57,11 @@ npm run build
 ## Release 
 
 To create a release build, run:
+
+- `esy x Oni2 -f --checkhealth`
 - `esy create-release`
+
+This will create a `_release` folder at the root with the application bundle inside.
 
 ### Windows
 


### PR DESCRIPTION
We were missing a step prior to `esy create-release` - we need to run `esy x Oni2` to get `esy` to set up the install layout in esy's cache - the `esy create-release` scripts expects this to have happened.