### PR TITLE
IntegrationTest - QuickOpenEventuallyCompletes - Make loading check less strict

### DIFF
--- a/integration_test/QuickOpenEventuallyCompletesTest.re
+++ b/integration_test/QuickOpenEventuallyCompletesTest.re
@@ -21,9 +21,9 @@ runTest(~name="QuickOpen eventually completes", (dispatch, wait, runEffects) => 
   runEffects();
 
   /* Wait for quickmenu 'isLoading' to be true */
-  wait(~name="Quickmenu is loading is true", (state: State.t) =>
+  wait(~name="Quickmenu is open", (state: State.t) =>
     switch (state.quickmenu) {
-    | Some({filterProgress: InProgress(_), _}) => true
+    | Some(_) => true
     | _ => false
     }
   );


### PR DESCRIPTION
This check:
```
[INFO]  WAITER (Quickmenu is loading is true): Iteration: 1
``` 
was failing intermittently on the CI machine.

It looks like, in some cases, the loading finishes quickly - we can see Ripgrep and the  filtering / processing occurring:
```
[DEBUG] [Job] Starting FilterJob
[INFO] [Job] FilterJob ran 1 iterations for 1.00135803223e-05s
[DEBUG] [Job] Detailed report: Name: FilterJob
 - Pending work: - Pending Work
 -- totalItemCount: 0 -- allItems: 1 -- itemsToFilter: 1
 - Completed work: - Completed Work
 -- allFiltered: 0 -- uiFiltered: 0

[DEBUG] [Job] Starting RipgrepProcessorJob
[INFO] [Job] RipgrepProcessorJob ran 1 iterations for 5.00679016113e-06s
[DEBUG] [Job] Detailed report: Name: RipgrepProcessorJob
 - Pending work: Byte chunks left: 0
 - Completed work:  (no printer) 
```

This makes the 'loading' check less strict, and just check for the quickmenu being open (ie, it is not `None`). 

I suspect what is happening is that, in some cases, the menu is being populated before hitting the waiter - so it is no longer `InProgress` but `Finished`.