### PR TITLE
Refactoring: Model - Add filetype for buffer

### DIFF
--- a/bench/lib/BufferBench.re
+++ b/bench/lib/BufferBench.re
@@ -9,16 +9,15 @@ let rootNode = (new node)();
 let setup = () => ();
 
 let emptyBuffer = Buffer.ofLines([||]);
-let emptyBufferId = Buffer.getMetadata(emptyBuffer).id;
+let emptyBufferId = Buffer.getId(emptyBuffer);
 
 let hundredThousandLineBuffer =
   Buffer.ofLines(Array.make(100000, "This buffer is pretty big"));
-let hundredThousandLineBufferId =
-  Buffer.getMetadata(hundredThousandLineBuffer).id;
+let hundredThousandLineBufferId = Buffer.getId(hundredThousandLineBuffer);
 
 let smallBuffer =
   Buffer.ofLines(Array.make(100, "This buffer is a bit smaller"));
-let smallBufferId = Buffer.getMetadata(smallBuffer).id;
+let smallBufferId = Buffer.getId(smallBuffer);
 
 let hundredThousandLines = Array.make(100000, "Another big buffer update");
 

--- a/src/editor/Model/Actions.re
+++ b/src/editor/Model/Actions.re
@@ -13,7 +13,7 @@ type t =
   | Init
   | Tick
   | BufferDisableSyntaxHighlighting(int)
-  | BufferEnter(Vim.BufferMetadata.t)
+  | BufferEnter(Vim.BufferMetadata.t, option(string))
   | BufferUpdate(BufferUpdate.t)
   | BufferSaved(Vim.BufferMetadata.t)
   | BufferSetIndentation(int, IndentationSettings.t)

--- a/src/editor/Model/Buffer.rei
+++ b/src/editor/Model/Buffer.rei
@@ -15,10 +15,11 @@ let ofLines: array(string) => t;
 let ofMetadata: Vim.BufferMetadata.t => t;
 
 let getFilePath: t => option(string);
+let getFileType: t => option(string);
+let setFileType: (option(string), t) => t;
 let getLine: (t, int) => string;
 let getLineLength: (t, int) => int;
 
-let getMetadata: t => Vim.BufferMetadata.t;
 let getUri: t => Uri.t;
 let getId: t => int;
 let getNumberOfLines: t => int;

--- a/src/editor/Model/Buffer.rei
+++ b/src/editor/Model/Buffer.rei
@@ -15,10 +15,13 @@ let ofLines: array(string) => t;
 let ofMetadata: Vim.BufferMetadata.t => t;
 
 let getFilePath: t => option(string);
+let setFilePath: (option(string), t) => t;
 let getFileType: t => option(string);
 let setFileType: (option(string), t) => t;
 let getLine: (t, int) => string;
 let getLineLength: (t, int) => int;
+let getVersion: t => int;
+let setVersion: (int, t) => t;
 
 let getUri: t => Uri.t;
 let getId: t => int;
@@ -33,6 +36,5 @@ let setModified: (bool, t) => t;
 let disableSyntaxHighlighting: t => t;
 
 let update: (t, BufferUpdate.t) => t;
-let updateMetadata: (Vim.BufferMetadata.t, t) => t;
 
 let empty: t;

--- a/src/editor/Model/Buffers.re
+++ b/src/editor/Model/Buffers.re
@@ -64,12 +64,10 @@ let reduce = (state: t, action: Actions.t) => {
           v
           |> Buffer.setModified(metadata.modified)
           |> Buffer.setFilePath(metadata.filePath)
-          |> Buffer.setVersion(metadata.version)
+          |> Buffer.setVersion(metadata.version),
         )
-      | None => Some(
-          Buffer.ofMetadata(metadata)
-          |> Buffer.setFileType(fileType)
-        )
+      | None =>
+        Some(Buffer.ofMetadata(metadata) |> Buffer.setFileType(fileType))
       };
     IntMap.update(metadata.id, f, state);
   /* | BufferDelete(bd) => IntMap.remove(bd, state) */

