### PR TITLE
API - Job: Add method for getting progress

### DIFF
--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -30,13 +30,12 @@ let getCompletedWork = (v: t('p, 'c)) => v.completedWork;
 
 let getPendingWork = (v: t('p, 'c)) => v.pendingWork;
 
-let getProgress = (v: t('p, 'c)) => {
+let getProgress = (v: t('p, 'c)) =>
   if (v.isComplete) {
-    1.0
+    1.0;
   } else {
     v.progressReporter(v.pendingWork, v.completedWork);
   };
-};
 
 let create =
     (
@@ -108,8 +107,11 @@ let tick: t('p, 'c) => t('p, 'c) =
     Log.info(
       "[Job] "
       ++ v.name
-      ++ " ran " ++ string_of_int(iterations^) ++ " iterations for "
-      ++ string_of_float(endTime -. startTime) ++ "s",
+      ++ " ran "
+      ++ string_of_int(iterations^)
+      ++ " iterations for "
+      ++ string_of_float(endTime -. startTime)
+      ++ "s",
     );
 
     if (Log.isDebugLoggingEnabled()) {

--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -2,8 +2,11 @@ open Revery;
 
 type mapFn('p, 'c) = ('p, 'c) => (bool, 'p, 'c);
 type doWork('p, 'c) = mapFn('p, 'c);
+type progressReporter('p, 'c) = ('p, 'c) => float;
 
 type workPrinter('a) = 'a => string;
+
+let defaultProgressRepoter = (_, _) => 0.;
 
 type t('p, 'c) = {
   f: doWork('p, 'c),
@@ -12,6 +15,7 @@ type t('p, 'c) = {
   completedWork: 'c,
   budget: Time.t,
   name: string,
+  progressReporter: progressReporter('p, 'c),
   pendingWorkPrinter: workPrinter('p),
   completedWorkPrinter: workPrinter('c),
 };
@@ -26,12 +30,21 @@ let getCompletedWork = (v: t('p, 'c)) => v.completedWork;
 
 let getPendingWork = (v: t('p, 'c)) => v.pendingWork;
 
+let getProgress = (v: t('p, 'c)) => {
+  if (v.isComplete) {
+    1.0
+  } else {
+    v.progressReporter(v.pendingWork, v.completedWork);
+  };
+};
+
 let create =
     (
       ~f: doWork('p, 'c),
       ~initialCompletedWork: 'c,
       ~name="anonymous",
       ~budget=defaultBudget,
+      ~progressReporter=defaultProgressReporter,
       ~pendingWorkPrinter=noopPrinter,
       ~completedWorkPrinter=noopPrinter,
       pendingWork: 'p,
@@ -43,6 +56,7 @@ let create =
     pendingWork,
     name,
     isComplete: false,
+    progressReporter,
     pendingWorkPrinter,
     completedWorkPrinter,
   };

--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -6,7 +6,7 @@ type progressReporter('p, 'c) = ('p, 'c) => float;
 
 type workPrinter('a) = 'a => string;
 
-let defaultProgressRepoter = (_, _) => 0.;
+let defaultProgressReporter = (_, _) => 0.;
 
 type t('p, 'c) = {
   f: doWork('p, 'c),
@@ -93,12 +93,14 @@ let tick: t('p, 'c) => t('p, 'c) =
     let budget = Time.to_float_seconds(v.budget);
     let startTime = Time.getTime() |> Time.to_float_seconds;
     let current = ref(v);
+    let iterations = ref(0);
 
     Log.debug("[Job] Starting " ++ v.name);
     while (Time.to_float_seconds(Time.getTime())
            -. startTime < budget
            && !current^.isComplete) {
       current := doWork(v);
+      incr(iterations);
     };
 
     let endTime = Time.to_float_seconds(Time.getTime());
@@ -106,8 +108,8 @@ let tick: t('p, 'c) => t('p, 'c) =
     Log.info(
       "[Job] "
       ++ v.name
-      ++ " ran for "
-      ++ string_of_float(endTime -. startTime),
+      ++ " ran " ++ string_of_int(iterations^) ++ " iterations for "
+      ++ string_of_float(endTime -. startTime) ++ "s",
     );
 
     if (Log.isDebugLoggingEnabled()) {


### PR DESCRIPTION
This adds a `Job.getProgress` API, with a parameter for the creator of job to specify how to show progress. This will be used in #695 to help with the animation.