### PR TITLE
Bugfix - Themes: Fix dark/light resolution when specified via uiTheme

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b7de67b27e5c7484dd779a34b681d550",
+  "checksum": "b226e367880fb4ed95e571e4b8d14f32",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -94,7 +94,7 @@
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "brisk-reconciler@0.0.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -148,7 +148,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -168,7 +168,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
@@ -265,14 +265,14 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
-    "reason-textmate@2.0.0@d41d8cd9": {
-      "id": "reason-textmate@2.0.0@d41d8cd9",
+    "reason-textmate@2.1.0@d41d8cd9": {
+      "id": "reason-textmate@2.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.0.0.tgz#sha1:f5b7a1d336e97186baeb68397d24dd791ee951b5"
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.1.0.tgz#sha1:9e018772c1bc21b139560b287880fbdb45c8f701"
         ]
       },
       "overrides": [],
@@ -303,7 +303,7 @@
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -363,7 +363,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
       ],
@@ -1000,7 +1000,7 @@
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#4947ead@d41d8cd9",
-        "reason-textmate@2.0.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
+        "reason-textmate@2.1.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#8fc399d@d41d8cd9",
         "reason-jsonrpc@1.2.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "isolinear@2.1.0@d41d8cd9", "esy-sdl2@2.0.10003@d41d8cd9",
@@ -1011,7 +1011,7 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1210,7 +1210,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.6@f4f83858",
@@ -1223,7 +1223,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -2008,12 +2008,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.2@ee59a0be": {
@@ -2037,14 +2037,14 @@
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2065,27 +2065,27 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
-    "@opam/lwt@opam:4.3.1@14b6a62e": {
-      "id": "@opam/lwt@opam:4.3.1@14b6a62e",
+    "@opam/lwt@opam:4.4.0@0357bb8b": {
+      "id": "@opam/lwt@opam:4.4.0@0357bb8b",
       "name": "@opam/lwt",
-      "version": "opam:4.3.1",
+      "version": "opam:4.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/92/926936860087c5819d6ca04241bc894a#md5:926936860087c5819d6ca04241bc894a",
-          "archive:https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz#md5:926936860087c5819d6ca04241bc894a"
+          "archive:https://opam.ocaml.org/cache/md5/8b/8bfc70c2944020fa08dd04877747f5f9#md5:8bfc70c2944020fa08dd04877747f5f9",
+          "archive:https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz#md5:8bfc70c2944020fa08dd04877747f5f9"
         ],
         "opam": {
           "name": "lwt",
-          "version": "4.3.1",
-          "path": "bench.esy.lock/opam/lwt.4.3.1"
+          "version": "4.4.0",
+          "path": "bench.esy.lock/opam/lwt.4.4.0"
         }
       },
       "overrides": [],
@@ -2135,7 +2135,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2144,7 +2144,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/camomile@opam:1.0.1@a244d067"
       ]
     },
@@ -2225,13 +2225,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7"

--- a/bench.esy.lock/opam/lwt.4.4.0/opam
+++ b/bench.esy.lock/opam/lwt.4.4.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
 
-version: "4.3.1"
+version: "4.4.0"
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt/manual/"
@@ -60,6 +60,6 @@ a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 
 url {
-  src: "https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz"
-  checksum: "md5=926936860087c5819d6ca04241bc894a"
+  src: "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz"
+  checksum: "md5=8bfc70c2944020fa08dd04877747f5f9"
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b7de67b27e5c7484dd779a34b681d550",
+  "checksum": "b226e367880fb4ed95e571e4b8d14f32",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -94,7 +94,7 @@
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "brisk-reconciler@0.0.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -148,7 +148,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -168,7 +168,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
@@ -265,14 +265,14 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
-    "reason-textmate@2.0.0@d41d8cd9": {
-      "id": "reason-textmate@2.0.0@d41d8cd9",
+    "reason-textmate@2.1.0@d41d8cd9": {
+      "id": "reason-textmate@2.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.0.0.tgz#sha1:f5b7a1d336e97186baeb68397d24dd791ee951b5"
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.1.0.tgz#sha1:9e018772c1bc21b139560b287880fbdb45c8f701"
         ]
       },
       "overrides": [],
@@ -303,7 +303,7 @@
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -363,7 +363,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
       ],
@@ -999,7 +999,7 @@
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#4947ead@d41d8cd9",
-        "reason-textmate@2.0.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
+        "reason-textmate@2.1.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#8fc399d@d41d8cd9",
         "reason-jsonrpc@1.2.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "isolinear@2.1.0@d41d8cd9", "esy-sdl2@2.0.10003@d41d8cd9",
