### PR TITLE
Syntax Highlighting: Add extra time for first highlight render

### DIFF
--- a/src/editor/Syntax/TextMateSyntaxHighlights.re
+++ b/src/editor/Syntax/TextMateSyntaxHighlights.re
@@ -8,7 +8,16 @@ type t = TextmateTokenizerJob.t;
 
 let hasPendingWork = (v: t) => !Job.isComplete(v);
 
-let doWork = (v: t) => Job.tick(v);
+let doWork = (v: t) => {
+  let hasRun = Job.getPendingWork(v).hasRun;
+  // For first render of a buffer, spend a little extra time on the tokenization
+  // so that can minimize flicker.
+  if (!hasRun) {
+    Job.tick(~budget=Some(0.025), v);
+  } else {
+    Job.tick(v);
+  };
+};
 
 let updateVisibleRanges = (_ranges, v) => v;
 

--- a/src/editor/Syntax/TextmateTokenizerJob.re
+++ b/src/editor/Syntax/TextmateTokenizerJob.re
@@ -14,6 +14,7 @@ type pendingWork = {
   tokenizer: Tokenizer.t,
   theme: TokenTheme.t,
   scope: string,
+  hasRun: bool,
 };
 
 type lineInfo = {
@@ -118,7 +119,11 @@ let doWork = (pending: pendingWork, completed: completedWork) => {
     let nextLine = currentLine + 1;
     let isComplete = nextLine >= Array.length(pending.lines);
 
-    (isComplete, {...pending, currentLine: nextLine}, completed);
+    (
+      isComplete,
+      {...pending, hasRun: true, currentLine: nextLine},
+      completed,
+    );
   };
 };
 
@@ -131,6 +136,7 @@ let create = (~scope, ~theme, ~grammarRepository, lines) => {
     tokenizer,
     theme,
     scope,
+    hasRun: false,
   };
 
   Job.create(


### PR DESCRIPTION
This change gives a 'bonus' time for syntax highlighting when we first open a buffer - 25ms budget from the 2ms/frame that we normally spend on it.