--- a/src/editor/Model/EditorGroupReducer.re
+++ b/src/editor/Model/EditorGroupReducer.re
@@ -20,7 +20,7 @@ let reduce = (v: EditorGroup.t, action: Actions.t) => {
   let v = {...v, metrics, editors};
 
   switch (action) {
-  | BufferEnter({id, _}) =>
+  | BufferEnter({id, _}, _) =>
     let (newState, activeEditorId) =
       EditorGroup.getOrCreateEditorForBuffer(v, id);
     {...newState, activeEditorId: Some(activeEditorId)};

--- a/src/editor/Store/CommandStoreConnector.re
+++ b/src/editor/Store/CommandStoreConnector.re
@@ -108,7 +108,7 @@ let start = _ => {
                 |> Seq.filter_map(element => {
                      let (_, buffer) = element;
 
-                     switch (Buffer.getMetadata(buffer).filePath) {
+                     switch (Buffer.getFilePath(buffer)) {
                      | Some(path) =>
                        Some({
                          category: None,

--- a/src/editor/Store/ExtensionClientStoreConnector.re
+++ b/src/editor/Store/ExtensionClientStoreConnector.re
@@ -135,7 +135,7 @@ let start = (extensions, setup: Core.Setup.t) => {
         state,
         modelChangedEffect(state.buffers, bu),
       )
-    | Model.Actions.BufferEnter(bm) => (state, sendBufferEnterEffect(bm))
+    | Model.Actions.BufferEnter(bm, _) => (state, sendBufferEnterEffect(bm))
     | Model.Actions.Tick => (state, pumpEffect)
     | _ => (state, Isolinear.Effect.none)
     };

--- a/src/editor/Store/IndentationStoreConnector.re
+++ b/src/editor/Store/IndentationStoreConnector.re
@@ -82,7 +82,7 @@ let start = () => {
 
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
-    | Actions.BufferEnter(bu) => (
+    | Actions.BufferEnter(bu, _) => (
         state,
         checkIndentationEffect(state, bu.id),
       )

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -61,7 +61,7 @@ let start =
 
   let commandUpdater = CommandStoreConnector.start(getState);
   let (vimUpdater, vimStream) =
-    VimStoreConnector.start(getState, getClipboardText, setClipboardText);
+    VimStoreConnector.start(languageInfo, getState, getClipboardText, setClipboardText);
 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);
@@ -122,7 +122,7 @@ let start =
       | Model.Actions.BufferUpdate(bs) =>
         let buffer = Model.Selectors.getBufferById(state, bs.id);
         Some(Model.Actions.RecalculateEditorView(buffer));
-      | Model.Actions.BufferEnter({id, _}) =>
+      | Model.Actions.BufferEnter({id, _}, _) =>
         let buffer = Model.Selectors.getBufferById(state, id);
         Some(Model.Actions.RecalculateEditorView(buffer));
       | _ => None

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -61,7 +61,12 @@ let start =
 
   let commandUpdater = CommandStoreConnector.start(getState);
   let (vimUpdater, vimStream) =
-    VimStoreConnector.start(languageInfo, getState, getClipboardText, setClipboardText);
+    VimStoreConnector.start(
+      languageInfo,
+      getState,
+      getClipboardText,
+      setClipboardText,
+    );
 
   let (textmateUpdater, textmateStream) =
     TextmateClientStoreConnector.start(languageInfo, setup);

--- a/src/editor/Store/TextmateClientStoreConnector.re
+++ b/src/editor/Store/TextmateClientStoreConnector.re
@@ -83,7 +83,7 @@ let start = (languageInfo: Model.LanguageInfo.t, setup: Core.Setup.t) => {
               < Core.Constants.default.largeFileLineCountThreshold
             )
             && Model.Buffer.isSyntaxHighlightingEnabled(buffer)) {
-          switch (Model.Buffer.getMetadata(buffer).filePath) {
+          switch (Model.Buffer.getFilePath(buffer)) {
           | None => default
           | Some(v) =>
             let extension = Path.extname(v);

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -14,7 +14,12 @@ module Log = Core.Log;
 module Zed_utf8 = Core.ZedBundled;
 
 let start =
-    (languageInfo: Model.LanguageInfo.t, getState: unit => Model.State.t, getClipboardText, setClipboardText) => {
+    (
+      languageInfo: Model.LanguageInfo.t,
+      getState: unit => Model.State.t,
+      getClipboardText,
+      setClipboardText,
+    ) => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
   Vim.Clipboard.setProvider(reg => {
@@ -134,12 +139,14 @@ let start =
          */
         version: 0,
       };
-      
-      let fileType = switch (meta.filePath) {
-      | Some(v) => Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
-      | None => None
-      };
-      
+
+      let fileType =
+        switch (meta.filePath) {
+        | Some(v) =>
+          Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
+        | None => None
+        };
+
       dispatch(Model.Actions.BufferEnter(meta, fileType));
     });
 
@@ -298,10 +305,12 @@ let start =
          */
         version: 0,
       };
-      let fileType = switch (meta.filePath) {
-      | Some(v) => Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
-      | None => None
-      };
+      let fileType =
+        switch (meta.filePath) {
+        | Some(v) =>
+          Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
+        | None => None
+        };
       dispatch(Model.Actions.BufferEnter(meta, fileType));
     });
 
@@ -452,11 +461,13 @@ let start =
 
       let buffer = Vim.Buffer.openFile(filePath);
       let metadata = Vim.BufferMetadata.ofBuffer(buffer);
-      
-      let fileType = switch (metadata.filePath) {
-      | Some(v) => Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
-      | None => None
-      };
+
+      let fileType =
+        switch (metadata.filePath) {
+        | Some(v) =>
+          Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
+        | None => None
+        };
 
       /*
        * If we're splitting, make sure a BufferEnter event gets dispatched.

--- a/src/editor/Store/VimStoreConnector.re
+++ b/src/editor/Store/VimStoreConnector.re
@@ -14,7 +14,7 @@ module Log = Core.Log;
 module Zed_utf8 = Core.ZedBundled;
 
 let start =
-    (getState: unit => Model.State.t, getClipboardText, setClipboardText) => {
+    (languageInfo: Model.LanguageInfo.t, getState: unit => Model.State.t, getClipboardText, setClipboardText) => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
   Vim.Clipboard.setProvider(reg => {
@@ -134,7 +134,13 @@ let start =
          */
         version: 0,
       };
-      dispatch(Model.Actions.BufferEnter(meta));
+      
+      let fileType = switch (meta.filePath) {
+      | Some(v) => Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
+      | None => None
+      };
+      
+      dispatch(Model.Actions.BufferEnter(meta, fileType));
     });
 
   let _ =
@@ -292,7 +298,11 @@ let start =
          */
         version: 0,
       };
-      dispatch(Model.Actions.BufferEnter(meta));
+      let fileType = switch (meta.filePath) {
+      | Some(v) => Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
+      | None => None
+      };
+      dispatch(Model.Actions.BufferEnter(meta, fileType));
     });
 
   let _ =
@@ -442,13 +452,18 @@ let start =
 
       let buffer = Vim.Buffer.openFile(filePath);
       let metadata = Vim.BufferMetadata.ofBuffer(buffer);
+      
+      let fileType = switch (metadata.filePath) {
+      | Some(v) => Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
+      | None => None
+      };
 
       /*
        * If we're splitting, make sure a BufferEnter event gets dispatched.
        * (This wouldn't happen if we're splitting the same buffer we're already at)
        */
       switch (dir) {
-      | Some(_) => dispatch(Model.Actions.BufferEnter(metadata))
+      | Some(_) => dispatch(Model.Actions.BufferEnter(metadata, fileType))
       | None => ()
       };
     });

