### PR TITLE
Bugfix:  Crash while undoing / redoing

### DIFF
--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -606,45 +606,45 @@ let createElement =
 
                  let lines = Buffer.getNumberOfLines(buffer);
                  if (line <= lines) {
-                 let text = Buffer.getLine(buffer, line);
-                 let (startOffset, _) =
-                   BufferViewTokenizer.getCharacterPositionAndWidth(
-                     ~indentation,
-                     ~viewOffset=leftVisibleColumn,
-                     text,
-                     start,
-                   );
-                 let (endOffset, _) =
-                   BufferViewTokenizer.getCharacterPositionAndWidth(
-                     ~indentation,
-                     ~viewOffset=leftVisibleColumn,
-                     text,
-                     endC,
-                   );
+                   let text = Buffer.getLine(buffer, line);
+                   let (startOffset, _) =
+                     BufferViewTokenizer.getCharacterPositionAndWidth(
+                       ~indentation,
+                       ~viewOffset=leftVisibleColumn,
+                       text,
+                       start,
+                     );
+                   let (endOffset, _) =
+                     BufferViewTokenizer.getCharacterPositionAndWidth(
+                       ~indentation,
+                       ~viewOffset=leftVisibleColumn,
+                       text,
+                       endC,
+                     );
 
-                 Shapes.drawRect(
-                   ~transform,
-                   ~x=
-                     lineNumberWidth
-                     +. float_of_int(startOffset)
-                     *. fontWidth
-                     -. halfOffset,
-                   ~y=
-                     fontHeight
-                     *. float_of_int(
-                          Index.toZeroBasedInt(r.startPosition.line),
-                        )
-                     -. editor.scrollY
-                     -. halfOffset,
-                   ~height=fontHeight +. offset,
-                   ~width=
-                     offset
-                     +. max(float_of_int(endOffset - startOffset), 1.0)
-                     *. fontWidth,
-                   ~color,
-                   (),
-                   
-                 )}};
+                   Shapes.drawRect(
+                     ~transform,
+                     ~x=
+                       lineNumberWidth
+                       +. float_of_int(startOffset)
+                       *. fontWidth
+                       -. halfOffset,
+                     ~y=
+                       fontHeight
+                       *. float_of_int(
+                            Index.toZeroBasedInt(r.startPosition.line),
+                          )
+                       -. editor.scrollY
+                       -. halfOffset,
+                     ~height=fontHeight +. offset,
+                     ~width=
+                       offset
+                       +. max(float_of_int(endOffset - startOffset), 1.0)
+                       *. fontWidth,
+                     ~color,
+                     (),
+                   );
+                 }};
 
               FlatList.render(
                 ~scrollY,

--- a/src/editor/UI/EditorSurface.re
+++ b/src/editor/UI/EditorSurface.re
@@ -604,6 +604,8 @@ let createElement =
                  let start = Index.toZeroBasedInt(r.startPosition.character);
                  let endC = Index.toZeroBasedInt(r.endPosition.character);
 
+                 let lines = Buffer.getNumberOfLines(buffer);
+                 if (line <= lines) {
                  let text = Buffer.getLine(buffer, line);
                  let (startOffset, _) =
                    BufferViewTokenizer.getCharacterPositionAndWidth(
@@ -641,7 +643,8 @@ let createElement =
                      *. fontWidth,
                    ~color,
                    (),
-                 )};
+                   
+                 )}};
 
               FlatList.render(
                 ~scrollY,


### PR DESCRIPTION
While undoing and redoing with a selection active, there was a bug where the viewport might get rendered with an out-of-range selection - this would cause us to try and query for a line that isn't available in the buffer.