### PR TITLE
Fix #600 - Unsaved / modified file indication is not reliable

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d8d49c4abc581729cf191583f3cf646",
+  "checksum": "26dd12ee5e82368651f260dedd0dae40",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -246,13 +246,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#56aa31a",
+      "version": "github:onivim/reason-libvim#b32b575",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#56aa31a" ]
+        "source": [ "github:onivim/reason-libvim#b32b575" ]
       },
       "overrides": [],
       "dependencies": [
@@ -796,7 +796,7 @@
         "revery@0.26.0@d41d8cd9", "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#d8ebc99@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d8d49c4abc581729cf191583f3cf646",
+  "checksum": "26dd12ee5e82368651f260dedd0dae40",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -246,13 +246,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#56aa31a",
+      "version": "github:onivim/reason-libvim#b32b575",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#56aa31a" ]
+        "source": [ "github:onivim/reason-libvim#b32b575" ]
       },
       "overrides": [],
       "dependencies": [
@@ -796,7 +796,7 @@
         "revery@0.26.0@d41d8cd9",
         "rench@github:bryphe/rench#d8ebc99@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/integration_test/RegressionFileModifiedIndicationTest.re
+++ b/integration_test/RegressionFileModifiedIndicationTest.re
@@ -1,0 +1,47 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// Regression test case covering #600:
+// https://github.com/onivim/oni2/issues/600
+//
+// Verify some simple cases around the file modified flag
+runTest(~name="RegressionFileModifiedIndication", (_, wait, _) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  Vim.command("e regression-file-modified-indication.txt");
+
+  let id = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
+
+  Vim.input("o");
+  Vim.input("a")
+
+  let validateBufferCondition = (f, state: State.t) => {
+    let buffer = Selectors.getBufferById(state, id);
+    switch (buffer) {
+    | Some(v) => f(v)
+    | None => false
+    }
+  };
+  
+  wait(~name="Wait for modified flag to be set", (state: State.t) => {
+    validateBufferCondition((b) => Buffer.isModified(b) == true, state);
+  });
+
+  // Save file, should clear modified flag
+  Vim.input("<esc>");
+  Vim.command("w")
+
+  wait(~name="Wait for modified flag to be set", (state: State.t) => {
+    validateBufferCondition((b) => Buffer.isModified(b) == false, state);
+  });
+  
+  // Make another modification, should set it again
+  Vim.input("o");
+  Vim.input("a")
+  
+  wait(~name="Wait for modified flag to be set", (state: State.t) => {
+    validateBufferCondition((b) => Buffer.isModified(b) == true, state);
+  });
+});

--- a/integration_test/RegressionFileModifiedIndicationTest.re
+++ b/integration_test/RegressionFileModifiedIndicationTest.re
@@ -15,33 +15,33 @@ runTest(~name="RegressionFileModifiedIndication", (_, wait, _) => {
   let id = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
 
   Vim.input("o");
-  Vim.input("a")
+  Vim.input("a");
 
   let validateBufferCondition = (f, state: State.t) => {
     let buffer = Selectors.getBufferById(state, id);
     switch (buffer) {
     | Some(v) => f(v)
     | None => false
-    }
+    };
   };
-  
-  wait(~name="Wait for modified flag to be set", (state: State.t) => {
-    validateBufferCondition((b) => Buffer.isModified(b) == true, state);
-  });
+
+  wait(~name="Wait for modified flag to be set", (state: State.t) =>
+    validateBufferCondition(b => Buffer.isModified(b) == true, state)
+  );
 
   // Save file, should clear modified flag
   Vim.input("<esc>");
-  Vim.command("w")
+  Vim.command("w");
 
-  wait(~name="Wait for modified flag to be set", (state: State.t) => {
-    validateBufferCondition((b) => Buffer.isModified(b) == false, state);
-  });
-  
+  wait(~name="Wait for modified flag to be set", (state: State.t) =>
+    validateBufferCondition(b => Buffer.isModified(b) == false, state)
+  );
+
   // Make another modification, should set it again
   Vim.input("o");
-  Vim.input("a")
-  
-  wait(~name="Wait for modified flag to be set", (state: State.t) => {
-    validateBufferCondition((b) => Buffer.isModified(b) == true, state);
-  });
+  Vim.input("a");
+
+  wait(~name="Wait for modified flag to be set", (state: State.t) =>
+    validateBufferCondition(b => Buffer.isModified(b) == true, state)
+  );
 });

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -10,6 +10,7 @@
            QuickOpenDoesntLeakFileDescriptorsTest
            SearchShowClearHighlightsTest
            RegressionCommandLineNoCompletionTest
+           RegressionFileModifiedIndicationTest
            RegressionVspEmptyInitialBufferTest
            RegressionVspEmptyExistingBufferTest
            TickTest
@@ -37,6 +38,7 @@
         QuickOpenEventuallyCompletesTest.exe
         QuickOpenDoesntLeakFileDescriptorsTest.exe
         RegressionCommandLineNoCompletionTest.exe
