### PR TITLE
ExtHost: Initial diagnostics integration

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
+const path = require('path');
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -9,6 +10,13 @@ function activate(context) {
     let showData = (val) => {
         vscode.window.showInformationMessage(JSON.stringify(val));
     }
+    // Create a simple status bar
+    let item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1000);
+    item.text = "Developer";
+    item.show();
+
+
+    const collection = vscode.languages.createDiagnosticCollection('test');
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with  registerCommand
@@ -27,6 +35,8 @@ function activate(context) {
         //     type: "workspace.onDidOpenTextDocument",
         //     filename: e.fileName,
         // });
+
+        item.text="HERE";
     });
 
     let disposable3 = vscode.workspace.onDidChangeTextDocument((e) => {
@@ -38,12 +48,23 @@ function activate(context) {
         //     contentChanges: e.contentChanges,
         //     fullText: e.document.getText(),
         // });
-    });
 
-    // Create a simple status bar
-    let item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1000);
-    item.text = "Developer";
-    item.show();
+		vscode.window.showInformationMessage('YO HELLO');
+        const document = e.document;
+        if (document && path.basename(document.uri.fsPath) == "test.oni-dev") {
+        item.text = "BEFORE2";
+           collection.clear(document.uri);
+           collection.set(document.uri, [{
+                code: '', 
+                message: "diag 1",
+                range: new vscode.Range(new vscode.Position(3, 4), new vscode.Position(3, 10)),
+                severity: vscode.DiagnosticSeverity.Error,
+                source: '',
+                relatedInformation: []
+           }]);
+        item.text = "BEFORE3";
+        }
+    });
 
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(disposable2);

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -35,8 +35,6 @@ function activate(context) {
         //     type: "workspace.onDidOpenTextDocument",
         //     filename: e.fileName,
         // });
-
-        item.text="HERE";
     });
 
     let disposable3 = vscode.workspace.onDidChangeTextDocument((e) => {
@@ -49,20 +47,17 @@ function activate(context) {
         //     fullText: e.document.getText(),
         // });
 
-		vscode.window.showInformationMessage('YO HELLO');
+		//vscode.window.showInformationMessage('Changed!');
         const document = e.document;
         if (document && path.basename(document.uri.fsPath) == "test.oni-dev") {
-        item.text = "BEFORE2";
-           collection.clear(document.uri);
            collection.set(document.uri, [{
                 code: '', 
                 message: "diag 1",
-                range: new vscode.Range(new vscode.Position(3, 4), new vscode.Position(3, 10)),
+                range: new vscode.Range(new vscode.Position(0, 4), new vscode.Position(0, 10)),
                 severity: vscode.DiagnosticSeverity.Error,
                 source: '',
                 relatedInformation: []
            }]);
-        item.text = "BEFORE3";
         }
     });
 

--- a/src/Core/Range.re
+++ b/src/Core/Range.re
@@ -29,6 +29,15 @@ let ofInt0 = (~startLine, ~startCharacter, ~endLine, ~endCharacter, ()) =>
     (),
   );
 
+let ofInt1 = (~startLine, ~startCharacter, ~endLine, ~endCharacter, ()) =>
+  create(
+    ~startLine=OneBasedIndex(startLine),
+    ~startCharacter=OneBasedIndex(startCharacter),
+    ~endLine=OneBasedIndex(endLine),
+    ~endCharacter=OneBasedIndex(endCharacter),
+    (),
+  );
+
 let contains = (v: t, position: Position.t) => {
   let l0 = Index.toInt0(v.startPosition.line);
   let c0 = Index.toInt0(v.startPosition.character);

--- a/src/Core/Range.rei
+++ b/src/Core/Range.rei
@@ -40,6 +40,16 @@ let ofInt0:
   ) =>
   t;
 
