### PR TITLE
Bugfix: Check that build is notarized before releasing

### DIFF
--- a/scripts/osx/notarize.sh
+++ b/scripts/osx/notarize.sh
@@ -31,8 +31,7 @@ if [ $success -eq 1 ] ; then
 	echo "Stapling and running packaging up"
 	xcrun stapler staple "_release/Onivim2.app"
 	echo "Staple success!"
-
-	echo "Checking gatekeeper conformance"
-	spctl --assess --verbose "_release/Onivim2.app"
-	echo "Complete!"
 fi
+	
+echo "Checking gatekeeper conformance"
+spctl --assess --verbose "_release/Onivim2.app"

--- a/scripts/osx/notarize.sh
+++ b/scripts/osx/notarize.sh
@@ -4,7 +4,7 @@ SHORT_COMMIT_ID=$(git rev-parse --short HEAD)
 echo "Code signing certificate specified - notarizing zip"
 
 echo "Uploading to apple to notarize..."
-notarize_uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onvim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.App.zip" 2>&1 | grep RequestUUID | awk '{print $3'})
+notarize_uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onivim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.App.zip" 2>&1 | grep RequestUUID | awk '{print $3'})
 echo "Notarize uuid: $notarize_uuid"
 # Load cert
 


### PR DESCRIPTION
It looks like the latest build released to the early access portal for OSX was not notarized - which triggers a gatekeeper warning:

![image](https://user-images.githubusercontent.com/13532591/66870863-390f2d80-ef57-11e9-8059-28a15072251a.png)

If there is a failure during notarization, we should not release the build. This updates the gatekeeper check to occur at the end of the script, so that if it fails, we'll fail the build.