### PR TITLE
Fix #688 - Shadow & Gamma fixes

### DIFF
--- a/docs/docs/using-onivim/configuration.md
+++ b/docs/docs/using-onivim/configuration.md
@@ -38,6 +38,10 @@ Onivim's configuration is designed to be mostly compatible with [VSCode's User S
 
 - `workbench.tree.indent` __(_int_ default: `2`)__ - Indentation of the tree explorer.
 
+### UI
+
+- `ui.shadows` __(_bool_ default: `true`)__ - Use drop-shadows in the rendering of menus, overlays, etc.
+
 ### Vim
 
 - `vim.useSystemClipboard` __(_`true`_|_`false`_|_`["yank", "paste", "delete"]`_ default: `["yank"]`)__ - Whether or not deletes / yanks should integrate with the system clipboard:

--- a/src/editor/Core/ConfigurationParser.re
+++ b/src/editor/Core/ConfigurationParser.re
@@ -201,6 +201,7 @@ let configurationParsers: list(configurationTuple) = [
     "editor.zenMode.singleFile",
     (s, v) => {...s, zenModeSingleFile: parseBool(v)},
   ),
+  ("ui.shadows", (s, v) => {...s, uiShadows: parseBool(v)}),
   (
     "vim.useSystemClipboard",
     (s, v) => {

--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -44,6 +44,7 @@ type t = {
   workbenchTreeIndent: int,
   filesExclude: list(string),
   vimUseSystemClipboard,
+  uiShadows: bool,
   zenModeHideTabs: bool,
   zenModeSingleFile: bool,
 };
@@ -72,6 +73,7 @@ let default = {
   workbenchIconTheme: "vs-seti",
   workbenchTreeIndent: 2,
   filesExclude: ["node_modules", "_esy"],
+  uiShadows: true,
   vimUseSystemClipboard: {
     yank: true,
     delete: false,

--- a/src/editor/UI/CommandlineView.re
+++ b/src/editor/UI/CommandlineView.re
@@ -42,6 +42,7 @@ let createElement =
         fontFamily(fontFile),
         fontSize(fontSize_),
         color(cmdFontColor),
+        backgroundColor(theme.editorBackground),
         textWrap(TextWrapping.WhitespaceWrap),
       ];
 

--- a/src/editor/UI/CommandlineView.re
+++ b/src/editor/UI/CommandlineView.re
@@ -31,7 +31,13 @@ let getFirstC = (t: Vim.Types.cmdlineType) => {
 };
 
 let createElement =
-    (~children as _, ~command: Commandline.t, ~theme: Theme.t, ()) =>
+    (
+      ~children as _,
+      ~command: Commandline.t,
+      ~configuration: Configuration.t,
+      ~theme: Theme.t,
+      (),
+    ) =>
   component(hooks => {
     let uiFont = State.(GlobalContext.current().state.uiFont);
     let {fontFile, _} = uiFont;
@@ -51,7 +57,7 @@ let createElement =
       ? (
         hooks,
         <View style=Style.[marginBottom(20)]>
-          <OniBoxShadow>
+          <OniBoxShadow configuration theme>
             <View
               style=Style.[
                 width(400),

--- a/src/editor/UI/CommandlineView.re
+++ b/src/editor/UI/CommandlineView.re
@@ -51,15 +51,7 @@ let createElement =
       ? (
         hooks,
         <View style=Style.[marginBottom(20)]>
-          <BoxShadow
-            boxShadow={Style.BoxShadow.make(
-              ~xOffset=-15.,
-              ~yOffset=5.,
-              ~blurRadius=30.,
-              ~spreadRadius=5.,
-              ~color=Color.rgba(0., 0., 0., 0.2),
-              (),
-            )}>
+          <OniBoxShadow>
             <View
               style=Style.[
                 width(400),
@@ -82,7 +74,7 @@ let createElement =
               />
               <Text style=textStyles text=endStr />
             </View>
-          </BoxShadow>
+          </OniBoxShadow>
         </View>,
       )
       : (hooks, React.empty);

--- a/src/editor/UI/MenuItem.re
+++ b/src/editor/UI/MenuItem.re
@@ -60,6 +60,7 @@ let createElement =
               textOverflow(`Ellipsis),
               fontSize(uiFont.fontSize),
               color(theme.editorMenuForeground),
+              backgroundColor(bg),
             ],
           ~target=style,
         )

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -90,15 +90,7 @@ let createElement =
       hooks,
       menu.isOpen
         ? <AllowPointer>
-            <BoxShadow
-              boxShadow={Style.BoxShadow.make(
-                ~xOffset=-15.,
-                ~yOffset=-10.,
-                ~blurRadius=30.,
-                ~spreadRadius=5.,
-                ~color=Color.rgba(0., 0., 0., 0.2),
-                (),
-              )}>
+            <OniBoxShadow>
               <View style={containerStyles(theme)}>
                 <View style=Style.[width(menuWidth), padding(5)]>
                   <OniInput
@@ -131,7 +123,7 @@ let createElement =
                   />
                 </View>
               </View>
-            </BoxShadow>
+            </OniBoxShadow>
           </AllowPointer>
         : React.listToElement([]),
     );

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -93,9 +93,9 @@ let createElement =
             <BoxShadow
               boxShadow={Style.BoxShadow.make(
                 ~xOffset=-15.,
-                ~yOffset=5.,
-                ~blurRadius=20.,
-                ~spreadRadius=10.,
+                ~yOffset=-10.,
+                ~blurRadius=30.,
+                ~spreadRadius=5.,
                 ~color=Color.rgba(0., 0., 0., 0.2),
                 (),
               )}>

--- a/src/editor/UI/MenuView.re
+++ b/src/editor/UI/MenuView.re
@@ -72,7 +72,14 @@ let getLabel = (command: Actions.menuCommand) => {
 };
 
 let createElement =
-    (~children as _, ~font: fontT, ~menu: Menu.t, ~theme: Theme.t, ()) =>
+    (
+      ~children as _,
+      ~font: fontT,
+      ~menu: Menu.t,
+      ~theme: Theme.t,
+      ~configuration: Configuration.t,
+      (),
+    ) =>
   component(hooks => {
     let hooks =
       React.Hooks.effect(
@@ -90,7 +97,7 @@ let createElement =
       hooks,
       menu.isOpen
         ? <AllowPointer>
-            <OniBoxShadow>
+            <OniBoxShadow configuration theme>
               <View style={containerStyles(theme)}>
                 <View style=Style.[width(menuWidth), padding(5)]>
                   <OniInput

--- a/src/editor/UI/NotificationsView.re
+++ b/src/editor/UI/NotificationsView.re
@@ -30,15 +30,7 @@ let notification =
     ) => {
   <AllowPointer>
     <Padding padding=16>
-      <BoxShadow
-        boxShadow={Style.BoxShadow.make(
-          ~xOffset=-15.,
-          ~yOffset=-10.,
-          ~blurRadius=30.,
-          ~spreadRadius=5.,
-          ~color=Color.rgba(0., 0., 0., 0.2),
-          (),
-        )}>
+      <OniBoxShadow>
         <View
           style=Style.[
             width(notificationWidth),
@@ -127,7 +119,7 @@ let notification =
             </View>
           </View>
         </View>
-      </BoxShadow>
+      </OniBoxShadow>
     </Padding>
   </AllowPointer>;
 };

--- a/src/editor/UI/NotificationsView.re
+++ b/src/editor/UI/NotificationsView.re
@@ -33,7 +33,7 @@ let notification =
       <BoxShadow
         boxShadow={Style.BoxShadow.make(
           ~xOffset=-15.,
-          ~yOffset=5.,
+          ~yOffset=-10.,
           ~blurRadius=30.,
           ~spreadRadius=5.,
           ~color=Color.rgba(0., 0., 0., 0.2),

--- a/src/editor/UI/NotificationsView.re
+++ b/src/editor/UI/NotificationsView.re
@@ -26,11 +26,13 @@ let notification =
       ~uiFont,
       ~message,
       ~title: string,
+      ~theme: Core.Theme.t,
+      ~configuration: Core.Configuration.t,
       (),
     ) => {
   <AllowPointer>
     <Padding padding=16>
-      <OniBoxShadow>
+      <OniBoxShadow theme configuration>
         <View
           style=Style.[
             width(notificationWidth),
@@ -177,6 +179,8 @@ let createElement = (~children as _, ~state: State.t, ()) => {
            icon
            title={n.title}
            message={n.message}
+           theme={state.theme}
+           configuration={state.configuration}
          />;
        });
 

--- a/src/editor/UI/OniBoxShadow.re
+++ b/src/editor/UI/OniBoxShadow.re
@@ -4,16 +4,22 @@ open Oni_Core;
 open Oni_Model;
 
 let createElement =
-    (~children, ()) => 
-            <BoxShadow
-              boxShadow={Style.BoxShadow.make(
-                ~xOffset=-11.,
-                ~yOffset=-11.,
-                ~blurRadius=25.,
-                ~spreadRadius=0.,
-                ~color=Color.rgba(0., 0., 0., 0.2),
-                (),
-              )}>
-              ...children
-              </BoxShadow>;
-  
+    (~children, ~theme: Theme.t, ~configuration: Configuration.t, ()) => {
+  let useBoxShadow = Configuration.getValue(c => c.uiShadows, configuration);
+
+  useBoxShadow
+    ? <BoxShadow
+        boxShadow={Style.BoxShadow.make(
+          ~xOffset=-11.,
+          ~yOffset=-11.,
+          ~blurRadius=25.,
+          ~spreadRadius=0.,
+          ~color=Color.rgba(0., 0., 0., 0.2),
+          (),
+        )}>
+        ...children
+      </BoxShadow>
+    : <View style=Style.[border(~color=theme.background, ~width=1)]>
+        ...children
+      </View>;
+};

--- a/src/editor/UI/OniBoxShadow.re
+++ b/src/editor/UI/OniBoxShadow.re
@@ -1,0 +1,19 @@
+open Revery;
+open Revery.UI;
+open Oni_Core;
+open Oni_Model;
+
+let createElement =
+    (~children, ()) => 
+            <BoxShadow
+              boxShadow={Style.BoxShadow.make(
+                ~xOffset=-11.,
+                ~yOffset=-11.,
+                ~blurRadius=25.,
+                ~spreadRadius=0.,
+                ~color=Color.rgba(0., 0., 0., 0.2),
+                (),
+              )}>
+              ...children
+              </BoxShadow>;
+  

--- a/src/editor/UI/OniBoxShadow.re
+++ b/src/editor/UI/OniBoxShadow.re
@@ -1,7 +1,6 @@
 open Revery;
 open Revery.UI;
 open Oni_Core;
-open Oni_Model;
 
 let createElement =
     (~children, ~theme: Theme.t, ~configuration: Configuration.t, ()) => {

--- a/src/editor/UI/Root.re
+++ b/src/editor/UI/Root.re
@@ -47,6 +47,7 @@ let statusBarStyle = statusBarHeight =>
 let createElement = (~state: State.t, ~children as _, ()) =>
   component(hooks => {
     let theme = state.theme;
+    let configuration = state.configuration;
     let style = rootStyle(theme.background, theme.foreground);
 
     let statusBarVisible =
@@ -69,9 +70,14 @@ let createElement = (~state: State.t, ~children as _, ()) =>
           <EditorView state />
         </View>
         <Overlay>
-          <CommandlineView theme command={state.commandline} />
-          <WildmenuView theme wildmenu={state.wildmenu} />
-          <MenuView theme menu={state.menu} font={state.uiFont} />
+          <CommandlineView theme configuration command={state.commandline} />
+          <WildmenuView theme configuration wildmenu={state.wildmenu} />
+          <MenuView
+            theme
+            configuration
+            menu={state.menu}
+            font={state.uiFont}
+          />
           <KeyDisplayerView state />
           <NotificationsView state />
         </Overlay>

--- a/src/editor/UI/WildmenuView.re
+++ b/src/editor/UI/WildmenuView.re
@@ -17,11 +17,17 @@ let containerStyles = (theme: Theme.t) =>
   ];
 
 let createElement =
-    (~children as _, ~wildmenu: Wildmenu.t, ~theme: Theme.t, ()) =>
+    (
+      ~children as _,
+      ~wildmenu: Wildmenu.t,
+      ~theme: Theme.t,
+      ~configuration,
+      (),
+    ) =>
   component(hooks => {
     let element =
       wildmenu.show
-        ? <OniBoxShadow>
+        ? <OniBoxShadow theme configuration>
             <ScrollView style={containerStyles(theme)}>
               ...{List.mapi(
                 (index, item) =>

--- a/src/editor/UI/WildmenuView.re
+++ b/src/editor/UI/WildmenuView.re
@@ -24,7 +24,7 @@ let createElement =
         ? <BoxShadow
             boxShadow={Style.BoxShadow.make(
               ~xOffset=-15.,
-              ~yOffset=5.,
+              ~yOffset=-10.,
               ~blurRadius=30.,
               ~spreadRadius=5.,
               ~color=Color.rgba(0., 0., 0., 0.2),

--- a/src/editor/UI/WildmenuView.re
+++ b/src/editor/UI/WildmenuView.re
@@ -21,15 +21,7 @@ let createElement =
   component(hooks => {
     let element =
       wildmenu.show
-        ? <BoxShadow
-            boxShadow={Style.BoxShadow.make(
-              ~xOffset=-15.,
-              ~yOffset=-10.,
-              ~blurRadius=30.,
-              ~spreadRadius=5.,
-              ~color=Color.rgba(0., 0., 0., 0.2),
-              (),
-            )}>
+        ? <OniBoxShadow>
             <ScrollView style={containerStyles(theme)}>
               ...{List.mapi(
                 (index, item) =>
@@ -42,7 +34,7 @@ let createElement =
                 wildmenu.items,
               )}
             </ScrollView>
-          </BoxShadow>
+          </OniBoxShadow>
         : React.listToElement([]);
     (hooks, element);
   });

--- a/src/editor/UI/WildmenuView.re
+++ b/src/editor/UI/WildmenuView.re
@@ -1,4 +1,3 @@
-open Revery;
 open Revery.UI;
 open Revery.UI.Components;
 


### PR DESCRIPTION
Was fixing up some of the non-gamma-corrected text places, so figured I could fix #688 along with this

There were a few fit-and-finish issues:
- The shadows are too intense. I toned them down a bit, but they still need work - in particular, the implementation in Revery fades to an opaque color, even with the alpha channel set (which is a bug) and makes them much harsher than they should be. Ideally we'd want them to be more subtle by blending to a mostly transparent value (like `rgba(0, 0, 0, 0.2)`).
- Refactored to a common shadow component used across the app.
- Added a configuration setting - `ui.shadows` that can be used to enable / disable shadows (if there aren't shadows, we add a 1px border around the elements)
- Several places in the UI had non-gamma-corrected text, which makes it look thin and washed out. With our current text rendering solution - we need to specify the background color to get proper gamma correction. Fixed this for Menu/Wildmenu.

Fixes #688 