### PR TITLE
Theming: Load tokenTheme for use with tree-sitter

### DIFF
--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -61,7 +61,13 @@ let perf = (msg, f) => {
   let startTime = Unix.gettimeofday();
   f();
   let endTime = Unix.gettimeofday();
-  logCore("[PERF] " ++ msg ++ " took " ++ string_of_float(endTime -. startTime) ++ "s");
+  logCore(
+    "[PERF] "
+    ++ msg
+    ++ " took "
+    ++ string_of_float(endTime -. startTime)
+    ++ "s",
+  );
 };
 
 let () =

--- a/src/editor/Core/Log.re
+++ b/src/editor/Core/Log.re
@@ -57,6 +57,13 @@ let debug = msg => debugLogging^ ? logCore("[DEBUG] " ++ msg) : ();
 
 let error = msg => logCore(~error=true, "[ERROR] " ++ msg);
 
+let perf = (msg, f) => {
+  let startTime = Unix.gettimeofday();
+  f();
+  let endTime = Unix.gettimeofday();
+  logCore("[PERF] " ++ msg ++ " took " ++ string_of_float(endTime -. startTime) ++ "s");
+};
+
 let () =
   switch (debugLogging^) {
   | false => ()

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -7,6 +7,7 @@
 open Oni_Core;
 open Oni_Core.Types;
 open Oni_Extensions;
+open Oni_Syntax;
 
 type t =
   | Init
@@ -81,7 +82,9 @@ type t =
   | SearchSetHighlights(int, list(Range.t))
   | SearchClearHighlights(int)
   | SetLanguageInfo(LanguageInfo.t)
+  | LoadThemeByPath(string)
   | SetIconTheme(IconTheme.t)
+  | SetTokenTheme(TextMateTheme.t)
   | SetInputControlMode(Input.controlMode)
   | StatusBarAddItem(StatusBarModel.Item.t)
   | StatusBarDisposeItem(int)

--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -38,7 +38,7 @@ let reduce: (State.t, Actions.t) => State.t =
       | CommandlineHide => {...s, inputControlMode: EditorTextFocus}
       | EnableZenMode => {...s, zenMode: true}
       | DisableZenMode => {...s, zenMode: false}
-      | SetTokenTheme(tokenTheme) => { ...s, tokenTheme }
+      | SetTokenTheme(tokenTheme) => {...s, tokenTheme}
       | _ => s
       };
     };

--- a/src/editor/Model/Reducer.re
+++ b/src/editor/Model/Reducer.re
@@ -38,6 +38,7 @@ let reduce: (State.t, Actions.t) => State.t =
       | CommandlineHide => {...s, inputControlMode: EditorTextFocus}
       | EnableZenMode => {...s, zenMode: true}
       | DisableZenMode => {...s, zenMode: false}
+      | SetTokenTheme(tokenTheme) => { ...s, tokenTheme }
       | _ => s
       };
     };

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -65,6 +65,9 @@ let start =
 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);