--- a/src/editor/UI/EditorGroupView.re
+++ b/src/editor/UI/EditorGroupView.re
@@ -39,8 +39,8 @@ let getBufferMetadata = (buffer: option(Buffer.t)) => {
   switch (buffer) {
   | None => (false, "untitled")
   | Some(v) =>
-    open Vim.BufferMetadata;
-    let {filePath, modified, _} = Buffer.getMetadata(v);
+    let filePath = Buffer.getFilePath(v);
+    let modified = Buffer.isModified(v);
 
     let title = filePath |> truncateFilepath;
     (modified, title);

--- a/src/editor/UI/StatusBar.re
+++ b/src/editor/UI/StatusBar.re
@@ -126,9 +126,8 @@ let createElement = (~children as _, ~height, ~state: State.t, ()) =>
     let fileType =
       switch (buffer) {
       | Some(v) =>
-        switch (Buffer.getMetadata(v).filePath) {
-        | Some(fp) =>
-          LanguageInfo.getLanguageFromFilePath(state.languageInfo, fp)
+        switch (Buffer.getFileType(v)) {
+        | Some(fp) => fp
         | None => "plaintext"
         }
       | None => "plaintext"

--- a/test/editor/Model/BufferTests.re
+++ b/test/editor/Model/BufferTests.re
@@ -120,8 +120,7 @@ describe("Buffer", ({describe, _}) =>
         );
       let updatedBuffer = Buffer.update(buffer, update);
       validateBuffer(expect, updatedBuffer, [|"a", "b", "c", "d"|]);
-      let metadata = Buffer.getMetadata(updatedBuffer);
-      expect.int(metadata.version).toBe(5);
+      expect.int(Buffer.getVersion(updatedBuffer)).toBe(5);
     });
 
     test("buffer update with lower version gets rejected", ({expect}) => {
@@ -148,8 +147,7 @@ describe("Buffer", ({describe, _}) =>
       let updatedBuffer = Buffer.update(bufferUpdate1, update);
 
       validateBuffer(expect, updatedBuffer, [|"d"|]);
-      let metadata = Buffer.getMetadata(updatedBuffer);
-      expect.int(metadata.version).toBe(6);
+      expect.int(Buffer.getVersion(updatedBuffer)).toBe(6);
     });
   })
 );

