### PR TITLE
Native Syntax Highlighting - Tree Sitter: TS scope map path

### DIFF
--- a/extensions/json/README.md
+++ b/extensions/json/README.md
@@ -1,0 +1,7 @@
+# json extension
+
+The majority of this extension is ported from the VSCode repository:
+- https://github.com/microsoft/vscode/tree/master/extensions/json-language-features
+
+However, the tree-sitter scope resolver is ported from ATOM (and converted from cson -> json):
+- https://github.com/atom/language-json/blob/master/grammars/tree-sitter-json.cson

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -57,7 +57,8 @@
       {
         "language": "json",
         "scopeName": "source.json",
-        "path": "./syntaxes/JSON.tmLanguage.json"
+        "path": "./syntaxes/JSON.tmLanguage.json",
+        "treeSitterPath": "./syntaxes/tree-sitter-json.json"
       },
       {
         "language": "jsonc",
@@ -71,5 +72,8 @@
         "url": "http://json-schema.org/draft-07/schema#"
       }
     ]
+  },
+  "dependencies": {
+    "cson": "^5.1.0"
   }
 }

--- a/extensions/json/syntaxes/tree-sitter-json.json
+++ b/extensions/json/syntaxes/tree-sitter-json.json
@@ -1,0 +1,87 @@
+{
+  "name": "JSON",
+  "scopeName": "source.json",
+  "type": "tree-sitter",
+  "parser": "tree-sitter-json",
+  "fileTypes": [
+    "avsc",
+    "babelrc",
+    "bowerrc",
+    "composer.lock",
+    "geojson",
+    "gltf",
+    "htmlhintrc",
+    "ipynb",
+    "jscsrc",
+    "jshintrc",
+    "jslintrc",
+    "json",
+    "jsonl",
+    "jsonld",
+    "languagebabel",
+    "ldj",
+    "ldjson",
+    "Pipfile.lock",
+    "schema",
+    "stylintrc",
+    "template",
+    "tern-config",
+    "tern-project",
+    "tfstate",
+    "tfstate.backup",
+    "topojson",
+    "webapp",
+    "webmanifest"
+  ],
+  "folds": [
+    {
+      "start": {
+        "index": 0,
+        "type": "{"
+      },
+      "end": {
+        "index": -1,
+        "type": "}"
+      }
+    },
+    {
+      "start": {
+        "index": 0,
+        "type": "["
+      },
+      "end": {
+        "index": -1,
+        "type": "]"
+      }
+    }
+  ],
+  "scopes": {
+    "value": "source.json",
+    "object": "meta.structure.dictionary.json",
+    "string": "string.quoted.double",
+    "string_content": [
+      {
+        "match": "^http://",
+        "scopes": "markup.underline.link.http.hyperlink"
+      },
+      {
+        "match": "^https://",
+        "scopes": "markup.underline.link.https.hyperlink"
+      }
+    ],
+    "pair > string:nth-child(0)": "string.quoted.double.dictionary.key.json",
+    "escape_sequence": "constant.character.escape",
+    "number": "constant.numeric",
+    "true": "constant.language",
+    "false": "constant.language",
+    "null": "constant.language",
+    "\"{\"": "punctuation.definition.dictionary.begin",
+    "\"}\"": "punctuation.definition.dictionary.end",
+    "\":\"": "punctuation.separator.dictionary.key-value",
+    "object > \",\"": "punctuation.separator.dictionary.pair",
+    "array > \",\"": "punctuation.separator.array",
+    "\"[\"": "punctuation.definition.array.begin",
+    "\"]\"": "punctuation.definition.array.end",
+    "\"\\\"\"": "punctuation.definition.string.json"
+  }
+}

--- a/src/editor/Extensions/ExtensionContributions.re
+++ b/src/editor/Extensions/ExtensionContributions.re
@@ -32,6 +32,16 @@ module Grammar = {
     path: string,
     treeSitterPath: [@default None] option(string),
   };
