### PR TITLE
Refactoring: Remove inputControlMode from state

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -81,7 +81,6 @@ type t =
   | LoadThemeByPath(string)
   | SetIconTheme(IconTheme.t)
   | SetTokenTheme(TokenTheme.t)
-  | SetInputControlMode(Input.controlMode)
   | StatusBarAddItem(StatusBarModel.Item.t)
   | StatusBarDisposeItem(int)
   | ViewCloseEditor(int)

--- a/src/Model/Reducer.re
+++ b/src/Model/Reducer.re
@@ -31,9 +31,6 @@ let reduce: (State.t, Actions.t) => State.t =
         let ret: State.t = {...s, mode: m};
         ret;
       | SetEditorFont(font) => {...s, editorFont: font}
-      | SetInputControlMode(m) => {...s, inputControlMode: m}
-      | CommandlineShow(_) => {...s, inputControlMode: CommandLineFocus}
-      | CommandlineHide => {...s, inputControlMode: EditorTextFocus}
       | EnableZenMode => {...s, zenMode: true}
       | DisableZenMode => {...s, zenMode: false}
       | SetTokenTheme(tokenTheme) => {...s, tokenTheme}

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -25,7 +25,6 @@ type t = {
   // Token theme is theming for syntax highlights
   tokenTheme: TokenTheme.t,
   editorGroups: EditorGroups.t,
-  inputControlMode: Input.controlMode,
   iconTheme: IconTheme.t,
   keyDisplayer: KeyDisplayer.t,
   languageInfo: LanguageInfo.t,
@@ -61,7 +60,6 @@ let create: unit => t =
     theme: Theme.default,
     tokenTheme: TokenTheme.empty,
     editorGroups: EditorGroups.create(),
-    inputControlMode: EditorTextFocus,
     iconTheme: IconTheme.create(),
     keyDisplayer: KeyDisplayer.empty,
     languageInfo: LanguageInfo.create(),

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -85,7 +85,6 @@ let start = _ => {
       _ =>
         multipleActionEffect([
           MenuOpen(CommandPalette.create),
-          SetInputControlMode(TextInputFocus),
         ]),
     ),
     ("quickOpen.open", _ => singleActionEffect(QuickOpen)),
@@ -133,7 +132,6 @@ let start = _ => {
               () => ();
             },
           ),
-          SetInputControlMode(TextInputFocus),
         ]);
       },
     ),
@@ -177,27 +175,17 @@ let start = _ => {
       _ =>
         multipleActionEffect([
           MenuClose,
-          SetInputControlMode(EditorTextFocus),
-        ]),
-    ),
-    (
-      "menu.open",
-      _ =>
-        multipleActionEffect([
-          MenuClose,
-          SetInputControlMode(EditorTextFocus),
         ]),
     ),
     (
       "menu.next",
       _ =>
-        multipleActionEffect([SetInputControlMode(MenuFocus), MenuNextItem]),
+        multipleActionEffect([MenuNextItem]),
     ),
     (
       "menu.previous",
       _ =>
         multipleActionEffect([
-          SetInputControlMode(MenuFocus),
           MenuPreviousItem,
         ]),
     ),
@@ -206,7 +194,6 @@ let start = _ => {
       _ =>
         multipleActionEffect([
           MenuSelect,
-          SetInputControlMode(EditorTextFocus),
         ]),
     ),
     ("view.closeEditor", state => closeEditorEffect(state)),

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -82,10 +82,7 @@ let start = _ => {
     ("keyDisplayer.disable", _ => singleActionEffect(DisableKeyDisplayer)),
     (
       "commandPalette.open",
-      _ =>
-        multipleActionEffect([
-          MenuOpen(CommandPalette.create),
-        ]),
+      _ => multipleActionEffect([MenuOpen(CommandPalette.create)]),
     ),
     ("quickOpen.open", _ => singleActionEffect(QuickOpen)),
     (
@@ -170,32 +167,10 @@ let start = _ => {
           ]);
         },
       ),*/
-    (
-      "menu.close",
-      _ =>
-        multipleActionEffect([
-          MenuClose,
-        ]),
-    ),
-    (
-      "menu.next",
-      _ =>
-        multipleActionEffect([MenuNextItem]),
-    ),
-    (
-      "menu.previous",
-      _ =>
-        multipleActionEffect([
-          MenuPreviousItem,
-        ]),
-    ),
-    (
-      "menu.select",
-      _ =>
-        multipleActionEffect([
-          MenuSelect,
-        ]),
-    ),
+    ("menu.close", _ => multipleActionEffect([MenuClose])),
+    ("menu.next", _ => multipleActionEffect([MenuNextItem])),
+    ("menu.previous", _ => multipleActionEffect([MenuPreviousItem])),
+    ("menu.select", _ => multipleActionEffect([MenuSelect])),
     ("view.closeEditor", state => closeEditorEffect(state)),
     ("view.splitVertical", state => splitEditorEffect(state, Vertical)),
     ("view.splitHorizontal", state => splitEditorEffect(state, Horizontal)),

