### PR TITLE
Exthost: Bring back the ExtHostStoreConnector

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -15,7 +15,6 @@ const isLinux = !isMac && !isWindows
 
 let nodePath
 let nodeScriptPath = path.join(rootDir, "node");
-let extensionHostPath = path.join(nodeScriptPath, "node_modules", "vscode-exthost", "out", "bootstrap-fork.js");
 let extensionsPath = path.join(rootDir, "extensions")
 let developmentExtensionsPath = path.join(rootDir, "development_extensions");
 let rgPath = path.join(vendorPath, "ripgrep-v0.10.0")
@@ -32,7 +31,6 @@ const getCygwinPath = inputPath => {
 if (isWindows) {
     nodePath = getCygwinPath(path.join(vendorPath, "node-v10.15.1", "win-x64", "node.exe"))
     nodeScriptPath = getCygwinPath(nodeScriptPath)
-    extensionHostPath = getCygwinPath(extensionHostPath);
     extensionsPath = getCygwinPath(extensionsPath)
     developmentExtensionsPath = getCygwinPath(developmentExtensionsPath);
     rgPath = getCygwinPath(path.join(rgPath, "windows", "rg.exe"))
@@ -53,7 +51,6 @@ const config = {
     nodeScript: nodeScriptPath,
     bundledExtensions: extensionsPath,
     developmentExtensions: developmentExtensionsPath,
-    extensionHost: extensionHostPath,
     rg: rgPath,
 }
 const oniConfig = JSON.stringify(config)

--- a/src/Core/Setup.re
+++ b/src/Core/Setup.re
@@ -15,8 +15,6 @@ type t = {
   bundledExtensionsPath: string,
   [@key "developmentExtensions"]
   developmentExtensionsPath: [@default None] option(string),
-  [@key "extensionHost"]
-  extensionHostPath: string,
   [@key "nodeScript"]
   nodeScriptPath: string,
   [@key "rg"]
@@ -36,7 +34,6 @@ let default = () => {
       camomilePath: execDir ++ "camomile",
       bundledExtensionsPath: execDir ++ "extensions",
       developmentExtensionsPath: None,
-      extensionHostPath: "",
       rgPath: execDir ++ "rg.exe",
       version,
     }
@@ -46,7 +43,6 @@ let default = () => {
       camomilePath: execDir ++ "../Resources/camomile",
       bundledExtensionsPath: execDir ++ "../Resources/extensions",
       developmentExtensionsPath: None,
-      extensionHostPath: "",
       rgPath: execDir ++ "rg",
       version,
     }
@@ -56,7 +52,6 @@ let default = () => {
       camomilePath: execDir ++ "../share/camomile",
       bundledExtensionsPath: execDir ++ "extensions",
       developmentExtensionsPath: None,
-      extensionHostPath: "",
       rgPath: execDir ++ "rg",
       version,
     }
@@ -69,6 +64,10 @@ let ofFile = filePath => Yojson.Safe.from_file(filePath) |> of_yojson_exn;
 
 let getNodeHealthCheckPath = (v: t) => {
   v.nodeScriptPath ++ "/check-health.js";
+};
+
+let getNodeExtensionHostPath = (v: t) => {
+  v.nodeScriptPath ++ "/node_modules/vscode-exthost/out/bootstrap-fork.js";
 };
 
 let init = () => {

--- a/src/Extensions/ExtHostTransport.re
+++ b/src/Extensions/ExtHostTransport.re
@@ -43,7 +43,12 @@ let start =
   ];
 
   let process =
-    NodeProcess.start(~args, ~env, setup, Setup.getNodeExtensionHostPath(setup));
+    NodeProcess.start(
+      ~args,
+      ~env,
+      setup,
+      Setup.getNodeExtensionHostPath(setup),
+    );
 
   let lastReqId = ref(0);
   let rpcRef = ref(None);

--- a/src/Extensions/ExtHostTransport.re
+++ b/src/Extensions/ExtHostTransport.re
@@ -43,7 +43,7 @@ let start =
   ];
 
   let process =
-    NodeProcess.start(~args, ~env, setup, setup.extensionHostPath);
+    NodeProcess.start(~args, ~env, setup, Setup.getNodeExtensionHostPath(setup));
 
   let lastReqId = ref(0);
   let rpcRef = ref(None);

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -94,27 +94,29 @@ let start = (extensions, setup: Core.Setup.t) => {
       switch (Model.Buffers.getBuffer(bu.id, buffers)) {
       | None => ()
       | Some(v) =>
-        let modelContentChange =
-          Protocol.ModelContentChange.ofBufferUpdate(
-            bu,
-            Protocol.Eol.default,
-          );
-        let modelChangedEvent =
-          Protocol.ModelChangedEvent.create(
-            ~changes=[modelContentChange],
-            ~eol=Protocol.Eol.default,
-            ~versionId=bu.version,
-            (),
-          );
+        Log.perf("exthost.bufferUpdate", () => {
+          let modelContentChange =
+            Protocol.ModelContentChange.ofBufferUpdate(
+              bu,
+              Protocol.Eol.default,
+            );
+          let modelChangedEvent =
+            Protocol.ModelChangedEvent.create(
+              ~changes=[modelContentChange],
+              ~eol=Protocol.Eol.default,
+              ~versionId=bu.version,
+              (),
+            );
 
-        let uri = Model.Buffer.getUri(v);
+          let uri = Model.Buffer.getUri(v);
 
-        ExtHostClient.updateDocument(
-          uri,
-          modelChangedEvent,
-          true,
-          extHostClient,
-        );
+          ExtHostClient.updateDocument(
+            uri,
+            modelChangedEvent,
+            true,
+            extHostClient,
+          );
+        });
       }
     );
 

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -94,7 +94,7 @@ let start = (extensions, setup: Core.Setup.t) => {
       switch (Model.Buffers.getBuffer(bu.id, buffers)) {
       | None => ()
       | Some(v) =>
-        Log.perf("exthost.bufferUpdate", () => {
+        Core.Log.perf("exthost.bufferUpdate", () => {
           let modelContentChange =
             Protocol.ModelContentChange.ofBufferUpdate(
               bu,
@@ -116,7 +116,7 @@ let start = (extensions, setup: Core.Setup.t) => {
             true,
             extHostClient,
           );
-        });
+        })
       }
     );
 

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -110,12 +110,8 @@ let start =
     SyntaxHighlightingStoreConnector.start(languageInfo, setup);
   let themeUpdater = ThemeStoreConnector.start(themeInfo);
 
-  /*
-     For our July builds, we won't be including the extension host -
-     but we'll bring this back as we start implementing those features!
-   */
-  /* let (extHostUpdater, extHostStream) =
-     ExtensionClientStoreConnector.start(extensions, setup); */
+  let (extHostUpdater, extHostStream) =
+     ExtensionClientStoreConnector.start(extensions, setup); 
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 
@@ -160,7 +156,7 @@ let start =
           Isolinear.Updater.ofReducer(Model.Reducer.reduce),
           vimUpdater,
           syntaxUpdater,
-          /* extHostUpdater, */
+          extHostUpdater,
           fontUpdater,
           menuHostUpdater,
           quickOpenUpdater,
@@ -226,7 +222,7 @@ let start =
   let _ = Isolinear.Stream.connect(dispatch, vimStream);
   let _ = Isolinear.Stream.connect(dispatch, editorEventStream);
   let _ = Isolinear.Stream.connect(dispatch, syntaxStream);
-  /* Isolinear.Stream.connect(dispatch, extHostStream); */
+  let _ = Isolinear.Stream.connect(dispatch, extHostStream);
   let _ = Isolinear.Stream.connect(dispatch, menuStream);
   let _ = Isolinear.Stream.connect(dispatch, explorerStream);
   let _ = Isolinear.Stream.connect(dispatch, lifecycleStream);

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -111,7 +111,7 @@ let start =
   let themeUpdater = ThemeStoreConnector.start(themeInfo);
 
   let (extHostUpdater, extHostStream) =
-     ExtensionClientStoreConnector.start(extensions, setup); 
+    ExtensionClientStoreConnector.start(extensions, setup);
 
   let (menuHostUpdater, menuStream) = MenuStoreConnector.start();
 

--- a/test/Extensions/ExtHostTransportTests.re
+++ b/test/Extensions/ExtHostTransportTests.re
@@ -1,93 +1,92 @@
+open Oni_Core;
+open Oni_Core_Test;
+open Oni_Extensions;
 
- open Oni_Core;
- open Oni_Core_Test;
- open Oni_Extensions;
+open TestFramework;
 
- open TestFramework;
-
- describe("ExtHostTransport", ({test, _}) => {
-   test("gets initialized message", ({expect}) =>
-     Helpers.repeat(() => {
-       let setup = Setup.init();
-       let initialized = ref(false);
-       let onInitialized = () => initialized := true;
-       let extClient = ExtHostTransport.start(~onInitialized, setup);
-       Oni_Core.Utility.waitForCondition(() => {
-         ExtHostTransport.pump(extClient);
-         initialized^;
-       });
-       expect.bool(initialized^).toBe(true);
-       ExtHostTransport.close(extClient);
-     })
-   );
-   test("doesn't die after a few seconds", ({expect}) => {
-     let setup = Setup.init();
-     let initialized = ref(false);
-     let closed = ref(false);
-     let onClosed = () => closed := true;
-     let onInitialized = () => initialized := true;
-     let extClient = ExtHostTransport.start(~onInitialized, ~onClosed, setup);
-     Oni_Core.Utility.waitForCondition(() => {
-       ExtHostTransport.pump(extClient);
-       initialized^;
-     });
-     expect.bool(initialized^).toBe(true);
-     /* The extension host process will die after a second if it doesn't see the parent PID */
-     /* We'll sleep for two seconds to be safe */
-     Unix.sleep(2);
-     expect.bool(closed^).toBe(false);
-   });
-   test("closes after close is called", ({expect}) => {
-     let setup = Setup.init();
-     let initialized = ref(false);
-     let closed = ref(false);
-     let onClosed = () => closed := true;
-     let onInitialized = () => initialized := true;
-     let extClient = ExtHostTransport.start(~onInitialized, ~onClosed, setup);
-     Oni_Core.Utility.waitForCondition(() => {
-       ExtHostTransport.pump(extClient);
-       initialized^;
-     });
-     expect.bool(initialized^).toBe(true);
-     ExtHostTransport.close(extClient);
-     Oni_Core.Utility.waitForCondition(() => {
-       ExtHostTransport.pump(extClient);
-       closed^;
-     });
-     expect.bool(closed^).toBe(false);
-   });
-   test("basic extension activation", _ => {
-     let setup = Setup.init();
-     let rootPath = Rench.Environment.getWorkingDirectory();
-     let testExtensionsPath =
-       Rench.Path.join(rootPath, "test/test_extensions");
-     let extensions =
-       ExtensionScanner.scan(testExtensionsPath)
-       |> List.map(ext =>
-            ExtHostInitData.ExtensionInfo.ofScannedExtension(ext)
-          );
-     let gotWillActivateMessage = ref(false);
-     let gotDidActivateMessage = ref(false);
-     let onMessage = (a, b, _c) => {
-       switch (a, b) {
-       | ("MainThreadExtensionService", "$onWillActivateExtension") =>
-         gotWillActivateMessage := true
-       | ("MainThreadExtensionService", "$onDidActivateExtension") =>
-         gotDidActivateMessage := true
-       | _ => ()
-       };
-       Ok(None);
-     };
-     let initData = ExtHostInitData.create(~extensions, ());
-     let extClient = ExtHostTransport.start(~initData, ~onMessage, setup);
-     Oni_Core.Utility.waitForCondition(() => {
-       ExtHostTransport.pump(extClient);
-       gotWillActivateMessage^;
-     });
-     Oni_Core.Utility.waitForCondition(() => {
-       ExtHostTransport.pump(extClient);
-       gotDidActivateMessage^;
-     });
-     ExtHostTransport.close(extClient);
-   });
- });
+describe("ExtHostTransport", ({test, _}) => {
+  test("gets initialized message", ({expect}) =>
+    Helpers.repeat(() => {
+      let setup = Setup.init();
+      let initialized = ref(false);
+      let onInitialized = () => initialized := true;
+      let extClient = ExtHostTransport.start(~onInitialized, setup);
+      Oni_Core.Utility.waitForCondition(() => {
+        ExtHostTransport.pump(extClient);
+        initialized^;
+      });
+      expect.bool(initialized^).toBe(true);
+      ExtHostTransport.close(extClient);
+    })
+  );
+  test("doesn't die after a few seconds", ({expect}) => {
+    let setup = Setup.init();
+    let initialized = ref(false);
+    let closed = ref(false);
+    let onClosed = () => closed := true;
+    let onInitialized = () => initialized := true;
+    let extClient = ExtHostTransport.start(~onInitialized, ~onClosed, setup);
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtHostTransport.pump(extClient);
+      initialized^;
+    });
+    expect.bool(initialized^).toBe(true);
+    /* The extension host process will die after a second if it doesn't see the parent PID */
+    /* We'll sleep for two seconds to be safe */
+    Unix.sleep(2);
+    expect.bool(closed^).toBe(false);
+  });
+  test("closes after close is called", ({expect}) => {
+    let setup = Setup.init();
+    let initialized = ref(false);
+    let closed = ref(false);
+    let onClosed = () => closed := true;
+    let onInitialized = () => initialized := true;
+    let extClient = ExtHostTransport.start(~onInitialized, ~onClosed, setup);
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtHostTransport.pump(extClient);
+      initialized^;
+    });
+    expect.bool(initialized^).toBe(true);
+    ExtHostTransport.close(extClient);
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtHostTransport.pump(extClient);
+      closed^;
+    });
+    expect.bool(closed^).toBe(false);
+  });
+  test("basic extension activation", _ => {
+    let setup = Setup.init();
+    let rootPath = Rench.Environment.getWorkingDirectory();
+    let testExtensionsPath =
+      Rench.Path.join(rootPath, "test/test_extensions");
+    let extensions =
+      ExtensionScanner.scan(testExtensionsPath)
+      |> List.map(ext =>
+           ExtHostInitData.ExtensionInfo.ofScannedExtension(ext)
+         );
+    let gotWillActivateMessage = ref(false);
+    let gotDidActivateMessage = ref(false);
+    let onMessage = (a, b, _c) => {
+      switch (a, b) {
+      | ("MainThreadExtensionService", "$onWillActivateExtension") =>
+        gotWillActivateMessage := true
+      | ("MainThreadExtensionService", "$onDidActivateExtension") =>
+        gotDidActivateMessage := true
+      | _ => ()
+      };
+      Ok(None);
+    };
+    let initData = ExtHostInitData.create(~extensions, ());
+    let extClient = ExtHostTransport.start(~initData, ~onMessage, setup);
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtHostTransport.pump(extClient);
+      gotWillActivateMessage^;
+    });
+    Oni_Core.Utility.waitForCondition(() => {
+      ExtHostTransport.pump(extClient);
+      gotDidActivateMessage^;
+    });
+    ExtHostTransport.close(extClient);
+  });
+});