+
+  let toAbsolutePath = (path: string, grammar: Grammar.t) => {
+  
+    let path = Path.join(path, g.path);
+
+    let treeSitterPath = switch(g.treeSitterPath) {
+    | Some(v) => Some(Path.join(path, v))
+    | None => None;
+    }
+  };
 };
 
 module Theme = {
@@ -62,7 +72,7 @@ type t = {
 };
 
 let _remapGrammars = (path: string, grammars: list(Grammar.t)) => {
-  List.map(g => Grammar.{...g, path: Path.join(path, g.path)}, grammars);
+  List.map(g => Grammar.toAbsolutePath(path, g), grammars);
 };
 
 let _remapThemes = (path: string, themes: list(Theme.t)) => {

--- a/src/editor/Extensions/ExtensionContributions.re
+++ b/src/editor/Extensions/ExtensionContributions.re
@@ -30,6 +30,7 @@ module Grammar = {
     language: [@default None] option(string),
     scopeName: string,
     path: string,
+    treeSitterPath: [@default None] option(string),
   };
 };
 

--- a/src/editor/Extensions/ExtensionContributions.re
+++ b/src/editor/Extensions/ExtensionContributions.re
@@ -33,14 +33,19 @@ module Grammar = {
     treeSitterPath: [@default None] option(string),
   };
 
-  let toAbsolutePath = (path: string, grammar: Grammar.t) => {
-  
+  let toAbsolutePath = (path: string, g: t) => {
     let path = Path.join(path, g.path);
 
     let treeSitterPath = switch(g.treeSitterPath) {
     | Some(v) => Some(Path.join(path, v))
     | None => None;
-    }
+    };
+
+    {
+    ...g,
+    path,
+    treeSitterPath
+    };
   };
 };
 

--- a/src/editor/Extensions/ExtensionContributions.re
+++ b/src/editor/Extensions/ExtensionContributions.re
@@ -36,16 +36,13 @@ module Grammar = {
   let toAbsolutePath = (path: string, g: t) => {
     let path = Path.join(path, g.path);
 
-    let treeSitterPath = switch(g.treeSitterPath) {
-    | Some(v) => Some(Path.join(path, v))
-    | None => None;
-    };
+    let treeSitterPath =
+      switch (g.treeSitterPath) {
+      | Some(v) => Some(Path.join(path, v))
+      | None => None
+      };
 
-    {
-    ...g,
-    path,
-    treeSitterPath
-    };
+    {...g, path, treeSitterPath};
   };
 };
 

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -133,6 +133,30 @@ module TextMateConverter = {
     );
   };
 
