### PR TITLE
API: Get visible ranges for buffer

### DIFF
--- a/src/editor/Core/Range.re
+++ b/src/editor/Core/Range.re
@@ -18,6 +18,15 @@ let create = (~startLine, ~startCharacter, ~endLine, ~endCharacter, ()) =>
     (),
   );
 
+let ofInt0 = (~startLine, ~startCharacter, ~endLine, ~endCharacter, ()) =>
+  create(
+    ~startLine=ZeroBasedIndex(startLine),
+    ~startCharacter=ZeroBasedIndex(startCharacter),
+    ~endLine=ZeroBasedIndex(endLine),
+    ~endCharacter=ZeroBasedIndex(endCharacter),
+    (),
+  );
+
 let zero =
   create(
     ~startLine=ZeroBasedIndex(0),

--- a/src/editor/Core/Range.rei
+++ b/src/editor/Core/Range.rei
@@ -25,6 +25,16 @@ let create:
   ) =>
   t;
 
+let ofInt0:
+  (
+    ~startLine: int,
+    ~startCharacter: int,
+    ~endLine: int,
+    ~endCharacter: int,
+    unit
+  ) =>
+  t;
+
 let zero: t;
 
 /*

--- a/src/editor/Model/Editor.re
+++ b/src/editor/Model/Editor.re
@@ -129,10 +129,8 @@ let scrollToLine = (view: t, line: int, metrics: EditorMetrics.t) => {
   };
 };
 
-let scrollToHorizontal = (view: t, newScrollX, metrics: EditorMetrics.t) => {
-  let newScrollX = max(0., newScrollX);
-
-  let layout =
+let getLayout = (view: t, metrics: EditorMetrics.t) => {
+  let layout: EditorLayout.t =
     EditorLayout.getLayout(
       ~maxMinimapCharacters=view.minimapMaxColumnWidth,
       ~pixelWidth=float_of_int(metrics.pixelWidth),
@@ -143,6 +141,14 @@ let scrollToHorizontal = (view: t, newScrollX, metrics: EditorMetrics.t) => {
       ~bufferLineCount=view.viewLines,
       (),
     );
+
+  layout;
+};
+
+let scrollToHorizontal = (view: t, newScrollX, metrics: EditorMetrics.t) => {
+  let newScrollX = max(0., newScrollX);
+
+  let layout = getLayout(view, metrics);
 
   let availableScroll =
     max(
@@ -156,20 +162,9 @@ let scrollToHorizontal = (view: t, newScrollX, metrics: EditorMetrics.t) => {
 };
 
 let getLinesAndColumns = (view: t, metrics: EditorMetrics.t) => {
-  open EditorLayout;
-  let {bufferWidthInCharacters, bufferHeightInCharacters, _} =
-    EditorLayout.getLayout(
-      ~maxMinimapCharacters=view.minimapMaxColumnWidth,
-      ~pixelWidth=float_of_int(metrics.pixelWidth),
-      ~pixelHeight=float_of_int(metrics.pixelHeight),
-      ~isMinimapShown=true,
-      ~characterWidth=metrics.characterWidth,
-      ~characterHeight=metrics.lineHeight,
-      ~bufferLineCount=view.viewLines,
-      (),
-    );
-
-  (bufferHeightInCharacters, bufferWidthInCharacters);
+  let layout = getLayout(view, metrics);
+  let ret = (layout.bufferHeightInCharacters, layout.bufferWidthInCharacters);
+  ret;
 };
 
 let scrollToColumn = (view: t, column: int, metrics: EditorMetrics.t) => {

--- a/src/editor/Model/EditorVisibleRanges.re
+++ b/src/editor/Model/EditorVisibleRanges.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Oni_Core.Types;
 
 open Actions;
 
@@ -85,7 +84,10 @@ let getVisibleRangesForBuffer = (bufferId: int, state: State.t) => {
            let tup = (eg.metrics, v);
            Some(tup);
          }
-       );
+       )
+    |> List.filter(((_, editor)) => {
+        editor.bufferId == bufferId
+    });
 
   let flatten = (prev: t, curr: individualRange) => {
     {

--- a/src/editor/Model/EditorVisibleRanges.re
+++ b/src/editor/Model/EditorVisibleRanges.re
@@ -1,0 +1,65 @@
+open Oni_Core;
+open Oni_Core.Types;
+
+open Actions;
+
+type t = {editorRanges: list(Range.t)};
+
+let default: t = {editorRanges: []};
+
+let getVisibleRangesForEditor = (editor: Editor.t, metrics: EditorMetrics.t) => {
+  let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
+  let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);
+
+  let leftVisibleColumn = Editor.getLeftVisibleColumn(editor, metrics);
+
+  let (_, bufferWidthInCharacters) =
+    Editor.getLinesAndColumns(editor, metrics);
+
+  let i = ref(topVisibleLine);
+  let eRanges = ref([]);
+
+  while (i^ < bottomVisibleLine) {
+    let idx = i^;
+    let range =
+      Range.ofInt0(
+        ~startLine=idx,
+        ~startCharacter=leftVisibleColumn,
+        ~endLine=idx,
+        ~endCharacter=leftVisibleColumn + bufferWidthInCharacters,
+        (),
+      );
+
+    eRanges := [range, ...eRanges^];
+    incr(i);
+  };
+
+  {editorRanges: eRanges^};
+};
+
+let getVisibleRangesForBuffer = (bufferId: int, state: State.t) => {
+  let editors =
+    WindowTree.getSplits(state.windowManager.windowTree)
+    |> List.map((split: WindowTree.split) => split.editorGroupId)
+    |> Utility.filterMap(
+         EditorGroups.getEditorGroupById(state.editorGroups),
+       )
+    |> Utility.filterMap(eg =>
+         switch (EditorGroup.getActiveEditor(eg)) {
+         | None => None
+         | Some(v) =>
+           let tup = (eg.metrics, v);
+           Some(tup);
+         }
+       );
+
+  let flatten = (prev: t, curr: t) => {
+    {editorRanges: List.append(prev.editorRanges, curr.editorRanges)};
+  };
+
+  editors
+  |> List.map(((metrics, editor)) =>
+       getVisibleRangesForEditor(editor, metrics)
+     )
+  |> List.fold_left(flatten, default);
+};

--- a/src/editor/Model/EditorVisibleRanges.re
+++ b/src/editor/Model/EditorVisibleRanges.re
@@ -85,9 +85,7 @@ let getVisibleRangesForBuffer = (bufferId: int, state: State.t) => {
            Some(tup);
          }
        )
-    |> List.filter(((_, editor)) => {
-        editor.bufferId == bufferId
-    });
+    |> List.filter(((_, editor)) => editor.bufferId == bufferId);
 
   let flatten = (prev: t, curr: individualRange) => {
     {

--- a/src/editor/UI/Minimap.re
+++ b/src/editor/UI/Minimap.re
@@ -118,7 +118,7 @@ let createElement =
                 evt => {
                   let scrollTo = getScrollTo(evt.mouseY);
                   let minimapLineSize =
-                    Constants.default.minimapCharacterWidth
+                    Constants.default.minimapLineSpacing
                     + Constants.default.minimapCharacterHeight;
                   let linesInMinimap = metrics.pixelHeight / minimapLineSize;
                   GlobalContext.current().editorScroll(
@@ -148,7 +148,7 @@ let createElement =
     let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
       let scrollTo = getScrollTo(evt.mouseY);
       let minimapLineSize =
-        Constants.default.minimapCharacterWidth
+        Constants.default.minimapLineSpacing
         + Constants.default.minimapCharacterHeight;
       let linesInMinimap = metrics.pixelHeight / minimapLineSize;
       if (evt.button == Revery_Core.MouseButton.BUTTON_LEFT) {


### PR DESCRIPTION
One issue with the current round of tree-sitter work in #663 is that, on every render, we are re-calculating highlights for all the visible lines - every frame.

This is expensive, because it involves:
1) Traversing the tree-sitter syntax tree to get the node encompassing the line
2) Getting the set of terminal syntax tokens for that node / line
3) Resolving the syntax tokens to textmate scopes
4) Resolving the textmate scopes into colorized token bounds based on the theme

We shouldn't need to do this every frame - instead, we can calculate these on demand when the view changes, or when a buffer update comes in. The first step in this on-demand calculation is being able to easily get the set of visible lines in the viewport for a buffer, and that's what this `EditorVisibleRanges` provides.

We'll use this API in our syntax highlighting when the viewport changes to find the visible lines, and then time-slice the resolution of the syntax tree to colorized tokens to fit into our budget so that it doesn't impact input or rendering latency.

This is less noticeable in the JSON strategy, but was apparent when I was testing using the C tree-sitter (the syntax token generation step seemed more expensive in that case).