### PR TITLE
Test: 'Single file' zen mode

### DIFF
--- a/integration_test/MenuFilteringSmartCaseTest.re
+++ b/integration_test/MenuFilteringSmartCaseTest.re
@@ -1,0 +1,38 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(~name="Regression: Command line no completions", (dispatch, wait, _) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  let createSimpleMenu = (setItems, _, _) => {
+    let commands: list(Actions.menuCommand) = [
+      {
+        category: Some("Preferences"),
+        name: "Open configuration file",
+        command: () => (),
+        icon: None,
+      },
+    ];
+
+    setItems(commands);
+  };
+
+  dispatch(MenuOpen(createSimpleMenu));
+
+  wait(~name="Mode switches to command line", (state: State.t) =>
+    state.mode == Vim.Types.CommandLine
+  );
+
+  dispatch(KeyboardInput("e"));
+  wait(~name="Mode switches to command line", (state: State.t) =>
+    state.commandline.text == "e"
+  );
+
+  dispatch(KeyboardInput("h"));
+
+  wait(~name="Mode switches to command line", (state: State.t) =>
+    state.commandline.text == "eh"
+  );
+});

--- a/integration_test/ZenModeSingleFileModeTest.re
+++ b/integration_test/ZenModeSingleFileModeTest.re
@@ -1,0 +1,34 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// We'll turn on 'single-file' zen mode, which means when the editor
+// is opened with only one file, we'll enter zen mode automatically
+let configuration = {|
+{ "editor.zenMode.singleFile": true }
+|};
+
+let cliOptions = Cli.create(
+  ~folder=Revery.Environment.getWorkingDirectory(),
+  // Specify a single file
+  ~filesToOpen=["some-random-file.txt"],
+  (),
+);
+
+runTest(
+  ~configuration=Some(configuration),
+  ~cliOptions=Some(cliOptions),
+  ~name="ZenMode: Single-file mode works as expected", 
+  (_dispatch, wait, _runEffects) => {
+  
+  wait(~name="Wait for split to be created 1", (state: State.t) => {
+    let splitCount =
+      state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
+    splitCount == 1;
+  });
+
+  // Verify we've entered zen-mode
+  wait(~name="We should be in zen-mode", (state: State.t) =>
+    state.zenMode == true
+  );
+});

--- a/integration_test/ZenModeSingleFileModeTest.re
+++ b/integration_test/ZenModeSingleFileModeTest.re
@@ -8,27 +8,28 @@ let configuration = {|
 { "editor.zenMode.singleFile": true }
 |};
 
-let cliOptions = Cli.create(
-  ~folder=Revery.Environment.getWorkingDirectory(),
-  // Specify a single file
-  ~filesToOpen=["some-random-file.txt"],
-  (),
-);
+let cliOptions =
+  Cli.create(
+    ~folder=Revery.Environment.getWorkingDirectory(),
+    // Specify a single file
+    ~filesToOpen=["some-random-file.txt"],
+    (),
+  );
 
 runTest(
   ~configuration=Some(configuration),
   ~cliOptions=Some(cliOptions),
-  ~name="ZenMode: Single-file mode works as expected", 
+  ~name="ZenMode: Single-file mode works as expected",
   (_dispatch, wait, _runEffects) => {
-  
-  wait(~name="Wait for split to be created 1", (state: State.t) => {
-    let splitCount =
-      state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
-    splitCount == 1;
-  });
+    wait(~name="Wait for split to be created 1", (state: State.t) => {
+      let splitCount =
+        state.windowManager.windowTree |> WindowTree.getSplits |> List.length;
+      splitCount == 1;
+    });
 
-  // Verify we've entered zen-mode
-  wait(~name="We should be in zen-mode", (state: State.t) =>
-    state.zenMode == true
-  );
-});
+    // Verify we've entered zen-mode
+    wait(~name="We should be in zen-mode", (state: State.t) =>
+      state.zenMode == true
+    );
+  },
+);

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -19,6 +19,7 @@
            AddRemoveSplitTest
            TypingBatchedTest
            TypingUnbatchedTest
+           ZenModeSingleFileModeTest
     )
     (libraries
         libvim
@@ -50,4 +51,5 @@
         TickTest.exe
         TypingBatchedTest.exe
         TypingUnbatchedTest.exe
+        ZenModeSingleFileModeTest.exe
         ))

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -22,7 +22,13 @@ let getTime = () => _currentTime^;
 
 let getScaleFactor = () => 1.0;
 
