### PR TITLE
Input: Support loading / reloading of keybindings.json

### DIFF
--- a/src/Core/ConfigurationDefaults.re
+++ b/src/Core/ConfigurationDefaults.re
@@ -43,26 +43,10 @@ let getDefaultConfigString = configName =>
     Some(
       {|
 [
-    { "key": "<C-TAB>", "command": "workbench.action.openNextRecentlyUsedEditorInGroup", "when": "editorTextFocus" },
-    { "key": "<C-P>", "command": "workbench.action.quickOpen", "when": "editorTextFocus" },
-    { "key": "<D-P>", "command": "workbench.action.quickOpen", "when": "editorTextFocus" },
-    { "key": "<S-C-P>", "command": "workbench.action.showCommands", "when": "editorTextFocus" },
-    { "key": "<D-S-P>", "command": "workbench.action.showCommands", "when": "editorTextFocus" },
-    { "key": "<C-V>", "command": "editor.action.clipboardPasteAction", "when": "insertMode" },
-    { "key": "<D-V>", "command": "editor.action.clipboardPasteAction", "when": "insertMode" },
-    { "key": "<ESC>", "command": "workbench.action.closeQuickOpen", "when": "inQuickOpen" },
-    { "key": "<C-N>", "command": "list.focusDown", "when": "listFocus || textInputFocus" },
-    { "key": "<C-P>", "command": "list.focusUp", "when": "listFocus || textInputFocus" },
-    { "key": "<D-N>", "command": "list.focusDown", "when": "listFocus || textInputFocus" },
-    { "key": "<D-P>", "command": "list.focusUp", "when": "listFocus || textInputFocus" },
-    { "key": "<TAB>", "command": "list.focusDown", "when": "listFocus || textInputFocus" },
-    { "key": "<S-TAB>", "command": "list.focusUp", "when": "listFocus || textInputFocus" },
-    { "key": "<CR>", "command": "list.select", "when": "listFocus || textInputFocus" },
-    { "key": "<S-C-B>", "command": "explorer.toggle", "when": "editorTextFocus"},
-    { "key": "<C-P>", "command": "selectPrevSuggestion", "when": "suggestWidgetVisible" },
-    { "key": "<C-N>", "command": "selectNextSuggestion", "when": "suggestWidgetVisible" },
-    { "key": "<CR>", "command": "insertBestCompletion", "when": "suggestWidgetVisible" },
-    { "key": "<TAB>", "command": "insertBestCompletion", "when": "suggestWidgetVisible" }
+  // See the onivim documentation for details on the format:
+  // https://onivim.github.io/docs/configuration/key-bindings
+  // Add key bindings here:
+  { "key": "<TAB>", "command": "workbench.action.quickOpen", when: "editorTextFocus" },
 ]
 |},
     )

--- a/src/Input/Keybindings.re
+++ b/src/Input/Keybindings.re
@@ -39,7 +39,7 @@ module Keybinding = {
   };
 };
 
-let default = [];
+let empty = [];
 
 type t = list(Keybinding.t);
 
@@ -90,31 +90,3 @@ let of_yojson_with_errors:
       Ok((bindings, errors));
     };
   };
-
-let getDefaultConfig = () => {
-  switch (ConfigurationDefaults.getDefaultConfigString("keybindings.json")) {
-  | Some(c) =>
-    let parsedBindings = Yojson.Safe.from_string(c) |> of_yojson_with_errors;
-
-    switch (parsedBindings) {
-    | Error(msg) => Error(msg)
-    // TODO: Bubble up individual key errors as notifications
-    | Ok((bindings, errors)) =>
-      List.iter(
-        err => Log.error("Error parsing keybinding: " ++ err),
-        errors,
-      );
-      Ok(bindings);
-    };
-  | None => Error("Unable to generate config")
-  };
-};
-
-let get = () => {
-  switch (getDefaultConfig()) {
-  | Ok(b) => b
-  | Error(e) =>
-    Log.error("Error parsing keybindings file ------- " ++ e);
-    [];
-  };
-};

