### PR TITLE
Fix #657 - Command+Alt insert characters on Mac

### DIFF
--- a/integration_test/InputIgnoreTest.re
+++ b/integration_test/InputIgnoreTest.re
@@ -23,7 +23,7 @@ runTest(~name="InputIgnore test", (dispatch, wait, runEffects) => {
     | Some(buf) =>
       let line1 = Buffer.getLine(buf, 0);
       Log.info("Line1 is: " ++ line1 ++ "|");
-      String.equal(line1, "b")
+      String.equal(line1, "b");
     }
   );
 });

--- a/integration_test/InputIgnoreTest.re
+++ b/integration_test/InputIgnoreTest.re
@@ -1,0 +1,29 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// This test validates that certain keystrokes are ignored by our Vim layer
+runTest(~name="InputIgnore test", (dispatch, wait, runEffects) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  dispatch(KeyboardInput("i"));
+
+  wait(~name="Mode switches to insert", (state: State.t) =>
+    state.mode == Vim.Types.Insert
+  );
+
+  dispatch(KeyboardInput("<D-A->"));
+  dispatch(KeyboardInput("b"));
+  runEffects();
+
+  wait(~name="Buffer is correct", (state: State.t) =>
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => false
+    | Some(buf) =>
+      let line1 = Buffer.getLine(buf, 0);
+      Log.info("Line1 is: " ++ line1 ++ "|");
+      String.equal(line1, "b")
+    }
+  );
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -6,6 +6,7 @@
            ClipboardNormalModePasteTest
            ClipboardYankTest
            CopyActiveFilepathToClipboardTest
+           InputIgnoreTest
            QuickOpenEventuallyCompletesTest
            QuickOpenDoesntLeakFileDescriptorsTest
            SearchShowClearHighlightsTest
@@ -35,6 +36,7 @@
         ClipboardNormalModePasteTest.exe
         ClipboardYankTest.exe
         CopyActiveFilepathToClipboardTest.exe
+        InputIgnoreTest.exe
         QuickOpenEventuallyCompletesTest.exe
         QuickOpenDoesntLeakFileDescriptorsTest.exe
         RegressionCommandLineNoCompletionTest.exe

--- a/src/editor/Input/Filter.re
+++ b/src/editor/Input/Filter.re
@@ -3,6 +3,7 @@ let filter = key => {
   && !String.equal(key, "<A-SHIFT>")
   && !String.equal(key, "<D-SHIFT>")
   && !String.equal(key, "<D->")
+  && !String.equal(key, "<D-A->")
   && !String.equal(key, "<D-S->")
   && !String.equal(key, "<C->")
   && !String.equal(key, "<A-C->")


### PR DESCRIPTION
Fixes #657 - we were missing a case in our input filter