### PR TITLE
Native Syntax Highlighting: Refactor to ColorizedToken2

### DIFF
--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -202,7 +202,7 @@ module Input = {
   };
 };
 
-// TEMPORARY representation of token colors, while we are 
+// TEMPORARY representation of token colors, while we are
 // migrating from the legacy node-based strategy to the new
 // native strategy.
 module ColorizedToken2 = {
@@ -210,16 +210,11 @@ module ColorizedToken2 = {
     index: int,
     backgroundColor: Revery.Color.t,
     foregroundColor: Revery.Color.t,
-  }
+  };
 
-   let create = (
-    ~index,
-    ~backgroundColor,
-    ~foregroundColor,
-    ()
-  ) => {
+  let create = (~index, ~backgroundColor, ~foregroundColor, ()) => {
     index,
     backgroundColor,
-    foregroundColor
+    foregroundColor,
   };
 };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -201,3 +201,25 @@ module Input = {
     command: string,
   };
 };
+
+// TEMPORARY representation of token colors, while we are 
+// migrating from the legacy node-based strategy to the new
+// native strategy.
+module ColorizedToken2 = {
+  type t = {
+    index: int,
+    backgroundColor: Revery.Color.t,
+    foregroundColor: Revery.Color.t,
+  }
+
+   let create = (
+    ~index,
+    ~backgroundColor,
+    ~foregroundColor,
+    ()
+  ) => {
+    index,
+    backgroundColor,
+    foregroundColor
+  };
+};

--- a/src/editor/Extensions/ColorizedToken.re
+++ b/src/editor/Extensions/ColorizedToken.re
@@ -46,15 +46,17 @@ let create: (int, int) => t =
 let default: t = {index: 0, foregroundColor: 0, backgroundColor: 1};
 
 let toColorizedToken2 = (colorMap: ColorMap.t, defaultFg, defaultBg, v: t) => {
-
   ColorizedToken2.create(
-    ~index=token.index,
-    ~foregroundColor=ColorMap.get(colorMap, token.foregroundColor, defaultFg, defaultBg),
-    ~backgroundColor=ColorMap.get(colorMap, token.backgroundColor, defaultFg, defaultBg),
-    ()
+    ~index=v.index,
+    ~foregroundColor=
+      ColorMap.get(colorMap, v.foregroundColor, defaultFg, defaultBg),
+    ~backgroundColor=
+      ColorMap.get(colorMap, v.backgroundColor, defaultFg, defaultBg),
+    (),
   );
 };
 
-let toColorizedToken2s = (colorMap: ColorMap.t, defaultFg, defaultBg, tokens: list(t)) => {
+let toColorizedToken2s =
+    (colorMap: ColorMap.t, defaultFg, defaultBg, tokens: list(t)) => {
   List.map(toColorizedToken2(colorMap, defaultFg, defaultBg), tokens);
 };

--- a/src/editor/Extensions/ColorizedToken.re
+++ b/src/editor/Extensions/ColorizedToken.re
@@ -2,6 +2,8 @@
  * ColorizedToken.re
  */
 
+open Oni_Core.Types;
+
 /* From:
  * https://github.com/Microsoft/vscode-textmate/blob/master/src/main.ts
  */
@@ -42,3 +44,17 @@ let create: (int, int) => t =
   };
 
 let default: t = {index: 0, foregroundColor: 0, backgroundColor: 1};
+
+let toColorizedToken2 = (colorMap: ColorMap.t, defaultFg, defaultBg, v: t) => {
+
+  ColorizedToken2.create(
+    ~index=token.index,
+    ~foregroundColor=ColorMap.get(colorMap, token.foregroundColor, defaultFg, defaultBg),
+    ~backgroundColor=ColorMap.get(colorMap, token.backgroundColor, defaultFg, defaultBg),
+    ()
+  );
+};
+
+let toColorizedToken2s = (colorMap: ColorMap.t, defaultFg, defaultBg, tokens: list(t)) => {
+  List.map(toColorizedToken2(colorMap, defaultFg, defaultBg), tokens);
+};

--- a/src/editor/Model/BufferLineColorizer.re
+++ b/src/editor/Model/BufferLineColorizer.re
@@ -5,8 +5,8 @@
 open Revery;
 
 open Oni_Core;
-open Oni_Core.Types;
 open Oni_Extensions;
+open Oni_Core.Types;
 
 type tokenColor = (Color.t, Color.t);
 type t = int => tokenColor;