--- a/src/Input/Keybindings.rei
+++ b/src/Input/Keybindings.rei
@@ -8,12 +8,7 @@ module Keybinding: {
 
 type t = list(Keybinding.t);
 
-let default: t;
-
-/*
-  [get] reads the keybindings from the file system
- */
-let get: unit => t;
+let empty: t;
 
 /*
    [of_yojson_with_errors] parses the keybindings,

--- a/src/Input/Oni_Input.re
+++ b/src/Input/Oni_Input.re
@@ -7,3 +7,4 @@ module Filter = Filter;
 module Handler = Handler;
 module Keybindings = Keybindings;
 module Parser = Parser;
+module When = When;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -31,6 +31,8 @@ type t =
   | ConfigurationTransform(string, configurationTransformer)
   | DarkModeSet(bool)
   | KeyBindingsSet(Keybindings.t)
+  // Reload keybindings from configuration
+  | KeyBindingsReload
   | HoverShow
   | ChangeMode(Vim.Mode.t)
   | CursorMove(Position.t)

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -69,7 +69,7 @@ let create: unit => t =
     tokenTheme: TokenTheme.empty,
     editorGroups: EditorGroups.create(),
     iconTheme: IconTheme.create(),
-    keyBindings: Keybindings.default,
+    keyBindings: Keybindings.empty,
     keyDisplayer: KeyDisplayer.empty,
     languageInfo: LanguageInfo.create(),
     notifications: Notifications.default,

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -16,27 +16,6 @@ type captureMode =
   | Wildmenu
   | Quickmenu;
 
-let fixedBindings =
-  Keybindings.Keybinding.[
-    {
-      key: "<UP>",
-      command: "list.focusUp",
-      condition:
-        Expression.(Or(Variable("listFocus"), Variable("textInputFocus"))),
-    },
-    {
-      key: "<DOWN>",
-      command: "list.focusDown",
-      condition:
-        Expression.(Or(Variable("listFocus"), Variable("textInputFocus"))),
-    },
-    {
-      key: "<RIGHT>",
-      command: "list.selectBackground",
-      condition: Expression.(Variable("quickmenuCursorEnd")),
-    },
-  ];
-
 let isQuickmenuOpen = (state: State.t) => state.quickmenu != None;
 
 let conditionsOfState = (state: State.t) => {
@@ -104,7 +83,7 @@ let start =
           Handler.matchesCondition(condition, inputKey, key, getValue)
             ? [Actions.Command(command)] : defaultAction,
         [],
-        fixedBindings @ bindings,
+        bindings,
       )
     );
   };

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -1,0 +1,199 @@
+/*
+ * KeyBindingsStoreConnector.re
+ *
+ * This implements an updater (reducer + side effects) for managing key bindings
+ */
+
+open Oni_Core;
+open Oni_Input;
+open Oni_Model;
+
+let start = () => {
+  // Helper function for parsing default expressions
+  let parseExp = stringExpression =>
+    switch (When.parse(stringExpression)) {
+    | Ok(v) => v
+    | Error(msg) => failwith(msg)
+    };
+
+  let defaultBindings =
+    Keybindings.Keybinding.[
+      {
+        key: "<UP>",
+        command: "list.focusUp",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<DOWN>",
+        command: "list.focusDown",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<RIGHT>",
+        command: "list.selectBackground",
+        condition: "quickmenuCursorEnd" |> parseExp,
+      },
+      {
+        key: "<C-TAB>",
+        command: "workbench.action.openNextRecentlyUsedEditorInGroup",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<C-P>",
+        command: "workbench.action.quickOpen",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<D-P>",
+        command: "workbench.action.quickOpen",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<S-C-P>",
+        command: "workbench.action.showCommands",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<D-S-P>",
+        command: "workbench.action.showCommands",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<C-V>",
+        command: "editor.action.clipboardPasteAction",
+        condition: "insertMode" |> parseExp,
+      },
+      {
+        key: "<D-V>",
+        command: "editor.action.clipboardPasteAction",
+        condition: "insertMode" |> parseExp,
+      },
+      {
+        key: "<ESC>",
+        command: "workbench.action.closeQuickOpen",
+        condition: "inQuickOpen" |> parseExp,
+      },
+      {
+        key: "<C-N>",
+        command: "list.focusDown",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<C-P>",
+        command: "list.focusUp",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<D-N>",
+        command: "list.focusDown",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<D-P>",
+        command: "list.focusUp",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<TAB>",
+        command: "list.focusDown",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<S-TAB>",
+        command: "list.focusUp",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<CR>",
+        command: "list.select",
+        condition: "listFocus || textInputFocus" |> parseExp,
+      },
+      {
+        key: "<S-C-B>",
+        command: "explorer.toggle",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<C-P>",
+        command: "selectPrevSuggestion",
+        condition: "suggestWidgetVisible" |> parseExp,
+      },
+      {
+        key: "<C-N>",
+        command: "selectNextSuggestion",
+        condition: "suggestWidgetVisible" |> parseExp,
+      },
+      {
+        key: "<CR>",
+        command: "insertBestCompletion",
+        condition: "suggestWidgetVisible" |> parseExp,
+      },
+      {
+        key: "<TAB>",
+        command: "insertBestCompletion",
+        condition: "suggestWidgetVisible" |> parseExp,
+      },
+    ];
+
+  let reloadConfigOnWritePost = (~configPath, dispatch) => {
+    let _ =
+      Vim.AutoCommands.onDispatch((cmd, buffer) => {
+        let bufferFileName =
+          switch (Vim.Buffer.getFilename(buffer)) {
+          | None => ""
+          | Some(fileName) => fileName
+          };
+        if (bufferFileName == configPath && cmd == Vim.Types.BufWritePost) {
+          Oni_Core.Log.info("Reloading key bindings from: " ++ configPath);
+          dispatch(Actions.KeyBindingsReload);
+        };
+      });
+    ();
+  };
+
+  let loadKeyBindingsEffect = isFirstLoad =>
+    Isolinear.Effect.createWithDispatch(~name="keyBindings.load", dispatch => {
+      let keyBindingsFile =
+        Filesystem.getOrCreateConfigFile("keybindings.json");
+
+      let keyBindings =
+        switch (keyBindingsFile) {
+        | Error(msg) =>
+          Log.error("Unable to load keybindings: " ++ msg);
+          Keybindings.empty;
+        | Ok(keyBindingPath) =>
+          if (isFirstLoad) {
+            reloadConfigOnWritePost(~configPath=keyBindingPath, dispatch);
+          };
+
+          let parseResult =
+            Yojson.Safe.from_file(keyBindingPath)
+            |> Keybindings.of_yojson_with_errors;
+
+          switch (parseResult) {
+          | Ok((bindings, _)) => bindings
+          | Error(msg) =>
+            Log.error("Error parsing keybindings: " ++ msg);
+            Keybindings.empty;
+          };
+        };
+
+      Log.info(
+        "Loading "
+        ++ string_of_int(List.length(keyBindings))
+        ++ " keybindings",
+      );
+
+      dispatch(Actions.KeyBindingsSet(defaultBindings @ keyBindings));
+    });
+
+  let updater = (state: State.t, action: Actions.t) => {
+    switch (action) {
+    | Actions.Init => (state, loadKeyBindingsEffect(true))
+    | Actions.KeyBindingsReload => (state, loadKeyBindingsEffect(false))
+    | _ => (state, Isolinear.Effect.none)
+    };
+  };
+
+  updater;
+};

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -124,6 +124,7 @@ let start =
       ~setZoom,
       ~setVsync,
     );