--- a/test/editor/Model/BuffersTests.re
+++ b/test/editor/Model/BuffersTests.re
@@ -38,7 +38,7 @@ describe("Buffer List Tests", ({test, _}) => {
         bufferList,
         BufferEnter(
           BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
-          None
+          None,
         ),
       );
 
@@ -61,7 +61,7 @@ describe("Buffer List Tests", ({test, _}) => {
         bufferList,
         BufferEnter(
           BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
-          None
+          None,
         ),
       );
     let addedAgain =
@@ -69,11 +69,12 @@ describe("Buffer List Tests", ({test, _}) => {
         added,
         BufferEnter(
           BufferMetadata.create(~id=0, ~filePath=Some("/test2.re"), ()),
-        None
+          None,
         ),
       );
 
-    expect.string(Buffers.getBuffer(0, addedAgain) |> getFilePathOrFail).toMatch(
+    expect.string(Buffers.getBuffer(0, addedAgain) |> getFilePathOrFail).
+      toMatch(
       "/test2.re",
     );
   });
@@ -92,7 +93,7 @@ describe("Buffer List Tests", ({test, _}) => {
     let path = getFilePathOrFail(activeBuffer);
     expect.string(path).toMatch("/myfile.js");
   });
-  
+
   test("Should set filetype", ({expect}) => {
     let bufferList = Buffers.empty;
     let updated =

--- a/test/editor/Model/BuffersTests.re
+++ b/test/editor/Model/BuffersTests.re
@@ -5,15 +5,26 @@ open Vim;
 module Buffers = Oni_Model.Buffers;
 module Buffer = Oni_Model.Buffer;
 
-let getOrFail = (v: option(Buffer.t)) => {
+let getFilePathOrFail = (v: option(Buffer.t)) => {
   let failedMsg = "failed - no buffer was specified";
   switch (v) {
   | Some(v) =>
-    let metadata = Buffer.getMetadata(v);
-    switch (metadata.filePath) {
+    switch (Buffer.getFilePath(v)) {
     | Some(path) => path
     | None => failedMsg
-    };
+    }
+  | None => failedMsg
+  };
+};
+
+let getFileTypeOrFail = (v: option(Buffer.t)) => {
+  let failedMsg = "failed - no buffer was specified";
+  switch (v) {
+  | Some(v) =>
+    switch (Buffer.getFileType(v)) {
+    | Some(t) => t
+    | None => failedMsg
+    }
   | None => failedMsg
   };
 };
@@ -27,10 +38,11 @@ describe("Buffer List Tests", ({test, _}) => {
         bufferList,
         BufferEnter(
           BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
+          None
         ),
       );
 
-    expect.string(Buffers.getBuffer(0, added) |> getOrFail).toMatch(
+    expect.string(Buffers.getBuffer(0, added) |> getFilePathOrFail).toMatch(
       "/test1.re",
     );
   });
@@ -49,6 +61,7 @@ describe("Buffer List Tests", ({test, _}) => {
         bufferList,
         BufferEnter(
           BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
+          None
         ),
       );
     let addedAgain =
@@ -56,10 +69,11 @@ describe("Buffer List Tests", ({test, _}) => {
         added,
         BufferEnter(
           BufferMetadata.create(~id=0, ~filePath=Some("/test2.re"), ()),
+        None
         ),
       );
 
-    expect.string(Buffers.getBuffer(0, addedAgain) |> getOrFail).toMatch(
+    expect.string(Buffers.getBuffer(0, addedAgain) |> getFilePathOrFail).toMatch(
       "/test2.re",
     );
   });
@@ -71,10 +85,26 @@ describe("Buffer List Tests", ({test, _}) => {
         bufferList,
         BufferEnter(
           BufferMetadata.create(~filePath=Some("/myfile.js"), ~id=4, ()),
+          None,
         ),
       );
     let activeBuffer = Buffers.getBuffer(4, updated);
-    let path = getOrFail(activeBuffer);
+    let path = getFilePathOrFail(activeBuffer);
     expect.string(path).toMatch("/myfile.js");
+  });
+  
+  test("Should set filetype", ({expect}) => {
+    let bufferList = Buffers.empty;
+    let updated =
+      Buffers.reduce(
+        bufferList,
+        BufferEnter(
+          BufferMetadata.create(~filePath=Some("/myfile.js"), ~id=4, ()),
+          Some("reason"),
+        ),
+      );
+    let activeBuffer = Buffers.getBuffer(4, updated);
+    let fileType = getFileTypeOrFail(activeBuffer);
+    expect.string(fileType).toEqual("reason");
   });
 });


### PR DESCRIPTION
This is a prepatory refactor to help simplify some aspects of syntax highlighting / language services.

For these features - it's important to be able to easily query the filetype (and, down the road, change filetype). Currently, we'd always query the file type against the `LanguageInfo.t`, but this is awkward, because that construct has to be passed around everywhere that needs it, and there's no faculty for changing the filetype.

This changes the model so that on `BufferEnter` we have an initial filetype (which would we could change later), and flattens the `Buffer.t` object to make it less awkward to query properties like path / filetype.