### PR TITLE
Bugfix: Duplicates in QuickOpen

### DIFF
--- a/src/editor/Core/Ripgrep.re
+++ b/src/editor/Core/Ripgrep.re
@@ -37,10 +37,7 @@ module RipgrepProcessingJob = {
 
   let dedup = (hash, str) => {
     switch (Hashtbl.find_opt(hash, str)) {
-    | Some(_) => {
-      print_endline ("DUP: "++str);
-      false
-    }
+    | Some(_) => false
     | None =>
       Hashtbl.add(hash, str, true);
       true;
@@ -52,15 +49,12 @@ module RipgrepProcessingJob = {
       switch (pendingWork.bytes) {
       | [] => []
       | [hd, ...tail] =>
-          let strs = hd
+        let items =
+          hd
           |> Bytes.to_string
           |> String.trim
           |> String.split_on_char('\n')
-          |> List.filter(dedup(pendingWork.duplicateHash));
-
-        //List.iter(print_endline, strs);
-        
-        let items = strs
+          |> List.filter(dedup(pendingWork.duplicateHash))
           |> List.map(pendingWork.itemMapping);
         pendingWork.callback(items);
         tail;

--- a/test/editor/Model/MenuJobTest.re
+++ b/test/editor/Model/MenuJobTest.re
@@ -97,25 +97,25 @@ describe("MenuJob", ({describe, _}) => {
       expect.string(second.name).toEqual("abcd");
     });
 
-    let runToCompletion = (j) => {
-      let job = ref(j); 
+    let runToCompletion = j => {
+      let job = ref(j);
 
       while (!Job.isComplete(job^)) {
         job := Job.tick(job^);
-      }
+      };
 
-      job^
+      job^;
     };
 
-    test("regresion test - already filterd items shouldn't get re-added", ({expect, _}) => {
+    test(
+      "regresion test - already filterd items shouldn't get re-added",
+      ({expect, _}) => {
       let job =
         MenuJob.create()
         |> Job.map(MenuJob.addItems([createItem("abcd")]))
         |> Job.map(MenuJob.updateQuery("a"))
         |> Job.tick
-        |> Job.map(
-             MenuJob.addItems([ createItem("a"), ]),
-           )
+        |> Job.map(MenuJob.addItems([createItem("a")]))
         |> Job.map(MenuJob.updateQuery("abc"))
         |> runToCompletion;
 


### PR DESCRIPTION
__Issue:__ In some cases, depending on timing (the order between add items and applying the query), we'd end up with duplicates showing up in the quickopen menu.

__Defect:__ When adding items, we'd add back all the items that we had already filtered, so they'd get filtered again and added as a duplicate.

__Fix:__ Don't add already-filtered items back when adding a new item.