### PR TITLE
Native Syntax Highlighting - Part 2 - Tree Sitter -> TextMate Scope Mapping

### DIFF
--- a/src/editor/Syntax/Oni_Syntax.re
+++ b/src/editor/Syntax/Oni_Syntax.re
@@ -6,4 +6,5 @@
 
 module TextMateScopes = TextMateScopes;
 module TextMateTheme = TextMateTheme;
+module TreeSitterScopes = TreeSitterScopes;
 module Trie = Trie;

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -33,25 +33,20 @@ module Matcher = {
 };
 
 module Selector = {
-
   let firstChildRegex = Str.regexp(".*:first-child$");
   let nthChildRegex = Str.regexp(".*:nth-child(\\([0-9]*\\))$");
 
-  let checkChildSelector  = (v: string) => {
+  let checkChildSelector = (v: string) => {
     let matches = Str.string_match(nthChildRegex, v, 0);
 
-    switch (matches) {
-    | true =>{ 
-      let v = Str.matched_group(1, v);
-      Some(v);
+    matches
+      ? {
+        let v = Str.matched_group(1, v);
+        Some(v);
       }
-    | false => switch (Str.string_match(firstChildRegex, v, 0)) {
-      | true => Some("0")
-      | false => None
-    }
-    }
+      : Str.string_match(firstChildRegex, v, 0) ? Some("0") : None;
   };
-}
+};
 
 /*
    [TextMateConverter] is a module that helps convert

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -1,0 +1,38 @@
+/*
+ TreeSitterScopes
+ */
+
+/*
+  [TextMateConverter] is a module that helps convert
+  tree-sitter paths into textmate scopes for th eming.
+*/
+module TextMateConverter = {
+  type matcher =
+  // Just a single scope, like: 'string.quoted.double'
+  | Scope(string)
+  // A regex match clause, like: '{ match: "^http:", scopes: 'markup.underline.link'}'
+  | RegExMatch(string, string)
+  // An exact match clause, like: '{ exact: "test": scopes: 'some.token' }'
+  | ExactMatch(string, string);
+
+  type scopeSelector = (string, list(matcher));
+
+  type t = {
+    // Tries to support 'nth-child(x)' rules
+    // byChildSelectors: IntMap.t(Trie.t(scopeSelector)),
+    // Tries to support the default case - no child selector
+    defaultSelectors: Trie.t(list(matcher)),
+  };
+
+  let create = (selectors: list(scopeSelector)) => {
+    let defaultSelectors = List.fold_left(
+      (prev, curr) => {
+        let (selector, matchers): scopeSelector = curr;
+        let f = _ => Some(matchers);
+        Trie.update([selector], f, prev);
+      }, Trie.empty, selectors);
+
+      { defaultSelectors };
+  };
+};
+

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -32,7 +32,25 @@ module TextMateConverter = {
         Trie.update([selector], f, prev);
       }, Trie.empty, selectors);
 
