### PR TITLE
Feature: Add position to OpenFileByPath action

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -80,7 +80,7 @@ type t =
   | ListFocusDown
   | ListSelect
   | ListSelectBackground
-  | OpenFileByPath(string, option(WindowTree.direction))
+  | OpenFileByPath(string, option(WindowTree.direction), option(Position.t))
   | RegisterDockItem(WindowManager.dock)
   | RemoveDockItem(WindowManager.docks)
   | AddDockItem(WindowManager.docks)

--- a/src/Store/ConfigurationStoreConnector.re
+++ b/src/Store/ConfigurationStoreConnector.re
@@ -126,7 +126,7 @@ let start =
     Isolinear.Effect.createWithDispatch(
       ~name="configuration.openFile", dispatch =>
       switch (Filesystem.getOrCreateConfigFile(filePath)) {
-      | Ok(path) => dispatch(Actions.OpenFileByPath(path, None))
+      | Ok(path) => dispatch(Actions.OpenFileByPath(path, None, None))
       | Error(e) => Log.error(e)
       }
     );

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -66,7 +66,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
                category: None,
                name: getDisplayPath(path, currentDirectory),
                command: () => {
-                 Oni_Model.Actions.OpenFileByPath(path, None);
+                 Oni_Model.Actions.OpenFileByPath(path, None, None);
                },
                icon:
                  Oni_Model.FileExplorer.getFileIcon(
@@ -353,7 +353,7 @@ let subscriptions = ripgrep => {
       Actions.{
         category: None,
         name: getDisplayPath(fullPath),
-        command: () => Model.Actions.OpenFileByPath(fullPath, None),
+        command: () => Model.Actions.OpenFileByPath(fullPath, None, None),
         icon:
           Model.FileExplorer.getFileIcon(languageInfo, iconTheme, fullPath),
         highlight: [],

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -240,13 +240,14 @@ let start =
       let command =
         switch (splitType) {
         | Vim.Types.Vertical =>
-          Model.Actions.OpenFileByPath(buf, Some(Model.WindowTree.Vertical))
+          Model.Actions.OpenFileByPath(buf, Some(Model.WindowTree.Vertical), None)
         | Vim.Types.Horizontal =>
           Model.Actions.OpenFileByPath(
             buf,
             Some(Model.WindowTree.Horizontal),
+            None,
           )
-        | Vim.Types.TabPage => Model.Actions.OpenFileByPath(buf, None)
+        | Vim.Types.TabPage => Model.Actions.OpenFileByPath(buf, None, None)
         };
       dispatch(command);
     });
@@ -487,7 +488,7 @@ let start =
       }
     );
 