@@ -1010,7 +1010,7 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1209,7 +1209,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.6@f4f83858",
@@ -1222,7 +1222,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -2007,12 +2007,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.2@ee59a0be": {
@@ -2036,14 +2036,14 @@
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2064,27 +2064,27 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
-    "@opam/lwt@opam:4.3.1@14b6a62e": {
-      "id": "@opam/lwt@opam:4.3.1@14b6a62e",
+    "@opam/lwt@opam:4.4.0@0357bb8b": {
+      "id": "@opam/lwt@opam:4.4.0@0357bb8b",
       "name": "@opam/lwt",
-      "version": "opam:4.3.1",
+      "version": "opam:4.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/92/926936860087c5819d6ca04241bc894a#md5:926936860087c5819d6ca04241bc894a",
-          "archive:https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz#md5:926936860087c5819d6ca04241bc894a"
+          "archive:https://opam.ocaml.org/cache/md5/8b/8bfc70c2944020fa08dd04877747f5f9#md5:8bfc70c2944020fa08dd04877747f5f9",
+          "archive:https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz#md5:8bfc70c2944020fa08dd04877747f5f9"
         ],
         "opam": {
           "name": "lwt",
-          "version": "4.3.1",
-          "path": "esy.lock/opam/lwt.4.3.1"
+          "version": "4.4.0",
+          "path": "esy.lock/opam/lwt.4.4.0"
         }
       },
       "overrides": [],
@@ -2134,7 +2134,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2143,7 +2143,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/camomile@opam:1.0.1@a244d067"
       ]
     },
@@ -2224,13 +2224,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7"

--- a/esy.lock/opam/lwt.4.4.0/opam
+++ b/esy.lock/opam/lwt.4.4.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
 
-version: "4.3.1"
+version: "4.4.0"
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt/manual/"
@@ -60,6 +60,6 @@ a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 
 url {
-  src: "https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz"
-  checksum: "md5=926936860087c5819d6ca04241bc894a"
+  src: "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz"
+  checksum: "md5=8bfc70c2944020fa08dd04877747f5f9"
 }

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b7de67b27e5c7484dd779a34b681d550",
+  "checksum": "b226e367880fb4ed95e571e4b8d14f32",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -94,7 +94,7 @@
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "brisk-reconciler@0.0.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -148,7 +148,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -168,7 +168,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
@@ -265,14 +265,14 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
-    "reason-textmate@2.0.0@d41d8cd9": {
-      "id": "reason-textmate@2.0.0@d41d8cd9",
+    "reason-textmate@2.1.0@d41d8cd9": {
+      "id": "reason-textmate@2.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.0.0.tgz#sha1:f5b7a1d336e97186baeb68397d24dd791ee951b5"
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.1.0.tgz#sha1:9e018772c1bc21b139560b287880fbdb45c8f701"
         ]
       },
       "overrides": [],
@@ -303,7 +303,7 @@
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -363,7 +363,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
       ],
@@ -999,7 +999,7 @@
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#4947ead@d41d8cd9",
-        "reason-textmate@2.0.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
+        "reason-textmate@2.1.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#8fc399d@d41d8cd9",
         "reason-jsonrpc@1.2.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "isolinear@2.1.0@d41d8cd9", "esy-sdl2@2.0.10003@d41d8cd9",
@@ -1010,7 +1010,7 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1209,7 +1209,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.6@f4f83858",
@@ -1222,7 +1222,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -2008,12 +2008,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.2@ee59a0be": {
@@ -2037,14 +2037,14 @@
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2065,27 +2065,27 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
-    "@opam/lwt@opam:4.3.1@14b6a62e": {
-      "id": "@opam/lwt@opam:4.3.1@14b6a62e",
+    "@opam/lwt@opam:4.4.0@0357bb8b": {
+      "id": "@opam/lwt@opam:4.4.0@0357bb8b",
       "name": "@opam/lwt",
-      "version": "opam:4.3.1",
+      "version": "opam:4.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/92/926936860087c5819d6ca04241bc894a#md5:926936860087c5819d6ca04241bc894a",
-          "archive:https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz#md5:926936860087c5819d6ca04241bc894a"
+          "archive:https://opam.ocaml.org/cache/md5/8b/8bfc70c2944020fa08dd04877747f5f9#md5:8bfc70c2944020fa08dd04877747f5f9",
+          "archive:https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz#md5:8bfc70c2944020fa08dd04877747f5f9"
         ],
         "opam": {
           "name": "lwt",
-          "version": "4.3.1",
-          "path": "integrationtest.esy.lock/opam/lwt.4.3.1"
+          "version": "4.4.0",
+          "path": "integrationtest.esy.lock/opam/lwt.4.4.0"
         }
       },
       "overrides": [],
@@ -2135,7 +2135,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2144,7 +2144,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/camomile@opam:1.0.1@a244d067"
       ]
     },
@@ -2225,13 +2225,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7"

--- a/integrationtest.esy.lock/opam/lwt.4.4.0/opam
+++ b/integrationtest.esy.lock/opam/lwt.4.4.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
 
-version: "4.3.1"
+version: "4.4.0"
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt/manual/"
@@ -60,6 +60,6 @@ a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 
 url {
-  src: "https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz"
-  checksum: "md5=926936860087c5819d6ca04241bc894a"
+  src: "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz"
+  checksum: "md5=8bfc70c2944020fa08dd04877747f5f9"
 }

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "rench": "1.7.1",
     "revery": "0.27.0",
     "reason-tree-sitter": "*",
