### PR TITLE
bugfix: resolve tab character to <TAB>

### DIFF
--- a/src/editor/bin_editor/Input.re
+++ b/src/editor/bin_editor/Input.re
@@ -14,6 +14,7 @@ module Zed_utf8 = Oni_Core.ZedBundled;
 
 let keyPressToString = (~altKey, ~shiftKey, ~ctrlKey, ~superKey, s) => {
   let s = s == "<" ? "lt" : s;
+  let s = s == "\t" ? "TAB" : s;
 
   let s = ctrlKey ? "C-" ++ s : s;
   let s = shiftKey ? "S-" ++ s : s;


### PR DESCRIPTION
Our key binding code is expected the tab character to resolve as `<tab>` (and for #661, control+tab should resolve as `<C-TAB>`). 

This adds a fix to resolve `\t` -> `TAB` to support that scenario. Depends on https://github.com/revery-ui/revery/pull/539