-      { defaultSelectors };
+      let ret: t = { 
+        defaultSelectors: defaultSelectors,
+      };
+      ret;
+  };
+
+  let getTextMateScope = (~_index=0, ~_token="", ~path=[], v: t) => {
+    switch (Trie.matches(v.defaultSelectors, path)) {
+    | [] => None
+    | [hd, ..._] => {
+
+      let (_, matchers) = hd;
+
+      switch (matchers) {
+      | Some([Scope(v)]) => Some(v)
+      | _ => None
+      }
+    }
+    }
   };
 };
 

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -51,9 +51,11 @@ module TextMateConverter = {
   let create = (selectors: list(scopeSelector)) => {
     let defaultSelectors = List.fold_left(
       (prev, curr) => {
+
         let (selector, matchers): scopeSelector = curr;
+        let expandedSelectors = Str.split(Str.regexp(" > "), selector) |> List.rev;
         let f = _ => Some(matchers);
-        Trie.update([selector], f, prev);
+        Trie.update(expandedSelectors, f, prev);
       }, Trie.empty, selectors);
 
       let ret: t = { 

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -32,6 +32,27 @@ module Matcher = {
   };
 };
 
+module Selector = {
+
+  let firstChildRegex = Str.regexp(".*:first-child$");
+  let nthChildRegex = Str.regexp(".*:nth-child(\\([0-9]*\\))$");
+
+  let checkChildSelector  = (v: string) => {
+    let matches = Str.string_match(nthChildRegex, v, 0);
+
+    switch (matches) {
+    | true =>{ 
+      let v = Str.matched_group(1, v);
+      Some(v);
+      }
+    | false => switch (Str.string_match(firstChildRegex, v, 0)) {
+      | true => Some("0")
+      | false => None
+    }
+    }
+  };
+}
+
 /*
    [TextMateConverter] is a module that helps convert
    tree-sitter paths into textmate scopes for th eming.

--- a/src/editor/Syntax/TreeSitterScopes.rei
+++ b/src/editor/Syntax/TreeSitterScopes.rei
@@ -4,7 +4,7 @@
  Module to help in mapping the tree-sitter syntax tree to textmate scopes
  */
 
-module Matcher {
+module Matcher: {
   type t =
     // Just a single scope, like: 'string.quoted.double'
     | Scope(string)
@@ -14,7 +14,7 @@ module Matcher {
     | ExactMatch(string, string);
 };
 
-module Selector { 
+module Selector: {
   let checkChildSelector: string => option(string);
 
   let parse: string => (list(string), option(string));
@@ -24,7 +24,7 @@ module Selector {
    [TextMateConverter] is a module that helps convert
    tree-sitter paths into textmate scopes for th eming.
  */
-module TextMateConverter {
+module TextMateConverter: {
   type scopeSelector = (string, list(Matcher.t));
 
   type t;
@@ -32,20 +32,22 @@ module TextMateConverter {
   let empty: t;
 
   /*
-    [create(scopeSelectors)] creates a converter based on a set of selectors
-  */
+     [create(scopeSelectors)] creates a converter based on a set of selectors
+   */
   let create: list(scopeSelector) => t;
 
   /*
-    [getTextMateScope(~index, ~token, ~path, v)] resolves information from
-    the tree-sitter syntax tree into a textmate scope. The information that 
-    must be provided is:
-    - [index] - the 'child-index' of the element, used for resolving :nth-child selectors
-    - [token] - the token of the element, used in some selectors for matching
-    - [path] - the path of the element from the parent, like ["pair", "value"]
+     [getTextMateScope(~index, ~token, ~path, v)] resolves information from
+     the tree-sitter syntax tree into a textmate scope. The information that
+     must be provided is:
+     - [index] - the 'child-index' of the element, used for resolving :nth-child selectors
+     - [token] - the token of the element, used in some selectors for matching
+     - [path] - the path of the element from the parent, like ["pair", "value"]
 
-    If there is no match, [None] will be returned, otherwise [Some(string)] will be returned
-    with the resolved textmate scope
-  */
-  let getTextMateScope: (~index:int=?, ~token:string=?, ~path:list(string)=?, t) => option(string);
+     If there is no match, [None] will be returned, otherwise [Some(string)] will be returned
+     with the resolved textmate scope
+   */
+  let getTextMateScope:
+    (~index: int=?, ~token: string=?, ~path: list(string)=?, t) =>
+    option(string);
 };

--- a/src/editor/Syntax/TreeSitterScopes.rei
+++ b/src/editor/Syntax/TreeSitterScopes.rei
@@ -1,0 +1,51 @@
+/*
+ TreeSitterScopes.rei
+
+ Module to help in mapping the tree-sitter syntax tree to textmate scopes
+ */
+
+module Matcher {
+  type t =
+    // Just a single scope, like: 'string.quoted.double'
+    | Scope(string)
+    // A regex match clause, like: '{ match: "^http:", scopes: 'markup.underline.link'}'
+    | RegExMatch(Str.regexp, string)
+    // An exact match clause, like: '{ exact: "test": scopes: 'some.token' }'
+    | ExactMatch(string, string);
+};
+
+module Selector { 
+  let checkChildSelector: string => option(string);
+
+  let parse: string => (list(string), option(string));
+};
+
+/*
+   [TextMateConverter] is a module that helps convert
+   tree-sitter paths into textmate scopes for th eming.
+ */
+module TextMateConverter {
+  type scopeSelector = (string, list(Matcher.t));
+
+  type t;
+
+  let empty: t;
+
+  /*
+    [create(scopeSelectors)] creates a converter based on a set of selectors
+  */
+  let create: list(scopeSelector) => t;
+
+  /*
+    [getTextMateScope(~index, ~token, ~path, v)] resolves information from
+    the tree-sitter syntax tree into a textmate scope. The information that 
+    must be provided is:
+    - [index] - the 'child-index' of the element, used for resolving :nth-child selectors
+    - [token] - the token of the element, used in some selectors for matching
+    - [path] - the path of the element from the parent, like ["pair", "value"]
+
+    If there is no match, [None] will be returned, otherwise [Some(string)] will be returned
+    with the resolved textmate scope
+  */
+  let getTextMateScope: (~index:int=?, ~token:string=?, ~path:list(string)=?, t) => option(string);
+};

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -5,7 +5,7 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 open TreeSitterScopes;
 
 describe("TreeSitterScopes", ({describe, _}) => {
-  describe("Selector", ({test, _}) =>
+  describe("Selector", ({test, _}) => {
     test("returns correct results", ({expect, _}) => {
       expect.bool(Selector.checkChildSelector("pair") == None).toBe(true);
       expect.bool(
@@ -26,8 +26,11 @@ describe("TreeSitterScopes", ({describe, _}) => {
         toBe(
         true,
       );
-    })
-  );
+    });
+    test("parse", ({expect, _}) => {
+      expect.bool(Selector.parse("pair > string:nth-child(0)") == (["string", "pair"], Some("0"))).toBe(true);
+    });
+  });
   describe("TextMateConverter", ({test, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -1,0 +1,24 @@
+open TestFramework;
+
+module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
+
+open TreeSitterScopes;
+
+describe("TreeSitterScopes", ({describe, _}) => {
+  describe("TextMateConverter", ({test, _}) => {
+
+    // Create a simple converter... this is a representation of grammars
+    // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
+    let simpleConverter = TextMateConverter.create([
+      ("value", [Scope("source.json")])
+    ]);
+
+    test("matches basic scopes", ({expect, _}) => {
+      let nonExistentScope  = TextMateConverter.getTextMateScope(
+        ~path=["non-existent-tree-sitter-scope"],
+        simpleConverter);
+
+      expect.bool(nonExistentScope == None).toBe(true);
+    })
+  });
+});

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -4,64 +4,87 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 
 open TreeSitterScopes;
 
-describe("TreeSitterScopes", ({describe, _}) => {
+describe("TreeSitterScopes", ({describe, _}) =>
   describe("TextMateConverter", ({test, _}) => {
-
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
-    let simpleConverter = TextMateConverter.create([
-      ("value", [Scope("source.json")]),
-      ("object", [Scope("meta.structure.dictionary.json")]),
-      ("string_content", [
-        RegExMatch(Str.regexp("^http:\\/\\/"), "markup.underline.link.http.hyperlink"),
-        RegExMatch(Str.regexp("^https:\\/\\/"), "markup.underline.link.https.hyperlink"),
-      ]),
-      ("pair > false", [Scope("constant.language")])
-    ]);
+    let simpleConverter =
+      TextMateConverter.create([
+        ("value", [Scope("source.json")]),
+        ("object", [Scope("meta.structure.dictionary.json")]),
+        (
+          "string_content",
+          [
+            RegExMatch(
+              Str.regexp("^http:\\/\\/"),
+              "markup.underline.link.http.hyperlink",
+            ),
+            RegExMatch(
+              Str.regexp("^https:\\/\\/"),
+              "markup.underline.link.https.hyperlink",
+            ),
+          ],
+        ),
+        ("pair > false", [Scope("constant.language")]),
+      ]);
 
     test("returns None for non-existent scopes", ({expect, _}) => {
-      let nonExistentScope  = TextMateConverter.getTextMateScope(
-        ~path=["non-existent-tree-sitter-scope"],
-        simpleConverter);
+      let nonExistentScope =
+        TextMateConverter.getTextMateScope(
+          ~path=["non-existent-tree-sitter-scope"],
+          simpleConverter,
+        );
 
       expect.bool(nonExistentScope == None).toBe(true);
     });
     test("matches simple scopes", ({expect, _}) => {
-      let scope  = TextMateConverter.getTextMateScope(
-        ~path=["value"],
-        simpleConverter);
+      let scope =
+        TextMateConverter.getTextMateScope(~path=["value"], simpleConverter);
 
       expect.bool(scope == Some("source.json")).toBe(true);
     });
     test("matches another simple scope", ({expect, _}) => {
-      let scope  = TextMateConverter.getTextMateScope(
-        ~path=["object"],
-        simpleConverter);
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~path=["object"],
+          simpleConverter,
+        );
 
-      expect.bool(scope == Some("meta.structure.dictionary.json")).toBe(true);
-    })
+      expect.bool(scope == Some("meta.structure.dictionary.json")).toBe(
+        true,
+      );
+    });
     test("regex match failure", ({expect, _}) => {
-      let scope  = TextMateConverter.getTextMateScope(
-        ~path=["string_content"],
-        ~token="derp",
-        simpleConverter);
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~path=["string_content"],
+          ~token="derp",
+          simpleConverter,
+        );
 
       expect.bool(scope == None).toBe(true);
-    })
+    });
     test("regex match success", ({expect, _}) => {
-      let scope  = TextMateConverter.getTextMateScope(
-        ~path=["string_content"],
-        ~token="https://v2.onivim.io",
-        simpleConverter);
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~path=["string_content"],
+          ~token="https://v2.onivim.io",
+          simpleConverter,
+        );
 
-      expect.bool(scope == Some("markup.underline.link.https.hyperlink")).toBe(true);
-    })
+      expect.bool(scope == Some("markup.underline.link.https.hyperlink")).
+        toBe(
+        true,
+      );
+    });
     test("child selector", ({expect, _}) => {
-      let scope  = TextMateConverter.getTextMateScope(
-        ~path=["false", "pair"],
-        simpleConverter);
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~path=["false", "pair"],
+          simpleConverter,
+        );
 
       expect.bool(scope == Some("constant.language")).toBe(true);
-    })
-  });
-});
+    });
+  })
+);

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -5,38 +5,6 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 open TreeSitterScopes;
 
 describe("TreeSitterScopes", ({describe, _}) => {
-  describe("Selector", ({test, _}) => {
-    test("returns correct results", ({expect, _}) => {
-      expect.bool(Selector.checkChildSelector("pair") == None).toBe(true);
-      expect.bool(
-        Selector.checkChildSelector("pair:nth-child(0)") == Some("0"),
-      ).
-        toBe(
-        true,
-      );
-      expect.bool(
-        Selector.checkChildSelector("pair:nth-child(99)") == Some("99"),
-      ).
-        toBe(
-        true,
-      );
-      expect.bool(
-        Selector.checkChildSelector("pair:first-child") == Some("0"),
-      ).
-        toBe(
-        true,
-      );
-    });
-    test("parse", ({expect, _}) =>
-      expect.bool(
-        Selector.parse("pair > string:nth-child(0)")
-        == (["string", "pair"], Some("0")),
-      ).
-        toBe(
-        true,
-      )
-    );
-  });
   describe("TextMateConverter", ({test, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -5,15 +5,29 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 open TreeSitterScopes;
 
 describe("TreeSitterScopes", ({describe, _}) => {
-  describe("Selector", ({test, _}) => {
+  describe("Selector", ({test, _}) =>
     test("returns correct results", ({expect, _}) => {
-
       expect.bool(Selector.checkChildSelector("pair") == None).toBe(true);
-      expect.bool(Selector.checkChildSelector("pair:nth-child(0)") == Some("0")).toBe(true);
-      expect.bool(Selector.checkChildSelector("pair:nth-child(99)") == Some("99")).toBe(true);
-      expect.bool(Selector.checkChildSelector("pair:first-child") == Some("0")).toBe(true);
-    });
-  });
+      expect.bool(
+        Selector.checkChildSelector("pair:nth-child(0)") == Some("0"),
+      ).
+        toBe(
+        true,
+      );
+      expect.bool(
+        Selector.checkChildSelector("pair:nth-child(99)") == Some("99"),
+      ).
+        toBe(
+        true,
+      );
+      expect.bool(
+        Selector.checkChildSelector("pair:first-child") == Some("0"),
+      ).
+        toBe(
+        true,
+      );
+    })
+  );
   describe("TextMateConverter", ({test, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
@@ -35,7 +49,10 @@ describe("TreeSitterScopes", ({describe, _}) => {
           ],
         ),
         ("pair > string", [Scope("constant.language")]),
-        ("pair > string:nth-child(1)", [Scope("string.quoted.dictionary.key.json")]),
+        (
+          "pair > string:nth-child(1)",
+          [Scope("string.quoted.dictionary.key.json")],
+        ),
       ]);
 
     test("returns None for non-existent scopes", ({expect, _}) => {
@@ -108,11 +125,11 @@ describe("TreeSitterScopes", ({describe, _}) => {
     test("child selector matches descendants", ({expect, _}) => {
       let scope =
         TextMateConverter.getTextMateScope(
-          ~path=["string", "pair" ,"random-scope"],
+          ~path=["string", "pair", "random-scope"],
           simpleConverter,
         );
 
       expect.bool(scope == Some("constant.language")).toBe(true);
     });
-  })
+  });
 });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -4,7 +4,7 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 
 open TreeSitterScopes;
 
-describe("TreeSitterScopes", ({describe, _}) => {
+describe("TreeSitterScopes", ({describe, _}) =>
   describe("TextMateConverter", ({test, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
@@ -121,5 +121,5 @@ describe("TreeSitterScopes", ({describe, _}) => {
         true,
       );
     });
-  });
-});
+  })
+);

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -4,7 +4,16 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 
 open TreeSitterScopes;
 
-describe("TreeSitterScopes", ({describe, _}) =>
+describe("TreeSitterScopes", ({describe, _}) => {
+  describe("Selector", ({test, _}) => {
+    test("returns correct results", ({expect, _}) => {
+
+      expect.bool(Selector.checkChildSelector("pair") == None).toBe(true);
+      expect.bool(Selector.checkChildSelector("pair:nth-child(0)") == Some("0")).toBe(true);
+      expect.bool(Selector.checkChildSelector("pair:nth-child(99)") == Some("99")).toBe(true);
+      expect.bool(Selector.checkChildSelector("pair:first-child") == Some("0")).toBe(true);
+    });
+  });
   describe("TextMateConverter", ({test, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
@@ -25,7 +34,8 @@ describe("TreeSitterScopes", ({describe, _}) =>
             ),
           ],
         ),
-        ("pair > false", [Scope("constant.language")]),
+        ("pair > string", [Scope("constant.language")]),
+        ("pair > string:nth-child(1)", [Scope("string.quoted.dictionary.key.json")]),
       ]);
 
     test("returns None for non-existent scopes", ({expect, _}) => {
@@ -80,11 +90,29 @@ describe("TreeSitterScopes", ({describe, _}) =>
     test("child selector", ({expect, _}) => {
       let scope =
         TextMateConverter.getTextMateScope(
-          ~path=["false", "pair"],
+          ~path=["string", "pair"],
+          simpleConverter,
+        );
+
+      expect.bool(scope == Some("constant.language")).toBe(true);
+    });
+    test("child selector only matches direct children", ({expect, _}) => {
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~path=["string", "random-scope", "pair"],
+          simpleConverter,
+        );
+
+      expect.bool(scope == None).toBe(true);
+    });
+    test("child selector matches descendants", ({expect, _}) => {
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~path=["string", "pair" ,"random-scope"],
           simpleConverter,
         );
 
       expect.bool(scope == Some("constant.language")).toBe(true);
     });
   })
-);
+});

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -15,7 +15,8 @@ describe("TreeSitterScopes", ({describe, _}) => {
       ("string_content", [
         RegExMatch(Str.regexp("^http:\\/\\/"), "markup.underline.link.http.hyperlink"),
         RegExMatch(Str.regexp("^https:\\/\\/"), "markup.underline.link.https.hyperlink"),
-      ])
+      ]),
+      ("pair > false", [Scope("constant.language")])
     ]);
 
     test("returns None for non-existent scopes", ({expect, _}) => {
@@ -54,6 +55,13 @@ describe("TreeSitterScopes", ({describe, _}) => {
         simpleConverter);
 
       expect.bool(scope == Some("markup.underline.link.https.hyperlink")).toBe(true);
+    })
+    test("child selector", ({expect, _}) => {
+      let scope  = TextMateConverter.getTextMateScope(
+        ~path=["false", "pair"],
+        simpleConverter);
+
+      expect.bool(scope == Some("constant.language")).toBe(true);
     })
   });
 });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -131,5 +131,15 @@ describe("TreeSitterScopes", ({describe, _}) => {
 
       expect.bool(scope == Some("constant.language")).toBe(true);
     });
