### PR TITLE
Refactoring: Tweaks to Diagnostics for exthost integration

### DIFF
--- a/src/Merlin/MerlinProtocolConverter.re
+++ b/src/Merlin/MerlinProtocolConverter.re
@@ -11,7 +11,7 @@ open Oni_Extensions;
 
 let toModelDiagnostics = (errors: MerlinProtocol.errorResult) => {
   let f = (err: MerlinProtocol.errorResultItem) => {
-    Model.Diagnostics.Diagnostic.create(
+    Model.Diagnostic.create(
       ~message=err.message,
       ~range=
         Core.Range.ofPositions(

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -33,7 +33,7 @@ type t =
   | HoverShow
   | ChangeMode(Vim.Mode.t)
   | CursorMove(Position.t)
-  | DiagnosticsSet(Buffer.t, string, list(Diagnostics.Diagnostic.t))
+  | DiagnosticsSet(Buffer.t, string, list(Diagnostic.t))
   | SelectionChanged(VisualRange.t)
   // LoadEditorFont is the request to load a new font
   // If successful, a SetEditorFont action will be dispatched.

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -33,7 +33,7 @@ type t =
   | HoverShow
   | ChangeMode(Vim.Mode.t)
   | CursorMove(Position.t)
-  | DiagnosticsSet(Buffer.t, string, list(Diagnostic.t))
+  | DiagnosticsSet(Uri.t, string, list(Diagnostic.t))
   | SelectionChanged(VisualRange.t)
   // LoadEditorFont is the request to load a new font
   // If successful, a SetEditorFont action will be dispatched.

--- a/src/Model/Diagnostic.re
+++ b/src/Model/Diagnostic.re
@@ -1,0 +1,19 @@
+/*
+ * Diagnostic.re
+ */
+
+open Oni_Core;
+
+type t = {
+  range: Range.t,
+  message: string,
+};
+
+let create = (~range: Range.t, ~message, ()) => {range, message};
+
+let explode = (buffer: Buffer.t, v: t) => {
+  let measure = Buffer.getLineLength(buffer);
+
+  Range.explode(measure, v.range)
+  |> List.map(range => create(~range, ~message=v.message, ()));
+};

--- a/src/Model/Diagnostic.rei
+++ b/src/Model/Diagnostic.rei
@@ -1,0 +1,17 @@
+/*
+ * Diagnostic.rei
+ */
+
+open Oni_Core;
+
+type t = {
+  range: Range.t,
+  message: string,
+};
+
+let create: (~range: Range.t, ~message: string, unit) => t;
+
+/* 
+ [explode(buffer, diagnostic)] splits up a multi-line diagnostic into a diagnostic per-line
+*/
+let explode: (Buffer.t, t) => list(t);

--- a/src/Model/Diagnostic.rei
+++ b/src/Model/Diagnostic.rei
@@ -11,7 +11,7 @@ type t = {
 
 let create: (~range: Range.t, ~message: string, unit) => t;
 
-/* 
- [explode(buffer, diagnostic)] splits up a multi-line diagnostic into a diagnostic per-line
-*/
+/*
+  [explode(buffer, diagnostic)] splits up a multi-line diagnostic into a diagnostic per-line
+ */
 let explode: (Buffer.t, t) => list(t);

--- a/src/Model/Diagnostics.re
+++ b/src/Model/Diagnostics.re
@@ -9,23 +9,6 @@
 open Oni_Core;
 open Oni_Core.Types;
 
-module Diagnostic = {
-  [@deriving show({with_path: false})]
-  type t = {
-    range: Range.t,
-    message: string,
-  };
-
-  let create = (~range: Range.t, ~message, ()) => {range, message};
-
-  let explode = (buffer: Buffer.t, v: t) => {
-    let measure = Buffer.getLineLength(buffer);
-
-    Range.explode(measure, v.range)
-    |> List.map(range => create(~range, ~message=v.message, ()));
-  };
-};
-
 /*
  * The type for diagnostics is a nested map:
  * - First level: Buffer Path

--- a/src/Model/Diagnostics.re
+++ b/src/Model/Diagnostics.re
@@ -11,7 +11,7 @@ open Oni_Core.Types;
 
 /*
  * The type for diagnostics is a nested map:
- * - First level: Buffer Path
+ * - First level: URI
  * - Second level: Diagnostic identifier / key.
  *   For example - TypeScript might have keys for both compiler errors and lint warnings
  * - Diagnostic list corresponding to the buffer, key pair
@@ -19,6 +19,10 @@ open Oni_Core.Types;
 type t = StringMap.t(StringMap.t(list(Diagnostic.t)));
 
 let create = () => StringMap.empty;
+
+let getKeyForUri = (uri: Uri.t) => {
+  uri |> Uri.toString;
+};
 
 let getKeyForBuffer = (b: Buffer.t) => {
   b |> Buffer.getUri |> Uri.toString;
@@ -59,8 +63,8 @@ let clear = (instance, key) => {
   StringMap.map(f, instance);
 };
 
-let change = (instance, buffer, diagKey, diagnostics) => {
-  let bufferKey = getKeyForBuffer(buffer);
+let change = (instance, uri, diagKey, diagnostics) => {
+  let bufferKey = getKeyForUri(uri);
 
   let updateBufferMap =
       (bufferMap: option(StringMap.t(list(Diagnostic.t)))) => {

--- a/src/Model/Diagnostics.re
+++ b/src/Model/Diagnostics.re
@@ -51,6 +51,14 @@ let explodeDiagnostics = (buffer, diagnostics) => {
   |> List.fold_left(f, IntMap.empty);
 };
 
+let clear = (instance, key) => {
+  let f = identifierMap => {
+    StringMap.remove(key, identifierMap);
+  };
+
+  StringMap.map(f, instance);
+};
+
 let change = (instance, buffer, diagKey, diagnostics) => {
   let bufferKey = getKeyForBuffer(buffer);
 

--- a/src/Model/Diagnostics.rei
+++ b/src/Model/Diagnostics.rei
@@ -9,16 +9,6 @@
 open Oni_Core;
 open Oni_Core.Types;
 
-module Diagnostic: {
-  [@deriving show({with_path: false})]
-  type t = {
-    range: Range.t,
-    message: string,
-  };
-
-  let create: (~range: Range.t, ~message: string, unit) => t;
-};
-
 type t;
 
 /*

--- a/src/Model/Diagnostics.rei
+++ b/src/Model/Diagnostics.rei
@@ -22,6 +22,11 @@ let create: unit => t;
 let change: (t, Buffer.t, string, list(Diagnostic.t)) => t;
 
 /*
+ * [clear(diagnostics, key)] removes diagnostics with the key named [key] across all buffers
+ */
+let clear: (t, string) => t;
+
+/*
  * Get all diagnostics for a buffer
  */
 let getDiagnostics: (t, Buffer.t) => list(Diagnostic.t);

--- a/src/Model/Diagnostics.rei
+++ b/src/Model/Diagnostics.rei
@@ -19,7 +19,7 @@ let create: unit => t;
 /*
  * Change diagnostics for a buffer+diagnostic key pair
  */
-let change: (t, Buffer.t, string, list(Diagnostic.t)) => t;
+let change: (t, Uri.t, string, list(Diagnostic.t)) => t;
 
 /*
  * [clear(diagnostics, key)] removes diagnostics with the key named [key] across all buffers

--- a/src/Model/HoverCollector.re
+++ b/src/Model/HoverCollector.re
@@ -5,7 +5,7 @@
  * based on the current state
  */
 
-type hoverInfo = {diagnostics: list(Diagnostics.Diagnostic.t)};
+type hoverInfo = {diagnostics: list(Diagnostic.t)};
 
 type t = option(hoverInfo);
 

--- a/src/Model/Oni_Model.re
+++ b/src/Model/Oni_Model.re
@@ -16,6 +16,7 @@ module Commandline = Commandline;
 module CommandPalette = CommandPalette;
 module Completions = Completions;
 module CompletionMeet = CompletionMeet;
+module Diagnostic = Diagnostic;
 module Diagnostics = Diagnostics;
 module Editor = Editor;
 module EditorGroup = EditorGroup;

--- a/src/Store/MerlinStoreConnector.re
+++ b/src/Store/MerlinStoreConnector.re
@@ -45,6 +45,7 @@ let start = () => {
         | Some(v) =>
           let lines = Model.Buffer.getLines(v);
           let fileType = Model.Buffer.getFileType(v);
+          let uri = Model.Buffer.getUri(v);
           switch (fileType, Model.Buffer.getFilePath(v)) {
           | (Some(ft), Some(path)) when ft == "reason" || ft == "ocaml" =>
             let cb = err => {
@@ -57,7 +58,11 @@ let start = () => {
               );
               Revery.App.runOnMainThread(() => {
                 dispatch(
-                  Model.Actions.DiagnosticsSet(v, "merlin", modelDiagnostics),
+                  Model.Actions.DiagnosticsSet(
+                    uri,
+                    "merlin",
+                    modelDiagnostics,
+                  ),
                 )
               });
             };

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -691,7 +691,7 @@ let createElement =
                 ~count,
                 ~render=
                   (item, _offset) => {
-                    let renderDiagnostics = (d: Diagnostics.Diagnostic.t) =>
+                    let renderDiagnostics = (d: Diagnostic.t) =>
                       renderUnderline(~color=Colors.red, d.range);
 
                     /* Draw error markers */

--- a/src/UI/EditorVerticalScrollbar.re
+++ b/src/UI/EditorVerticalScrollbar.re
@@ -20,7 +20,7 @@ let createElement =
       ~editor: Editor.t,
       ~height as totalHeight,
       ~width as totalWidth,
-      ~diagnostics: IntMap.t(list(Diagnostics.Diagnostic.t)),
+      ~diagnostics: IntMap.t(list(Diagnostic.t)),
       ~metrics,
       ~children as _,
       (),

--- a/src/UI/HoverView.re
+++ b/src/UI/HoverView.re
@@ -66,7 +66,7 @@ let createElement =
 
       let (_maxWidth, height, diags) =
         List.fold_left(
-          (prev, curr: Model.Diagnostics.Diagnostic.t) => {
+          (prev, curr: Model.Diagnostic.t) => {
             let (prevWidth, prevHeight, prevDiags) = prev;
 
             let message = curr.message;

--- a/src/UI/Minimap.re
+++ b/src/UI/Minimap.re
@@ -10,7 +10,7 @@ open Revery.UI;
 
 open Oni_Core;
 module BufferViewTokenizer = Oni_Model.BufferViewTokenizer;
-module Diagnostics = Oni_Model.Diagnostics;
+module Diagnostic = Oni_Model.Diagnostic;
 module Editor = Oni_Model.Editor;
 module Selectors = Oni_Model.Selectors;
 module State = Oni_Model.State;
@@ -327,7 +327,7 @@ let createElement =
                   switch (IntMap.find_opt(item, diagnostics)) {
                   | Some(v) =>
                     List.iter(
-                      (d: Diagnostics.Diagnostic.t) =>
+                      (d: Diagnostic.t) =>
                         renderUnderline(
                           ~offset,
                           ~color=Color.rgba(1.0, 0., 0., 1.0),

--- a/test/Model/DiagnosticsTests.re
+++ b/test/Model/DiagnosticsTests.re
@@ -4,10 +4,11 @@ open Oni_Core;
 open Oni_Core.Types;
 
 module Buffer = Oni_Model.Buffer;
+module Diagnostic = Oni_Model.Diagnostic;
 module Diagnostics = Oni_Model.Diagnostics;
 
 let singleDiagnostic = [
-  Diagnostics.Diagnostic.create(
+  Diagnostic.create(
     ~range=Range.zero,
     ~message="single error",
     (),
@@ -15,8 +16,8 @@ let singleDiagnostic = [
 ];
 
 let doubleDiagnostic = [
-  Diagnostics.Diagnostic.create(~range=Range.zero, ~message="error 1", ()),
-  Diagnostics.Diagnostic.create(~range=Range.zero, ~message="error 2", ()),
+  Diagnostic.create(~range=Range.zero, ~message="error 1", ()),
+  Diagnostic.create(~range=Range.zero, ~message="error 2", ()),
 ];
 
 describe("Diagnostics", ({describe, _}) => {
@@ -34,7 +35,7 @@ describe("Diagnostics", ({describe, _}) => {
   describe("getDiagnosticsAtPosition", ({test, _}) =>
     test("simple diagnostic", ({expect}) => {
       let singleDiagnostic = [
-        Diagnostics.Diagnostic.create(
+        Diagnostic.create(
           ~range=
             Range.ofInt0(
               ~startLine=1,

--- a/test/Model/DiagnosticsTests.re
+++ b/test/Model/DiagnosticsTests.re
@@ -8,11 +8,7 @@ module Diagnostic = Oni_Model.Diagnostic;
 module Diagnostics = Oni_Model.Diagnostics;
 
 let singleDiagnostic = [
-  Diagnostic.create(
-    ~range=Range.zero,
-    ~message="single error",
-    (),
-  ),
+  Diagnostic.create(~range=Range.zero, ~message="single error", ()),
 ];
 
 let doubleDiagnostic = [

--- a/test/Model/DiagnosticsTests.re
+++ b/test/Model/DiagnosticsTests.re
@@ -99,6 +99,31 @@ describe("Diagnostics", ({describe, _}) => {
       expect.int(List.length(diags)).toBe(0);
     })
   );
+  describe("clear", ({test, _}) => {
+    test("single diagnostic", ({expect}) => {
+      let buffer = Buffer.ofLines([||]);
+
+      let v = Diagnostics.create();
+      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
+      let v = Diagnostics.clear(v, "test_key1");
+
+      let diagnostics = Diagnostics.getDiagnostics(v, buffer);
+
+      expect.int(List.length(diagnostics)).toBe(0);
+    });
+    test("doesn't remove other keys", ({expect}) => {
+      let buffer = Buffer.ofLines([||]);
+
+      let v = Diagnostics.create();
+      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, buffer, "test_key2", doubleDiagnostic);
+      let v = Diagnostics.clear(v, "test_key1");
+
+      let diagnostics = Diagnostics.getDiagnostics(v, buffer);
+
+      expect.int(List.length(diagnostics)).toBe(2);
+    });
+  });
 
   describe("change", ({test, _}) => {
     test("simple diagnostic add", ({expect}) => {

--- a/test/Model/DiagnosticsTests.re
+++ b/test/Model/DiagnosticsTests.re
@@ -16,6 +16,9 @@ let doubleDiagnostic = [
   Diagnostic.create(~range=Range.zero, ~message="error 2", ()),
 ];
 
+let buffer = Buffer.ofLines([||]);
+let uri = Buffer.getUri(buffer);
+
 describe("Diagnostics", ({describe, _}) => {
   describe("getDiagnostics", ({test, _}) =>
     test("no diagnostics", ({expect}) => {
@@ -45,10 +48,9 @@ describe("Diagnostics", ({describe, _}) => {
         ),
       ];
 
-      let buffer = Buffer.ofLines([||]);
       let v = Diagnostics.create();
 
-      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key1", singleDiagnostic);
 
       let diags =
         Diagnostics.getDiagnosticsAtPosition(
@@ -104,7 +106,7 @@ describe("Diagnostics", ({describe, _}) => {
       let buffer = Buffer.ofLines([||]);
 
       let v = Diagnostics.create();
-      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key1", singleDiagnostic);
       let v = Diagnostics.clear(v, "test_key1");
 
       let diagnostics = Diagnostics.getDiagnostics(v, buffer);
@@ -115,8 +117,8 @@ describe("Diagnostics", ({describe, _}) => {
       let buffer = Buffer.ofLines([||]);
 
       let v = Diagnostics.create();
-      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
-      let v = Diagnostics.change(v, buffer, "test_key2", doubleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key2", doubleDiagnostic);
       let v = Diagnostics.clear(v, "test_key1");
 
       let diagnostics = Diagnostics.getDiagnostics(v, buffer);
@@ -130,7 +132,7 @@ describe("Diagnostics", ({describe, _}) => {
       let buffer = Buffer.ofLines([||]);
       let v = Diagnostics.create();
 
-      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key1", singleDiagnostic);
 
       let diagnostics = Diagnostics.getDiagnostics(v, buffer);
 
@@ -141,8 +143,8 @@ describe("Diagnostics", ({describe, _}) => {
       let buffer = Buffer.ofLines([||]);
       let v = Diagnostics.create();
 
-      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
-      let v = Diagnostics.change(v, buffer, "test_key2", doubleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key2", doubleDiagnostic);
 
       let diagnostics = Diagnostics.getDiagnostics(v, buffer);
 
@@ -155,9 +157,9 @@ describe("Diagnostics", ({describe, _}) => {
       let buffer = Buffer.ofLines([||]);
       let v = Diagnostics.create();
 
-      let v = Diagnostics.change(v, buffer, "test_key1", singleDiagnostic);
-      let v = Diagnostics.change(v, buffer, "test_key2", doubleDiagnostic);
-      let v = Diagnostics.change(v, buffer, "test_key1", []);
+      let v = Diagnostics.change(v, uri, "test_key1", singleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key2", doubleDiagnostic);
+      let v = Diagnostics.change(v, uri, "test_key1", []);
 
       let diagnostics = Diagnostics.getDiagnostics(v, buffer);
 


### PR DESCRIPTION
A few refactorings to prep diagnostics for integration with exthost:
- Add a `clear` method to `Diagnostics`
- Move `Diagnostic` to its own module, outside of `Diagnostics`
- Refactor such that the `change` method and `DiagnosticsSet` action use a `Uri.t` instead of a `Buffer.t`, since this is more convenient to use from the exthost