### PR TITLE
Remove windows publish build cache for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ jobs:
     workingDirectory: _release/win32
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-win.yml
-  - template: .ci/publish-build-cache.yml
+  # - template: .ci/publish-build-cache.yml
 
 - job: ValidateLinuxRelease
   displayName: "Linux: Validate Release"


### PR DESCRIPTION
There is a bug with the windows build cache strategy; but let the MacOS / Linux ones work - so we can at least cache those builds.