### PR TITLE
Refactoring: Editor model cleanup

### DIFF
--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -21,7 +21,7 @@ let editorSurfaceMinimalState = () => {
       rootNode,
       <EditorSurface
         isActiveSplit=true
-        editorGroupId
+        editorGroup
         editor=simpleEditor
         state=simpleState
         metrics
@@ -36,7 +36,7 @@ let editorSurfaceThousandLineState = () => {
       rootNode,
       <EditorSurface
         isActiveSplit=true
-        editorGroupId
+        editorGroup
         editor=simpleEditor
         state=thousandLineState
         metrics
@@ -51,7 +51,7 @@ let editorSurfaceThousandLineStateWithIndents = () => {
       rootNode,
       <EditorSurface
         isActiveSplit=true
-        editorGroupId
+        editorGroup
         editor=simpleEditor
         state=thousandLineStateWithIndents
         metrics
@@ -66,7 +66,7 @@ let editorSurfaceHundredThousandLineState = () => {
       rootNode,
       <EditorSurface
         isActiveSplit=true
-        editorGroupId
+        editorGroup
         editor=simpleEditor
         state=hundredThousandLineState
         metrics
@@ -87,7 +87,7 @@ let setupSurfaceThousandLineLayout = () => {
     container,
     <EditorSurface
       isActiveSplit=true
-      editorGroupId
+      editorGroup
       editor=simpleEditor
       state=thousandLineState
       metrics

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -1,6 +1,8 @@
 open Oni_Core;
 open Oni_Model;
 
+module Option = Utility.Option;
+
 let metrics = EditorMetrics.create();
 
 /* Create a state with some editor size */
@@ -10,7 +12,7 @@ let simpleState = {
   Reducer.reduce(
     state,
     Actions.EditorGroupSetSize(
-      state.editorGroups.activeId,
+      EditorGroups.activeGroupId(state.editorGroups),
       Types.EditorSize.create(~pixelWidth=1600, ~pixelHeight=1200, ()),
     ),
   );
@@ -31,7 +33,9 @@ let simpleState =
   );
 
 let simpleEditor = Editor.create();
-let editorGroupId = simpleState.editorGroups.activeId;
+let editorGroup =
+  EditorGroups.getActiveEditorGroup(simpleState.editorGroups)
+  |> Option.value(~default=EditorGroup.create());
 
 let thousandLines =
   Array.make(1000, "This is a buffer with a thousand lines!");

--- a/bench/lib/ReducerBench.re
+++ b/bench/lib/ReducerBench.re
@@ -17,7 +17,7 @@ let doubleEditorSize = () => {
     Reducer.reduce(
       state,
       Actions.EditorGroupSetSize(
-        editorGroupId,
+        editorGroup.editorGroupId,
         Types.EditorSize.create(~pixelWidth=3200, ~pixelHeight=2400, ()),
       ),
     );

--- a/src/Model/Editor.rei
+++ b/src/Model/Editor.rei
@@ -1,0 +1,46 @@
+open Oni_Core;
+open Oni_Core.Types;
+
+type t =
+  Actions.editor = {
+    editorId: EditorId.t,
+    bufferId: int,
+    scrollX: float,
+    scrollY: float,
+    minimapMaxColumnWidth: int,
+    minimapScrollY: float,
+    /*
+     * The maximum line visible in the view.
+     * TODO: This will be dependent on line-wrap settings.
+     */
+    maxLineLength: int,
+    viewLines: int,
+    cursors: list(Vim.Cursor.t),
+    selection: VisualRange.t,
+  };
+
+type scrollbarMetrics = {
+  visible: bool,
+  thumbSize: int,
+  thumbOffset: int,
+};
+
+let create: (~bufferId: int=?, unit) => t;
+
+let getId: t => int;
+let getTopVisibleLine: (t, EditorMetrics.t) => int;
+let getBottomVisibleLine: (t, EditorMetrics.t) => int;
+let getLeftVisibleColumn: (t, EditorMetrics.t) => int;
+let getLayout: (t, EditorMetrics.t) => EditorLayout.t;
+let getPrimaryCursor: t => Position.t;
+let getVisibleView: EditorMetrics.t => int; // TODO: Move to EditorMetrics?
+let getTotalSizeInPixels: (t, EditorMetrics.t) => int;
+let getVerticalScrollbarMetrics: (t, int, EditorMetrics.t) => scrollbarMetrics;
+let getHorizontalScrollbarMetrics:
+  (t, int, EditorMetrics.t) => scrollbarMetrics;
+let pixelPositionToLineColumn:
+  (t, EditorMetrics.t, float, float) => (int, int);
+let getVimCursors: t => list(Vim.Cursor.t);
+let getLinesAndColumns: (t, EditorMetrics.t) => (int, int);
+
+let reduce: (t, Actions.t, EditorMetrics.t) => t;

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -5,63 +5,48 @@
  */
 
 open Oni_Core;
-open Actions;
 
 module EditorGroupId =
   Revery.UniqueId.Make({});
 
-type t = Actions.editorGroup;
+type t =
+  Actions.editorGroup = {
+    editorGroupId: int,
+    activeEditorId: option(int),
+    editors: IntMap.t(Editor.t),
+    bufferIdToEditorId: IntMap.t(int),
+    reverseTabOrder: list(int),
+    metrics: EditorMetrics.t,
+  };
 
 let create: unit => t =
   () => {
-    {
-      editorGroupId: EditorGroupId.getUniqueId(),
-      editors: IntMap.empty,
-      bufferIdToEditorId: IntMap.empty,
-      activeEditorId: None,
-      reverseTabOrder: [],
-      metrics: EditorMetrics.create(),
-    };
+    editorGroupId: EditorGroupId.getUniqueId(),
+    editors: IntMap.empty,
+    bufferIdToEditorId: IntMap.empty,
+    activeEditorId: None,
+    reverseTabOrder: [],
+    metrics: EditorMetrics.create(),
   };
 
-let show = (v: t) => {
-  IntMap.fold(
-    (key, v: Editor.t, prev) =>
-      prev
-      ++ " |Editor: "
-      ++ string_of_int(key)
-      ++ " (buffer: "
-      ++ string_of_int(v.bufferId)
-      ++ ")|",
-    v.editors,
-    "",
-  );
-};
+let getEditorById = (id, model) => IntMap.find_opt(id, model.editors);
 
-let getEditorById = (id: int, v: t) => {
-  IntMap.find_opt(id, v.editors);
-};
+let getMetrics = model => model.metrics;
 
-let getMetrics = (v: t) => v.metrics;
-
-let getActiveEditor = (v: t) => {
-  switch (v.activeEditorId) {
-  | Some(id) =>
-    switch (getEditorById(id, v)) {
-    | Some(v) => Some(v)
-    | None => None
-    }
+let getActiveEditor = model =>
+  switch (model.activeEditorId) {
+  | Some(id) => getEditorById(id, model)
   | None => None
   };
+
+let setActiveEditor = (model, editorId) => {
+  ...model,
+  activeEditorId: Some(editorId),
 };
 
-let setActiveEditor = (v: t, editorId: int) => {
-  {...v, activeEditorId: Some(editorId)};
-};
-
-let getOrCreateEditorForBuffer = (state: t, bufferId: int) => {
+let getOrCreateEditorForBuffer = (state, bufferId) => {
   switch (IntMap.find_opt(bufferId, state.bufferIdToEditorId)) {
-  | Some(v) => (state, v)
+  | Some(editor) => (state, editor)
   | None =>
     let newEditor = Editor.create(~bufferId, ());
     let newState = {
@@ -75,15 +60,14 @@ let getOrCreateEditorForBuffer = (state: t, bufferId: int) => {
   };
 };
 
-let rec getIndexOfElement = (l, elem) => {
-  switch (l) {
+// TODO: Just use List.find_opt?
+let rec _getIndexOfElement = elem =>
+  fun
   | [] => (-1)
-  | [hd, ...tl] => hd === elem ? 0 : getIndexOfElement(tl, elem) + 1
-  };
-};
+  | [hd, ...tl] => hd === elem ? 0 : _getIndexOfElement(elem, tl) + 1;
 
 let _getAdjacentEditor = (editor: int, reverseTabOrder: list(int)) => {
-  switch (getIndexOfElement(reverseTabOrder, editor)) {
+  switch (_getIndexOfElement(editor, reverseTabOrder)) {
   | (-1) => None
   | idx =>
     switch (
@@ -97,22 +81,13 @@ let _getAdjacentEditor = (editor: int, reverseTabOrder: list(int)) => {
   };
 };
 
-let isEmpty = v => {
-  IntMap.is_empty(v.editors);
-};
-
-let isActiveEditor = (state, editorId) => {
-  switch (state.activeEditorId) {
-  | None => false
-  | Some(v) => v == editorId
-  };
-};
+let isEmpty = model => IntMap.is_empty(model.editors);
 
 let removeEditorById = (state, editorId) => {
   switch (IntMap.find_opt(editorId, state.editors)) {
   | None => state
-  | Some(v) =>
-    let bufferId = v.bufferId;
+  | Some(editor) =>
+    let bufferId = editor.bufferId;
     let filteredTabList =
       List.filter(t => editorId != t, state.reverseTabOrder);
     let bufferIdToEditorId =
@@ -133,20 +108,12 @@ let removeEditorById = (state, editorId) => {
         }
       };
 
-    let ret: t = {
+    {
       ...state,
       activeEditorId: newActiveEditorId,
       editors,
       bufferIdToEditorId,
       reverseTabOrder: filteredTabList,
     };
-    ret;
-  };
-};
-
-let removeEditorsForBuffer = (state, bufferId) => {
-  switch (IntMap.find_opt(bufferId, state.bufferIdToEditorId)) {
-  | None => state
-  | Some(v) => removeEditorById(state, v)
   };
 };

--- a/src/Model/EditorGroup.rei
+++ b/src/Model/EditorGroup.rei
@@ -1,0 +1,22 @@
+open Oni_Core;
+
+type t =
+  Actions.editorGroup = {
+    editorGroupId: int,
+    activeEditorId: option(int),
+    editors: IntMap.t(Editor.t), // TODO: internal
+    bufferIdToEditorId: IntMap.t(int), // TODO: internal
+    reverseTabOrder: list(int),
+    metrics: EditorMetrics.t,
+  };
+
+let create: unit => t;
+
+let getMetrics: t => EditorMetrics.t;
+let getActiveEditor: t => option(Editor.t);
+let setActiveEditor: (t, int) => t;
+let getEditorById: (int, t) => option(Editor.t);
+let getOrCreateEditorForBuffer: (t, int) => (t, EditorId.t);
+let removeEditorById: (t, int) => t;
+
+let isEmpty: t => bool;

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -1,0 +1,12 @@
+type t;
+
+let create: unit => t;
+
+let activeGroupId: t => int; // TODO: Should return an option, or be removed entirely
+let getEditorGroupById: (t, int) => option(EditorGroup.t);
+let getActiveEditorGroup: t => option(EditorGroup.t);
+
+let isActive: (t, EditorGroup.t) => bool;
+let isEmpty: (int, t) => bool;
+
+let reduce: (t, Actions.t) => t;

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -34,12 +34,10 @@ let start = getState => {
 
   let initializeDefaultViewEffect = (state: State.t) =>
     Isolinear.Effect.create(~name="windows.init", () => {
-      open WindowManager;
-      open WindowTree;
       open Oni_UI;
 
       let dock =
-        registerDock(
+        WindowManager.registerDock(
           ~order=1,
           ~width=50,
           ~id=MainDock,
@@ -47,12 +45,14 @@ let start = getState => {
           (),
         );
 
-      let editorGroupId = state.editorGroups.activeId;
-
-      let editor = createSplit(~editorGroupId, ());
+      let editor =
+        WindowTree.createSplit(
+          ~editorGroupId=EditorGroups.activeGroupId(state.editorGroups),
+          (),
+        );
 
       let explorer =
-        registerDock(
+        WindowManager.registerDock(
           ~order=2,
           ~width=225,
           ~id=ExplorerDock,

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -62,18 +62,13 @@ let toUiTabs = (editorGroup: Model.EditorGroup.t, buffers: Model.Buffers.t) => {
   List.filter_map(f, editorGroup.reverseTabOrder) |> List.rev;
 };
 
-let make = (~state: State.t, ~windowId: int, ~editorGroupId: int, ()) => {
+let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) => {
   let theme = state.theme;
   let mode = state.mode;
 
-  let editorGroup = Selectors.getEditorGroupById(state, editorGroupId);
   let style = editorViewStyle(theme.background, theme.foreground);
 
-  let isActive =
-    switch (editorGroup) {
-    | None => false
-    | Some(v) => v.editorGroupId == state.editorGroups.activeId
-    };
+  let isActive = EditorGroups.isActive(state.editorGroups, editorGroup);
 
   let overlayStyle =
     Style.[
@@ -83,7 +78,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroupId: int, ()) => {
       right(0),
       bottom(0),
       pointerEvents(`Ignore),
-      backgroundColor(Revery.Color.rgba(0.0, 0., 0., isActive ? 0.0 : 0.1)),
+      backgroundColor(Revery.Color.rgba(0., 0., 0., isActive ? 0. : 0.1)),
     ];
 
   let absoluteStyle =
@@ -99,47 +94,48 @@ let make = (~state: State.t, ~windowId: int, ~editorGroupId: int, ()) => {
       );
     };
 
-  let children =
-    switch (editorGroup) {
-    | None => React.empty
-    | Some((v: EditorGroup.t)) =>
-      let editor = Some(v) |> Selectors.getActiveEditor;
-      let tabs = toUiTabs(v, state.buffers);
-      let uiFont = state.uiFont;
+  let children = {
+    let maybeEditor = EditorGroup.getActiveEditor(editorGroup);
+    let tabs = toUiTabs(editorGroup, state.buffers);
+    let uiFont = state.uiFont;
 
-      let metrics = v.metrics;
+    let metrics = editorGroup.metrics;
 
-      let editorView =
-        switch (editor) {
-        | Some(v) =>
-          <EditorSurface
-            isActiveSplit=isActive
-            editorGroupId
-            metrics
-            editor=v
-            state
-          />
-        | None => React.empty
-        };
-      switch (showTabs) {
-      | false => editorView
-      | true =>
-        React.listToElement([
-          <Tabs
-            active=isActive
-            activeEditorId={v.activeEditorId}
-            theme
-            tabs
-            mode
-            uiFont
-          />,
-          editorView,
-        ])
+    let editorView =
+      switch (maybeEditor) {
+      | Some(editor) =>
+        <EditorSurface
+          isActiveSplit=isActive
+          editorGroup
+          metrics
+          editor
+          state
+        />
+      | None => React.empty
       };
+
+    switch (showTabs) {
+    | false => editorView
+    | true =>
+      React.listToElement([
+        <Tabs
+          active=isActive
+          activeEditorId={editorGroup.activeEditorId}
+          theme
+          tabs
+          mode
+          uiFont
+        />,
+        editorView,
+      ])
     };
+  };
 
   let onMouseDown = _ => {
-    GlobalContext.current().setActiveWindow(windowId, editorGroupId);
+    GlobalContext.current().setActiveWindow(
+      windowId,
+      editorGroup.editorGroupId,
+    );
   };
 
   <View onMouseDown style>

--- a/src/UI/EditorLayoutView.re
+++ b/src/UI/EditorLayoutView.re
@@ -73,11 +73,16 @@ let renderTree = (state, tree) => {
            width(item.width),
            height(item.height),
          ]>
-         <EditorGroupView
-           state
-           windowId={item.split.id}
-           editorGroupId={item.split.editorGroupId}
-         />
+         {switch (
+            EditorGroups.getEditorGroupById(
+              state.editorGroups,
+              item.split.editorGroupId,
+            )
+          ) {
+          | Some(editorGroup) =>
+            <EditorGroupView state windowId={item.split.id} editorGroup />
+          | None => React.empty
+          }}
        </View>
      )
   |> React.listToElement;

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -186,7 +186,7 @@ let%component make =
               (
                 ~state: State.t,
                 ~isActiveSplit: bool,
-                ~editorGroupId: int,
+                ~editorGroup: EditorGroup.t,
                 ~metrics: EditorMetrics.t,
                 ~editor: Editor.t,
                 (),
@@ -404,7 +404,7 @@ let%component make =
   let onDimensionsChanged =
       ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
     GlobalContext.current().notifyEditorSizeChanged(
-      ~editorGroupId,
+      ~editorGroupId=editorGroup.editorGroupId,
       ~width,
       ~height,
       (),

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -24,11 +24,15 @@ let make = (~state: State.t, ()) => {
 
   if (state.zenMode) {
     <View style>
-      <EditorGroupView
-        state
-        windowId={state.windowManager.activeWindowId}
-        editorGroupId={state.editorGroups.activeId}
-      />
+      {switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
+       | Some(editorGroup) =>
+         <EditorGroupView
+           state
+           windowId={state.windowManager.activeWindowId}
+           editorGroup
+         />
+       | None => React.empty
+       }}
     </View>;
   } else {
     <View style> <EditorLayoutView state /> </View>;


### PR DESCRIPTION
I might have gotten a bit carried away with this, but to my defense I _wanted_ to go a lot further! Initially I just wanted to add a few interfaces to get a better overview of what's in each module, but then it snowballed a bit.

The changes are roughly as follows:
- Add .rei
- Hide internal implementation details as much as possible, to have better control of potential invariants and to have the flexibility to change it without breaking external code.
- Mirror the type definition from `Actions`  so it's easier to look up, so `open Actions` isn't needed to bring the fields into scope and so unnecessary type annotations can be removed in the implementation. That the type is initially defined elsewhere is now a minor detail that doesn't otherwise affect how it's used.
- Replace non-descriptive abbreviations with more descriptive names. Especially every occurrence of `v`, which sometimes had multiple different meanings in a single function.
- Remove unnecessary `open`s that pollute the namespace and obscure the origin of functions. At the top level, generally only modules that are explicitly designed to be opened should be.
- Pass the model down through the view, instead of an id that needs to be looked up later.
- Some unused functions have been removed, but it might be that they ought to be commented out or exposed for debugging purposes, for example, but then they ought to have names that reflect their purpose.

Longer term I'd like to remove all type definitions (except `t` of course) from `Actions`, as having them there prevents proper encapsulation and hiding of internal state. As far as I can see, the only reason they're there is because some modules contain a `reducer` function which depends on `Actions`, causing a dependency cycle. I don't think `reducer ` functions should be associated with specific models, however, and might be better to move them to the `Store` project. If there are dependency cycles between other types, it might be better to use recursive modules defined together, and then include their implementations in separate "module files" which hides the recursion behind its interface.