+    test("nth-child(1) selector matches", ({expect, _}) => {
+      let scope =
+        TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["string", "pair", "random-scope"],
+          simpleConverter,
+        );
+
+      expect.bool(scope == Some("string.quoted.dictionary.key.json")).toBe(true);
+    });
   });
 });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -10,15 +10,34 @@ describe("TreeSitterScopes", ({describe, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
     let simpleConverter = TextMateConverter.create([
-      ("value", [Scope("source.json")])
+      ("value", [Scope("source.json")]),
+      ("object", [Scope("meta.structure.dictionary.json")]),
+      ("string_content", [
+        RegExMatch("^http:\/\/", scopes: "markup.underline.link.http.hyperlink"),
+        RegExMatch("^https:\/\/", scopes: "markup.underline.link.https.hyperlink"),
+      ])
     ]);
 
-    test("matches basic scopes", ({expect, _}) => {
+    test("returns None for non-existent scopes", ({expect, _}) => {
       let nonExistentScope  = TextMateConverter.getTextMateScope(
         ~path=["non-existent-tree-sitter-scope"],
         simpleConverter);
 
       expect.bool(nonExistentScope == None).toBe(true);
+    });
+    test("matches simple scopes", ({expect, _}) => {
+      let scope  = TextMateConverter.getTextMateScope(
+        ~path=["value"],
+        simpleConverter);
+
+      expect.bool(scope == Some("source.json")).toBe(true);
+    });
+    test("matches another simple scope", ({expect, _}) => {
+      let scope  = TextMateConverter.getTextMateScope(
+        ~path=["object"],
+        simpleConverter);
+
+      expect.bool(scope == Some("meta.structure.dictionary.json")).toBe(true);
     })
   });
 });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -27,9 +27,15 @@ describe("TreeSitterScopes", ({describe, _}) => {
         true,
       );
     });