+        RegressionFileModifiedIndicationTest.exe
         RegressionVspEmptyInitialBufferTest.exe
         RegressionVspEmptyExistingBufferTest.exe
         SearchShowClearHighlightsTest.exe

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d8d49c4abc581729cf191583f3cf646",
+  "checksum": "26dd12ee5e82368651f260dedd0dae40",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -246,13 +246,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#56aa31a",
+      "version": "github:onivim/reason-libvim#b32b575",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#56aa31a" ]
+        "source": [ "github:onivim/reason-libvim#b32b575" ]
       },
       "overrides": [],
       "dependencies": [
@@ -796,7 +796,7 @@
         "revery@0.26.0@d41d8cd9",
         "rench@github:bryphe/rench#d8ebc99@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "@opam/ocaml-migrate-parsetree": "1.3.1",
     "@opam/ppx_tools_versioned": "5.2.2",
     "revery": "0.26.0",
-    "reason-libvim": "github:onivim/reason-libvim#56aa31a",
+    "reason-libvim": "github:onivim/reason-libvim#b32b575",
     "reason-fontkit": "2.5.0",
     "@opam/camomile": "1.0.1",
     "@opam/ocamlfind": "1.8.0",

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -16,7 +16,7 @@ type t =
   | BufferUpdate(BufferUpdate.t)
   | BufferSaved(Vim.BufferMetadata.t)
   | BufferSetIndentation(int, IndentationSettings.t)
-  | BufferMarkDirty(int)
+  | BufferSetModified(int, bool)
   | Command(string)
   | ConfigurationReload
   | ConfigurationSet(Configuration.t)

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -46,8 +46,8 @@ let setModified = (modified: bool, buffer: t) => {
   ...buffer,
   metadata: {
     ...buffer.metadata,
-    modified
-  }
+    modified,
+  },
 };
 
 let isSyntaxHighlightingEnabled = (buffer: t) =>

--- a/src/editor/Model/Buffer.re
+++ b/src/editor/Model/Buffer.re
@@ -42,6 +42,14 @@ let getLine = (buffer: t, line: int) => buffer.lines[line];
 
 let isModified = (buffer: t) => buffer.metadata.modified;
 
+let setModified = (modified: bool, buffer: t) => {
+  ...buffer,
+  metadata: {
+    ...buffer.metadata,
+    modified
+  }
+};
+
 let isSyntaxHighlightingEnabled = (buffer: t) =>
   buffer.syntaxHighlightingEnabled;
 let disableSyntaxHighlighting = (buffer: t) => {

--- a/src/editor/Model/Buffer.rei
+++ b/src/editor/Model/Buffer.rei
@@ -28,6 +28,7 @@ let isSyntaxHighlightingEnabled: t => bool;
 let isIndentationSet: t => bool;
 let setIndentation: (IndentationSettings.t, t) => t;
 let getIndentation: t => option(IndentationSettings.t);
+let setModified: (bool, t) => t;
 let disableSyntaxHighlighting: t => t;
 
 let update: (t, BufferUpdate.t) => t;

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -58,6 +58,9 @@ let setIndentation = indent =>
 let disableSyntaxHighlighting =
   ofBufferOpt(buffer => Buffer.disableSyntaxHighlighting(buffer));
 
+let setModified = modified =>
+  ofBufferOpt(buffer => Buffer.setModified(modified, buffer));
+
 let reduce = (state: t, action: Actions.t) => {
   switch (action) {
   | BufferDisableSyntaxHighlighting(id) =>
@@ -70,6 +73,8 @@ let reduce = (state: t, action: Actions.t) => {
       };
     IntMap.update(metadata.id, f, state);
   /* | BufferDelete(bd) => IntMap.remove(bd, state) */
+  | BufferSetModified(id, modified) =>
+    IntMap.update(id, setModified(modified), state)
   | BufferSetIndentation(id, indent) =>
     IntMap.update(id, setIndentation(indent), state)
   | BufferUpdate(bu) => IntMap.update(bu.id, applyBufferUpdate(bu), state)

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -114,6 +114,12 @@ let start =
     });
 
   let _ =
+    Vim.Buffer.onModifiedChanged((id, modified) => {
+      Log.info("Buffer metadata changed: " ++ string_of_int(id) ++ " | " ++ string_of_bool(modified));
+      dispatch(Model.Actions.BufferSetModified(id, modified));
+    });
+
+  let _ =
     Vim.Cursor.onMoved(newPosition => {
       let cursorPos =
         Core.Types.Position.createFromOneBasedIndices(

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -115,7 +115,12 @@ let start =
 
   let _ =
     Vim.Buffer.onModifiedChanged((id, modified) => {
-      Log.info("Buffer metadata changed: " ++ string_of_int(id) ++ " | " ++ string_of_bool(modified));
+      Log.info(
+        "Buffer metadata changed: "
+        ++ string_of_int(id)
+        ++ " | "
+        ++ string_of_bool(modified),
+      );
       dispatch(Model.Actions.BufferSetModified(id, modified));
     });
 

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d8d49c4abc581729cf191583f3cf646",
+  "checksum": "26dd12ee5e82368651f260dedd0dae40",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -246,13 +246,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#56aa31a",
+      "version": "github:onivim/reason-libvim#b32b575",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#56aa31a" ]
+        "source": [ "github:onivim/reason-libvim#b32b575" ]
       },
       "overrides": [],
       "dependencies": [
@@ -796,7 +796,7 @@
         "revery@0.26.0@d41d8cd9",
         "rench@github:bryphe/rench#d8ebc99@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#56aa31a@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#b32b575@d41d8cd9",
         "reason-jsonrpc@1.1.0@d41d8cd9", "reason-glfw@3.2.1027@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.0.0@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",


### PR DESCRIPTION
This fixes #600 - we weren't really paying attention to the `modified` flag coming from Vim. This would sometimes happen serendipitously when we'd get updated metadata... but most times not.

This picks up a new API from `reason-libvim`: `Vim.Buffer.onModifiedChanged` which lets us know when the modified state of a buffer changes, so we can pick it up and show it in the UI. Added here: https://github.com/onivim/reason-libvim/pull/66