### PR TITLE
Bugfix: Shift tokens when applying delta updates

### DIFF
--- a/src/editor/Core/IntMap.re
+++ b/src/editor/Core/IntMap.re
@@ -15,15 +15,21 @@ include Map.Make({
  * This is helpful for line-based consumers of the map - often, when lines are added / removed,
  * we want to shift existing lines to line up with the new delta.
  */
-let noop = (_) => None;
-let shift = (~default:option('a) => option('a) = noop, 
-  ~startPos: int, 
-  ~endPos: int, ~delta: int, map) =>
+let noop = _ => None;
+let shift =
+    (
+      ~default: option('a) => option('a)=noop,
+      ~startPos: int,
+      ~endPos: int,
+      ~delta: int,
+      map,
+    ) =>
   if (endPos - startPos == delta) {
     map;
   } else {
-      // Shift all items based on delta
-      let newMap = fold(
+    // Shift all items based on delta
+    let newMap =
+      fold(
         (key, v, prev) =>
           if (delta > 0) {
             if (key < startPos) {
@@ -40,16 +46,16 @@ let shift = (~default:option('a) => option('a) = noop,
         empty,
       );
 
-      // Set 'new' items to be the default value
-      let start_ = ref(startPos);
-      let current = find_opt(startPos, newMap);
-      let end_ = startPos + (endPos - startPos + delta);
-      let ret = ref(newMap);
+    // Set 'new' items to be the default value
+    let start_ = ref(startPos);
+    let current = find_opt(startPos, newMap);
+    let end_ = startPos + (endPos - startPos + delta);
+    let ret = ref(newMap);
 
-      while ((start_)^ < end_) {
-        ret := update((start_)^, (_) =>  default(current), ret^);
-        incr(start_);
-      };
-      
-      ret^;
+    while (start_^ < end_) {
+      ret := update(start_^, _ => default(current), ret^);
+      incr(start_);
+    };
+
+    ret^;
   };

--- a/src/editor/Core/IntMap.re
+++ b/src/editor/Core/IntMap.re
@@ -8,3 +8,31 @@ include Map.Make({
   type t = int;
   let compare = compare;
 });
+
+/*
+ * Shift adjust the locations of the map by a specified _delta_
+ *
+ * This is helpful for line-based consumers of the map - often, when lines are added / removed,
+ * we want to shift existing lines to line up with the new delta.
+ */
+let shift = (map: t('a), startPos: int, endPos: int, delta: int) =>
+  if (endPos - startPos == delta) {
+    map;
+  } else {
+      fold(
+        (key, v, prev) =>
+          if (delta > 0) {
+            if (key < startPos) {
+              update(key, _opt => Some(v), prev);
+            } else {
+              update(key + delta, _opt => Some(v), prev);
+            };
+          } else if (key <= endPos) {
+            update(key, _opt => Some(v), prev);
+          } else {
+            update(key + delta, _opt => Some(v), prev);
+          },
+        map,
+        empty,
+      );
+  };

--- a/src/editor/Core/IntMap.re
+++ b/src/editor/Core/IntMap.re
@@ -15,7 +15,10 @@ include Map.Make({
  * This is helpful for line-based consumers of the map - often, when lines are added / removed,
  * we want to shift existing lines to line up with the new delta.
  */
-let shift = (~default: option('a) = None, map: t('a), startPos: int, endPos: int, delta: int) =>
+let noop = (_) => None;
+let shift = (~default:option('a) => option('a) = noop, 
+  ~startPos: int, 
+  ~endPos: int, ~delta: int, map) =>
   if (endPos - startPos == delta) {
     map;
   } else {
@@ -39,11 +42,12 @@ let shift = (~default: option('a) = None, map: t('a), startPos: int, endPos: int
 
       // Set 'new' items to be the default value
       let start_ = ref(startPos);
+      let current = find_opt(startPos, newMap);
       let end_ = startPos + (endPos - startPos + delta);
       let ret = ref(newMap);
 
       while ((start_)^ < end_) {
-        ret := update((start_)^, (_) =>  default, ret^);
+        ret := update((start_)^, (_) =>  default(current), ret^);
         incr(start_);
       };
       

--- a/src/editor/Core/IntMap.re
+++ b/src/editor/Core/IntMap.re
@@ -15,11 +15,12 @@ include Map.Make({
  * This is helpful for line-based consumers of the map - often, when lines are added / removed,
  * we want to shift existing lines to line up with the new delta.
  */
-let shift = (map: t('a), startPos: int, endPos: int, delta: int) =>
+let shift = (~default: option('a) = None, map: t('a), startPos: int, endPos: int, delta: int) =>
   if (endPos - startPos == delta) {
     map;
   } else {
-      fold(
+      // Shift all items based on delta
+      let newMap = fold(
         (key, v, prev) =>
           if (delta > 0) {
             if (key < startPos) {
@@ -35,4 +36,16 @@ let shift = (map: t('a), startPos: int, endPos: int, delta: int) =>
         map,
         empty,
       );
+
+      // Set 'new' items to be the default value
+      let start_ = ref(startPos);
+      let end_ = startPos + (endPos - startPos + delta);
+      let ret = ref(newMap);
+
+      while ((start_)^ < end_) {
+        ret := update((start_)^, (_) =>  default, ret^);
+        incr(start_);
+      };
+      
+      ret^;
   };

--- a/src/editor/Core/Types.re
+++ b/src/editor/Core/Types.re
@@ -203,7 +203,6 @@ module Input = {
     command: string,
   };
 };
-
 // TEMPORARY representation of token colors, while we are
 // migrating from the legacy node-based strategy to the new
 // native strategy.

--- a/src/editor/Syntax/TextmateTokenizerJob.re
+++ b/src/editor/Syntax/TextmateTokenizerJob.re
@@ -37,6 +37,9 @@ let getTokenColors = (line: int, v: t) => {
 };
 
 let onBufferUpdate = (bufferUpdate: BufferUpdate.t, lines, v: t) => {
+  let startPos = Index.toInt0(bufferUpdate.startLine);
+  let endPos = Index.toInt0(bufferUpdate.endLine);
+
   let f = (p: pendingWork, c: completedWork) => {
     (
       false,
@@ -44,10 +47,15 @@ let onBufferUpdate = (bufferUpdate: BufferUpdate.t, lines, v: t) => {
         ...p,
         lines,
         currentLine:
-          min(Index.toInt0(bufferUpdate.startLine), p.currentLine),
+          min(startPos, p.currentLine),
         currentVersion: bufferUpdate.version,
       },
-      c,
+      IntMap.shift(~default={(prev) => switch(prev) {
+      | None => None
+      | Some({scopeStack, _}) => Some({tokens: [], scopeStack, version: -1});
+      }}, ~startPos, ~endPos, 
+        ~delta=Array.length(lines),
+      c)
     );
   };
 

--- a/src/editor/Syntax/TextmateTokenizerJob.re
+++ b/src/editor/Syntax/TextmateTokenizerJob.re
@@ -54,7 +54,7 @@ let onBufferUpdate = (bufferUpdate: BufferUpdate.t, lines, v: t) => {
       | None => None
       | Some({scopeStack, _}) => Some({tokens: [], scopeStack, version: -1});
       }}, ~startPos, ~endPos, 
-        ~delta=Array.length(lines),
+        ~delta=Array.length(bufferUpdate.lines),
       c)
     );
   };

--- a/src/editor/Syntax/TextmateTokenizerJob.re
+++ b/src/editor/Syntax/TextmateTokenizerJob.re
@@ -46,16 +46,22 @@ let onBufferUpdate = (bufferUpdate: BufferUpdate.t, lines, v: t) => {
       {
         ...p,
         lines,
-        currentLine:
-          min(startPos, p.currentLine),
+        currentLine: min(startPos, p.currentLine),
         currentVersion: bufferUpdate.version,
       },
-      IntMap.shift(~default={(prev) => switch(prev) {
-      | None => None
-      | Some({scopeStack, _}) => Some({tokens: [], scopeStack, version: -1});
-      }}, ~startPos, ~endPos, 
+      IntMap.shift(
+        ~default=
+          prev =>
+            switch (prev) {
+            | None => None
+            | Some({scopeStack, _}) =>
+              Some({tokens: [], scopeStack, version: (-1)})
+            },
+        ~startPos,
+        ~endPos,
         ~delta=Array.length(bufferUpdate.lines),
-      c)
+        c,
+      ),
     );
   };
 

--- a/test/editor/Core/IntMapTests.re
+++ b/test/editor/Core/IntMapTests.re
@@ -18,7 +18,7 @@ let map = simpleList
 describe("IntMap", ({describe, _}) => {
   describe("shift", ({test, _}) => {
     test("no shift if no add / deletions", ({expect}) => {
-      let newMap = IntMap.shift(map, 1, 1, 0);
+      let newMap = IntMap.shift(~startPos=1, ~endPos=1, ~delta=0, map);
 
       let firstVal = IntMap.find(0, newMap);
       let secondVal = IntMap.find(1, newMap);
@@ -30,7 +30,7 @@ describe("IntMap", ({describe, _}) => {
     });
     
     test("add lines between 1 and 2", ({expect}) => {
-      let newMap = IntMap.shift(~default=Some("f"), map, 1, 1, 2);
+      let newMap = IntMap.shift(~default=(_) => Some("f"), ~startPos=1, ~endPos=1, ~delta=2, map);
 
       let val0 = IntMap.find(0, newMap);
       let val1 =  IntMap.find(1,  newMap);
@@ -46,7 +46,7 @@ describe("IntMap", ({describe, _}) => {
     });
 
     test("remove line", ({expect}) => {
-      let newMap = IntMap.shift(~default=Some("f"), map, 1, 1, -1);
+      let newMap = IntMap.shift(~default=(_) =>Some("f"), ~startPos=1, ~endPos=1, ~delta={-1}, map);
 
       let val0 = IntMap.find(0, newMap);
       let val1 =  IntMap.find(1,  newMap);

--- a/test/editor/Core/IntMapTests.re
+++ b/test/editor/Core/IntMapTests.re
@@ -3,17 +3,9 @@ open TestFramework;
 
 module IntMap = Oni_Core.IntMap;
 
-let simpleList = [
-(0, "a"),
-(1, "b"),
-(2, "c"),
-(3, "d"),
-(4, "e"),
-];
+let simpleList = [(0, "a"), (1, "b"), (2, "c"), (3, "d"), (4, "e")];
 
-let map = simpleList
-  |> List.to_seq
-  |> IntMap.of_seq;
+let map = simpleList |> List.to_seq |> IntMap.of_seq;
 
 describe("IntMap", ({describe, _}) => {
   describe("shift", ({test, _}) => {
@@ -22,18 +14,25 @@ describe("IntMap", ({describe, _}) => {
 
       let firstVal = IntMap.find(0, newMap);
       let secondVal = IntMap.find(1, newMap);
-      let thirdVal = IntMap.find(2,  newMap);
+      let thirdVal = IntMap.find(2, newMap);
 
       expect.string(firstVal).toEqual("a");
       expect.string(secondVal).toEqual("b");
       expect.string(thirdVal).toEqual("c");
     });
-    
+
     test("add lines between 1 and 2", ({expect}) => {
-      let newMap = IntMap.shift(~default=(_) => Some("f"), ~startPos=1, ~endPos=1, ~delta=2, map);
+      let newMap =
+        IntMap.shift(
+          ~default=_ => Some("f"),
+          ~startPos=1,
+          ~endPos=1,
+          ~delta=2,
+          map,
+        );
 
       let val0 = IntMap.find(0, newMap);
-      let val1 =  IntMap.find(1,  newMap);
+      let val1 = IntMap.find(1, newMap);
       let val2 = IntMap.find(2, newMap);
       let val3 = IntMap.find(3, newMap);
       let val4 = IntMap.find(4, newMap);
@@ -46,13 +45,20 @@ describe("IntMap", ({describe, _}) => {
     });
 
     test("remove line", ({expect}) => {
-      let newMap = IntMap.shift(~default=(_) =>Some("f"), ~startPos=1, ~endPos=1, ~delta={-1}, map);
+      let newMap =
+        IntMap.shift(
+          ~default=_ => Some("f"),
+          ~startPos=1,
+          ~endPos=1,
+          ~delta=[@reason.preserve_braces] -1,
+          map,
+        );
 
       let val0 = IntMap.find(0, newMap);
-      let val1 =  IntMap.find(1,  newMap);
-      
+      let val1 = IntMap.find(1, newMap);
+
       expect.string(val0).toEqual("a");
       expect.string(val1).toEqual("c");
     });
-  });
+  })
 });

--- a/test/editor/Core/IntMapTests.re
+++ b/test/editor/Core/IntMapTests.re
@@ -1,0 +1,58 @@
+/* open Oni_Core; */
+open TestFramework;
+
+module IntMap = Oni_Core.IntMap;
+
+let simpleList = [
+(0, "a"),
+(1, "b"),
+(2, "c"),
+(3, "d"),
+(4, "e"),
+];
+
+let map = simpleList
+  |> List.to_seq
+  |> IntMap.of_seq;
+
+describe("IntMap", ({describe, _}) => {
+  describe("shift", ({test, _}) => {
+    test("no shift if no add / deletions", ({expect}) => {
+      let newMap = IntMap.shift(map, 1, 1, 0);
+
+      let firstVal = IntMap.find(0, newMap);
+      let secondVal = IntMap.find(1, newMap);
+      let thirdVal = IntMap.find(2,  newMap);
+
+      expect.string(firstVal).toEqual("a");
+      expect.string(secondVal).toEqual("b");
+      expect.string(thirdVal).toEqual("c");
+    });
+    
+    test("add lines between 1 and 2", ({expect}) => {
+      let newMap = IntMap.shift(~default=Some("f"), map, 1, 1, 2);
+
+      let val0 = IntMap.find(0, newMap);
+      let val1 =  IntMap.find(1,  newMap);
+      let val2 = IntMap.find(2, newMap);
+      let val3 = IntMap.find(3, newMap);
+      let val4 = IntMap.find(4, newMap);
+
+      expect.string(val0).toEqual("a");
+      expect.string(val1).toEqual("f");
+      expect.string(val2).toEqual("f");
+      expect.string(val3).toEqual("b");
+      expect.string(val4).toEqual("c");
+    });
+
+    test("remove line", ({expect}) => {
+      let newMap = IntMap.shift(~default=Some("f"), map, 1, 1, -1);
+
+      let val0 = IntMap.find(0, newMap);
+      let val1 =  IntMap.find(1,  newMap);
+      
+      expect.string(val0).toEqual("a");
+      expect.string(val1).toEqual("c");
+    });
+  });
+});


### PR DESCRIPTION
One small implementation detail that was missed when moving from the 'external' textmate to the 'native' textmate implementation was an optimization - when a buffer update comes in, and adds/remove lines, we preemptively shift the highlights to match the new lines.

This helps minimize unstyled frames, especially in the minimap.

Previously, the `shift` method was specific to a buffer-lines data structure, but this makes it generally applicable to any `IntMap` (might be useful for other cases.... like shifting search highlights or diagnostics!)