### PR TITLE
Enable native textmate highlighting by default

### DIFF
--- a/src/editor/Core/ConfigurationValues.re
+++ b/src/editor/Core/ConfigurationValues.re
@@ -86,6 +86,6 @@ let default = {
   zenModeHideTabs: true,
   zenModeSingleFile: true,
   experimentalTreeSitter: false,
-  experimentalNativeTextMate: false,
+  experimentalNativeTextMate: true,
   experimentalAutoClosingPairs: false,
 };


### PR DESCRIPTION
Turning on native syntax highlighting - if everything goes OK, will remove this flag and remove our legacy textmate implementation.