+  let keyBindingsUpdater = KeyBindingsStoreConnector.start();
 
   let ripgrep = Core.Ripgrep.make(setup.rgPath);
 
@@ -160,6 +161,7 @@ let start =
           fontUpdater,
           quickmenuUpdater,
           configurationUpdater,
+          keyBindingsUpdater,
           commandUpdater,
           lifecycleUpdater,
           fileExplorerUpdater,

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -137,7 +137,6 @@ let init = app => {
   });
 
   dispatch(Model.Actions.Init);
-  dispatch(Model.Actions.KeyBindingsSet(Input.Keybindings.get()));
   runEffects();
 
   List.iter(


### PR DESCRIPTION
This is an extension of @CrossR 's work in #875 to load keybindings. 

A few additions on top of #875:
- Move our 'default' built-in bindings to `KeyBindingsStoreConnector`, which we augment when load the file (this also incorporates the `fixed` bindings that were in the handler)
- Add just a scaffold / template for `keybindings.json` to point to docs + add keybindings. We should look at an even nicer experience down the road, but this is at least customizable!
- Support reloading of keybindings like we do for config

__Next steps:__
- We should show error messages when there is a failure to load bindings - there is no indication of parse failures at the moment
- There is a decent amount of duplication between `KeyBindingStoreConnector` and `ConfigurationStoreConnector` - if we have an additional config-strategy , it'll make sense to refactor and consolidate that duplicate logic.