### PR TITLE
Completion: Refactor to carry position in completionMeet 

### DIFF
--- a/src/Core/Types.re
+++ b/src/Core/Types.re
@@ -22,6 +22,8 @@ module Index = {
 
   let ofInt0 = i => ZeroBasedIndex(i);
   let ofInt1 = i => OneBasedIndex(i);
+
+  let equals = (a: t, b: t) => toInt0(a) == toInt0(b);
 };
 
 module EditorSize = {
@@ -91,6 +93,10 @@ module Position = {
   };
 
   let ofInt1 = createFromOneBasedIndices;
+
+  let equals = (a: t, b: t) => {
+    Index.equals(a.line, b.line) && Index.equals(a.character, b.character);
+  };
 };
 
 module BufferUpdate = {

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -117,8 +117,8 @@ and command = {
 }
 and completionMeet = {
   completionMeetBufferId: int,
-  completionMeetLine: int,
-  completionMeetColumn: int,
+  completionMeetLine: Index.t,
+  completionMeetColumn: Index.t,
 }
 and completionItem = {
   completionLabel: string,

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -229,8 +229,14 @@ let start = (extensions, setup: Core.Setup.t) => {
         state,
         (buf, fileType) => {
           let uri = Model.Buffer.getUri(buf);
+          open Model.Actions;
+          open Oni_Core.Types;
           let position =
-            Protocol.OneBasedPosition.ofInt1(~lineNumber=1, ~column=2, ());
+            Protocol.OneBasedPosition.ofInt1(
+              ~lineNumber=completionMeet.completionMeetLine |> Index.toInt1,
+              ~column=completionMeet.completionMeetColumn |> Index.toInt1,
+              (),
+            );
           getAndDispatchCompletions(
             ~fileType,
             ~uri,

--- a/src/Store/MerlinStoreConnector.re
+++ b/src/Store/MerlinStoreConnector.re
@@ -110,9 +110,9 @@ let start = () => {
               ();
               // TODO: Show completion UI
             };
-
-            let cursorLine = meet.completionMeetLine;
-            let position = meet.completionMeetColumn;
+            open Oni_Core.Types;
+            let cursorLine = meet.completionMeetLine |> Index.toInt0;
+            let position = meet.completionMeetColumn |> Index.toInt0;
 
             if (cursorLine < Array.length(lines)
                 && id == meet.completionMeetBufferId) {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -698,28 +698,31 @@ let start =
       let completions = state.completions;
       let bestMatch = Model.Completions.getBestCompletion(completions);
       let meet = Model.Completions.getMeet(completions);
-      switch (bestMatch, meet) {
-      | (Some(completion), Some(meet)) =>
-        let cursorPosition = Vim.Cursor.getPosition();
-        let delta = cursorPosition.column - (meet.completionMeetColumn + 1);
+      Oni_Core.Types.(
+        switch (bestMatch, meet) {
+        | (Some(completion), Some(meet)) =>
+          let cursorPosition = Vim.Cursor.getPosition();
+          let delta =
+            cursorPosition.column - Index.toInt1(meet.completionMeetColumn);
 
-        let idx = ref(delta);
-        while (idx^ >= 0) {
-          let _ = Vim.input("<BS>");
-          decr(idx);
-        };
+          let idx = ref(delta);
+          while (idx^ >= 0) {
+            let _ = Vim.input("<BS>");
+            decr(idx);
+          };
 
-        let latestCursors = ref([]);
-        Zed_utf8.iter(
-          s => {
-            latestCursors := Vim.input(Zed_utf8.singleton(s));
-            ();
-          },
-          completion.completionLabel,
-        );
-        updateActiveEditorCursors(latestCursors^);
-      | _ => ()
-      };
+          let latestCursors = ref([]);
+          Zed_utf8.iter(
+            s => {
+              latestCursors := Vim.input(Zed_utf8.singleton(s));
+              ();
+            },
+            completion.completionLabel,
+          );
+          updateActiveEditorCursors(latestCursors^);
+        | _ => ()
+        }
+      );
     });
 
   let prevViml = ref([]);

--- a/test/Model/CompletionMeetTests.re
+++ b/test/Model/CompletionMeetTests.re
@@ -5,44 +5,49 @@ open Oni_Core.Types;
 module CompletionMeet = Oni_Model.CompletionMeet;
 
 describe("CompletionMeet", ({describe, _}) => {
-  describe("getMeetFromLine", ({test, _}) => {
+  describe("createFromLine", ({test, _}) => {
+    let line0column0 = Position.ofInt0(0, 0);
+    let line0column1 = Position.ofInt0(0, 1);
+    let line0column2 = Position.ofInt0(0, 2);
+    let line0column8 = Position.ofInt0(0, 8);
+
     test("empty line - no meet", ({expect}) => {
       let result =
-        CompletionMeet.getMeetFromLine(~cursor=Index.ofInt0(0), "");
+        CompletionMeet.createFromLine(~cursor=Index.ofInt0(0), "");
       expect.equal(result, None);
     });
 
     test("single character at beginning", ({expect}) => {
       let result =
-        CompletionMeet.getMeetFromLine(~cursor=Index.ofInt0(1), "a");
-      expect.equal(result, Some({index: 0, base: "a"}));
+        CompletionMeet.createFromLine(~cursor=Index.ofInt0(1), "a");
+      expect.equal(result, Some({meet: line0column0, base: "a"}));
     });
 
     test("spaces prior to character", ({expect}) => {
       let result =
-        CompletionMeet.getMeetFromLine(~cursor=Index.ofInt0(1), " a");
-      expect.equal(result, Some({index: 1, base: "a"}));
+        CompletionMeet.createFromLine(~cursor=Index.ofInt0(1), " a");
+      expect.equal(result, Some({meet: line0column1, base: "a"}));
     });
 
     test("longer base", ({expect}) => {
       let result =
-        CompletionMeet.getMeetFromLine(~cursor=Index.ofInt0(4), " abc");
-      expect.equal(result, Some({index: 1, base: "abc"}));
+        CompletionMeet.createFromLine(~cursor=Index.ofInt0(4), " abc");
+      expect.equal(result, Some({meet: line0column1, base: "abc"}));
     });
 
     test("default trigger character", ({expect}) => {
       let result =
-        CompletionMeet.getMeetFromLine(~cursor=Index.ofInt0(1), " .");
-      expect.equal(result, Some({index: 2, base: ""}));
+        CompletionMeet.createFromLine(~cursor=Index.ofInt0(1), " .");
+      expect.equal(result, Some({meet: line0column2, base: ""}));
     });
 
     test("default trigger character with base", ({expect}) => {
       let result =
-        CompletionMeet.getMeetFromLine(
+        CompletionMeet.createFromLine(
           ~cursor=Index.ofInt0(10),
           "console.lo",
         );
-      expect.equal(result, Some({index: 8, base: "lo"}));
+      expect.equal(result, Some({meet: line0column8, base: "lo"}));
     });
   })
 });


### PR DESCRIPTION
This is a refactoring to carry the `Position.t` in the `CompletionMeet.t`, so we have the context (both line / column) available for requesting completions in the exthost.

In addition, this fixes a bug where we were always sending a hard-coded position for completion.

Need for #957 