--- a/test/Extensions/ExtHostTransportTests.re
+++ b/test/Extensions/ExtHostTransportTests.re
@@ -1,5 +1,3 @@
-/*
- TODO: Bring back for exthost work
 
  open Oni_Core;
  open Oni_Core_Test;
@@ -93,5 +91,3 @@
      ExtHostTransport.close(extClient);
    });
  });
-
- */

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -1,213 +1,213 @@
- open Oni_Core;
- open Oni_Core_Test;
- open Oni_Extensions;
+open Oni_Core;
+open Oni_Core_Test;
+open Oni_Extensions;
 
- open TestFramework;
+open TestFramework;
 
- open ExtensionClientHelper;
- open ExtHostProtocol;
+open ExtensionClientHelper;
+open ExtHostProtocol;
 
- describe("ExtHostClient", ({describe, _}) => {
-   describe("activation", ({test, _}) => {
-     test("activates by language", ({expect}) => {
-       let activations: ref(list(string)) = ref([]);
-       let onDidActivateExtension = id => activations := [id, ...activations^];
+describe("ExtHostClient", ({describe, _}) => {
+  describe("activation", ({test, _}) => {
+    test("activates by language", ({expect}) => {
+      let activations: ref(list(string)) = ref([]);
+      let onDidActivateExtension = id => activations := [id, ...activations^];
 
-       let isExpectedExtensionActivated = () =>
-         isStringValueInList(activations, "oni-activation-events-test");
+      let isExpectedExtensionActivated = () =>
+        isStringValueInList(activations, "oni-activation-events-test");
 
-       withExtensionClient(
-         ~onDidActivateExtension,
-         client => {
-           ExtHostClient.activateByEvent("onLanguage:testlang", client);
+      withExtensionClient(
+        ~onDidActivateExtension,
+        client => {
+          ExtHostClient.activateByEvent("onLanguage:testlang", client);
 
-           Waiters.wait(isExpectedExtensionActivated, client);
-           expect.bool(isExpectedExtensionActivated()).toBe(true);
-         },
-       );
-     });
+          Waiters.wait(isExpectedExtensionActivated, client);
+          expect.bool(isExpectedExtensionActivated()).toBe(true);
+        },
+      );
+    });
 
-     test("activates by command", ({expect}) => {
-       let activations: ref(list(string)) = ref([]);
-       let onDidActivateExtension = id => activations := [id, ...activations^];
+    test("activates by command", ({expect}) => {
+      let activations: ref(list(string)) = ref([]);
+      let onDidActivateExtension = id => activations := [id, ...activations^];
 
-       let isExpectedExtensionActivated = () =>
-         isStringValueInList(activations, "oni-activation-events-test");
-       withExtensionClient(
-         ~onDidActivateExtension,
-         client => {
-           ExtHostClient.activateByEvent(
-             "onCommand:extension.activationTest",
-             client,
-           );
+      let isExpectedExtensionActivated = () =>
+        isStringValueInList(activations, "oni-activation-events-test");
+      withExtensionClient(
+        ~onDidActivateExtension,
+        client => {
+          ExtHostClient.activateByEvent(
+            "onCommand:extension.activationTest",
+            client,
+          );
 
-           Waiters.wait(isExpectedExtensionActivated, client);
-           expect.bool(isExpectedExtensionActivated()).toBe(true);
-         },
-       );
-     });
-   });
+          Waiters.wait(isExpectedExtensionActivated, client);
+          expect.bool(isExpectedExtensionActivated()).toBe(true);
+        },
+      );
+    });
+  });
 
-   describe("commands", ({test, _}) =>
-     test("executes simple command", ({expect}) => {
-       let registeredCommands = empty();
-       let messages = empty();
+  describe("commands", ({test, _}) =>
+    test("executes simple command", ({expect}) => {
+      let registeredCommands = empty();
+      let messages = empty();
 
-       let onShowMessage = append(messages);
-       let onRegisterCommand = append(registeredCommands);
+      let onShowMessage = append(messages);
+      let onRegisterCommand = append(registeredCommands);
 
-       let isExpectedCommandRegistered = () =>
-         isStringValueInList(registeredCommands, "extension.helloWorld");
+      let isExpectedCommandRegistered = () =>
+        isStringValueInList(registeredCommands, "extension.helloWorld");
 
-       let anyMessages = any(messages);
+      let anyMessages = any(messages);
 
-       withExtensionClient(
-         ~onShowMessage,
-         ~onRegisterCommand,
-         client => {
-           Waiters.wait(isExpectedCommandRegistered, client);
-           expect.bool(isExpectedCommandRegistered()).toBe(true);
+      withExtensionClient(
+        ~onShowMessage,
+        ~onRegisterCommand,
+        client => {
+          Waiters.wait(isExpectedCommandRegistered, client);
+          expect.bool(isExpectedCommandRegistered()).toBe(true);
 
-           clear(messages);
+          clear(messages);
 
-           ExtHostClient.executeContributedCommand(
-             "extension.helloWorld",
-             client,
-           );
+          ExtHostClient.executeContributedCommand(
+            "extension.helloWorld",
+            client,
+          );
 
-           Waiters.wait(anyMessages, client);
-           expect.bool(anyMessages()).toBe(true);
-         },
-       );
-     })
-   );
+          Waiters.wait(anyMessages, client);
+          expect.bool(anyMessages()).toBe(true);
+        },
+      );
+    })
+  );
 
-   describe("DocumentsAndEditors", ({test, _}) => {
-     let createInitialDocumentModel = (~lines, ~path, ()) => {
-       ModelAddedDelta.create(
-         ~uri=Uri.fromPath(path),
-         ~lines,
-         ~modeId="test_language",
-         ~isDirty=false,
-         (),
-       );
-     };
-     test("document added successfully", ({expect}) => {
-       let registeredCommands = empty();
-       let messages = emptyInfoMsgs();
+  describe("DocumentsAndEditors", ({test, _}) => {
+    let createInitialDocumentModel = (~lines, ~path, ()) => {
+      ModelAddedDelta.create(
+        ~uri=Uri.fromPath(path),
+        ~lines,
+        ~modeId="test_language",
+        ~isDirty=false,
+        (),
+      );
+    };
+    test("document added successfully", ({expect}) => {
+      let registeredCommands = empty();
+      let messages = emptyInfoMsgs();
 
-       let onShowMessage = appendInfoMsg(messages);
-       let onRegisterCommand = append(registeredCommands);
+      let onShowMessage = appendInfoMsg(messages);
+      let onRegisterCommand = append(registeredCommands);
 
-       let isExpectedCommandRegistered = () =>
-         isStringValueInList(registeredCommands, "extension.helloWorld");
+      let isExpectedCommandRegistered = () =>
+        isStringValueInList(registeredCommands, "extension.helloWorld");
 
-       let didGetOpenMessage = () =>
-         doesInfoMessageMatch(messages, info =>
-           String.equal(info.filename, "test.txt")
-           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
-         );
+      let didGetOpenMessage = () =>
+        doesInfoMessageMatch(messages, info =>
+          String.equal(info.filename, "test.txt")
+          && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
+        );
 
-       withExtensionClient(
-         ~onRegisterCommand,
-         ~onShowMessage,
-         client => {
-           Waiters.wait(isExpectedCommandRegistered, client);
-           expect.bool(isExpectedCommandRegistered()).toBe(true);
+      withExtensionClient(
+        ~onRegisterCommand,
+        ~onShowMessage,
+        client => {
+          Waiters.wait(isExpectedCommandRegistered, client);
+          expect.bool(isExpectedCommandRegistered()).toBe(true);
 
-           ExtHostClient.addDocument(
-             createInitialDocumentModel(
-               ~lines=["Hello world"],
-               ~path="test.txt",
-               (),
-             ),
-             client,
-           );
-           Waiters.wait(didGetOpenMessage, client);
-           expect.bool(didGetOpenMessage()).toBe(true);
-         },
-       );
-     });
+          ExtHostClient.addDocument(
+            createInitialDocumentModel(
+              ~lines=["Hello world"],
+              ~path="test.txt",
+              (),
+            ),
+            client,
+          );
+          Waiters.wait(didGetOpenMessage, client);
+          expect.bool(didGetOpenMessage()).toBe(true);
+        },
+      );
+    });
 
-     test("document updated successfully", ({expect}) => {
-       let registeredCommands = empty();
-       let messages = emptyInfoMsgs();
+    test("document updated successfully", ({expect}) => {
+      let registeredCommands = empty();
+      let messages = emptyInfoMsgs();
 
-       let onShowMessage = appendInfoMsg(messages);
-       let onRegisterCommand = append(registeredCommands);
+      let onShowMessage = appendInfoMsg(messages);
+      let onRegisterCommand = append(registeredCommands);
 
-       let isExpectedCommandRegistered = () =>
-         isStringValueInList(registeredCommands, "extension.helloWorld");
+      let isExpectedCommandRegistered = () =>
+        isStringValueInList(registeredCommands, "extension.helloWorld");
 
-       let didGetOpenMessage = () =>
-         doesInfoMessageMatch(messages, info =>
-           String.equal(info.filename, "test.txt")
-           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
-         );
+      let didGetOpenMessage = () =>
+        doesInfoMessageMatch(messages, info =>
+          String.equal(info.filename, "test.txt")
+          && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
+        );
 
-       let didGetUpdateMessage = () =>
-         doesInfoMessageMatch(messages, info =>
-           String.equal(info.filename, "test.txt")
-           && String.equal(
-                info.messageType,
-                "workspace.onDidChangeTextDocument",
-              )
-           && String.equal(
-                info.fullText,
-                "Greetings" ++ Eol.toString(Eol.default) ++ "world",
-              )
-         );
+      let didGetUpdateMessage = () =>
+        doesInfoMessageMatch(messages, info =>
+          String.equal(info.filename, "test.txt")
+          && String.equal(
+               info.messageType,
+               "workspace.onDidChangeTextDocument",
+             )
+          && String.equal(
+               info.fullText,
+               "Greetings" ++ Eol.toString(Eol.default) ++ "world",
+             )
+        );
 
-       withExtensionClient(
-         ~onShowMessage,
-         ~onRegisterCommand,
-         client => {
-           Waiters.wait(isExpectedCommandRegistered, client);
-           expect.bool(isExpectedCommandRegistered()).toBe(true);
+      withExtensionClient(
+        ~onShowMessage,
+        ~onRegisterCommand,
+        client => {
+          Waiters.wait(isExpectedCommandRegistered, client);
+          expect.bool(isExpectedCommandRegistered()).toBe(true);
 
-           ExtHostClient.addDocument(
-             createInitialDocumentModel(
-               ~lines=["hello", "world"],
-               ~path="test.txt",
-               (),
-             ),
-             client,
-           );
-           Waiters.wait(didGetOpenMessage, client);
-           expect.bool(didGetOpenMessage()).toBe(true);
+          ExtHostClient.addDocument(
+            createInitialDocumentModel(
+              ~lines=["hello", "world"],
+              ~path="test.txt",
+              (),
+            ),
+            client,
+          );
+          Waiters.wait(didGetOpenMessage, client);
+          expect.bool(didGetOpenMessage()).toBe(true);
 
-           let contentChange =
-             ModelContentChange.create(
-               ~range=
-                 Range.create(
-                   ~startLine=ZeroBasedIndex(0),
-                   ~endLine=ZeroBasedIndex(0),
-                   ~startCharacter=ZeroBasedIndex(0),
-                   ~endCharacter=ZeroBasedIndex(5),
-                   (),
-                 ),
-               ~text="Greetings",
-               (),
-             );
+          let contentChange =
+            ModelContentChange.create(
+              ~range=
+                Range.create(
+                  ~startLine=ZeroBasedIndex(0),
+                  ~endLine=ZeroBasedIndex(0),
+                  ~startCharacter=ZeroBasedIndex(0),
+                  ~endCharacter=ZeroBasedIndex(5),
+                  (),
+                ),
+              ~text="Greetings",
+              (),
+            );
 
-           let modelChangedEvent =
-             ModelChangedEvent.create(
-               ~changes=[contentChange],
-               ~eol=Eol.default,
-               ~versionId=1,
-               (),
-             );
-           ExtHostClient.updateDocument(
-             Uri.fromPath("test.txt"),
-             modelChangedEvent,
-             true,
-             client,
-           );
+          let modelChangedEvent =
+            ModelChangedEvent.create(
+              ~changes=[contentChange],
+              ~eol=Eol.default,
+              ~versionId=1,
+              (),
+            );
+          ExtHostClient.updateDocument(
+            Uri.fromPath("test.txt"),
+            modelChangedEvent,
+            true,
+            client,
+          );
 
-           Waiters.wait(didGetUpdateMessage, client);
-           expect.bool(didGetUpdateMessage()).toBe(true);
-         },
-       );
-     });
-   });
- });
+          Waiters.wait(didGetUpdateMessage, client);
+          expect.bool(didGetUpdateMessage()).toBe(true);
+        },
+      );
+    });
+  });
+});

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -1,7 +1,3 @@
-/*
-
- TODO: Bring back for exthost work
-
  open Oni_Core;
  open Oni_Core_Test;
  open Oni_Extensions;
@@ -215,4 +211,3 @@
      });
    });
  });
- */