+  
+  let themeUpdater =
+    ThemeStoreConnector.start(languageInfo, setup);
 
   /*
      For our July builds, we won't be including the extension host -
@@ -109,6 +112,7 @@ let start =
           indentationUpdater,
           windowUpdater,
           keyDisplayerUpdater,
+          themeUpdater,
         ]),
       (),
     );

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -66,7 +66,7 @@ let start =
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);
 
-  let themeUpdater = ThemeStoreConnector.start(languageInfo, setup);
+  let themeUpdater = ThemeStoreConnector.start(setup);
 
   /*
      For our July builds, we won't be including the extension host -

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -65,9 +65,8 @@ let start =
 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);
-  
-  let themeUpdater =
-    ThemeStoreConnector.start(languageInfo, setup);
+
+  let themeUpdater = ThemeStoreConnector.start(languageInfo, setup);
 
   /*
      For our July builds, we won't be including the extension host -

--- a/src/editor/Store/ThemeStoreConnector.re
+++ b/src/editor/Store/ThemeStoreConnector.re
@@ -10,7 +10,7 @@ open Oni_Core;
 open Oni_Model;
 open Oni_Syntax;
 
-let start = (languageInfo: LanguageInfo.t, setup: Setup.t) => {
+let start = (setup: Setup.t) => {
   let defaultThemePath =
     setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
 

--- a/src/editor/Store/ThemeStoreConnector.re
+++ b/src/editor/Store/ThemeStoreConnector.re
@@ -14,32 +14,32 @@ let start = (languageInfo: LanguageInfo.t, setup: Setup.t) => {
   let defaultThemePath =
     setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
 
-  let loadThemeByPathEffect = (themePath) =>
-    Isolinear.Effect.createWithDispatch(~name="theme.loadThemeByPath", dispatch => {
-      
+  let loadThemeByPathEffect = themePath =>
+    Isolinear.Effect.createWithDispatch(
+      ~name="theme.loadThemeByPath", dispatch =>
       Log.perf("theme.load", () => {
         let themeJson = Yojson.Safe.from_file(themePath);
 
-        let tokenColorsJson = Yojson.Safe.Util.member("tokenColors", themeJson);
-        let tokenTheme =  TextMateTheme.of_yojson(
+        let tokenColorsJson =
+          Yojson.Safe.Util.member("tokenColors", themeJson);
+        let tokenTheme =
+          TextMateTheme.of_yojson(
             ~defaultBackground=Colors.black,
             ~defaultForeground=Colors.white,
-            tokenColorsJson);
+            tokenColorsJson,
+          );
 
         if (Log.isDebugLoggingEnabled()) {
           Log.debug("Tokens: " ++ TextMateTheme.show(tokenTheme));
-        }
+        };
 
         dispatch(Actions.SetTokenTheme(tokenTheme));
-      });
-    });
+      })
+    );
 
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
-    | Actions.Init => (
-        state,
-        loadThemeByPathEffect(defaultThemePath),
-      )
+    | Actions.Init => (state, loadThemeByPathEffect(defaultThemePath))
     | Actions.LoadThemeByPath(themePath) => (
         state,
         loadThemeByPathEffect(themePath),

--- a/src/editor/Store/ThemeStoreConnector.re
+++ b/src/editor/Store/ThemeStoreConnector.re
@@ -1,0 +1,52 @@
+/*
+ * ThemeStoreConnector.re
+ *
+ * This connector handles loading themes and tokenThemes.
+ */
+
+open Revery;
+
+open Oni_Core;
+open Oni_Model;
+open Oni_Syntax;
+
+let start = (languageInfo: LanguageInfo.t, setup: Setup.t) => {
+  let defaultThemePath =
+    setup.bundledExtensionsPath ++ "/onedark-pro/themes/OneDark-Pro.json";
+
+  let loadThemeByPathEffect = (themePath) =>
+    Isolinear.Effect.createWithDispatch(~name="theme.loadThemeByPath", dispatch => {
+      
+      Log.perf("theme.load", () => {
+        let themeJson = Yojson.Safe.from_file(themePath);
+
+        let tokenColorsJson = Yojson.Safe.Util.member("tokenColors", themeJson);
+        let tokenTheme =  TextMateTheme.of_yojson(
+            ~defaultBackground=Colors.black,
+            ~defaultForeground=Colors.white,
+            tokenColorsJson);
+
+        if (Log.isDebugLoggingEnabled()) {
+          Log.debug("Tokens: " ++ TextMateTheme.show(tokenTheme));
+        }
+
+        dispatch(Actions.SetTokenTheme(tokenTheme));
+      });
+    });
+
+  let updater = (state: State.t, action: Actions.t) => {
+    switch (action) {
+    | Actions.Init => (
+        state,
+        loadThemeByPathEffect(defaultThemePath),
+      )
+    | Actions.LoadThemeByPath(themePath) => (
+        state,
+        loadThemeByPathEffect(themePath),
+      )
+    | _ => (state, Isolinear.Effect.none)
+    };
+  };
+
+  updater;
+};


### PR DESCRIPTION
One blocker for integrating tree-sitter is that we don't currently load the theme information on the Reason side - the node process we use for syntax highlighting currently handles both the syntax tokenization and application of the theming.

This change is needed to hook up the tree-sitter syntax tree and the syntax map to actual theme information - this loads theme in the reason side so we have it available as part of our model. Necessary to move #663 further