### PR TITLE
TextMate Theme: Use colors instead of indices

### DIFF
--- a/src/editor/Syntax/TextMateScopes.re
+++ b/src/editor/Syntax/TextMateScopes.re
@@ -72,7 +72,7 @@ module TokenStyle = {
   let show = (v: t) => {
     switch (v.foreground) {
     | None => "Foreground: None"
-    | Some(v) => "Foreground: Some"
+    | Some(_) => "Foreground: Some"
     };
   };
 

--- a/src/editor/Syntax/TextMateScopes.re
+++ b/src/editor/Syntax/TextMateScopes.re
@@ -1,4 +1,5 @@
 /*
+
  TextMateScopes
  */
 
@@ -6,6 +7,8 @@
    [scope] is a list representation of TextMate scopes.
    For example, "source.js" would be represented as ["source", "js"]
  */
+
+open Revery;
 
 module Scope = {
   type t = list(string);
@@ -60,8 +63,8 @@ module Scopes = {
 module TokenStyle = {
   [@deriving show({with_path: false})]
   type t = {
-    foreground: option(int),
-    background: option(int),
+    foreground: option(Color.t),
+    background: option(Color.t),
     bold: option(bool),
     italic: option(bool),
   };
@@ -69,14 +72,14 @@ module TokenStyle = {
   let show = (v: t) => {
     switch (v.foreground) {
     | None => "Foreground: None"
-    | Some(v) => "Foreground: Some(" ++ string_of_int(v) ++ ")"
+    | Some(v) => "Foreground: Some"
     };
   };
 
   let create =
       (
-        ~foreground: option(int)=?,
-        ~background: option(int)=?,
+        ~foreground: option(Color.t)=?,
+        ~background: option(Color.t)=?,
         ~bold: option(bool)=?,
         ~italic: option(bool)=?,
         (),
@@ -97,13 +100,13 @@ module TokenStyle = {
 
 module ResolvedStyle = {
   type t = {
-    foreground: int,
-    background: int,
+    foreground: Color.t,
+    background: Color.t,
     bold: bool,
     italic: bool,
   };
 
-  let default = {foreground: 1, background: 0, bold: false, italic: false};
+  let default (~foreground, ~background, ()) = {foreground, background, bold: false, italic: false};
 };
 
 module Selector = {

--- a/src/editor/Syntax/TextMateScopes.re
+++ b/src/editor/Syntax/TextMateScopes.re
@@ -106,7 +106,12 @@ module ResolvedStyle = {
     italic: bool,
   };
 
-  let default (~foreground, ~background, ()) = {foreground, background, bold: false, italic: false};
+  let default = (~foreground, ~background, ()) => {
+    foreground,
+    background,
+    bold: false,
+    italic: false,
+  };
 };
 
 module Selector = {

--- a/src/editor/Syntax/TextMateTheme.re
+++ b/src/editor/Syntax/TextMateTheme.re
@@ -19,7 +19,7 @@ type selectorWithParents = {
 type t = {
   defaultBackground: Color.t,
   defaultForeground: Color.t,
-  trie: Trie.t(selectorWithParents)
+  trie: Trie.t(selectorWithParents),
 };
 
 /* Helper to split the selectors on ',' for groups */
@@ -27,7 +27,8 @@ let _explodeSelectors = (s: string) => {
   s |> String.split_on_char(',') |> List.map(s => String.trim(s));
 };
 
-let create = (~defaultBackground, ~defaultForeground, selectors: list(themeSelector)) => {
+let create =
+    (~defaultBackground, ~defaultForeground, selectors: list(themeSelector)) => {
   let f = (v: themeSelector) => {
     let (s, style) = v;
 
@@ -79,11 +80,7 @@ let create = (~defaultBackground, ~defaultForeground, selectors: list(themeSelec
       selectors,
     );
 
-  let ret: t = {
-    defaultBackground,
-    defaultForeground,
-    trie: trie
-  };
+  let ret: t = {defaultBackground, defaultForeground, trie};
 
   ret;
 };
@@ -119,11 +116,13 @@ let _applyStyle = (prev: TokenStyle.t, style: TokenStyle.t) => {
 
 let match = (theme: t, scopes: string) => {
   let scopes = Scopes.ofString(scopes) |> List.rev;
-    let default = ResolvedStyle.default(
-    ~foreground=theme.defaultForeground,
-    ~background=theme.defaultBackground,
-    ());
-    
+  let default =
+    ResolvedStyle.default(
+      ~foreground=theme.defaultForeground,
+      ~background=theme.defaultBackground,
+      (),
+    );
+
   switch (scopes) {
   | [] => default
   | [scope, ...scopeParents] =>

--- a/src/editor/Syntax/TextMateTheme.re
+++ b/src/editor/Syntax/TextMateTheme.re
@@ -2,6 +2,8 @@
  TextMateTheme.re
  */
 
+open Revery;
+
 open TextMateScopes;
 
 module TokenStyle = TextMateScopes.TokenStyle;
@@ -14,14 +16,18 @@ type selectorWithParents = {
   parents: list(Selector.t),
 };
 
-type t = {trie: Trie.t(selectorWithParents)};
+type t = {
+  defaultBackground: Color.t,
+  defaultForeground: Color.t,
+  trie: Trie.t(selectorWithParents)
+};
 
 /* Helper to split the selectors on ',' for groups */
 let _explodeSelectors = (s: string) => {
   s |> String.split_on_char(',') |> List.map(s => String.trim(s));
 };
 
-let create = (selectors: list(themeSelector)) => {
+let create = (~defaultBackground, ~defaultForeground, selectors: list(themeSelector)) => {
   let f = (v: themeSelector) => {
     let (s, style) = v;
 
@@ -73,7 +79,11 @@ let create = (selectors: list(themeSelector)) => {
       selectors,
     );
 
-  let ret: t = {trie: trie};
+  let ret: t = {
+    defaultBackground,
+    defaultForeground,
+    trie: trie
+  };
 
   ret;
 };
@@ -109,8 +119,13 @@ let _applyStyle = (prev: TokenStyle.t, style: TokenStyle.t) => {
 
 let match = (theme: t, scopes: string) => {
   let scopes = Scopes.ofString(scopes) |> List.rev;
+    let default = ResolvedStyle.default(
+    ~foreground=theme.defaultForeground,
+    ~background=theme.defaultBackground,
+    ());
+    
   switch (scopes) {
-  | [] => ResolvedStyle.default
+  | [] => default
   | [scope, ...scopeParents] =>
     let p = Trie.matches(theme.trie, scope);
 
@@ -152,21 +167,21 @@ let match = (theme: t, scopes: string) => {
     let foreground =
       switch (result.foreground) {
       | Some(v) => v
-      | None => ResolvedStyle.default.foreground
+      | None => default.foreground
       };
 
     let bold =
       switch (result.bold) {
       | Some(v) => v
-      | None => ResolvedStyle.default.bold
+      | None => default.bold
       };
 
     let italic =
       switch (result.italic) {
       | Some(v) => v
-      | None => ResolvedStyle.default.italic
+      | None => default.italic
       };
 
-    {...ResolvedStyle.default, foreground, bold, italic};
+    {...default, foreground, bold, italic};
   };
 };

--- a/src/editor/Syntax/TextMateTheme.rei
+++ b/src/editor/Syntax/TextMateTheme.rei
@@ -21,7 +21,13 @@ type t;
 /*
    [create] builds a Theme [t] from a list of styles
  */
-let create: (~defaultBackground: Color.t, ~defaultForeground: Color.t, list(themeSelector)) => t;
+let create:
+  (
+    ~defaultBackground: Color.t,
+    ~defaultForeground: Color.t,
+    list(themeSelector)
+  ) =>
+  t;
 
 /*
     [match] returns the resolved style information,

--- a/src/editor/Syntax/TextMateTheme.rei
+++ b/src/editor/Syntax/TextMateTheme.rei
@@ -4,6 +4,7 @@
  Interface for textmate theme matching
  */
 
+open Revery;
 open TextMateScopes;
 
 /*
@@ -20,7 +21,7 @@ type t;
 /*
    [create] builds a Theme [t] from a list of styles
  */
-let create: list(themeSelector) => t;
+let create: (~defaultBackground: Color.t, ~defaultForeground: Color.t, list(themeSelector)) => t;
 
 /*
     [match] returns the resolved style information,

--- a/test/editor/Syntax/TextMateThemeTests.re
+++ b/test/editor/Syntax/TextMateThemeTests.re
@@ -15,26 +15,41 @@ describe("TextMateTheme", ({describe, _}) => {
 
   let simpleTextMateTheme =
     TextMateTheme.create(
-    ~defaultBackground=Colors.black,
-    ~defaultForeground=Colors.white,
-    [
-      ("var", TokenStyle.create(~foreground=Colors.aqua, ())),
-      ("var.identifier", TokenStyle.create(~foreground=Colors.azure, ~bold=true, ())),
-      ("constant", TokenStyle.create(~foreground=Colors.cyan, ~italic=true, ())),
-      ("constant.numeric", TokenStyle.create(~foreground=Colors.crimson, ())),
-      ("constant.numeric.hex", TokenStyle.create(~bold=true, ())),
-      ("foo, bar", TokenStyle.create(~foreground=Colors.lavender, ())),
-      ("entity", TokenStyle.create(~bold=true, ())),
-      
-      (
-        "entity.other.attribute-name.foo,entity.other.attribute-name.bar",
-        TokenStyle.create(~foreground=Colors.salmon, ()),
-      ),
-      ("html", TokenStyle.create(~foreground=Colors.slateGray, ())),
-      ("meta html", TokenStyle.create(~foreground=Colors.whiteSmoke, ())),
-      ("source.php string", TokenStyle.create(~foreground=Colors.peachPuff, ())),
-      ("text.html source.php", TokenStyle.create(~foreground=Colors.navy, ())),
-    ]);
+      ~defaultBackground=Colors.black,
+      ~defaultForeground=Colors.white,
+      [
+        ("var", TokenStyle.create(~foreground=Colors.aqua, ())),
+        (
+          "var.identifier",
+          TokenStyle.create(~foreground=Colors.azure, ~bold=true, ()),
+        ),
+        (
+          "constant",
+          TokenStyle.create(~foreground=Colors.cyan, ~italic=true, ()),
+        ),
+        (
+          "constant.numeric",
+          TokenStyle.create(~foreground=Colors.crimson, ()),
+        ),
+        ("constant.numeric.hex", TokenStyle.create(~bold=true, ())),
+        ("foo, bar", TokenStyle.create(~foreground=Colors.lavender, ())),
+        ("entity", TokenStyle.create(~bold=true, ())),
+        (
+          "entity.other.attribute-name.foo,entity.other.attribute-name.bar",
+          TokenStyle.create(~foreground=Colors.salmon, ()),
+        ),
+        ("html", TokenStyle.create(~foreground=Colors.slateGray, ())),
+        ("meta html", TokenStyle.create(~foreground=Colors.whiteSmoke, ())),
+        (
+          "source.php string",
+          TokenStyle.create(~foreground=Colors.peachPuff, ()),
+        ),
+        (
+          "text.html source.php",
+          TokenStyle.create(~foreground=Colors.navy, ()),
+        ),
+      ],
+    );
 
   describe("match", ({test, _}) => {
     test(
@@ -108,8 +123,8 @@ describe("TextMateTheme", ({describe, _}) => {
             simpleTextMateTheme,
             "entity.other.attribute-name.foo",
           );
-      expect.bool(style.foreground == Colors.salmon).toBe(true);
-      expect.bool(style.background == Colors.black).toBe(true);
+        expect.bool(style.foreground == Colors.salmon).toBe(true);
+        expect.bool(style.background == Colors.black).toBe(true);
         expect.bool(style.bold).toBe(true);
         expect.bool(style.italic).toBe(false);
 
@@ -118,13 +133,13 @@ describe("TextMateTheme", ({describe, _}) => {
             simpleTextMateTheme,
             "entity.other.attribute-name.bar",
           );
-      expect.bool(style.foreground == Colors.salmon).toBe(true);
-      expect.bool(style.background == Colors.black).toBe(true);
+        expect.bool(style.foreground == Colors.salmon).toBe(true);
+        expect.bool(style.background == Colors.black).toBe(true);
         expect.bool(style.bold).toBe(true);
         expect.bool(style.italic).toBe(false);
       },
     );
-    
+
     test("baz gets default style (no match)", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "baz");
@@ -132,7 +147,7 @@ describe("TextMateTheme", ({describe, _}) => {
       expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
-    })
+    });
     test("var gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "var");
@@ -160,7 +175,7 @@ describe("TextMateTheme", ({describe, _}) => {
     test("constant gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "constant");
-      
+
       expect.bool(style.foreground == Colors.cyan).toBe(true);
       expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);

--- a/test/editor/Syntax/TextMateThemeTests.re
+++ b/test/editor/Syntax/TextMateThemeTests.re
@@ -6,27 +6,34 @@ module Selector = Oni_Syntax.TextMateScopes.Selector;
 module ResolvedStyle = Oni_Syntax.TextMateScopes.ResolvedStyle;
 module TokenStyle = Oni_Syntax.TextMateScopes.TokenStyle;
 
+open Revery;
+
 describe("TextMateTheme", ({describe, _}) => {
   /* Test theme inspired by:
         https://code.visualstudio.com/blogs/2017/02/08/syntax-highlighting-optimizations#_finally-whats-new-in-vs-code-19
      */
+
   let simpleTextMateTheme =
-    TextMateTheme.create([
-      ("var", TokenStyle.create(~foreground=9, ())),
-      ("var.identifier", TokenStyle.create(~foreground=2, ~bold=true, ())),
-      ("constant", TokenStyle.create(~foreground=4, ~italic=true, ())),
-      ("constant.numeric", TokenStyle.create(~foreground=5, ())),
+    TextMateTheme.create(
+    ~defaultBackground=Colors.black,
+    ~defaultForeground=Colors.white,
+    [
+      ("var", TokenStyle.create(~foreground=Colors.aqua, ())),
+      ("var.identifier", TokenStyle.create(~foreground=Colors.azure, ~bold=true, ())),
+      ("constant", TokenStyle.create(~foreground=Colors.cyan, ~italic=true, ())),
+      ("constant.numeric", TokenStyle.create(~foreground=Colors.crimson, ())),
       ("constant.numeric.hex", TokenStyle.create(~bold=true, ())),
-      ("foo, bar", TokenStyle.create(~foreground=10, ())),
+      ("foo, bar", TokenStyle.create(~foreground=Colors.lavender, ())),
       ("entity", TokenStyle.create(~bold=true, ())),
+      
       (
         "entity.other.attribute-name.foo,entity.other.attribute-name.bar",
-        TokenStyle.create(~foreground=11, ()),
+        TokenStyle.create(~foreground=Colors.salmon, ()),
       ),
-      ("html", TokenStyle.create(~foreground=12, ())),
-      ("meta html", TokenStyle.create(~foreground=14, ())),
-      ("source.php string", TokenStyle.create(~foreground=15, ())),
-      ("text.html source.php", TokenStyle.create(~foreground=16, ())),
+      ("html", TokenStyle.create(~foreground=Colors.slateGray, ())),
+      ("meta html", TokenStyle.create(~foreground=Colors.whiteSmoke, ())),
+      ("source.php string", TokenStyle.create(~foreground=Colors.peachPuff, ())),
+      ("text.html source.php", TokenStyle.create(~foreground=Colors.navy, ())),
     ]);
 
   describe("match", ({test, _}) => {
@@ -39,8 +46,8 @@ describe("TextMateTheme", ({describe, _}) => {
           "text.html.basic source.php.html string.quoted",
         );
 
-      expect.int(style.foreground).toBe(15);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.peachPuff).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
@@ -48,24 +55,24 @@ describe("TextMateTheme", ({describe, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "meta html");
 
-      expect.int(style.foreground).toBe(14);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.whiteSmoke).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
 
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "meta.source.js html");
 
-      expect.int(style.foreground).toBe(14);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.whiteSmoke).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
 
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "html");
 
-      expect.int(style.foreground).toBe(12);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.slateGray).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
@@ -73,23 +80,23 @@ describe("TextMateTheme", ({describe, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "meta foo");
 
-      expect.int(style.foreground).toBe(10);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.lavender).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
     test("foo & bar gets correctly style (compound rule)", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "foo");
-      expect.int(style.foreground).toBe(10);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.lavender).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
 
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "bar");
-      expect.int(style.foreground).toBe(10);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.lavender).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
@@ -101,8 +108,8 @@ describe("TextMateTheme", ({describe, _}) => {
             simpleTextMateTheme,
             "entity.other.attribute-name.foo",
           );
-        expect.int(style.foreground).toBe(11);
-        expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.salmon).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
         expect.bool(style.bold).toBe(true);
         expect.bool(style.italic).toBe(false);
 
@@ -111,52 +118,51 @@ describe("TextMateTheme", ({describe, _}) => {
             simpleTextMateTheme,
             "entity.other.attribute-name.bar",
           );
-        expect.int(style.foreground).toBe(11);
-        expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.salmon).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
         expect.bool(style.bold).toBe(true);
         expect.bool(style.italic).toBe(false);
       },
     );
+    
     test("baz gets default style (no match)", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "baz");
-      expect.int(style.foreground).toBe(1);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.white).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
-    });
+    })
     test("var gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "var");
-      expect.int(style.foreground).toBe(9);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.aqua).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
-
     test("var.baz gets correct style (should match var)", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "var.baz");
-      expect.int(style.foreground).toBe(9);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.aqua).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
-
     test("var.identifier gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "var.identifier");
-      expect.int(style.foreground).toBe(2);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.azure).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(true);
       expect.bool(style.italic).toBe(false);
     });
-
     test("constant gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "constant");
-      expect.int(style.foreground).toBe(4);
-      expect.int(style.background).toBe(0);
+      
+      expect.bool(style.foreground == Colors.cyan).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(true);
     });
@@ -164,8 +170,8 @@ describe("TextMateTheme", ({describe, _}) => {
     test("constant.numeric gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "constant.numeric");
-      expect.int(style.foreground).toBe(5);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.crimson).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(true);
     });
@@ -173,8 +179,8 @@ describe("TextMateTheme", ({describe, _}) => {
     test("constant.numeric.hex gets correct style", ({expect, _}) => {
       let style: ResolvedStyle.t =
         TextMateTheme.match(simpleTextMateTheme, "constant.numeric.hex");
-      expect.int(style.foreground).toBe(5);
-      expect.int(style.background).toBe(0);
+      expect.bool(style.foreground == Colors.crimson).toBe(true);
+      expect.bool(style.background == Colors.black).toBe(true);
       expect.bool(style.bold).toBe(true);
       expect.bool(style.italic).toBe(true);
     });


### PR DESCRIPTION
Pre-req for #677 - this simplifies the JSON parsing so we don't have to maintain a separate color map