@@ -22,10 +22,11 @@ let create =
       matchingPair: option(int),
       searchHighlightRanges: list(Range.t),
     ) => {
-    let defaultToken2 = ColorizedToken2.create(
+  let defaultToken2 =
+    ColorizedToken2.create(
       ~index=0,
-      ~backgroundColor=theme.editorBackgroundColor,
-      ~foregroundColor=theme.editorForegroundColor,
+      ~backgroundColor=defaultBackgroundColor,
+      ~foregroundColor=theme.editorForeground,
       (),
     );
   let tokenColorArray: array(ColorizedToken2.t) =
@@ -67,7 +68,7 @@ let create =
 
     let backgroundColor =
       i >= selectionStart && i < selectionEnd || i == matchingPair
-        ? selectionColor : defaultBackgroundColor;
+        ? selectionColor : colorIndex.backgroundColor;
 
     let doesSearchIntersect = (range: Range.t) => {
       Range.(
@@ -80,9 +81,9 @@ let create =
       List.exists(doesSearchIntersect, searchHighlightRanges);
 
     let backgroundColor =
-      isSearchHighlight ? theme.editorFindMatchBackground : colorIndex.backgroundColor;
+      isSearchHighlight ? theme.editorFindMatchBackground : backgroundColor;
 
-    let color = colorindex.foregroundColor;
+    let color = colorIndex.foregroundColor;
     (backgroundColor, color);
   };
 };

--- a/src/editor/Model/BufferLineColorizer.re
+++ b/src/editor/Model/BufferLineColorizer.re
@@ -5,7 +5,6 @@
 open Revery;
 
 open Oni_Core;
-open Oni_Extensions;
 open Oni_Core.Types;
 
 type tokenColor = (Color.t, Color.t);

--- a/src/editor/Model/BufferLineColorizer.re
+++ b/src/editor/Model/BufferLineColorizer.re
@@ -15,18 +15,23 @@ let create =
     (
       length: int,
       theme: Theme.t,
-      tokenColors: list(ColorizedToken.t),
-      colorMap: ColorMap.t,
+      tokenColors: list(ColorizedToken2.t),
       selection: option(Range.t),
       defaultBackgroundColor: Color.t,
       selectionColor: Color.t,
       matchingPair: option(int),
       searchHighlightRanges: list(Range.t),
     ) => {
-  let tokenColorArray: array(ColorizedToken.t) =
-    Array.make(length, ColorizedToken.default);
+    let defaultToken2 = ColorizedToken2.create(
+      ~index=0,
+      ~backgroundColor=theme.editorBackgroundColor,
+      ~foregroundColor=theme.editorForegroundColor,
+      (),
+    );
+  let tokenColorArray: array(ColorizedToken2.t) =
+    Array.make(length, defaultToken2);
 
-  let rec f = (tokens: list(ColorizedToken.t), start) =>
+  let rec f = (tokens: list(ColorizedToken2.t), start) =>
     switch (tokens) {
     | [] => ()
     | [hd, ...tail] =>
@@ -75,15 +80,9 @@ let create =
       List.exists(doesSearchIntersect, searchHighlightRanges);
 
     let backgroundColor =
-      isSearchHighlight ? theme.editorFindMatchBackground : backgroundColor;
+      isSearchHighlight ? theme.editorFindMatchBackground : colorIndex.backgroundColor;
 
-    let color =
-      ColorMap.get(
-        colorMap,
-        colorIndex.foregroundColor,
-        theme.editorForeground,
-        theme.editorBackground,
-      );
+    let color = colorindex.foregroundColor;
     (backgroundColor, color);
   };
 };

--- a/src/editor/Model/BufferLineColorizer.re
+++ b/src/editor/Model/BufferLineColorizer.re
@@ -68,7 +68,7 @@ let create =
 
     let backgroundColor =
       i >= selectionStart && i < selectionEnd || i == matchingPair
-        ? selectionColor : colorIndex.backgroundColor;
+        ? selectionColor : defaultBackgroundColor;
 
     let doesSearchIntersect = (range: Range.t) => {
       Range.(

--- a/src/editor/Model/BufferLineColorizer.rei
+++ b/src/editor/Model/BufferLineColorizer.rei
@@ -5,7 +5,6 @@
 open Revery;
 open Oni_Core;
 open Oni_Core.Types;
-open Oni_Extensions;
 
 /*
  * Type [tokenColor] is a tuple of [(backgroundColor, foregroundColor)]

--- a/src/editor/Model/BufferLineColorizer.rei
+++ b/src/editor/Model/BufferLineColorizer.rei
@@ -27,8 +27,7 @@ let create:
   (
     int,
     Theme.t,
-    list(ColorizedToken.t),
-    ColorMap.t,
+    list(ColorizedToken2.t),
     option(Range.t),
     Color.t,
     Color.t,

--- a/src/editor/Model/BufferLineColorizer.rei
+++ b/src/editor/Model/BufferLineColorizer.rei
@@ -4,6 +4,7 @@
 
 open Revery;
 open Oni_Core;
+open Oni_Core.Types;
 open Oni_Extensions;
 
 /*

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -377,7 +377,7 @@ let createElement =
         Oni_Extensions.ColorizedToken.toColorizedToken2s(
           state.syntaxHighlighting.colorMap,
           theme.editorForeground,
-          defaultBackground,
+          theme.editorBackground,
           tokenColors,
         );
 

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -373,12 +373,19 @@ let createElement =
           }
         };
 
+      let tokenColors2 =
+        Oni_Extensions.ColorizedToken.toColorizedToken2s(
+          state.syntaxHighlighting.colorMap,
+          theme.editorForeground,
+          defaultBackground,
+          tokenColors,
+        );
+
       let colorizer =
         BufferLineColorizer.create(
           ZedBundled.length(line),
           state.theme,
-          tokenColors,
-          state.syntaxHighlighting.colorMap,
+          tokenColors2,
           selection,
           defaultBackground,
           theme.editorSelectionBackground,


### PR DESCRIPTION
This change introduces a new token for representing syntax highlights. This removes the indirection with the `ColorMap` from the textmate service, because it isn't necessary in the reason world (the memory overhead is already smaller due to the use of pointers / immutable references), and simplifies downstream code in the new, native syntax highlight strategy.

This introduces a temporary type - `ColorizedToken2` - and maps the rendering / editor surface APIs to use this (and shims to convert the old `ColorizedToken` to this new one). Once we've fully migrated to native syntax highlighting, we can remove the old `ColorizedToken` and rename `ColorizedToken2` -> `ColorizedToken`