### PR TITLE
ExtHost: Hook up OutputService

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -15,6 +15,11 @@ function activate(context) {
     item.text = "Developer";
     item.show();
 
+    const output = vscode.window.createOutputChannel("oni-dev");
+    output.appendLine("Hello output channel!");
+
+    const output2 = vscode.window.createOutputChannel("oni-dev2");
+    output2.append("Hello output channel!");
 
     const collection = vscode.languages.createDiagnosticCollection('test');
 

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -33,7 +33,7 @@ let start =
       ~onDiagnosticsChangeMany=defaultOneArgCallback,
       ~onDiagnosticsClear=defaultOneArgCallback,
       ~onDidActivateExtension=defaultOneArgCallback,
-      ~onMessage=defaultOneArgCallback,
+      ~onTelemetry=defaultOneArgCallback,
       ~onOutput=defaultOneArgCallback,
       ~onRegisterCommand=defaultOneArgCallback,
       ~onShowMessage=defaultOneArgCallback,
@@ -46,7 +46,7 @@ let start =
       // TODO: No-op
       Ok(None)
     | ("MainThreadOutputService", "$append", [_, `String(msg)]) =>
-      onMessage(msg);
+      onOutput(msg);
       Ok(None);
     | ("MainThreadDiagnostics", "$changeMany", args) =>
       In.Diagnostics.parseChangeMany(args) |> apply(onDiagnosticsChangeMany);
@@ -55,7 +55,7 @@ let start =
       In.Diagnostics.parseClear(args) |> apply(onDiagnosticsClear);
       Ok(None);
     | ("MainThreadTelemetry", "$publicLog", [`String(eventName), json]) =>
-      Log.info(eventName ++ ":" ++ Yojson.Safe.to_string(json));
+      onTelemetry(eventName ++ ":" ++ Yojson.Safe.to_string(json));
       Ok(None);
     | ("MainThreadMessageService", "$showMessage", [_, `String(s), ..._]) =>
       onShowMessage(s);

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -33,6 +33,8 @@ let start =
       ~onDiagnosticsChangeMany=defaultOneArgCallback,
       ~onDiagnosticsClear=defaultOneArgCallback,
       ~onDidActivateExtension=defaultOneArgCallback,
+      ~onMessage=defaultOneArgCallback,
+      ~onOutput=defaultOneArgCallback,
       ~onRegisterCommand=defaultOneArgCallback,
       ~onShowMessage=defaultOneArgCallback,
       ~onStatusBarSetEntry,
@@ -40,6 +42,12 @@ let start =
     ) => {
   let onMessage = (scope, method, args) => {
     switch (scope, method, args) {
+    | ("MainThreadOutputService", "$register", _) =>
+      // TODO: No-op
+      Ok(None);
+    | ("MainThreadOutputService", "$append" , [_, `String(msg)]) =>
+      onMessage(msg);
+      Ok(None);
     | ("MainThreadDiagnostics", "$changeMany", args) =>
       In.Diagnostics.parseChangeMany(args) |> apply(onDiagnosticsChangeMany);
       Ok(None);

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -44,8 +44,8 @@ let start =
     switch (scope, method, args) {
     | ("MainThreadOutputService", "$register", _) =>
       // TODO: No-op
-      Ok(None);
-    | ("MainThreadOutputService", "$append" , [_, `String(msg)]) =>
+      Ok(None)
+    | ("MainThreadOutputService", "$append", [_, `String(msg)]) =>
       onMessage(msg);
       Ok(None);
     | ("MainThreadDiagnostics", "$changeMany", args) =>

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -62,6 +62,10 @@ let start = (extensions, setup: Core.Setup.t) => {
     );
   };
 
+  let onMessage = (msg) => {
+    Core.Log.info("[ExtHost]: " ++ msg);
+  };
+
   let initData = ExtHostInitData.create(~extensions=extensionInfo, ());
   let extHostClient =
     Extensions.ExtHostClient.start(
@@ -70,6 +74,7 @@ let start = (extensions, setup: Core.Setup.t) => {
       ~onStatusBarSetEntry,
       ~onDiagnosticsClear,
       ~onDiagnosticsChangeMany,
+      ~onMessage,
       setup,
     );
 

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -62,7 +62,7 @@ let start = (extensions, setup: Core.Setup.t) => {
     );
   };
 
-  let onMessage = (msg) => {
+  let onMessage = msg => {
     Core.Log.info("[ExtHost]: " ++ msg);
   };
 
@@ -78,7 +78,8 @@ let start = (extensions, setup: Core.Setup.t) => {
       setup,
     );
 
-  let _bufferMetadataToModelAddedDelta = (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
+  let _bufferMetadataToModelAddedDelta =
+      (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
     switch (bm.filePath, fileType) {
     | (Some(fp), Some(ft)) =>
       Core.Log.info("Creating model for filetype: " ++ ft);
@@ -91,7 +92,7 @@ let start = (extensions, setup: Core.Setup.t) => {
           ~isDirty=true,
           (),
         ),
-      )
+      );
     | _ => None
     };
 
@@ -100,7 +101,8 @@ let start = (extensions, setup: Core.Setup.t) => {
       ExtHostClient.pump(extHostClient)
     );
 
-  let sendBufferEnterEffect = (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
+  let sendBufferEnterEffect =
+      (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
     Isolinear.Effect.create(~name="exthost.bufferEnter", () =>
       switch (_bufferMetadataToModelAddedDelta(bm, fileType)) {
       | None => ()
@@ -157,7 +159,10 @@ let start = (extensions, setup: Core.Setup.t) => {
         state,
         modelChangedEffect(state.buffers, bu),
       )
-    | Model.Actions.BufferEnter(bm, fileTypeOpt) => (state, sendBufferEnterEffect(bm, fileTypeOpt))
+    | Model.Actions.BufferEnter(bm, fileTypeOpt) => (
+        state,
+        sendBufferEnterEffect(bm, fileTypeOpt),
+      )
     | Model.Actions.Tick(_) => (state, pumpEffect)
     | _ => (state, Isolinear.Effect.none)
     };

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -62,7 +62,7 @@ let start = (extensions, setup: Core.Setup.t) => {
     );
   };
 
-  let onMessage = msg => {
+  let onOutput = msg => {
     Core.Log.info("[ExtHost]: " ++ msg);
   };
 
@@ -74,7 +74,7 @@ let start = (extensions, setup: Core.Setup.t) => {
       ~onStatusBarSetEntry,
       ~onDiagnosticsClear,
       ~onDiagnosticsChangeMany,
-      ~onMessage,
+      ~onOutput,
       setup,
     );
 


### PR DESCRIPTION
This adds an integration to the VSCode extension's [`OutputChannel ` API](https://code.visualstudio.com/api/references/vscode-api#OutputChannel), which is important for debugging - because it allows us to capture logs from the extensions (and exposes logging from language servers, which log through `connection.console`).