-let runTest = (~configuration=None, ~cliOptions=None, ~name="AnonymousTest", test: testCallback) => {
+let runTest =
+    (
+      ~configuration=None,
+      ~cliOptions=None,
+      ~name="AnonymousTest",
+      test: testCallback,
+    ) => {
   Printexc.record_backtrace(true);
   Log.enablePrinting();
   Log.enableDebugLogging();
@@ -40,16 +46,16 @@ let runTest = (~configuration=None, ~cliOptions=None, ~name="AnonymousTest", tes
 
   logInit("Starting store...");
 
-  let configPath = switch (configuration) {
-  | None => None
-  | Some(v) => {
-    let tempFile = Filename.temp_file("configuration", ".json");
-    let oc = open_out(tempFile);
-    Printf.fprintf(oc,  "%s\n", v);
-    close_out(oc);
-    Some(tempFile);
-    }
-  }
+  let configPath =
+    switch (configuration) {
+    | None => None
+    | Some(v) =>
+      let tempFile = Filename.temp_file("configuration", ".json");
+      let oc = open_out(tempFile);
+      Printf.fprintf(oc, "%s\n", v);
+      close_out(oc);
+      Some(tempFile);
+    };
 
   let (dispatch, runEffects) =
     Store.StoreThread.start(
@@ -60,7 +66,7 @@ let runTest = (~configuration=None, ~cliOptions=None, ~name="AnonymousTest", tes
       ~getTime,
       ~executingDirectory=Revery.Environment.getExecutingDirectory(),
       ~onStateChanged,
-      ~cliOptions=cliOptions,
+      ~cliOptions,
       ~configurationFilePath=configPath,
       (),
     );

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -22,7 +22,7 @@ let getTime = () => _currentTime^;
 
 let getScaleFactor = () => 1.0;
 
-let runTest = (~name="AnonymousTest", test: testCallback) => {
+let runTest = (~configuration=None, ~cliOptions=None, ~name="AnonymousTest", test: testCallback) => {
   Printexc.record_backtrace(true);
   Log.enablePrinting();
   Log.enableDebugLogging();
@@ -36,9 +36,20 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
     currentState := v;
   };
 
-  let logInit = s => Log.debug("[INITILIAZATION] " ++ s);
+  let logInit = s => Log.debug("[INITIALIZATION] " ++ s);
 
   logInit("Starting store...");
+
+  let configPath = switch (configuration) {
+  | None => None
+  | Some(v) => {
+    let tempFile = Filename.temp_file("configuration", ".json");
+    let oc = open_out(tempFile);
+    Printf.fprintf(oc,  "%s\n", v);
+    close_out(oc);
+    Some(tempFile);
+    }
+  }
 
   let (dispatch, runEffects) =
     Store.StoreThread.start(
@@ -49,7 +60,8 @@ let runTest = (~name="AnonymousTest", test: testCallback) => {
       ~getTime,
       ~executingDirectory=Revery.Environment.getExecutingDirectory(),
       ~onStateChanged,
-      ~cliOptions=None,
+      ~cliOptions=cliOptions,
+      ~configurationFilePath=configPath,
       (),
     );
 

--- a/src/editor/Core/Cli.re
+++ b/src/editor/Core/Cli.re
@@ -10,10 +10,7 @@ type t = {
   filesToOpen: list(string),
 };
 
-let create = (~folder, ~filesToOpen, ()) => {
-  folder,
-  filesToOpen,
-};
+let create = (~folder, ~filesToOpen, ()) => {folder, filesToOpen};
 
 let newline = "\n";
 

--- a/src/editor/Core/Cli.re
+++ b/src/editor/Core/Cli.re
@@ -10,6 +10,11 @@ type t = {
   filesToOpen: list(string),
 };
 
+let create = (~folder, ~filesToOpen, ()) => {
+  folder,
+  filesToOpen,
+};
+
 let newline = "\n";
 
 let show = (v: t) => {

--- a/src/editor/Store/ConfigurationStoreConnector.re
+++ b/src/editor/Store/ConfigurationStoreConnector.re
@@ -7,25 +7,24 @@
 open Oni_Core;
 open Oni_Model;
 
-let start = (~configurationFilePath: option(string), ~cliOptions: option(Cli.t)) => {
-
+let start =
+    (~configurationFilePath: option(string), ~cliOptions: option(Cli.t)) => {
   let defaultConfigurationFileName = "configuration.json";
   let getConfigurationFile = () => {
-
-    let errorLoading = (path) => {
-      Log.error("Error loading configuration file at: " ++ path); 
-      Filesystem.getOrCreateConfigFile(defaultConfigurationFileName); 
+    let errorLoading = path => {
+      Log.error("Error loading configuration file at: " ++ path);
+      Filesystem.getOrCreateConfigFile(defaultConfigurationFileName);
     };
 
     switch (configurationFilePath) {
     | None => Filesystem.getOrCreateConfigFile(defaultConfigurationFileName)
-    | Some(v) => 
+    | Some(v) =>
       switch (Sys.file_exists(v)) {
-      | exception _ => errorLoading(v);
+      | exception _ => errorLoading(v)
       | false => errorLoading(v)
-      | true => Ok(v) 
+      | true => Ok(v)
       }
-    }
+    };
   };
 
   let reloadConfigOnWritePost = (~configPath, dispatch) => {

--- a/src/editor/Store/ConfigurationStoreConnector.re
+++ b/src/editor/Store/ConfigurationStoreConnector.re
@@ -7,8 +7,27 @@
 open Oni_Core;
 open Oni_Model;
 
-let start = (~cliOptions: option(Cli.t)) => {
-  let configurationFileName = "configuration.json";
+let start = (~configurationFilePath: option(string), ~cliOptions: option(Cli.t)) => {
+
+  let defaultConfigurationFileName = "configuration.json";
+  let getConfigurationFile = () => {
+
+    let errorLoading = (path) => {
+      Log.error("Error loading configuration file at: " ++ path); 
+      Filesystem.getOrCreateConfigFile(defaultConfigurationFileName); 
+    };
+
+    switch (configurationFilePath) {
+    | None => Filesystem.getOrCreateConfigFile(defaultConfigurationFileName)
+    | Some(v) => 
+      switch (Sys.file_exists(v)) {
+      | exception _ => errorLoading(v);
+      | false => errorLoading(v)
+      | true => Ok(v) 
+      }
+    }
+  };
+
   let reloadConfigOnWritePost = (~configPath, dispatch) => {
     let _ =
       Vim.AutoCommands.onDispatch((cmd, buffer) => {
@@ -26,8 +45,7 @@ let start = (~cliOptions: option(Cli.t)) => {
 
   let reloadConfigurationEffect =
     Isolinear.Effect.createWithDispatch(~name="configuration.reload", dispatch => {
-      let configPath =
-        Filesystem.getOrCreateConfigFile(configurationFileName);
+      let configPath = getConfigurationFile();
       switch (configPath) {
       | Ok(configPathAsString) =>
         switch (ConfigurationParser.ofFile(configPathAsString)) {
@@ -40,8 +58,7 @@ let start = (~cliOptions: option(Cli.t)) => {
 
   let initConfigurationEffect =
     Isolinear.Effect.createWithDispatch(~name="configuration.init", dispatch => {
-      let configPath =
-        Filesystem.getOrCreateConfigFile(configurationFileName);
+      let configPath = getConfigurationFile();
       switch (configPath) {
       | Ok(configPathAsString) =>
         switch (ConfigurationParser.ofFile(configPathAsString), cliOptions) {

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -37,6 +37,7 @@ let discoverExtensions = (setup: Core.Setup.t) => {
 
 let start =
     (
+      ~configurationFilePath=None,
       ~setup: Core.Setup.t,
       ~executingDirectory,
       ~onStateChanged,
@@ -82,7 +83,7 @@ let start =
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 
-  let configurationUpdater = ConfigurationStoreConnector.start(~cliOptions);
+  let configurationUpdater = ConfigurationStoreConnector.start(~configurationFilePath, ~cliOptions);
 
   let ripgrep = Core.Ripgrep.make(setup.rgPath);
   let quickOpenUpdater = QuickOpenStoreConnector.start(ripgrep);

--- a/src/editor/Store/StoreThread.re
+++ b/src/editor/Store/StoreThread.re
@@ -83,7 +83,8 @@ let start =
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 
-  let configurationUpdater = ConfigurationStoreConnector.start(~configurationFilePath, ~cliOptions);
+  let configurationUpdater =
+    ConfigurationStoreConnector.start(~configurationFilePath, ~cliOptions);
 
   let ripgrep = Core.Ripgrep.make(setup.rgPath);
   let quickOpenUpdater = QuickOpenStoreConnector.start(ripgrep);


### PR DESCRIPTION
I realized with #713 that we didn't have a test around the single-file zen mode case, and we didn't really have the infrastructure to easily write such a test, either.

I added a few things to our integration test framework to make this testable:
- Ability to specify a custom configuration string
- Ability to specify cli options

And then added a test to verify the 'single-file' zen mode scenario. These additional features for our integration test also mean we can test scenarios we couldn't before (invalid config, certain command line arguments, etc).