### PR TITLE
ExtHost - Test: Verify buffer updates

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -48,16 +48,6 @@ function activate(context) {
 
     const collection = vscode.languages.createDiagnosticCollection('test');
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('developer.oni.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World!');
-	});
-
     let disposable2 = vscode.workspace.onDidOpenTextDocument((e) => {
         // TODO:
         // Add command / option to toggle this
@@ -66,6 +56,8 @@ function activate(context) {
         //     filename: e.fileName,
         // });
     });
+
+    let latestText = "";
 
     let disposable3 = vscode.workspace.onDidChangeTextDocument((e) => {
         // TODO:
@@ -76,6 +68,10 @@ function activate(context) {
         //     contentChanges: e.contentChanges,
         //     fullText: e.document.getText(),
         // });
+
+        if (e.document) {
+           latestText = e.document.getText().split("\n").join("|");
+        }
 
 		//vscode.window.showInformationMessage('Changed!');
         const document = e.document;
@@ -91,9 +87,26 @@ function activate(context) {
         }
     });
 
-	context.subscriptions.push(disposable);
+	// The command has been defined in the package.json file
+	// Now provide the implementation of the command with  registerCommand
+	// The commandId parameter must match the command field in package.json
+	let disposable4 = vscode.commands.registerCommand('developer.oni.showNotification', () => {
+		// The code you place here will be executed every time your command is executed
+
+		// Display a message box to the user
+		vscode.window.showInformationMessage('Hello from extension!');
+	});
+
+    // Helper command to show buffer text
+    // This helps us create a test case to validate buffer manipulations
+	let disposable5 = vscode.commands.registerCommand('developer.oni.getBufferText', () => {
+		vscode.window.showInformationMessage("fulltext:" + latestText);
+	});
+
 	context.subscriptions.push(disposable2);
 	context.subscriptions.push(disposable3);
+	context.subscriptions.push(disposable4);
+	context.subscriptions.push(disposable5);
 }
 
 // this method is called when your extension is deactivated

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -2,6 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 const path = require('path');
+const os = require('os');
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -70,7 +71,7 @@ function activate(context) {
         // });
 
         if (e.document) {
-           latestText = e.document.getText().split("\n").join("|");
+           latestText = e.document.getText().split(os.EOL).join("|");
         }
 
 		//vscode.window.showInformationMessage('Changed!');

--- a/development_extensions/oni-dev-extension/package.json
+++ b/development_extensions/oni-dev-extension/package.json
@@ -14,8 +14,12 @@
 	"contributes": {
 		"commands": [
 			{
-				"command": "developer.oni.helloWorld",
-				"title": "Hello World"
+				"command": "developer.oni.showNotification",
+				"title": "Onivim - Developer: Show Notification"
+			},
+			{
+				"command": "developer.oni.getBufferText",
+				"title": "Onivim - Developer: Buffer Text"
 			}
 		],
 		"languages": [{

--- a/integration_test/ExtHostBufferUpdatesTest.re
+++ b/integration_test/ExtHostBufferUpdatesTest.re
@@ -1,0 +1,95 @@
+open Oni_Core.Utility;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// This test validates:
+// - The 'oni-dev' extension gets activated
+// - When typing in an 'oni-dev' buffer, the buffer received by the extension host
+// is in sync with the buffer in the main process
+runTest(~name="ExtHostBufferUpdates", (dispatch, wait, _runEffects) => {
+  wait(~name="Capture initial state", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  // Wait until the extension is activated
+  // Give some time for the exthost to start
+  wait(
+    ~timeout=30.0,
+    ~name="Validate the 'oni-dev' extension gets activated",
+    (state: State.t) =>
+    List.exists(
+      id => id == "oni-dev-extension",
+      state.extensions.activatedIds,
+    )
+  );
+
+  // Create a buffer
+  Vim.command("new test.oni-dev");
+
+  // Wait for the oni-dev filetype
+  wait(
+    ~timeout=30.0,
+    ~name="Validate the 'oni-dev' extension gets activated",
+    (state: State.t) => {
+      let fileType =
+        Some(state)
+        |> Option.bind(Selectors.getActiveBuffer)
+        |> Option.bind(Buffer.getFileType);
+
+      switch (fileType) {
+      | Some("oni-dev") => true
+      | _ => false
+      };
+    },
+  );
+
+  // Enter some text
+  Vim.input("i");
+
+  Vim.input("a");
+  Vim.input("<CR>");
+
+  Vim.input("b");
+  Vim.input("<CR>");
+
+  Vim.input("c");
+  Vim.input("<esc>");
+
+  // Helper function to wait for the buffer text to match
+  // The extension maps newlines -> |
+  let waitForTextToMatch = expectedText =>
+    wait(
+      ~timeout=30.0,
+      ~name="Validate buffer text matches: " ++ expectedText,
+      (state: State.t) => {
+        dispatch(
+          Actions.CommandExecuteContributed("developer.oni.getBufferText"),
+        );
+        switch (state.notifications) {
+        | [hd, ..._] => String.equal(hd.message, "fulltext:" ++ expectedText)
+        | [] => false
+        };
+      },
+    );
+
+  // TODO: Do we need to wait to ensure the buffer update gets sent?
+  waitForTextToMatch("a|b|c");
+
+  // Now, delete a line - we had some bugs where deletes were not sync'd properly
+  Vim.input("gg");
+  Vim.input("j");
+  Vim.input("dd");
+
+  waitForTextToMatch("a|c");
+
+  // Undo the change - we also had bugs here!
+  Vim.input("u");
+
+  waitForTextToMatch("a|b|c");
+
+  // Finally, modify a single line
+  Vim.input("gg");
+  Vim.input("Iabc");
+
+  waitForTextToMatch("abca|b|c");
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -9,6 +9,7 @@
            EchoNotificationTest
            EditorFontFromPathTest
            EditorFontValidTest
+           ExtHostBufferUpdatesTest
            ExtHostCompletionTest
            FontSizeChangeTest
            InputIgnoreTest
@@ -46,6 +47,7 @@
         EchoNotificationTest.exe
         EditorFontFromPathTest.exe
         EditorFontValidTest.exe
+        ExtHostBufferUpdatesTest.exe
         ExtHostCompletionTest.exe
         FontSizeChangeTest.exe
         InputIgnoreTest.exe

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -169,7 +169,6 @@ module ModelContentChange = {
   };
 
   let getRangeFromEdit = (bu: BufferUpdate.t) => {
-    prerr_endline("BUFFER UPDATE: " ++ BufferUpdate.show(bu));
     let newLines = Array.length(bu.lines);
     let isInsert = Index.toInt0(bu.endLine) == Index.toInt0(bu.startLine);
 
@@ -201,9 +200,6 @@ module ModelContentChange = {
   let ofBufferUpdate = (bu: BufferUpdate.t, eol: Eol.t) => {
     let (isInsert, range) = getRangeFromEdit(bu);
     let text = joinLines(Eol.toString(eol), bu.lines |> Array.to_list);
-
-    prerr_endline("ISINSERT: " ++ (isInsert ? "true" : "false"));
-    prerr_endline("RANGE: " ++ Range.show(range));
 
     let text = isInsert ? text ++ Eol.toString(eol) : text;
 

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -171,21 +171,18 @@ module ModelContentChange = {
   let getRangeFromEdit = (bu: BufferUpdate.t) => {
     prerr_endline("BUFFER UPDATE: " ++ BufferUpdate.show(bu));
     let newLines = Array.length(bu.lines);
-    let isInsert =
-      Index.toInt0(bu.endLine) == Index.toInt0(bu.startLine);
+    let isInsert = Index.toInt0(bu.endLine) == Index.toInt0(bu.startLine);
 
-    let isDelete =
-      newLines == 0;
+    let isDelete = newLines == 0;
 
     let startLine = Index.toInt0(bu.startLine);
     let endLine = Index.toInt0(bu.endLine);
 
-    let endLine = endLine <= -1 ? 2147483647 : endLine - 1;
-
+    let endLine = endLine <= (-1) ? 2147483647 : endLine - 1;
 
     let endLine = max(endLine, startLine);
-    let endCharacter = (isInsert || isDelete) ? 0 : 2147483647;
-//    let endCharacter = 0;
+    let endCharacter = isInsert || isDelete ? 0 : 2147483647;
+    //    let endCharacter = 0;
 
     let endLine = isDelete ? endLine + 1 : endLine;
 
@@ -205,8 +202,8 @@ module ModelContentChange = {
     let (isInsert, range) = getRangeFromEdit(bu);
     let text = joinLines(Eol.toString(eol), bu.lines |> Array.to_list);
 
-    prerr_endline ("ISINSERT: " ++ (isInsert ? "true": "false"));
-    prerr_endline ("RANGE: " ++ Range.show(range));
+    prerr_endline("ISINSERT: " ++ (isInsert ? "true" : "false"));
+    prerr_endline("RANGE: " ++ Range.show(range));
 
     let text = isInsert ? text ++ Eol.toString(eol) : text;
 

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -169,14 +169,25 @@ module ModelContentChange = {
   };
 
   let getRangeFromEdit = (bu: BufferUpdate.t) => {
+    prerr_endline("BUFFER UPDATE: " ++ BufferUpdate.show(bu));
+    let newLines = Array.length(bu.lines);
     let isInsert =
-      Index.toZeroBasedInt(bu.endLine) == Index.toZeroBasedInt(bu.startLine);
+      Index.toInt0(bu.endLine) == Index.toInt0(bu.startLine);
 
-    let startLine = Index.toZeroBasedInt(bu.startLine);
-    let endLine = Index.toZeroBasedInt(bu.endLine) - 1;
+    let isDelete =
+      newLines == 0;
+
+    let startLine = Index.toInt0(bu.startLine);
+    let endLine = Index.toInt0(bu.endLine);
+
+    let endLine = endLine <= -1 ? 2147483647 : endLine - 1;
+
 
     let endLine = max(endLine, startLine);
-    let endCharacter = isInsert ? 0 : 2147483647;
+    let endCharacter = (isInsert || isDelete) ? 0 : 2147483647;
+//    let endCharacter = 0;
+
+    let endLine = isDelete ? endLine + 1 : endLine;
 
     let range =
       Range.create(
@@ -193,6 +204,9 @@ module ModelContentChange = {
   let ofBufferUpdate = (bu: BufferUpdate.t, eol: Eol.t) => {
     let (isInsert, range) = getRangeFromEdit(bu);
     let text = joinLines(Eol.toString(eol), bu.lines |> Array.to_list);
+
+    prerr_endline ("ISINSERT: " ++ (isInsert ? "true": "false"));
+    prerr_endline ("RANGE: " ++ Range.show(range));
 
     let text = isInsert ? text ++ Eol.toString(eol) : text;
 

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -245,7 +245,7 @@ let start = (extensions, setup: Core.Setup.t) => {
 
   let executeContributedCommandEffect = cmd =>
     Isolinear.Effect.create(~name="exthost.executeContributedCommand", () => {
-      ExtHostClient.executeContributedCommand(cmd, extHostClient)
+      ExtHostClient.executeContributedCommand(cmd, extHostClient);
     });
 
   let registerQuitCleanupEffect =

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -245,7 +245,7 @@ let start = (extensions, setup: Core.Setup.t) => {
 
   let executeContributedCommandEffect = cmd =>
     Isolinear.Effect.create(~name="exthost.executeContributedCommand", () => {
-      ExtHostClient.executeContributedCommand(cmd, extHostClient);
+      ExtHostClient.executeContributedCommand(cmd, extHostClient)
     });
 
   let registerQuitCleanupEffect =


### PR DESCRIPTION
This fixes and adds an integration test for buffer synchronization cases between Onivim 2 <-> VSCode extension host.

This adds a helper command for development that sends the full-text of a buffer back, for debugging and verification.