### PR TITLE
fix(menu): improve scrolling behavior of menu

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -63,6 +63,7 @@ type t =
   | MenuClose
   | MenuSelect
   | MenuNextItem
+  | MenuScroll(float)
   | MenuPreviousItem
   | MenuPosition(int)
   | OpenFileByPath(string, option(WindowTree.direction))

--- a/src/Model/Menu.re
+++ b/src/Model/Menu.re
@@ -13,9 +13,13 @@ type t = {
   isLoading: bool,
   loadingAnimation: Animation.t,
   selectedItem: int,
+  rowOffset: int,
   filterJob: MenuJob.t,
   onQueryChanged: Event.t(string),
   dispose: unit => unit,
+  maxRows: int,
+  rowHeight: int,
+  scrollY: float,
 };
 
 let create = () => {
@@ -25,7 +29,11 @@ let create = () => {
   isOpen: false,
   isLoading: false,
   selectedItem: 0,
+  rowOffset: 0,
+  maxRows: 8,
   filterJob: MenuJob.create(),
   onQueryChanged: Event.create(),
   dispose: () => (),
+  rowHeight: 40,
+  scrollY: 0.0,
 };

--- a/src/UI/MenuView.re
+++ b/src/UI/MenuView.re
@@ -7,7 +7,6 @@ open Oni_Model;
 let component = React.component("Menu");
 
 let menuWidth = 400;
-let menuHeight = 320;
 
 let containerStyles = (theme: Theme.t) =>
   Style.[
@@ -133,6 +132,12 @@ let createElement =
             </View>
           </Opacity>;
 
+    let onScroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
+      GlobalContext.current().dispatch(
+        MenuScroll(wheelEvent.deltaY *. (-25.)),
+      );
+    };
+
     React.(
       hooks,
       menu.isOpen
@@ -151,10 +156,13 @@ let createElement =
                 </View>
                 <View>
                   <FlatList
-                    rowHeight=40
-                    height=menuHeight
+                    scrollY={menu.scrollY}
+                    rowHeight={menu.rowHeight}
+                    height={menu.rowHeight * menu.maxRows}
                     width=menuWidth
                     count={Array.length(commands)}
+                    onScroll
+                    rowsToRender={menu.maxRows}
                     render={index => {
                       let cmd = commands[index];
                       <MenuItem
@@ -163,7 +171,6 @@ let createElement =
                         style=menuItemStyle
                         label={getLabel(cmd)}
                         icon={cmd.icon}
-                        onMouseOver={_ => onMouseOver(index)}
                         selected={index == menu.selectedItem}
                       />;
                     }}


### PR DESCRIPTION
Apply a vscode style scrolling behavior where we keep track of offset separately from scroll and handle the circular behavior of scrolling back to the top when reaching the end and vice versa.

This handles #314 , #321, and #818 partially by resolving: 

> When I navigate with down arrow key below the position of last entry in the list I can't navigate with arrow keys anymore