-  let openFileByPathEffect = (filePath, dir) =>
+  let openFileByPathEffect = (filePath, dir, position) =>
     Isolinear.Effect.create(~name="vim.openFileByPath", () => {
       /* If a split was requested, create that first! */
       switch (dir) {
@@ -511,6 +512,29 @@ let start =
           Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
         | None => None
         };
+
+      open Oni_Core.Utility;
+      open Oni_Core.Types;
+      let () = position
+      |> Option.iter((pos: Position.t) => {
+        open Position;
+        let cursor =
+        Vim.Cursor.create(
+          ~line=Index.toInt1(pos.line), 
+          ~column=Index.toInt0(pos.character),
+          (),
+        );
+        let () = updateActiveEditorCursors([cursor]);
+
+        let topLine: int = max(Index.toInt0(pos.line) - 10, 0);
+
+        let () = getState()
+        |> Model.Selectors.getActiveEditorGroup
+        |> Model.Selectors.getActiveEditor
+        |> Option.map(Model.Editor.getId)
+        |> Option.iter(id => dispatch(Model.Actions.EditorScrollToLine(id, topLine)));
+        ();
+      });
 
       /*
        * If we're splitting, make sure a BufferEnter event gets dispatched.
@@ -762,9 +786,9 @@ let start =
       (state, eff);
 
     | Model.Actions.Init => (state, initEffect)
-    | Model.Actions.OpenFileByPath(path, direction) => (
+    | Model.Actions.OpenFileByPath(path, direction, position) => (
         state,
-        openFileByPathEffect(path, direction),
+        openFileByPathEffect(path, direction, position),
       )
     | Model.Actions.BufferEnter(_)
     | Model.Actions.SetEditorFont(_)

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -240,7 +240,11 @@ let start =
       let command =
         switch (splitType) {
         | Vim.Types.Vertical =>
-          Model.Actions.OpenFileByPath(buf, Some(Model.WindowTree.Vertical), None)
+          Model.Actions.OpenFileByPath(
+            buf,
+            Some(Model.WindowTree.Vertical),
+            None,
+          )
         | Vim.Types.Horizontal =>
           Model.Actions.OpenFileByPath(
             buf,
@@ -512,29 +516,32 @@ let start =
           Some(Model.LanguageInfo.getLanguageFromFilePath(languageInfo, v))
         | None => None
         };
-
       open Oni_Core.Utility;
       open Oni_Core.Types;
-      let () = position
-      |> Option.iter((pos: Position.t) => {
-        open Position;
-        let cursor =
-        Vim.Cursor.create(
-          ~line=Index.toInt1(pos.line), 
-          ~column=Index.toInt0(pos.character),
-          (),
-        );
-        let () = updateActiveEditorCursors([cursor]);
+      let () =
+        position
+        |> Option.iter((pos: Position.t) => {
+             open Position;
+             let cursor =
+               Vim.Cursor.create(
+                 ~line=Index.toInt1(pos.line),
+                 ~column=Index.toInt0(pos.character),
+                 (),
+               );
+             let () = updateActiveEditorCursors([cursor]);
 
-        let topLine: int = max(Index.toInt0(pos.line) - 10, 0);
+             let topLine: int = max(Index.toInt0(pos.line) - 10, 0);
 
-        let () = getState()
-        |> Model.Selectors.getActiveEditorGroup
-        |> Model.Selectors.getActiveEditor
-        |> Option.map(Model.Editor.getId)
-        |> Option.iter(id => dispatch(Model.Actions.EditorScrollToLine(id, topLine)));
-        ();
-      });
+             let () =
+               getState()
+               |> Model.Selectors.getActiveEditorGroup
+               |> Model.Selectors.getActiveEditor
+               |> Option.map(Model.Editor.getId)
+               |> Option.iter(id =>
+                    dispatch(Model.Actions.EditorScrollToLine(id, topLine))
+                  );
+             ();
+           });
 
       /*
        * If we're splitting, make sure a BufferEnter event gets dispatched.

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -204,6 +204,15 @@ let start = getState => {
     | _ => s
     };
 
+  // This effect 'steals' focus from Revery. When we're selecting an active editor,
+  // we want to be sure the editor has focus, not a Revery UI component.
+  let getFocusEffect = Isolinear.Effect.create(
+    ~name="windows.getFocus",
+    () => {
+      Revery.UI.Focus.loseFocus();
+    }
+  );
+
   let updater = (state: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
     | Model.Actions.Tick(_) => (state, Isolinear.Effect.none)
@@ -214,6 +223,8 @@ let start = getState => {
         switch (action) {
         | Init => initializeDefaultViewEffect(state)
         | ConfigurationSet(c) => synchronizeConfiguration(c)
+        // When opening a file, ensure that the active editor is getting focus
+        | OpenFileByPath(_) => getFocusEffect
         | ViewCloseEditor(_) =>
           if (List.length(
                 WindowTree.getSplits(state.windowManager.windowTree),

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -206,12 +206,10 @@ let start = getState => {
 
   // This effect 'steals' focus from Revery. When we're selecting an active editor,
   // we want to be sure the editor has focus, not a Revery UI component.
-  let getFocusEffect = Isolinear.Effect.create(
-    ~name="windows.getFocus",
-    () => {
-      Revery.UI.Focus.loseFocus();
-    }
-  );
+  let getFocusEffect =
+    Isolinear.Effect.create(~name="windows.getFocus", () => {
+      Revery.UI.Focus.loseFocus()
+    });
 
   let updater = (state: Model.State.t, action: Model.Actions.t) =>
     switch (action) {

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -1,7 +1,6 @@
 open Oni_Model;
 open Revery_UI;
 open Oni_Core.Constants;
-open Oni_Core.Types;
 
 let%component make = (~state: State.t, ()) => {
   let%hook () =

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -21,7 +21,7 @@ let%component make = (~state: State.t, ()) => {
       | Node({data: FileSystemNode({isDirectory: false, path, _}), _}, _) =>
         GlobalContext.current().dispatch(SetExplorerTree(tree));
         /* Only open files not directories */
-        GlobalContext.current().dispatch(OpenFileByPath(path, None, Some(Position.ofInt0(10, 10))));
+        GlobalContext.current().dispatch(OpenFileByPath(path, None, None));
       /*
        * If the depth of the clicked node is at the maximum depth its children
        * will have no content so we call the update action which will populate

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -1,6 +1,7 @@
 open Oni_Model;
 open Revery_UI;
 open Oni_Core.Constants;
+open Oni_Core.Types;
 
 let%component make = (~state: State.t, ()) => {
   let%hook () =
@@ -20,7 +21,7 @@ let%component make = (~state: State.t, ()) => {
       | Node({data: FileSystemNode({isDirectory: false, path, _}), _}, _) =>
         GlobalContext.current().dispatch(SetExplorerTree(tree));
         /* Only open files not directories */
-        GlobalContext.current().dispatch(OpenFileByPath(path, None));
+        GlobalContext.current().dispatch(OpenFileByPath(path, None, Some(Position.ofInt0(10, 10))));
       /*
        * If the depth of the clicked node is at the maximum depth its children
        * will have no content so we call the update action which will populate

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -151,7 +151,7 @@ let init = app => {
   runEffects();
 
   List.iter(
-    v => dispatch(Model.Actions.OpenFileByPath(v, None)),
+    v => dispatch(Model.Actions.OpenFileByPath(v, None, None)),
     cliOptions.filesToOpen,
   );
 };


### PR DESCRIPTION
This just adds + tests the new `option(Position.t)` parameter for the `OpenFileByPath` action independently of #971 (Locally, I hooked it up to use a hardcoded position for the file explorer - seemed to work OK now!)