### PR TITLE
ExtHost - Commands: Hook up contributed commands

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -51,7 +51,7 @@ function activate(context) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with  registerCommand
 	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
+	let disposable = vscode.commands.registerCommand('developer.oni.helloWorld', () => {
 		// The code you place here will be executed every time your command is executed
 
 		// Display a message box to the user

--- a/extensions/vscode-reasonml/package.json
+++ b/extensions/vscode-reasonml/package.json
@@ -22,24 +22,6 @@
   "activationEvents": ["onLanguage:ocaml", "onLanguage:reason"],
   "main": "./out/src/extension",
   "contributes": {
-    "commands": [
-      {
-        "command": "reason.caseSplit",
-        "title": "Reason: Case Split"
-      },
-      {
-        "command": "reason.showMerlinFiles",
-        "title": "Reason: Show Merlin Files"
-      },
-      {
-        "command": "reason.showAvailableLibraries",
-        "title": "Reason: Show Libraries Available via Dependencies"
-      },
-      {
-        "command": "reason.showProjectEnv",
-        "title": "Reason: Show Environment"
-      }
-    ],
     "configuration": {
       "type": "object",
       "title": "Reason configuration",

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -59,7 +59,11 @@ let start =
     | ("MainThreadTelemetry", "$publicLog", [`String(eventName), json]) =>
       onTelemetry(eventName ++ ":" ++ Yojson.Safe.to_string(json));
       Ok(None);
-    | ("MainThreadMessageService", "$showMessage", [_, `String(s), ..._]) =>
+    | (
+        "MainThreadMessageService",
+        "$showMessage",
+        [_level, `String(s), _extInfo, ..._],
+      ) =>
       onShowMessage(s);
       Ok(None);
     | ("MainThreadExtensionService", "$onDidActivateExtension", [v, ..._]) =>

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -21,6 +21,8 @@ type t =
   | BufferSetModified(int, bool)
   | Command(string)
   | CommandsRegister(list(command))
+  // Execute a contribute command, from an extension
+  | CommandExecuteContributed(string)
   | CompletionStart(completionMeet)
   | CompletionAddItems(completionMeet, list(completionItem))
   | CompletionBaseChanged(string)

--- a/src/Model/Commands.re
+++ b/src/Model/Commands.re
@@ -4,6 +4,8 @@
  * Type definitions for commands.
  */
 
+open Oni_Extensions;
+
 type t = list(Command.t);
 
 let empty = [];
@@ -19,6 +21,28 @@ let getEnabled = (v: t) => {
 
 let toQuickMenu = (v: t) => {
   getEnabled(v) |> List.map(Command.toQuickMenu);
+};
+
+let ofExtensions = (extensions: list(ExtensionScanner.t)) => {
+  open ExtensionContributions;
+  open ExtensionContributions.Commands;
+
+  let getContributedCommands = (v: ExtensionScanner.t) =>
+    v.manifest.contributes.commands;
+
+  let toCommand = (v: ExtensionContributions.Commands.t) => {
+    Command.create(
+      ~name=v.title,
+      ~action=Actions.CommandExecuteContributed(v.command),
+      ~category=v.category,
+      (),
+    );
+  };
+
+  extensions
+  |> List.map(getContributedCommands)
+  |> List.flatten
+  |> List.map(toCommand);
 };
 
 let reduce = (v: t, action: Actions.t) =>

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -98,7 +98,7 @@ let createDefaultCommands = getState => {
   );
 };
 
-let start = getState => {
+let start = (getState, contributedCommands) => {
   let singleActionEffect = (action, name) =>
     Isolinear.Effect.createWithDispatch(~name="command." ++ name, dispatch =>
       dispatch(action)
@@ -248,7 +248,7 @@ let start = getState => {
 
   let setInitialCommands =
     Isolinear.Effect.createWithDispatch(~name="commands.setInitial", dispatch => {
-      let commands = createDefaultCommands(getState);
+      let commands = createDefaultCommands(getState) @ contributedCommands;
       dispatch(CommandsRegister(commands));
     });
 

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -245,7 +245,7 @@ let start = (extensions, setup: Core.Setup.t) => {
 
   let executeContributedCommandEffect = cmd =>
     Isolinear.Effect.create(~name="exthost.executeContributedCommand", () => {
-      ExtHostClient.executeContributedCommand(cmd, extHostClient);
+      ExtHostClient.executeContributedCommand(cmd, extHostClient)
     });
 
   let registerQuitCleanupEffect =

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -96,8 +96,10 @@ let start =
   let extensions = discoverExtensions(setup);
   let languageInfo = Model.LanguageInfo.ofExtensions(extensions);
   let themeInfo = Model.ThemeInfo.ofExtensions(extensions);
+  let contributedCommands = Model.Commands.ofExtensions(extensions);
 
-  let commandUpdater = CommandStoreConnector.start(getState);
+  let commandUpdater =
+    CommandStoreConnector.start(getState, contributedCommands);
   let (vimUpdater, vimStream) =
     VimStoreConnector.start(
       languageInfo,


### PR DESCRIPTION
This hooks up contributed commands (commands specified in an extension's manifest) to be visible and executable from our command palette.