### PR TITLE
Fix quickmenu retaining focus after being closed

### DIFF
--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -275,7 +275,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
         }
 
       | _ => (state, Isolinear.Effect.none)
-      }
+      };
 
     | ListSelectBackground =>
       switch (state) {
@@ -295,7 +295,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
       switch (state) {
       | Some({variant: Wildmenu(_), _}) => (None, exitModeEffect)
       | _ => (None, Isolinear.Effect.none)
-      }
+      };
 
     | _ => (state, Isolinear.Effect.none)
     };

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -264,6 +264,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
       )
 
     | ListSelect =>
+      Revery_UI.Focus.loseFocus(); // TODO: Remove once revery-ui/revery#412 has been fixed
       switch (state) {
       | Some({variant: Wildmenu(_), _}) => (None, executeVimCommandEffect)
 
@@ -290,6 +291,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
       }
 
     | QuickmenuClose =>
+      Revery_UI.Focus.loseFocus(); // TODO: Remove once revery-ui/revery#412 has been fixed
       switch (state) {
       | Some({variant: Wildmenu(_), _}) => (None, exitModeEffect)
       | _ => (None, Isolinear.Effect.none)

--- a/src/UI/QuickmenuView.re
+++ b/src/UI/QuickmenuView.re
@@ -10,18 +10,6 @@ module Constants = {
 
 let component = React.component("Quickmenu");
 
-let loseFocusOnClose = isOpen =>
-  /**
-   TODO: revery-ui/revery#412 if the menu is hidden abruptly the element is not automatically unfocused
-   as revery is unaware the element is no longer in focus
- */
-  (
-    switch (Focus.focused, isOpen) {
-    | ({contents: Some(_)}, false) => Focus.loseFocus()
-    | (_, _) => ()
-    }
-  );
-
 module Styles = {
   let container = (theme: Theme.t) =>
     Style.[


### PR DESCRIPTION
This fixes a bug introduced in #914 where closing the menu in any way other than pressing `Esc` would retain focus, and therefore not forward input to `libvim`. This is a known bug in revery-ui/revery#412, which had a workaround that was only partly removed and not replaced.