### PR TITLE
CI: Upgrade to node 10.x

### DIFF
--- a/.ci/use-node.yml
+++ b/.ci/use-node.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NodeTool@0
-    displayName: 'Use Node 8.x'
+    displayName: 'Use Node 10.x'
     inputs:
-      versionSpec: '8.x'
+      versionSpec: '10.x'
   - script: npm install -g rimraf
     displayName: "Install rimraf"

--- a/.ci/use-node.yml
+++ b/.ci/use-node.yml
@@ -2,6 +2,6 @@ steps:
   - task: NodeTool@0
     displayName: 'Use Node 8.x'
     inputs:
-      versionSpec: 8.x
+      versionSpec: '8.x'
   - script: npm install -g rimraf
     displayName: "Install rimraf"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,9 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
+  - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
-  - template: .ci/use-node.yml
   # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-check-hygiene.yml
   # - template: .ci/publish-build-cache.yml
@@ -40,9 +40,9 @@ jobs:
     # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
 
   steps:
+  - template: .ci/use-node.yml
   - script: sudo apt-get update
   - script: sudo apt-get install -y libncurses5-dev libacl1-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev
-  - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
     parameters:
@@ -87,9 +87,9 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
+  - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
-  - template: .ci/use-node.yml
   # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
     parameters:
@@ -112,9 +112,9 @@ jobs:
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
+  - template: .ci/use-node.yml
   - powershell: ./scripts/windows/verify-signtool.ps1
     displayName: 'Validate signtool path'
-  - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
     parameters:


### PR DESCRIPTION
...and trying to install it again is giving us errors. Unfortunately the default node 6.x isn't sufficent, though.

Related issues:
https://github.com/microsoft/azure-pipelines-tasks/issues/11627
https://github.com/microsoft/azure-pipelines-tasks/issues/11626
https://github.com/nodejs/build/issues/1993