### PR TITLE
OSX - Notarization: Check for returned notarization UUID

### DIFF
--- a/scripts/osx/notarize.sh
+++ b/scripts/osx/notarize.sh
@@ -4,9 +4,19 @@ SHORT_COMMIT_ID=$(git rev-parse --short HEAD)
 echo "Code signing certificate specified - notarizing zip"
 
 echo "Uploading to apple to notarize..."
-notarize_uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onvim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.App.zip" 2>&1 | grep RequestUUID | awk '{print $3'})
-echo "Notarize uuid: $notarize_uuid"
+notarize_uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onivim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.App.zip" 2>&1 | grep RequestUUID | awk '{print $3'})
 # Load cert
+
+if  [ -z "$notarize_uuid" ]
+then
+	echo "Notarization failed; running again to get error message"
+	failure=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onvim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.App.zip" 2>&1)
+	echo "MESSAGE: $failure"
+	exit 1
+else
+	echo "Got notarization UUID: $notarize_uuid"
+fi
+
 
 success=0
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do


### PR DESCRIPTION
Check the returned notarization UUID value; if invalid - fail the script. We should fail instead of publishing un-notarized builds.