### PR TITLE
#820 - Additional logging

### DIFF
--- a/src/Store/FontStoreConnector.re
+++ b/src/Store/FontStoreConnector.re
@@ -35,7 +35,12 @@ let loadAndValidateEditorFont =
       let firstShape = shapedText[0];
       let secondShape = shapedText[1];
 
-      Log.info("Checking font rendering - glyph1: " ++ string_of_int(firstShape.glyphId) ++ " glyph2: " ++ string_of_int(secondShape.glyphId));
+      Log.info(
+        "Checking font rendering - glyph1: "
+        ++ string_of_int(firstShape.glyphId)
+        ++ " glyph2: "
+        ++ string_of_int(secondShape.glyphId),
+      );
 
       let glyph = Fontkit.renderGlyph(font, firstShape.glyphId);
       Log.info("Got glyph for firstShape");

--- a/src/Store/FontStoreConnector.re
+++ b/src/Store/FontStoreConnector.re
@@ -35,8 +35,12 @@ let loadAndValidateEditorFont =
       let firstShape = shapedText[0];
       let secondShape = shapedText[1];
 
+      Log.info("Checking font rendering - glyph1: " ++ string_of_int(firstShape.glyphId) ++ " glyph2: " ++ string_of_int(secondShape.glyphId));
+
       let glyph = Fontkit.renderGlyph(font, firstShape.glyphId);
+      Log.info("Got glyph for firstShape");
       let secondGlyph = Fontkit.renderGlyph(font, secondShape.glyphId);
+      Log.info("Got glyph for secondShape");
 
       if (glyph.advance != secondGlyph.advance) {
         onError("Not a monospace font.");


### PR DESCRIPTION
This is additional logging to help diagnose #820 - in particular, to figure out if we are failing at **shaping** (getting the `glyphId`s that we sent to freetype - that would mean the failure is in `harfbuzz`), or if the failure is actually in the rendering of the glyph in `freetype`.

Unfortunately, we didn't log enough to get this information - so this addresses that gap.

This doesn't fix the issue - but hopefully give enough for the next level of investigation.