--- a/test/test_extensions/oni-activation-events-tests/extension.js
+++ b/test/test_extensions/oni-activation-events-tests/extension.js
@@ -1,0 +1,21 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	vscode.window.showInformationMessage('Activated!');
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/test_extensions/oni-activation-events-tests/package.json
+++ b/test/test_extensions/oni-activation-events-tests/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "oni-activation-events-test",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": [
+		"onLanguage:testlang",
+		"onCommand:extension.activationTest"
+	],
+	"main": "./extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.activationTest",
+				"title": "Hello World"
+			}
+		]
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}

--- a/test/test_extensions/oni-api-tests/extension.js
+++ b/test/test_extensions/oni-api-tests/extension.js
@@ -1,0 +1,67 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	// Use the console to output diagnostic information (console.log) and errors (console.error)
+	// This line of code will only be executed once when your extension is activated
+
+	// console.log('Congratulations, your extension "helloworld-minimal-sample" is now active!');
+
+    let showData = (val) => {
+        vscode.window.showInformationMessage(JSON.stringify(val));
+    }
+
+	// The command has been defined in the package.json file
+	// Now provide the implementation of the command with  registerCommand
+	// The commandId parameter must match the command field in package.json
+	let disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
+		// The code you place here will be executed every time your command is executed
+
+		// Display a message box to the user
+		vscode.window.showInformationMessage('Hello World!');
+	});
+
+    let disposable2 = vscode.workspace.onDidOpenTextDocument((e) => {
+        showData({
+            type: "workspace.onDidOpenTextDocument",
+            filename: e.fileName,
+            fullText: e.getText(),
+        });
+    });
+
+    let disposable3 = vscode.workspace.onDidChangeTextDocument((e) => {
+        showData({
+            type: "workspace.onDidChangeTextDocument",
+            filename: e.document.fileName,
+            contentChanges: e.contentChanges,
+            fullText: e.document.getText(),
+        });
+    });
+
+    let disposable4 = vscode.workspace.onDidCloseTextDocument((e) => {
+        showData({
+            type: "workspace.onDidCloseTextDocument",
+            filename: e.fileName,
+        });
+    });
+
+	context.subscriptions.push(disposable);
+    context.subscriptions.push(disposable2);
+    context.subscriptions.push(disposable3);
+    context.subscriptions.push(disposable4);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/test_extensions/oni-api-tests/package.json
+++ b/test/test_extensions/oni-api-tests/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "helloworld-minimal-sample",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": [
+		"*"
+	],
+	"main": "./extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.helloWorld",
+				"title": "Hello World"
+			}
+		]
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
This wires up the 'ExtHostStoreConnector' - which is how the VSCode extension host gets connected to Onivim's store.

Currently, there is only very limited integration:
- Status bar
- Sending buffer updates

And brings back the tests / test extensions we used in our unit tests.

This is the core piece that we need to extend to add more functionality from the VSCode extensions. In particular, we now have UI support for the following:
- Notifications
- Completions
- Diagnostics
- QuickInfo

So the next step will be to connect that to our existing UI (we also need to bring some of the richer extensions, like TypeScript/JavaScript to utilize it!)