### PR TITLE
Test: Bump timeout for exthost initialization test

### DIFF
--- a/test/Extensions/ExtensionClientHelper.re
+++ b/test/Extensions/ExtensionClientHelper.re
@@ -98,10 +98,13 @@ let withExtensionClient =
       setup,
     );
 
-  Oni_Core.Utility.waitForCondition(() => {
-    ExtHostClient.pump(v);
-    initialized^;
-  });
+  Oni_Core.Utility.waitForCondition(
+    ~timeout=30.0,
+    () => {
+      ExtHostClient.pump(v);
+      initialized^;
+    },
+  );
 
   if (! initialized^) {
     failwith("extension host client did not initialize successfully");


### PR DESCRIPTION
On Windows, sometimes the exthost doesn't initialize within the timeout in the unit tests. This bumps the timeout to give some breathing room for that initialization step.