### PR TITLE
Fix #817 - Minimap improvements

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -46,6 +46,7 @@ type t =
   | WindowTreeSetSize(int, int)
   | EditorGroupAdd(editorGroup)
   | EditorGroupSetSize(int, EditorSize.t)
+  | EditorSetScroll(float)
   | EditorScroll(float)
   | EditorScrollToLine(int)
   | EditorScrollToColumn(int)

--- a/src/Model/Editor.re
+++ b/src/Model/Editor.re
@@ -237,7 +237,8 @@ let reduce = (view, action, metrics: EditorMetrics.t) =>
     }
   | SelectionChanged(selection) => {...view, selection}
   | RecalculateEditorView(buffer) => recalculate(view, buffer)
-  | EditorScroll(scrollY) => scroll(view, scrollY, metrics)
+  | EditorSetScroll(scrollY) => scrollTo(view, scrollY, metrics)
+  | EditorScroll(scrollDeltaY) => scroll(view, scrollDeltaY, metrics)
   | EditorScrollToLine(line) => scrollToLine(view, line, metrics)
   | EditorScrollToColumn(column) => scrollToColumn(view, column, metrics)
   | _ => view

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -463,14 +463,14 @@ let createElement =
       ];
 
     let scrollSurface = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
-      GlobalContext.current().editorScroll(
+      GlobalContext.current().editorScrollDelta(
         ~deltaY=wheelEvent.deltaY *. (-50.),
         (),
       );
     };
 
     let scrollMinimap = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
-      GlobalContext.current().editorScroll(
+      GlobalContext.current().editorScrollDelta(
         ~deltaY=wheelEvent.deltaY *. (-150.),
         (),
       );

--- a/src/UI/FlatList.re
+++ b/src/UI/FlatList.re
@@ -99,7 +99,7 @@ let createElement =
       ];
 
     let scroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