--- a/src/Store/MenuStoreConnector.re
+++ b/src/Store/MenuStoreConnector.re
@@ -130,7 +130,7 @@ let start = () => {
       /* Also close menu */
       let (closeState, closeEffect) = menuUpdater(state, MenuClose);
 
-      (closeState, Isolinear.Effect.batch([effect, closeEffect]));
+      (closeState, Isolinear.Effect.batch([closeEffect, effect]));
     | _ => (state, Isolinear.Effect.none)
     };
   };

--- a/src/Store/QuickOpenStoreConnector.re
+++ b/src/Store/QuickOpenStoreConnector.re
@@ -69,7 +69,6 @@ let start = (rg: Core.Ripgrep.t(Model.Actions.menuCommand)) => {
       dispatch(
         Model.Actions.MenuOpen(createQuickOpen(languageInfo, iconTheme)),
       );
-      dispatch(Model.Actions.SetInputControlMode(TextInputFocus));
     });
 
   let updater = (state: Model.State.t, action) => {

--- a/src/Store/QuickOpenStoreConnector.re
+++ b/src/Store/QuickOpenStoreConnector.re
@@ -68,7 +68,7 @@ let start = (rg: Core.Ripgrep.t(Model.Actions.menuCommand)) => {
     Isolinear.Effect.createWithDispatch(~name="quickOpen.show", dispatch => {
       dispatch(
         Model.Actions.MenuOpen(createQuickOpen(languageInfo, iconTheme)),
-      );
+      )
     });
 
   let updater = (state: Model.State.t, action) => {

--- a/src/UI/MenuView.re
+++ b/src/UI/MenuView.re
@@ -39,8 +39,6 @@ let handleKeyDown = (event: NodeEvents.keyEventParams) =>
     GlobalContext.current().dispatch(MenuNextItem)
   | {key: Revery.Key.KEY_UP, _} =>
     GlobalContext.current().dispatch(MenuPreviousItem)
-  | {key: Revery.Key.KEY_ESCAPE, _} =>
-    GlobalContext.current().dispatch(SetInputControlMode(MenuFocus))
   | _ => ()
   };
 
@@ -58,7 +56,6 @@ let loseFocusOnClose = isOpen =>
 
 let onClick = () => {
   GlobalContext.current().dispatch(MenuSelect);
-  GlobalContext.current().dispatch(SetInputControlMode(EditorTextFocus));
 };
 
 let onMouseOver = pos => GlobalContext.current().dispatch(MenuPosition(pos));

--- a/src/bin_editor/Input.re
+++ b/src/bin_editor/Input.re
@@ -114,11 +114,11 @@ module Conditions = {
 
     if (state.commandline.show) {
       Hashtbl.add(ret, CommandLineFocus, true);
-    }
-    
+    };
+
     if (state.menu.isOpen) {
       Hashtbl.add(ret, MenuFocus, true);
-    }
+    };
 
     // HACK: Because we don't have AND conditions yet for input
     // (the conditions array are OR's), we are making `insertMode`
@@ -126,10 +126,9 @@ module Conditions = {
     // editor (editorTextFocus is set)
     switch (state.menu.isOpen || state.commandline.show, state.mode) {
     | (false, Vim.Types.Insert) =>
-      Hashtbl.add(ret, Types.Input.InsertMode, true)
-      Hashtbl.add(ret, Types.Input.EditorTextFocus, true)
-    | (false, _) =>
-      Hashtbl.add(ret, Types.Input.EditorTextFocus, true)
+      Hashtbl.add(ret, Types.Input.InsertMode, true);
+      Hashtbl.add(ret, Types.Input.EditorTextFocus, true);
+    | (false, _) => Hashtbl.add(ret, Types.Input.EditorTextFocus, true)
     | _ => ()
     };
 
@@ -166,8 +165,6 @@ let getActionsForBinding = (inputKey, commands, state: State.t) => {
     )
   );
 };
-
-
 
 /**
   Handle Input from Oni or Vim


### PR DESCRIPTION
This is a change that is needed by both #779 (for the nested menu) and #780 (for proper handling of SDL's concept of text input), so I'm pulling it out separately.

This simplifies our input model - we were manually setting an `inputControlMode` on our state, which required additional `dispatch`'s to keep in sync with our state. It turns out this can instead be fully derived by our current state, which simplifies our state management by removing the synchronization.