-    "reason-textmate": "^2.0.0",
+    "reason-textmate": "^2.1.0",
     "esy-sdl2": "*"
   },
   "resolutions": {

--- a/src/Store/ThemeStoreConnector.re
+++ b/src/Store/ThemeStoreConnector.re
@@ -19,7 +19,8 @@ let start = (themeInfo: ThemeInfo.t, setup: Setup.t) => {
     Isolinear.Effect.createWithDispatch(
       ~name="theme.loadThemeByPath", dispatch =>
       Log.perf("theme.load", () => {
-        let theme = Textmate.Theme.from_file(themePath);
+        let dark = uiTheme == "vs-dark" || uiTheme == "hc-black";
+        let theme = Textmate.Theme.from_file(~isDark=dark, themePath);
         let colors = Textmate.Theme.getColors(theme);
         let isDark = Textmate.Theme.isDark(theme);
         let tokenColors = Textmate.Theme.getTokenColors(theme);

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f56ef85bd1092236deda0760f6f73bd3",
+  "checksum": "f06fc02944699b9b3d75a4e4fa5b6277",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -94,7 +94,7 @@
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "brisk-reconciler@0.0.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -148,7 +148,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -168,7 +168,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
@@ -265,14 +265,14 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
-    "reason-textmate@2.0.0@d41d8cd9": {
-      "id": "reason-textmate@2.0.0@d41d8cd9",
+    "reason-textmate@2.1.0@d41d8cd9": {
+      "id": "reason-textmate@2.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.0.0.tgz#sha1:f5b7a1d336e97186baeb68397d24dd791ee951b5"
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-2.1.0.tgz#sha1:9e018772c1bc21b139560b287880fbdb45c8f701"
         ]
       },
       "overrides": [],
@@ -303,7 +303,7 @@
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
@@ -363,7 +363,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/merlin@opam:3.2.2@e3edecdd", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
       ],
@@ -999,7 +999,7 @@
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#63d4056@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#4947ead@d41d8cd9",
-        "reason-textmate@2.0.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
+        "reason-textmate@2.1.0@d41d8cd9", "reason-sdl2@2.10.3004@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#8fc399d@d41d8cd9",
         "reason-jsonrpc@1.2.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "isolinear@2.1.0@d41d8cd9", "esy-sdl2@2.0.10003@d41d8cd9",
@@ -1010,7 +1010,7 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1209,7 +1209,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/cppo@opam:1.6.6@f4f83858",
@@ -1222,7 +1222,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/lambda-term@opam:1.13@c3c2dc92",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -2007,12 +2007,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.2@ee59a0be": {
@@ -2036,14 +2036,14 @@
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.2@8d1998c4",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2064,27 +2064,27 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.1@14b6a62e", "@opam/dune@opam:1.7.3@e23fe0a7"
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
-    "@opam/lwt@opam:4.3.1@14b6a62e": {
-      "id": "@opam/lwt@opam:4.3.1@14b6a62e",
+    "@opam/lwt@opam:4.4.0@0357bb8b": {
+      "id": "@opam/lwt@opam:4.4.0@0357bb8b",
       "name": "@opam/lwt",
-      "version": "opam:4.3.1",
+      "version": "opam:4.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/92/926936860087c5819d6ca04241bc894a#md5:926936860087c5819d6ca04241bc894a",
-          "archive:https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz#md5:926936860087c5819d6ca04241bc894a"
+          "archive:https://opam.ocaml.org/cache/md5/8b/8bfc70c2944020fa08dd04877747f5f9#md5:8bfc70c2944020fa08dd04877747f5f9",
+          "archive:https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz#md5:8bfc70c2944020fa08dd04877747f5f9"
         ],
         "opam": {
           "name": "lwt",
-          "version": "4.3.1",
-          "path": "test.esy.lock/opam/lwt.4.3.1"
+          "version": "4.4.0",
+          "path": "test.esy.lock/opam/lwt.4.4.0"
         }
       },
       "overrides": [],
@@ -2134,7 +2134,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2143,7 +2143,7 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:1.6@fac10bda",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/camomile@opam:1.0.1@a244d067"
       ]
     },
@@ -2224,13 +2224,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7"

--- a/test.esy.lock/opam/lwt.4.4.0/opam
+++ b/test.esy.lock/opam/lwt.4.4.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
 
-version: "4.3.1"
+version: "4.4.0"
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt/manual/"
@@ -60,6 +60,6 @@ a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 
 url {
-  src: "https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz"
-  checksum: "md5=926936860087c5819d6ca04241bc894a"
+  src: "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz"
+  checksum: "md5=8bfc70c2944020fa08dd04877747f5f9"
 }


### PR DESCRIPTION
Right now, some tokens are inadvertently set to a wrong default - like `#FFF` - which makes them show up too brightly.

This lets us send the `uiTheme` configuration from the theme to reason-textmate.