-      GlobalContext.current().editorScroll(
+      GlobalContext.current().editorScrollDelta(
         ~deltaY=wheelEvent.deltaY *. 25.,
         (),
       );

--- a/src/UI/GlobalContext.re
+++ b/src/UI/GlobalContext.re
@@ -14,11 +14,13 @@ type notifyWindowTreeSizeChanged = (~width: int, ~height: int, unit) => unit;
 type notifyEditorSizeChanged =
   (~editorGroupId: int, ~width: int, ~height: int, unit) => unit;
 type editorScroll = (~deltaY: float, unit) => unit;
+type editorScroll2 = (~scrollY: float, unit) => unit;
 
 type t = {
   notifyEditorSizeChanged,
   notifyWindowTreeSizeChanged,
   editorScroll,
+  editorScroll2,
   setActiveWindow: (int, int) => unit,
   openEditorById: int => unit,
   closeEditorById: int => unit,
@@ -39,6 +41,7 @@ let default = {
     (~editorGroupId as _, ~width as _, ~height as _, ()) =>
     (),
   editorScroll: (~deltaY as _, ()) => (),
+  editorScroll2: (~scrollY as _, ()) => (),
   hideNotification: _ => (),
   openEditorById: _ => (),
   setActiveWindow: (_, _) => (),

--- a/src/UI/GlobalContext.re
+++ b/src/UI/GlobalContext.re
@@ -13,14 +13,14 @@ open Oni_Model;
 type notifyWindowTreeSizeChanged = (~width: int, ~height: int, unit) => unit;
 type notifyEditorSizeChanged =
   (~editorGroupId: int, ~width: int, ~height: int, unit) => unit;
-type editorScroll = (~deltaY: float, unit) => unit;
-type editorScroll2 = (~scrollY: float, unit) => unit;
+type editorScrollDelta = (~deltaY: float, unit) => unit;
+type editorSetScroll = (~scrollY: float, unit) => unit;
 
 type t = {
   notifyEditorSizeChanged,
   notifyWindowTreeSizeChanged,
-  editorScroll,
-  editorScroll2,
+  editorScrollDelta,
+  editorSetScroll,
   setActiveWindow: (int, int) => unit,
   openEditorById: int => unit,
   closeEditorById: int => unit,
@@ -40,8 +40,8 @@ let default = {
   notifyEditorSizeChanged:
     (~editorGroupId as _, ~width as _, ~height as _, ()) =>
     (),
-  editorScroll: (~deltaY as _, ()) => (),
-  editorScroll2: (~scrollY as _, ()) => (),
+  editorScrollDelta: (~deltaY as _, ()) => (),
+  editorSetScroll: (~scrollY as _, ()) => (),
   hideNotification: _ => (),
   openEditorById: _ => (),
   setActiveWindow: (_, _) => (),

--- a/src/UI/Minimap.re
+++ b/src/UI/Minimap.re
@@ -79,7 +79,7 @@ type mouseCaptureState = {isCapturing: bool};
 type action =
   | IsCapturing(bool);
 
-let reducer = (action, state) =>
+let reducer = (action, _state) =>
   switch (action) {
   | IsCapturing(isCapturing) => {isCapturing: isCapturing}
   };
@@ -110,7 +110,7 @@ let createElement =
       );
 
     let (mouseState, dispatch, hooks) =
-      React.Hooks.reducer(initialState, reducer, hooks);
+      React.Hooks.reducer(~initialState, reducer, hooks);
 
     let getScrollTo = (mouseY: float) => {
       let totalHeight: int = Editor.getTotalSizeInPixels(editor, metrics);

--- a/src/UI/Minimap.re
+++ b/src/UI/Minimap.re
@@ -74,9 +74,7 @@ let getMinimapSize = (view: Editor.t, metrics) => {
   view.viewLines < currentViewSize ? 0 : currentViewSize + 1;
 };
 
-type mouseCaptureState = {
-  isCapturing: bool,
-};
+type mouseCaptureState = {isCapturing: bool};
 
 type action =
   | IsCapturing(bool);
@@ -167,10 +165,7 @@ let createElement =
               let scrollTo = scrollTo -. float_of_int(linesInMinimap);
               GlobalContext.current().editorSetScroll(~scrollY=scrollTo, ());
             },
-          ~onMouseUp=
-            _evt => {
-              scrollComplete();
-            },
+          ~onMouseUp=_evt => {scrollComplete()},
           (),
         );
         dispatch(IsCapturing(true));

--- a/src/UI/Minimap.re
+++ b/src/UI/Minimap.re
@@ -58,16 +58,34 @@ let renderLine =
   List.iter(f, tokens);
 };
 
-let component = React.component("Minimap");
-
 let absoluteStyle =
-  Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
+  Style.[position(`Absolute), top(0), bottom(0), left(0), right(0), cursor(MouseCursors.pointer)];
 
 let getMinimapSize = (view: Editor.t, metrics) => {
   let currentViewSize = Editor.getVisibleView(metrics);
 
   view.viewLines < currentViewSize ? 0 : currentViewSize + 1;
 };
+
+type mouseCaptureState = {
+  shouldCapture: bool,
+  isCapturing: bool,
+};
+
+type action = 
+| StartCapture
+| EndCapture
+| IsCapturing(bool);
+
+let reducer = (action, state) => switch(action) {
+| StartCapture => { ...state, shouldCapture: true }
+| EndCapture => { ...state, shouldCapture: false }
+| IsCapturing(isCapturing) => { ...state, isCapturing }
+}
+
+let initialState = { shouldCapture: false, isCapturing: false };
+
+let component = React.component("Minimap");
 
 let createElement =
     (
@@ -90,7 +108,7 @@ let createElement =
         + Constants.default.minimapLineSpacing,
       );
 
-    let (isActive, setActive, hooks) = React.Hooks.state(false, hooks);
+    let (mouseState, dispatch, hooks) = React.Hooks.reducer(initialState, reducer, hooks);
 
     let getScrollTo = (mouseY: float) => {
       let totalHeight: int = Editor.getTotalSizeInPixels(editor, metrics);
@@ -103,41 +121,22 @@ let createElement =
     };
 
     let scrollComplete = () => {
-      setActive(false);
+      Mouse.releaseCapture();
+      dispatch(IsCapturing(false));
     };
+
+    let string_of_bool = (v) => v ? "true" : "false";
 
     let hooks =
       React.Hooks.effect(
-        Always,
+        OnMount,
         () => {
-          let isCaptured = isActive;
-          let startPosition = editor.scrollY;
-          if (isCaptured) {
-            Mouse.setCapture(
-              ~onMouseMove=
-                evt => {
-                  let scrollTo = getScrollTo(evt.mouseY);
-                  let minimapLineSize =
-                    Constants.default.minimapLineSpacing
-                    + Constants.default.minimapCharacterHeight;
-                  let linesInMinimap = metrics.pixelHeight / minimapLineSize;
-                  GlobalContext.current().editorScroll(
-                    ~deltaY=
-                      (startPosition -. scrollTo)
-                      *. (-1.)
-                      -. float_of_int(linesInMinimap),
-                    (),
-                  );
-                },
-              ~onMouseUp=_evt => scrollComplete(),
-              (),
-            );
-          };
           Some(
-            () =>
-              if (isCaptured) {
+            () => {
+              if (mouseState.isCapturing) {
                 Mouse.releaseCapture();
-              },
+              }
+            }
           );
         },
         hooks,
@@ -146,6 +145,7 @@ let createElement =
     let scrollY = editor.minimapScrollY;
 
     let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
+      Log.info("ONMOUSEDOWN");
       let scrollTo = getScrollTo(evt.mouseY);
       let minimapLineSize =
         Constants.default.minimapLineSpacing
@@ -156,7 +156,37 @@ let createElement =
           ~deltaY=scrollTo -. editor.scrollY -. float_of_int(linesInMinimap),
           (),
         );
-        setActive(true);
+            Mouse.setCapture(
+              ~onMouseMove=
+                evt => {
+                  let scrollTo = getScrollTo(evt.mouseY);
+                  let minimapLineSize =
+                    Constants.default.minimapLineSpacing
+                    + Constants.default.minimapCharacterHeight;
+                  let linesInMinimap = metrics.pixelHeight / minimapLineSize;
+                  /*GlobalContext.current().editorScroll(
+                    ~deltaY=
+                      (editor.scrollY -. scrollTo)
+                      *. (-1.)
+                      -. float_of_int(linesInMinimap),
+                    (),
+                  );*/
+                  GlobalContext.current().editorScroll2(
+                    ~scrollY=scrollTo,
+                    (),
+                  );
+                },
+              ~onMouseUp=_evt => {
+                Log.info("onMouseUp");
+                scrollComplete();
+              },
+              ~onMouseLeaveWindow=() => {
+                Log.info("onMouseLeaveWindow");
+                scrollComplete();
+              },
+              (),
+            );
+            dispatch(IsCapturing(true));
       };
     };
 

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -104,6 +104,8 @@ let init = app => {
     closeEditorById: id => dispatch(Model.Actions.ViewCloseEditor(id)),
     editorScroll: (~deltaY, ()) =>
       dispatch(Model.Actions.EditorScroll(deltaY)),
+    editorScroll2: (~scrollY, ()) =>
+      dispatch(Model.Actions.EditorSetScroll(scrollY)),
     setActiveWindow: (splitId, editorGroupId) =>
       dispatch(Model.Actions.WindowSetActive(splitId, editorGroupId)),
     hideNotification: id => dispatch(Model.Actions.HideNotification(id)),

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -102,9 +102,9 @@ let init = app => {
       dispatch(Model.Actions.ViewSetActiveEditor(id));
     },
     closeEditorById: id => dispatch(Model.Actions.ViewCloseEditor(id)),
-    editorScroll: (~deltaY, ()) =>
+    editorScrollDelta: (~deltaY, ()) =>
       dispatch(Model.Actions.EditorScroll(deltaY)),
-    editorScroll2: (~scrollY, ()) =>
+    editorSetScroll: (~scrollY, ()) =>
       dispatch(Model.Actions.EditorSetScroll(scrollY)),
     setActiveWindow: (splitId, editorGroupId) =>
       dispatch(Model.Actions.WindowSetActive(splitId, editorGroupId)),


### PR DESCRIPTION
Fix #817 - fix case where `OnMouseUp` wouldn't get picked up by capturing.

__Issue:__ We'd use a `React.Hooks.effect` to listen to the capture with an `Always` flag - that relied on an `isCapturing` value to be set. So to start capturing, there'd be this sequence of events:
- `mouse down` -> update scroll position
(re-render, run effect hook - no capturing)
- update `setActive`
(re-render, run effect hook - capturing)

The problem is - there is a frame where we are 'capturing' but we haven't yet called `Mouse.setCapture` - and if a `mouseup` happens in that time, we lose it and just get stuck capturing.

__Fix:__ Don't use the effect to listen to events - use it just to track if we need to dispose the handler (with an `OnMount` instead of `Always` flag - so we'd only call the dispose if the element goes away).