### PR TITLE
Fix #872 - Windows: Onivim2 does not launch correctly from CLI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,6 +185,7 @@ jobs:
   - powershell: ./scripts/windows/validate-release.ps1
     env:
       SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+  - script: echo %PATH%
   # The validate-release.ps1 installs Onivim 2 and checks it,
-  # but we need to check from the command prompt, too - for #872
-  - script: D:/a/1/s/Onivim2/Oni2.exe -f --checkhealth 
+  # but we need to check from the command prompt, too via %PATH% - for #872
+  - script: Oni2.exe -f --checkhealth 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,3 +185,6 @@ jobs:
   - powershell: ./scripts/windows/validate-release.ps1
     env:
       SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+  # The validate-release.ps1 installs Onivim 2 and checks it,
+  # but we need to check from the command prompt, too - for #872
+  - script: D:/a/1/s/Onivim2/Oni2.exe -f --checkhealth 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,4 +188,7 @@ jobs:
   - script: echo %PATH%
   # The validate-release.ps1 installs Onivim 2 and checks it,
   # but we need to check from the command prompt, too via %PATH% - for #872
-  - script: Oni2.exe -f --checkhealth 
+  - script: |
+      set PATH=%PATH%;D:/a/1/s/Onivim2
+      Oni2.exe -f --checkhealth 
+    displayName: "Oni2.exe - run installed"

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -29,12 +29,12 @@ let discoverExtensions = (setup: Core.Setup.t) => {
         };
       let userExtensions =
         switch (userExtensions) {
-        | Ok(p) => 
+        | Ok(p) =>
           Core.Log.info("Searching for user extensions in: " ++ p);
-          ExtensionScanner.scan(p)
-        | Error(msg) => 
+          ExtensionScanner.scan(p);
+        | Error(msg) =>
           Core.Log.error("Error discovering user extensions: " ++ msg);
-          []
+          [];
         };
 
       Core.Log.debug(() =>

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -29,8 +29,12 @@ let discoverExtensions = (setup: Core.Setup.t) => {
         };
       let userExtensions =
         switch (userExtensions) {
-        | Ok(p) => ExtensionScanner.scan(p)
-        | Error(_) => []
+        | Ok(p) => 
+          Core.Log.info("Searching for user extensions in: " ++ p);
+          ExtensionScanner.scan(p)
+        | Error(msg) => 
+          Core.Log.error("Error discovering user extensions: " ++ msg);
+          []
         };
 
       Core.Log.debug(() =>

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -122,13 +122,7 @@ let startProcess = (stdio, stdout, stderr) => {
   let cmdToRun = executingDirectory ++ executable;
   // The first argument is the executable, so we need to update that to point to 'Oni2_editor'
   args[0] = cmdToRun;
-  Unix.create_process(
-    cmdToRun,
-    args,
-    stdio,
-    stdout,
-    stderr,
-  );
+  Unix.create_process(cmdToRun, args, stdio, stdout, stderr);
 };
 
 let launch = () =>

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -119,6 +119,9 @@ let executingDirectory = {
 let executable = Sys.win32 ? "Oni2_editor.exe" : "Oni2_editor";
 
 let startProcess = (stdio, stdout, stderr) => {
+  print_endline ("EXECUTING DIRECTORY: " ++ executingDirectory);
+  List.iteri((i, arg) => Printf.printf("arg %d: %s\n", i, arg), args |> Array.to_list);
+  args[0] = executingDirectory ++ executable;
   Unix.create_process(
     executingDirectory ++ executable,
     args,

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -119,11 +119,11 @@ let executingDirectory = {
 let executable = Sys.win32 ? "Oni2_editor.exe" : "Oni2_editor";
 
 let startProcess = (stdio, stdout, stderr) => {
-  print_endline ("EXECUTING DIRECTORY: " ++ executingDirectory);
-  List.iteri((i, arg) => Printf.printf("arg %d: %s\n", i, arg), args |> Array.to_list);
-  args[0] = executingDirectory ++ executable;
+  let cmdToRun = executingDirectory ++ executable;
+  // The first argument is the executable, so we need to update that to point to 'Oni2_editor'
+  args[0] = cmdToRun;
   Unix.create_process(
-    executingDirectory ++ executable,
+    cmdToRun,
     args,
     stdio,
     stdout,

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -100,6 +100,9 @@ let executingDirectory = {
       | (Some(v), None) => String.sub(Sys.executable_name, 0, v)
       | _ => Sys.executable_name
       }
+    // For Windows, we need to use Sys.executable_name - Sys.argv is `./` when running
+    // from %PATH% - see onivim/oni#872
+    | Windows => Filename.dirname(Sys.executable_name)
     | _ => Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep
     };
 


### PR DESCRIPTION
__Issue:__ When launching via `PATH`, on Windows, the `Oni2.exe` was not finding the correct `Oni2_editor.exe` - it was a relative path specified instead of an absolute path.

__Fix:__ On Windows, use `Sys.executable_filename`, which seems to consistently return the full path in all scenarios tested (powershell, cmd, from path, running exe directly).

__Test:__ Update our CI test to properly exercise this case so we don't regress it again