### PR TITLE
Fix #907 - Don't allow invalid values for ui.zoom setting

### DIFF
--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -20,6 +20,7 @@ let parseInt = json =>
 
 let parseFloat = json =>
   switch (json) {
+  | `Int(v) => float_of_int(v)
   | `Float(v) => v
   | _ => 0.
   };

--- a/src/Store/ConfigurationStoreConnector.re
+++ b/src/Store/ConfigurationStoreConnector.re
@@ -136,7 +136,8 @@ let start =
   let vsync = ref(Revery.Vsync.Immediate);
   let synchronizeConfigurationEffect = configuration =>
     Isolinear.Effect.create(~name="configuration.synchronize", () => {
-      let zoomValue = max(1.0, Configuration.getValue(c => c.uiZoom, configuration));
+      let zoomValue =
+        max(1.0, Configuration.getValue(c => c.uiZoom, configuration));
       if (zoomValue != zoom^) {
         Log.info(
           "Configuration - setting zoom: " ++ string_of_float(zoomValue),

--- a/src/Store/ConfigurationStoreConnector.re
+++ b/src/Store/ConfigurationStoreConnector.re
@@ -136,7 +136,7 @@ let start =
   let vsync = ref(Revery.Vsync.Immediate);
   let synchronizeConfigurationEffect = configuration =>
     Isolinear.Effect.create(~name="configuration.synchronize", () => {
-      let zoomValue = Configuration.getValue(c => c.uiZoom, configuration);
+      let zoomValue = max(1.0, Configuration.getValue(c => c.uiZoom, configuration));
       if (zoomValue != zoom^) {
         Log.info(
           "Configuration - setting zoom: " ++ string_of_float(zoomValue),


### PR DESCRIPTION
There were two problems:
- We were allowing invalid values like `ui.zoom` of `0`, which made the editor unusable - this is very frustrating because there is no entry point to fix or update the editor.
- We were only accepting float values like `1.0` for the setting... so you could hit the above case by using a value of `1` which is invalid.

This issue updates the store connector to make sure the zoom isn't set to a lower value than `1`, as well as our configuration parsing for float values - there is no reason not to accept integers as well.