### PR TITLE
Bugfix: Fix 'tick' in Job and add unit test

### DIFF
--- a/src/editor/Core/Job.re
+++ b/src/editor/Core/Job.re
@@ -90,19 +90,17 @@ let show = (v: t('p, 'c)) => {
 let tick: t('p, 'c) => t('p, 'c) =
   (v: t('p, 'c)) => {
     let budget = Time.to_float_seconds(v.budget);
-    let startTime = Time.getTime() |> Time.to_float_seconds;
+    let startTime = Unix.gettimeofday();
     let current = ref(v);
     let iterations = ref(0);
 
     Log.debug("[Job] Starting " ++ v.name);
-    while (Time.to_float_seconds(Time.getTime())
-           -. startTime < budget
-           && !current^.isComplete) {
-      current := doWork(v);
+    while (Unix.gettimeofday() -. startTime < budget && !current^.isComplete) {
+      current := doWork(current^);
       incr(iterations);
     };
 
-    let endTime = Time.to_float_seconds(Time.getTime());
+    let endTime = Unix.gettimeofday();
 
     Log.info(
       "[Job] "

--- a/test/editor/Core/JobTests.re
+++ b/test/editor/Core/JobTests.re
@@ -1,0 +1,29 @@
+open Oni_Core;
+open TestFramework;
+
+describe("Job", ({describe, _}) =>
+  describe("tick", ({test, _}) =>
+    test("does multiple iterations of work", ({expect}) => {
+      let f = ((), c) =>
+        if (c == 3) {
+          (true, (), 3);
+        } else {
+          (false, (), c + 1);
+        };
+
+      let job =
+        Job.create(
+          ~f,
+          ~initialCompletedWork=0,
+          ~budget=Milliseconds(8.),
+          (),
+        );
+
+      // Tick will run the job for 8 ms.
+      // That should be plenty of time to do a few iterations of [f]...
+      let job = Job.tick(job);
+
+      expect.bool(Job.isComplete(job)).toBe(true);
+    })
+  )
+);


### PR DESCRIPTION
__Issue:__ `Job.tick` was only running a single iteration of the worker function

__Defect:__ We weren't passing the latest `current` ref in the tick function

__Fix:__ Always past the latest `Job.t` iteration