-    test("parse", ({expect, _}) => {
-      expect.bool(Selector.parse("pair > string:nth-child(0)") == (["string", "pair"], Some("0"))).toBe(true);
-    });
+    test("parse", ({expect, _}) =>
+      expect.bool(
+        Selector.parse("pair > string:nth-child(0)")
+        == (["string", "pair"], Some("0")),
+      ).
+        toBe(
+        true,
+      )
+    );
   });
   describe("TextMateConverter", ({test, _}) => {
     // Create a simple converter... this is a representation of grammars
@@ -128,6 +134,7 @@ describe("TreeSitterScopes", ({describe, _}) => {
     test("child selector matches descendants", ({expect, _}) => {
       let scope =
         TextMateConverter.getTextMateScope(
+          ~index=0,
           ~path=["string", "pair", "random-scope"],
           simpleConverter,
         );
@@ -142,7 +149,9 @@ describe("TreeSitterScopes", ({describe, _}) => {
           simpleConverter,
         );
 
-      expect.bool(scope == Some("string.quoted.dictionary.key.json")).toBe(true);
+      expect.bool(scope == Some("string.quoted.dictionary.key.json")).toBe(
+        true,
+      );
     });
   });
 });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -13,8 +13,8 @@ describe("TreeSitterScopes", ({describe, _}) => {
       ("value", [Scope("source.json")]),
       ("object", [Scope("meta.structure.dictionary.json")]),
       ("string_content", [
-        RegExMatch("^http:\/\/", scopes: "markup.underline.link.http.hyperlink"),
-        RegExMatch("^https:\/\/", scopes: "markup.underline.link.https.hyperlink"),
+        RegExMatch(Str.regexp("^http:\\/\\/"), "markup.underline.link.http.hyperlink"),
+        RegExMatch(Str.regexp("^https:\\/\\/"), "markup.underline.link.https.hyperlink"),
       ])
     ]);
 
@@ -38,6 +38,22 @@ describe("TreeSitterScopes", ({describe, _}) => {
         simpleConverter);
 
       expect.bool(scope == Some("meta.structure.dictionary.json")).toBe(true);
+    })
+    test("regex match failure", ({expect, _}) => {
+      let scope  = TextMateConverter.getTextMateScope(
+        ~path=["string_content"],
+        ~token="derp",
+        simpleConverter);
+
+      expect.bool(scope == None).toBe(true);
+    })
+    test("regex match success", ({expect, _}) => {
+      let scope  = TextMateConverter.getTextMateScope(
+        ~path=["string_content"],
+        ~token="https://v2.onivim.io",
+        simpleConverter);
+
+      expect.bool(scope == Some("markup.underline.link.https.hyperlink")).toBe(true);
     })
   });
 });