+  let of_yojson = (json: Yojson.Safe.json) => {
+
+    let parseSelector = (selectorJson: Yojson.Safe.json) => {
+      switch (selectorJson) {
+      | `String(v) => [Matcher.Scope(v)]
+      | _ => [];
+      }
+    };
+
+    switch (json) {
+    | `Assoc(dict) => {
+      let selectors = 
+      dict
+      |> List.map(v => {
+        let (key, selectorJson) = v;
+        [(key, parseSelector(selectorJson))]
+      })
+      |> List.flatten;
+      create(selectors);
+    }
+    | _ => empty
+    }
+  };
+
   let _getTextMateScopeForNonChildSelector = (token, path, v) => {
     switch (Trie.matches(v.defaultSelectors, path)) {
     | [] => None

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -136,13 +136,18 @@ module TextMateConverter = {
   let of_yojson = (json: Yojson.Safe.json) => {
     let parseSelectorList = (selectorJson: list(Yojson.Safe.json)) => {
       let f = (json: Yojson.Safe.json) => {
-        let match = Yojson.Safe.Util.member("match", json);
-        let scopes = Yojson.Safe.Util.member("scopes", json);
+        switch (json) {
+        | `String(v) => [Matcher.Scope(v)]
+        | `Assoc(_) =>
+          let match = Yojson.Safe.Util.member("match", json);
+          let scopes = Yojson.Safe.Util.member("scopes", json);
 
-        switch (match, scopes) {
-        | (`String(m), `String(s)) => [
-            Matcher.RegExMatch(Str.regexp(m), s),
-          ]
+          switch (match, scopes) {
+          | (`String(m), `String(s)) => [
+              Matcher.RegExMatch(Str.regexp(m), s),
+            ]
+          | _ => []
+          };
         | _ => []
         };
       };

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -134,45 +134,42 @@ module TextMateConverter = {
   };
 
   let of_yojson = (json: Yojson.Safe.json) => {
-
     let parseSelectorList = (selectorJson: list(Yojson.Safe.json)) => {
       let f = (json: Yojson.Safe.json) => {
-
         let match = Yojson.Safe.Util.member("match", json);
         let scopes = Yojson.Safe.Util.member("scopes", json);
 
-        switch ((match, scopes)) {
-        | (`String(m), `String(s)) => [Matcher.RegExMatch(Str.regexp(m), s)]
+        switch (match, scopes) {
+        | (`String(m), `String(s)) => [
+            Matcher.RegExMatch(Str.regexp(m), s),
+          ]
         | _ => []
-        }
+        };
       };
 
-      selectorJson
-      |> List.map(f)
-      |> List.flatten
+      selectorJson |> List.map(f) |> List.flatten;
     };
 
     let parseSelectors = (selectorJson: Yojson.Safe.json) => {
       switch (selectorJson) {
       | `String(v) => [Matcher.Scope(v)]
       | `List(v) => parseSelectorList(v)
-      | _ => [];
-      }
+      | _ => []
+      };
     };
 
     switch (json) {
-    | `Assoc(dict) => {
-      let selectors = 
-      dict
-      |> List.map(v => {
-        let (key, selectorJson) = v;
-        [(key, parseSelectors(selectorJson))]
-      })
-      |> List.flatten;
+    | `Assoc(dict) =>
+      let selectors =
+        dict
+        |> List.map(v => {
+             let (key, selectorJson) = v;
+             [(key, parseSelectors(selectorJson))];
+           })
+        |> List.flatten;
       create(selectors);
-    }
     | _ => empty
-    }
+    };
   };
 
   let _getTextMateScopeForNonChildSelector = (token, path, v) => {

--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -139,13 +139,15 @@ module TextMateConverter = {
         switch (json) {
         | `String(v) => [Matcher.Scope(v)]
         | `Assoc(_) =>
+          let exact = Yojson.Safe.Util.member("exact", json);
           let match = Yojson.Safe.Util.member("match", json);
           let scopes = Yojson.Safe.Util.member("scopes", json);
 
-          switch (match, scopes) {
-          | (`String(m), `String(s)) => [
+          switch (exact, match, scopes) {
+          | (_, `String(m), `String(s)) => [
               Matcher.RegExMatch(Str.regexp(m), s),
             ]
+          | (`String(e), _, `String(s)) => [Matcher.ExactMatch(e, s)]
           | _ => []
           };
         | _ => []

--- a/src/editor/Syntax/TreeSitterScopes.rei
+++ b/src/editor/Syntax/TreeSitterScopes.rei
@@ -36,6 +36,8 @@ module TextMateConverter: {
    */
   let create: list(scopeSelector) => t;
 
+  let of_yojson: (Yojson.Safe.json) => t;
+
   /*
      [getTextMateScope(~index, ~token, ~path, v)] resolves information from
      the tree-sitter syntax tree into a textmate scope. The information that

--- a/src/editor/Syntax/TreeSitterScopes.rei
+++ b/src/editor/Syntax/TreeSitterScopes.rei
@@ -36,7 +36,7 @@ module TextMateConverter: {
    */
   let create: list(scopeSelector) => t;
 
-  let of_yojson: (Yojson.Safe.json) => t;
+  let of_yojson: Yojson.Safe.json => t;
 
   /*
      [getTextMateScope(~index, ~token, ~path, v)] resolves information from

--- a/test/editor/Extensions/TextmateTokenizerTests.re
+++ b/test/editor/Extensions/TextmateTokenizerTests.re
@@ -95,6 +95,7 @@ describe("Textmate Service", ({test, _}) => {
         {
           scopeName: "source.reason",
           path: reasonSyntaxPath(setup),
+          treeSitterPath: None,
           language: None,
         },
       ],
@@ -151,6 +152,7 @@ describe("Textmate Service", ({test, _}) => {
         {
           scopeName: "source.reason",
           path: reasonSyntaxPath(setup),
+          treeSitterPath: None,
           language: None,
         },
       ],
@@ -198,6 +200,7 @@ describe("Textmate Service", ({test, _}) => {
         {
           scopeName: "source.reason",
           path: reasonSyntaxPath(setup),
+          treeSitterPath: None,
           language: None,
         },
       ],

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -166,6 +166,44 @@ describe("TreeSitterScopes", ({describe, _}) => {
         expect.bool(scope1 == Some("source.json")).toBe(true);
         expect.bool(scope2 == Some("meta.structure.dictionary.json")).toBe(true);
       });
+      test("list of matchers", ({expect, _}) => {
+        let json = Yojson.Safe.from_string({| { 
+        "string_content": [
+          {
+            "match": "^http://",
+            "scopes": "markup.underline.link.http.hyperlink"
+          },
+          {
+            "match": "^https://",
+            "scopes": "markup.underline.link.https.hyperlink"
+          }
+        ]
+        } |});
+
+        let converter = TextMateConverter.of_yojson(json);
+
+        let scopeNoMatch = TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["string_content"],
+          converter,
+        );
+        let scopeHttpMatch = TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["string_content"],
+          ~token="http://v2.onivim.io",
+          converter,
+        );
+        let scopeHttpsMatch = TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["string_content"],
+          ~token="https://v2.onivim.io",
+          converter,
+        );
+
+        expect.bool(scopeNoMatch == None).toBe(true);
+        expect.bool(scopeHttpMatch == Some("markup.underline.link.http.hyperlink")).toBe(true);
+        expect.bool(scopeHttpsMatch == Some("markup.underline.link.https.hyperlink")).toBe(true);
+      });
     });
   });
 });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -4,8 +4,8 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 
 open TreeSitterScopes;
 
-describe("TreeSitterScopes", ({describe, _}) =>
-  describe("TextMateConverter", ({test, _}) => {
+describe("TreeSitterScopes", ({describe, _}) => {
+  describe("TextMateConverter", ({test, describe, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
     let simpleConverter =
@@ -121,5 +121,51 @@ describe("TreeSitterScopes", ({describe, _}) =>
         true,
       );
     });
-  })
-);
+
+    describe("of_yojson", ({test, _}) => {
+      test("empty json dictionary", ({expect, _}) => {
+        let json = Yojson.Safe.from_string({| { } |});
+
+        let converter = TextMateConverter.of_yojson(json);
+        expect.bool(converter == TextMateConverter.empty).toBe(true);
+      });
+      test("single item dictionary", ({expect, _}) => {
+        let json = Yojson.Safe.from_string({| { 
+        "value": "source.json"
+        } |});
+
+        let converter = TextMateConverter.of_yojson(json);
+
+        let scope = TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["value"],
+          converter,
+        );
+
+        expect.bool(scope == Some("source.json")).toBe(true);
+      });
+      test("multiple item dictionary", ({expect, _}) => {
+        let json = Yojson.Safe.from_string({| { 
+        "value": "source.json",
+        "object": "meta.structure.dictionary.json"
+        } |});
+
+        let converter = TextMateConverter.of_yojson(json);
+
+        let scope1 = TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["value"],
+          converter,
+        );
+        let scope2 = TextMateConverter.getTextMateScope(
+          ~index=1,
+          ~path=["object"],
+          converter,
+        );
+
+        expect.bool(scope1 == Some("source.json")).toBe(true);
+        expect.bool(scope2 == Some("meta.structure.dictionary.json")).toBe(true);
+      });
+    });
+  });
+});

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -231,6 +231,50 @@ describe("TreeSitterScopes", ({describe, _}) =>
           true,
         );
       });
+      test("fallback to scope matcher", ({expect, _}) => {
+        let json =
+          Yojson.Safe.from_string(
+            {| {
+        "comment": [
+          {
+            "match": "^//",
+            "scopes": "comment.line"
+          },
+          "comment.block"
+        ]
+        } |},
+          );
+
+        let converter = TextMateConverter.of_yojson(json);
+
+        let scopeCommentLineMatch =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["comment"],
+            ~token="// hello",
+            converter,
+          );
+        let scopeCommentBlockMatch =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["comment"],
+            ~token="test",
+            converter,
+          );
+
+        expect.bool(
+          scopeCommentLineMatch == Some("comment.line"),
+        ).
+          toBe(
+          true,
+        );
+        expect.bool(
+          scopeCommentBlockMatch == Some("comment.block"),
+        ).
+          toBe(
+          true,
+        );
+      });
     });
   })
 );

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -237,6 +237,10 @@ describe("TreeSitterScopes", ({describe, _}) =>
             {| {
         "comment": [
           {
+            "exact": "// special //",
+            "scopes": "comment.special"
+          },
+          {
             "match": "^//",
             "scopes": "comment.line"
           },
@@ -262,16 +266,21 @@ describe("TreeSitterScopes", ({describe, _}) =>
             converter,
           );
 
-        expect.bool(
-          scopeCommentLineMatch == Some("comment.line"),
-        ).
-          toBe(
+        let scopeCommentSpecialMatch =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["comment"],
+            ~token="// special //",
+            converter,
+          );
+
+        expect.bool(scopeCommentLineMatch == Some("comment.line")).toBe(
           true,
         );
-        expect.bool(
-          scopeCommentBlockMatch == Some("comment.block"),
-        ).
-          toBe(
+        expect.bool(scopeCommentSpecialMatch == Some("comment.special")).toBe(
+          true,
+        );
+        expect.bool(scopeCommentBlockMatch == Some("comment.block")).toBe(
           true,
         );
       });

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -4,7 +4,7 @@ module TreeSitterScopes = Oni_Syntax.TreeSitterScopes;
 
 open TreeSitterScopes;
 
-describe("TreeSitterScopes", ({describe, _}) => {
+describe("TreeSitterScopes", ({describe, _}) =>
   describe("TextMateConverter", ({test, describe, _}) => {
     // Create a simple converter... this is a representation of grammars
     // like: https://github.com/atom/language-json/blob/04f1fbd5eb3aabcfc91b30a2c091a9fc657438ee/grammars/tree-sitter-json.cson#L48
@@ -130,44 +130,57 @@ describe("TreeSitterScopes", ({describe, _}) => {
         expect.bool(converter == TextMateConverter.empty).toBe(true);
       });
       test("single item dictionary", ({expect, _}) => {
-        let json = Yojson.Safe.from_string({| { 
+        let json =
+          Yojson.Safe.from_string(
+            {| {
         "value": "source.json"
-        } |});
+        } |},
+          );
 
         let converter = TextMateConverter.of_yojson(json);
 
-        let scope = TextMateConverter.getTextMateScope(
-          ~index=1,
-          ~path=["value"],
-          converter,
-        );
+        let scope =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["value"],
+            converter,
+          );
 
         expect.bool(scope == Some("source.json")).toBe(true);
       });
       test("multiple item dictionary", ({expect, _}) => {
-        let json = Yojson.Safe.from_string({| { 
+        let json =
+          Yojson.Safe.from_string(
+            {| {
         "value": "source.json",
         "object": "meta.structure.dictionary.json"
-        } |});
+        } |},
+          );
 
         let converter = TextMateConverter.of_yojson(json);
 
-        let scope1 = TextMateConverter.getTextMateScope(
-          ~index=1,
-          ~path=["value"],
-          converter,
-        );
-        let scope2 = TextMateConverter.getTextMateScope(
-          ~index=1,
-          ~path=["object"],
-          converter,
-        );
+        let scope1 =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["value"],
+            converter,
+          );
+        let scope2 =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["object"],
+            converter,
+          );
 
         expect.bool(scope1 == Some("source.json")).toBe(true);
-        expect.bool(scope2 == Some("meta.structure.dictionary.json")).toBe(true);
+        expect.bool(scope2 == Some("meta.structure.dictionary.json")).toBe(
+          true,
+        );
       });
       test("list of matchers", ({expect, _}) => {
-        let json = Yojson.Safe.from_string({| { 
+        let json =
+          Yojson.Safe.from_string(
+            {| {
         "string_content": [
           {
             "match": "^http://",
@@ -178,32 +191,46 @@ describe("TreeSitterScopes", ({describe, _}) => {
             "scopes": "markup.underline.link.https.hyperlink"
           }
         ]
-        } |});
+        } |},
+          );
 
         let converter = TextMateConverter.of_yojson(json);
 
-        let scopeNoMatch = TextMateConverter.getTextMateScope(
-          ~index=1,
-          ~path=["string_content"],
-          converter,
-        );
-        let scopeHttpMatch = TextMateConverter.getTextMateScope(
-          ~index=1,
-          ~path=["string_content"],
-          ~token="http://v2.onivim.io",
-          converter,
-        );
-        let scopeHttpsMatch = TextMateConverter.getTextMateScope(
-          ~index=1,
-          ~path=["string_content"],
-          ~token="https://v2.onivim.io",
-          converter,
-        );
+        let scopeNoMatch =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["string_content"],
+            converter,
+          );
+        let scopeHttpMatch =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["string_content"],
+            ~token="http://v2.onivim.io",
+            converter,
+          );
+        let scopeHttpsMatch =
+          TextMateConverter.getTextMateScope(
+            ~index=1,
+            ~path=["string_content"],
+            ~token="https://v2.onivim.io",
+            converter,
+          );
 
         expect.bool(scopeNoMatch == None).toBe(true);
-        expect.bool(scopeHttpMatch == Some("markup.underline.link.http.hyperlink")).toBe(true);
-        expect.bool(scopeHttpsMatch == Some("markup.underline.link.https.hyperlink")).toBe(true);
+        expect.bool(
+          scopeHttpMatch == Some("markup.underline.link.http.hyperlink"),
+        ).
+          toBe(
+          true,
+        );
+        expect.bool(
+          scopeHttpsMatch == Some("markup.underline.link.https.hyperlink"),
+        ).
+          toBe(
+          true,
+        );
       });
     });
-  });
-});
+  })
+);


### PR DESCRIPTION
This adds an extension to the `grammar` contribution section, allowing us to specify a path to a file that has tree-sitter scope mappings. When this is provided, we'll prefer tree-sitter parsing over textmate parsing.