### PR TITLE
Bugfix: Tree sitter scope fallback when child selector doesn't match

### DIFF
--- a/src/editor/Syntax/TreeSitterScopes.re
+++ b/src/editor/Syntax/TreeSitterScopes.re
@@ -197,16 +197,17 @@ module TextMateConverter = {
       // First, try and see if a child selector matches
       let matches =
         switch (StringMap.find_opt(string_of_int(index), v.byChildSelectors)) {
-        | Some(trie) => switch(Trie.matches(trie, path)) {
-        | [] => None
-        | [hd, ..._] =>
-          let (_, matchers) = hd;
+        | Some(trie) =>
+          switch (Trie.matches(trie, path)) {
+          | [] => None
+          | [hd, ..._] =>
+            let (_, matchers) = hd;
 
-          switch (matchers) {
-          | None => None
-          | Some(v) => Matcher.firstMatch(~token, v)
-          };
-        }
+            switch (matchers) {
+            | None => None
+            | Some(v) => Matcher.firstMatch(~token, v)
+            };
+          }
         | None => None
         };
 

--- a/test/editor/Syntax/TreeSitterScopesTests.re
+++ b/test/editor/Syntax/TreeSitterScopesTests.re
@@ -53,7 +53,6 @@ describe("TreeSitterScopes", ({describe, _}) =>
       );
     });
     test("non-matching child rule doesn't break other rules", ({expect, _}) => {
-
       let stringConverter =
         TextMateConverter.create([
           ("string", [Scope("string.quoted.double")]),
@@ -61,8 +60,8 @@ describe("TreeSitterScopes", ({describe, _}) =>
             "pair > string:nth-child(0)",
             [Scope("string.quoted.dictionary.key.json")],
           ),
-          ]);
-      
+        ]);
+
       let scope1 =
         TextMateConverter.getTextMateScope(
           ~path=["string"],
@@ -70,7 +69,7 @@ describe("TreeSitterScopes", ({describe, _}) =>
         );
 
       expect.string(scope1).toEqual("string.quoted.double");
-      
+
       let scope2 =
         TextMateConverter.getTextMateScope(
           ~path=["string", "array"],


### PR DESCRIPTION
__Issue:__ If there are two potential matching scopes, like:
- `string`
- `pair > string:nth-child(0)`

And the child-selector match fails, it ends up not matching the fallback scope `string`.

__Fix:__ Update the logic in our selector resolution to properly fall back, and add test case.