### PR DESCRIPTION
We're working on tree-sitter has a native syntax highlighting alternative to TextMate grammars. Much of the work for that is happening here: https://github.com/onivim/reason-tree-sitter (which adds a ReasonML API for tree-sitter).

When parsing with `tree-sitter`, for example, a simple JSON document like `[1, "2"]`, we end up with a syntax tree like:
```
(value (array (number) (string (string_content))))
```

The problem is - there aren't any theming solutions at the moment that theme the syntax tree directly. And, we want to leverage VSCode themes, which use textmate selectors.

Therefore, we need a mapping - a way to take the tree-sitter syntax tree, and resolve nodes to textmate-scopes. It turns out Atom has the same issue, and implement a mapping format - the JSON mapping is defined here: 
https://github.com/atom/language-json/tree/master/grammars

Our plan, then, for the languages we will support with `tree-sitter` is to:
1) Create the `tree-sitter` syntax tree using `reason-tree-sitter`
2) Resolve the syntax tree into textmate scopes (which is what this PR implements)
3) Resolve the textmate scopes into theme colors using selectors (This was implemented by #650)

So we're getting closer to having the full pipeline in place to start integrating tree-sitter. In addition to the above, we also need to add some logic to read in the themes from JSON, and hook up tree-sitter to our syntax highlighting pipeline.