+let ofInt1:
+  (
+    ~startLine: int,
+    ~startCharacter: int,
+    ~endLine: int,
+    ~endCharacter: int,
+    unit
+  ) =>
+  t;
+
 let zero: t;
 
 /*

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -90,6 +90,7 @@ let escapeSpaces = str => {
   Str.global_replace(whitespace, "\\ ", str);
 };
 
+// TODO: Remove / replace when upgraded to OCaml 4.08
 let filterMap = (f, l) => {
   let rec inner = l =>
     switch (l) {
@@ -102,6 +103,14 @@ let filterMap = (f, l) => {
     };
 
   inner(l);
+};
+
+// TODO: Remove / replace with Result.to_option when upgraded to OCaml 4.08
+let resultToOption = (r) => {
+  switch (r) {
+  | Ok(v) => Some(v)
+  | Error(_) => None
+  }
 };
 
 type commandLineCompletionMeet = {

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -106,11 +106,11 @@ let filterMap = (f, l) => {
 };
 
 // TODO: Remove / replace with Result.to_option when upgraded to OCaml 4.08
-let resultToOption = (r) => {
+let resultToOption = r => {
   switch (r) {
   | Ok(v) => Some(v)
   | Error(_) => None
-  }
+  };
 };
 
 type commandLineCompletionMeet = {

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -42,16 +42,9 @@ let start =
     switch (scope, method, args) {
     | ("MainThreadDiagnostics", "$changeMany", args) =>
       In.Diagnostics.parseChangeMany(args) |> apply(onDiagnosticsChangeMany);
-      print_endline(
-        "MAINTHREADDIAG - changeMany - args: "
-        ++ Yojson.Safe.to_string(`List(args)),
-      );
       Ok(None);
     | ("MainThreadDiagnostics", "$clear", args) =>
       In.Diagnostics.parseClear(args) |> apply(onDiagnosticsClear);
-      print_endline(
-        "MAINTHREADDIAG - clear: " ++ Yojson.Safe.to_string(`List(args)),
-      );
       Ok(None);
     | ("MainThreadTelemetry", "$publicLog", [`String(eventName), json]) =>
       Log.info(eventName ++ ":" ++ Yojson.Safe.to_string(json));

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -30,6 +30,8 @@ let start =
       ~initData=ExtHostInitData.create(),
       ~onInitialized=defaultCallback,
       ~onClosed=defaultCallback,
+      ~onDiagnosticsChangeMany=defaultOneArgCallback,
+      ~onDiagnosticsClear=defaultOneArgCallback,
       ~onDidActivateExtension=defaultOneArgCallback,
       ~onRegisterCommand=defaultOneArgCallback,
       ~onShowMessage=defaultOneArgCallback,
@@ -38,6 +40,8 @@ let start =
     ) => {
   let onMessage = (scope, method, args) => {
     switch (scope, method, args) {
+    | ("MainThreadDiagnostics", "$changeMany", args) => In.Diagnostics.parseChangeMany(args) |> apply(onDiagnosticsChangeMany);
+    | ("MainThreadDiagnostics", "$clear", args) => In.Diagnostics.parseClear(args) |> apply(onDiagnosticsClear);
     | ("MainThreadTelemetry", "$publicLog", [`String(eventName), json]) =>
       Log.info(eventName ++ ":" ++ Yojson.Safe.to_string(json));
       Ok(None);

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -40,8 +40,19 @@ let start =
     ) => {
   let onMessage = (scope, method, args) => {
     switch (scope, method, args) {
-    | ("MainThreadDiagnostics", "$changeMany", args) => In.Diagnostics.parseChangeMany(args) |> apply(onDiagnosticsChangeMany);
-    | ("MainThreadDiagnostics", "$clear", args) => In.Diagnostics.parseClear(args) |> apply(onDiagnosticsClear);
+    | ("MainThreadDiagnostics", "$changeMany", args) =>
+      In.Diagnostics.parseChangeMany(args) |> apply(onDiagnosticsChangeMany);
+      print_endline(
+        "MAINTHREADDIAG - changeMany - args: "
+        ++ Yojson.Safe.to_string(`List(args)),
+      );
+      Ok(None);
+    | ("MainThreadDiagnostics", "$clear", args) =>
+      In.Diagnostics.parseClear(args) |> apply(onDiagnosticsClear);
+      print_endline(
+        "MAINTHREADDIAG - clear: " ++ Yojson.Safe.to_string(`List(args)),
+      );
+      Ok(None);
     | ("MainThreadTelemetry", "$publicLog", [`String(eventName), json]) =>
       Log.info(eventName ++ ":" ++ Yojson.Safe.to_string(json));
       Ok(None);

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -125,6 +125,15 @@ module OneBasedRange = {
     startColumn: r.startPosition.character |> Index.toOneBasedInt,
     endColumn: r.endPosition.character |> Index.toOneBasedInt,
   };
+
+  let toRange = (v: t) => {
+    Range.ofInt1(
+    ~startLine=v.startLineNumber,
+    ~endLine=v.endLineNumber,
+    ~startCharacter=v.startColumn,
+    ~endCharacter=v.endColumn,
+    ());
+  };
 };
 
 module ModelContentChange = {

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -205,6 +205,21 @@ module IncomingNotifications = {
       };
     };
   };
+
+  module Diagnostics = {
+    let parseClear = args => switch(args) {
+    | [`String(owner)] => Some(owner)
+    | _ => None
+    };
+
+    let parseChangeMany = args => switch(args) {
+    | [`String(owner), `List([uri, markers])] => 
+      print_endline ("!! PARSING URI: " ++ Yojson.Safe.to_string(uri));
+      print_endline ("!! PARSING MARKERS: " ++ Yojson.Safe.to_string(uri));
+      None;
+    | _ => None
+    };
+  };
 };
 
 module OutgoingNotifications = {

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -186,6 +186,81 @@ module ModelChangedEvent = {
   let create = (~changes, ~eol, ~versionId, ()) => {changes, eol, versionId};
 };
 
+module Diagnostic = {
+  [@deriving yojson({strict: false})]
+  type json = {
+    startLineNumber: int,
+    endLineNumber: int,
+    startColumn: int,
+    endColumn: int,
+    message: string,
+    source: string,
+    code: string,
+    severity: int,
+    // TODO:
+    // relatedInformation: DiagnosticRelatedInformation.t,
+  };
+
+  type t = {
+    range: OneBasedRange.t,
+    message: string,
+    source: string,
+    code: string,
+    severity: int,
+    // TODO:
+    // relatedInformation: DiagnosticRelatedInformation.t,
+  };
+
+  let of_yojson = json => {
+    switch (json_of_yojson(json)) {
+    | Ok(ret) =>
+      let range =
+        OneBasedRange.create(
+          ~startLineNumber=ret.startLineNumber,
+          ~startColumn=ret.startColumn,
+          ~endLineNumber=ret.endLineNumber,
+          ~endColumn=ret.endColumn,
+          (),
+        );
+
+      Ok({
+        range,
+        message: ret.message,
+        source: ret.source,
+        code: ret.code,
+        severity: ret.severity,
+      });
+    | Error(msg) => Error(msg)
+    };
+  };
+
+  let to_yojson = _ => {
+    // TODO:
+    failwith("Not used");
+  };
+};
+
+module Diagnostics = {
+  [@deriving yojson({strict: false})]
+  type t = (Uri.t, list(Diagnostic.t));
+};
+
+module DiagnosticsCollection = {
+  type t = {
+    name: string,
+    perFileDiagnostics: list(Diagnostics.t),
+  };
+
+  let of_yojson = (json: Yojson.Safe.t) => {
+    switch (json) {
+    | `List([`String(name), `List(perFileDiagnostics)]) =>
+      let perFileDiagnostics = List.map(Diagnostics.of_yojson, perFileDiagnostics) |> Utility.filterMap(Utility.resultToOption);
+      Some({name, perFileDiagnostics})
+    | _ => None
+    };
+  };
+};
+
 module IncomingNotifications = {
   module StatusBar = {
     let parseSetEntry = args => {
@@ -207,18 +282,14 @@ module IncomingNotifications = {
   };
 
   module Diagnostics = {
-    let parseClear = args => switch(args) {
-    | [`String(owner)] => Some(owner)
-    | _ => None
-    };
+    let parseClear = args =>
+      switch (args) {
+      | [`String(owner)] => Some(owner)
+      | _ => None
+      };
 
-    let parseChangeMany = args => switch(args) {
-    | [`String(owner), `List([uri, markers])] => 
-      print_endline ("!! PARSING URI: " ++ Yojson.Safe.to_string(uri));
-      print_endline ("!! PARSING MARKERS: " ++ Yojson.Safe.to_string(uri));
-      None;
-    | _ => None
-    };
+    let parseChangeMany = args =>
+      DiagnosticsCollection.of_yojson(`List(args));
   };
 };
 

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -128,11 +128,12 @@ module OneBasedRange = {
 
   let toRange = (v: t) => {
     Range.ofInt1(
-    ~startLine=v.startLineNumber,
-    ~endLine=v.endLineNumber,
-    ~startCharacter=v.startColumn,
-    ~endCharacter=v.endColumn,
-    ());
+      ~startLine=v.startLineNumber,
+      ~endLine=v.endLineNumber,
+      ~startCharacter=v.startColumn,
+      ~endCharacter=v.endColumn,
+      (),
+    );
   };
 };
 
@@ -263,8 +264,10 @@ module DiagnosticsCollection = {
   let of_yojson = (json: Yojson.Safe.t) => {
     switch (json) {
     | `List([`String(name), `List(perFileDiagnostics)]) =>
-      let perFileDiagnostics = List.map(Diagnostics.of_yojson, perFileDiagnostics) |> Utility.filterMap(Utility.resultToOption);
-      Some({name, perFileDiagnostics})
+      let perFileDiagnostics =
+        List.map(Diagnostics.of_yojson, perFileDiagnostics)
+        |> Utility.filterMap(Utility.resultToOption);
+      Some({name, perFileDiagnostics});
     | _ => None
     };
   };

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -34,6 +34,7 @@ type t =
   | ChangeMode(Vim.Mode.t)
   | CursorMove(Position.t)
   | DiagnosticsSet(Buffer.t, string, list(Diagnostics.Diagnostic.t))
+  | DiagnosticsClear(string)
   | SelectionChanged(VisualRange.t)
   // LoadEditorFont is the request to load a new font
   // If successful, a SetEditorFont action will be dispatched.

--- a/src/Model/Diagnostics.re
+++ b/src/Model/Diagnostics.re
@@ -38,9 +38,7 @@ type t = StringMap.t(StringMap.t(list(Diagnostic.t)));
 let create = () => StringMap.empty;
 
 let getKeyForBuffer = (b: Buffer.t) => {
-  let ret = b |> Buffer.getUri |> Uri.toString;
-  print_endline("getKeyForBuffer: " ++ ret);
-  ret;
+  b |> Buffer.getUri |> Uri.toString;
 };
 
 let updateDiagnosticsMap =

--- a/src/Model/Diagnostics.re
+++ b/src/Model/Diagnostics.re
@@ -38,7 +38,9 @@ type t = StringMap.t(StringMap.t(list(Diagnostic.t)));
 let create = () => StringMap.empty;
 
 let getKeyForBuffer = (b: Buffer.t) => {
-  b |> Buffer.getUri |> Uri.toString;
+  let ret = b |> Buffer.getUri |> Uri.toString;
+  print_endline("getKeyForBuffer: " ++ ret);
+  ret;
 };
 
 let updateDiagnosticsMap =

--- a/src/Model/Reducer.re
+++ b/src/Model/Reducer.re
@@ -34,7 +34,7 @@ let reduce: (State.t, Actions.t) => State.t =
         }
       | DiagnosticsClear(key) => {
           ...s,
-          diagnostics: Diagnostics.clear(key),
+          diagnostics: Diagnostics.clear(s.diagnostics, key),
         }
       | KeyBindingsSet(keyBindings) => {...s, keyBindings}
       | SetLanguageInfo(languageInfo) => {...s, languageInfo}

--- a/src/Model/Reducer.re
+++ b/src/Model/Reducer.re
@@ -32,6 +32,10 @@ let reduce: (State.t, Actions.t) => State.t =
           ...s,
           diagnostics: Diagnostics.change(s.diagnostics, buffer, key, diags),
         }
+      | DiagnosticsClear(key) => {
+          ...s,
+          diagnostics: Diagnostics.clear(key),
+        }
       | KeyBindingsSet(keyBindings) => {...s, keyBindings}
       | SetLanguageInfo(languageInfo) => {...s, languageInfo}
       | SetIconTheme(iconTheme) => {...s, iconTheme}

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -30,8 +30,7 @@ let start = (extensions, setup: Core.Setup.t) => {
 
   let onDiagnosticsChangeMany =
       (diagCollection: Protocol.DiagnosticsCollection.t) => {
-    let protocolDiagToDiag:
-      Protocol.Diagnostic.t => Model.Diagnostic.t =
+    let protocolDiagToDiag: Protocol.Diagnostic.t => Model.Diagnostic.t =
       d => {
         let range = Protocol.OneBasedRange.toRange(d.range);
         let message = d.message;

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -24,6 +24,14 @@ let start = (extensions, setup: Core.Setup.t) => {
          Extensions.ExtHostInitData.ExtensionInfo.ofScannedExtension(ext)
        );
 
+  let onDiagnosticsClear = owner => {
+    print_endline("!! onDiagnosticsClear: " ++ owner);
+  };
+
+  let onDiagnosticsChangeMany = _ => {
+    print_endline("!! onDiagnosticsChangeMany: " ++ "[NONE]");
+  };
+
   let onStatusBarSetEntry = ((id, text, alignment, priority)) => {
     dispatch(
       Model.Actions.StatusBarAddItem(
@@ -44,6 +52,8 @@ let start = (extensions, setup: Core.Setup.t) => {
       ~initData,
       ~onClosed=onExtHostClosed,
       ~onStatusBarSetEntry,
+      ~onDiagnosticsClear,
+      ~onDiagnosticsChangeMany,
       setup,
     );
 

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -31,18 +31,17 @@ let start = (extensions, setup: Core.Setup.t) => {
   let onDiagnosticsChangeMany =
       (diagCollection: Protocol.DiagnosticsCollection.t) => {
     let protocolDiagToDiag:
-      Protocol.Diagnostic.t => Model.Diagnostics.Diagnostic.t =
+      Protocol.Diagnostic.t => Model.Diagnostic.t =
       d => {
         let range = Protocol.OneBasedRange.toRange(d.range);
         let message = d.message;
-        Model.Diagnostics.Diagnostic.create(~range, ~message, ());
+        Model.Diagnostic.create(~range, ~message, ());
       };
 
     let f = (d: Protocol.Diagnostics.t) => {
       let diagnostics = List.map(protocolDiagToDiag, snd(d));
-      let _uri = fst(d);
-      let buffer = Model.Buffer.ofLines([||]);
-      Model.Actions.DiagnosticsSet(buffer, diagCollection.name, diagnostics);
+      let uri = fst(d);
+      Model.Actions.DiagnosticsSet(uri, diagCollection.name, diagnostics);
     };
 
     diagCollection.perFileDiagnostics

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -28,23 +28,26 @@ let start = (extensions, setup: Core.Setup.t) => {
     dispatch(Model.Actions.DiagnosticsClear(owner));
   };
 
-  let onDiagnosticsChangeMany = (diagCollection: Protocol.DiagnosticsCollection.t) => {
-
-    let protocolDiagToDiag: Protocol.Diagnostic.t => Model.Diagnostics.Diagnostic.t = (d) => {
-      let range = Protocol.OneBasedRange.toRange(d.range);
-      let message = d.message;
-      Model.Diagnostics.Diagnostic.create(~range, ~message, ());
-    };
+  let onDiagnosticsChangeMany =
+      (diagCollection: Protocol.DiagnosticsCollection.t) => {
+    let protocolDiagToDiag:
+      Protocol.Diagnostic.t => Model.Diagnostics.Diagnostic.t =
+      d => {
+        let range = Protocol.OneBasedRange.toRange(d.range);
+        let message = d.message;
+        Model.Diagnostics.Diagnostic.create(~range, ~message, ());
+      };
 
     let f = (d: Protocol.Diagnostics.t) => {
-      let diagnostics = List.map(protocolDiagToDiag, snd(d)); 
+      let diagnostics = List.map(protocolDiagToDiag, snd(d));
       let _uri = fst(d);
       let buffer = Model.Buffer.ofLines([||]);
       Model.Actions.DiagnosticsSet(buffer, diagCollection.name, diagnostics);
     };
 
-   let _actions =  List.map(f, diagCollection.perFileDiagnostics);
-   ();
+    diagCollection.perFileDiagnostics
+    |> List.map(f)
+    |> List.iter(a => dispatch(a));
   };
 
   let onStatusBarSetEntry = ((id, text, alignment, priority)) => {

--- a/test/Extensions/ExtHostProtocolTests.re
+++ b/test/Extensions/ExtHostProtocolTests.re
@@ -10,10 +10,11 @@ let diagnosticCollectionJSON = {|
 ["test",[[{"$mid":1,"fsPath":"/Users/bryphe/oni2/test.oni-dev","external":"file:/Users/bryphe/oni2/test.oni-dev","path":"/Users/bryphe/oni2/test.oni-dev","scheme":["file"]},[{"startLineNumber":4,"startColumn":5,"endLineNumber":4,"endColumn":11,"message":"diag 1","source":"","code":"","severity":8,"relatedInformation":[]}]]]]
 |};
 
-let jsonListToList = json => switch(json) {
-| `List(args) => args
-| _ => failwith("Expected list");
-};
+let jsonListToList = json =>
+  switch (json) {
+  | `List(args) => args
+  | _ => failwith("Expected list")
+  };
 
 describe("ExtHostProtocol", ({describe, _}) => {
   describe("IncomingNotifications", ({describe, _}) => {
@@ -25,7 +26,7 @@ describe("ExtHostProtocol", ({describe, _}) => {
               let diagnostics: option(DiagnosticsCollection.t) =
                 parseChangeMany(
                   Yojson.Safe.from_string(diagnosticCollectionJSON)
-                  |> jsonListToList
+                  |> jsonListToList,
                 );
               switch (diagnostics) {
               | None => failwith("Expected successful parse")
@@ -34,7 +35,9 @@ describe("ExtHostProtocol", ({describe, _}) => {
                 expect.int(List.length(v.perFileDiagnostics)).toBe(1);
 
                 let (uri, diags) = List.hd(v.perFileDiagnostics);
-                expect.string(Uri.toString(uri)).toEqual("file:///Users/bryphe/oni2/test.oni-dev");
+                expect.string(Uri.toString(uri)).toEqual(
+                  "file:///Users/bryphe/oni2/test.oni-dev",
+                );
                 expect.int(List.length(diags)).toBe(1);
               };
             })

--- a/test/Extensions/ExtHostProtocolTests.re
+++ b/test/Extensions/ExtHostProtocolTests.re
@@ -1,0 +1,46 @@
+open Oni_Core;
+open Oni_Core_Test;
+open Oni_Extensions;
+
+open ExtHostProtocol;
+
+open TestFramework;
+
+let diagnosticCollectionJSON = {|
+["test",[[{"$mid":1,"fsPath":"/Users/bryphe/oni2/test.oni-dev","external":"file:/Users/bryphe/oni2/test.oni-dev","path":"/Users/bryphe/oni2/test.oni-dev","scheme":["file"]},[{"startLineNumber":4,"startColumn":5,"endLineNumber":4,"endColumn":11,"message":"diag 1","source":"","code":"","severity":8,"relatedInformation":[]}]]]]
+|};
+
+let jsonListToList = json => switch(json) {
+| `List(args) => args
+| _ => failwith("Expected list");
+};
+
+describe("ExtHostProtocol", ({describe, _}) => {
+  describe("IncomingNotifications", ({describe, _}) => {
+    IncomingNotifications.(
+      describe("Diagnostics", ({test, _}) => {
+        Diagnostics.(
+          DiagnosticsCollection.(
+            test("parse collection", ({expect, _}) => {
+              let diagnostics: option(DiagnosticsCollection.t) =
+                parseChangeMany(
+                  Yojson.Safe.from_string(diagnosticCollectionJSON)
+                  |> jsonListToList
+                );
+              switch (diagnostics) {
+              | None => failwith("Expected successful parse")
+              | Some(v) =>
+                expect.string(v.name).toEqual("test");
+                expect.int(List.length(v.perFileDiagnostics)).toBe(1);
+
+                let (uri, diags) = List.hd(v.perFileDiagnostics);
+                expect.string(Uri.toString(uri)).toEqual("file:///Users/bryphe/oni2/test.oni-dev");
+                expect.int(List.length(diags)).toBe(1);
+              };
+            })
+          )
+        )
+      })
+    )
+  })
+});


### PR DESCRIPTION
This adds handler for the Diagnostics `$changeMany` and `$clear` calls from the VSCode extension host.
- Document via types the incoming data
- Deserialize from JSON RPC
- Coerce to types that are used by our Model
- Dispatch actions when we get updates