### PR TITLE
Refactoring - Syntax Highlighting: Use packed module

### DIFF
--- a/src/Syntax/NativeSyntaxHighlights.re
+++ b/src/Syntax/NativeSyntaxHighlights.re
@@ -7,7 +7,7 @@ module ColorizedToken = Core.Types.ColorizedToken;
 module Range = Core.Range;
 
 module type SyntaxHighlighter = {
-  type t; 
+  type t;
 
   let hasPendingWork: t => bool;
   let doWork: t => t;
@@ -22,11 +22,12 @@ module type SyntaxHighlighter = {
 
 type highlighter('a) = (module SyntaxHighlighter with type t = 'a);
 
-type t  =
-| Highlighter({
-    highlighter: highlighter('a),
-    state: 'a
-  }) : t;
+type t =
+  | Highlighter({
+      highlighter: highlighter('a),
+      state: 'a,
+    })
+    : t;
 
 let _hasTreeSitterScope = (configuration, scope: string) => {
   let treeSitterEnabled =
@@ -54,30 +55,21 @@ let doWork = hl => {
   let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
 
   let newState = SyntaxHighlighter.doWork(state);
-  Highlighter({
-    highlighter: (module SyntaxHighlighter),
-    state: newState,
-  })
+  Highlighter({highlighter: (module SyntaxHighlighter), state: newState});
 };
 
 let updateVisibleRanges = (ranges, hl) => {
   let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
 
   let newState = SyntaxHighlighter.updateVisibleRanges(ranges, state);
-  Highlighter({
-    highlighter: (module SyntaxHighlighter),
-    state: newState,
-  });
+  Highlighter({highlighter: (module SyntaxHighlighter), state: newState});
 };
 
 let updateTheme = (theme, hl) => {
   let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
 
   let newState = SyntaxHighlighter.updateTheme(theme, state);
-  Highlighter({
-    highlighter: (module SyntaxHighlighter),
-    state: newState,
-  });
+  Highlighter({highlighter: (module SyntaxHighlighter), state: newState});
 };
 
 let create =
@@ -99,8 +91,8 @@ let create =
         );
       Highlighter({
         highlighter: (module TreeSitterSyntaxHighlights),
-        state: ts
-      })
+        state: ts,
+      });
     }
     : {
       let tm =
@@ -112,7 +104,7 @@ let create =
         );
       Highlighter({
         highlighter: (module TextMateSyntaxHighlights),
-        state: tm
+        state: tm,
       });
     };
 };
@@ -122,10 +114,7 @@ let update =
   let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
 
   let newState = SyntaxHighlighter.update(~bufferUpdate, ~lines, state);
-  Highlighter({
-    highlighter: (module SyntaxHighlighter),
-    state: newState,
-  });
+  Highlighter({highlighter: (module SyntaxHighlighter), state: newState});
 };
 
 let getTokensForLine = (hl: t, line: int) => {

--- a/src/Syntax/NativeSyntaxHighlights.re
+++ b/src/Syntax/NativeSyntaxHighlights.re
@@ -3,13 +3,30 @@
  */
 
 module Core = Oni_Core;
+module ColorizedToken = Core.Types.ColorizedToken;
+module Range = Core.Range;
 
-type t =
-  | TextMate(TextMateSyntaxHighlights.t)
-  | TreeSitter(TreeSitterSyntaxHighlights.t)
-  | None;
+module type SyntaxHighlighter = {
+  type t; 
 
-let default = None;
+  let hasPendingWork: t => bool;
+  let doWork: t => t;
+  let updateVisibleRanges: (list(Range.t), t) => t;
+  let updateTheme: (TokenTheme.t, t) => t;
+
+  let update:
+    (~bufferUpdate: Core.Types.BufferUpdate.t, ~lines: array(string), t) => t;
+
+  let getTokenColors: (t, int) => list(ColorizedToken.t);
+};
+
+type highlighter('a) = (module SyntaxHighlighter with type t = 'a);
+
+type t  =
+| Highlighter({
+    highlighter: highlighter('a),
+    state: 'a
+  }) : t;
 
 let _hasTreeSitterScope = (configuration, scope: string) => {
   let treeSitterEnabled =
@@ -27,39 +44,40 @@ let _hasTreeSitterScope = (configuration, scope: string) => {
   };
 };
 
-let anyPendingWork = v => {
-  switch (v) {
-  | None => false
-  | TextMate(tm) => TextMateSyntaxHighlights.hasPendingWork(tm)
-  | TreeSitter(ts) => TreeSitterSyntaxHighlights.hasPendingWork(ts)
-  };
+let anyPendingWork = hl => {
+  let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
+
+  SyntaxHighlighter.hasPendingWork(state);
 };
 
-let doWork = v => {
-  switch (v) {
-  | None => v
-  | TextMate(tm) => TextMate(TextMateSyntaxHighlights.doWork(tm))
-  | TreeSitter(ts) => TreeSitter(TreeSitterSyntaxHighlights.doWork(ts))
-  };
+let doWork = hl => {
+  let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
+
+  let newState = SyntaxHighlighter.doWork(state);
+  Highlighter({
+    highlighter: (module SyntaxHighlighter),
+    state: newState,
+  })
 };
 
-let updateVisibleRanges = (ranges, v) => {
-  switch (v) {
-  | None => v
-  | TextMate(tm) =>
-    TextMate(TextMateSyntaxHighlights.updateVisibleRanges(ranges, tm))
-  | TreeSitter(ts) =>
-    TreeSitter(TreeSitterSyntaxHighlights.updateVisibleRanges(ranges, ts))
-  };
+let updateVisibleRanges = (ranges, hl) => {
+  let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
+
+  let newState = SyntaxHighlighter.updateVisibleRanges(ranges, state);
+  Highlighter({
+    highlighter: (module SyntaxHighlighter),
+    state: newState,
+  });
 };
 
-let updateTheme = (theme: TokenTheme.t, v) => {
-  switch (v) {
-  | None => v
-  | TextMate(tm) => TextMate(TextMateSyntaxHighlights.updateTheme(theme, tm))
-  | TreeSitter(ts) =>
-    TreeSitter(TreeSitterSyntaxHighlights.updateTheme(theme, ts))
-  };
+let updateTheme = (theme, hl) => {
+  let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
+
+  let newState = SyntaxHighlighter.updateTheme(theme, state);
+  Highlighter({
+    highlighter: (module SyntaxHighlighter),
+    state: newState,
+  });
 };
 
 let create =
@@ -79,7 +97,10 @@ let create =
           ~getTreeSitterScopeMapper,
           lines,
         );
-      TreeSitter(ts);
+      Highlighter({
+        highlighter: (module TreeSitterSyntaxHighlights),
+        state: ts
+      })
     }
     : {
       let tm =
@@ -89,27 +110,26 @@ let create =
           ~getTextmateGrammar,
           lines,
         );
-      TextMate(tm);
+      Highlighter({
+        highlighter: (module TextMateSyntaxHighlights),
+        state: tm
+      });
     };
 };
 
 let update =
-    (~bufferUpdate: Core.Types.BufferUpdate.t, ~lines: array(string), v: t) => {
-  switch (v) {
-  | TextMate(tm) =>
-    TextMate(TextMateSyntaxHighlights.update(~bufferUpdate, ~lines, tm))
-  | TreeSitter(ts) =>
-    let newTs: TreeSitterSyntaxHighlights.t =
-      TreeSitterSyntaxHighlights.update(~bufferUpdate, ~lines, ts);
-    TreeSitter(newTs);
-  | _ => v
-  };
+    (~bufferUpdate: Core.Types.BufferUpdate.t, ~lines: array(string), hl: t) => {
+  let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
+
+  let newState = SyntaxHighlighter.update(~bufferUpdate, ~lines, state);
+  Highlighter({
+    highlighter: (module SyntaxHighlighter),
+    state: newState,
+  });
 };
 
-let getTokensForLine = (v: t, line: int) => {
-  switch (v) {
-  | TextMate(tm) => TextMateSyntaxHighlights.getTokenColors(tm, line)
-  | TreeSitter(ts) => TreeSitterSyntaxHighlights.getTokenColors(ts, line)
-  | _ => []
-  };
+let getTokensForLine = (hl: t, line: int) => {
+  let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;
+
+  SyntaxHighlighter.getTokenColors(state, line);
 };


### PR DESCRIPTION
This uses the packed-module technique like @glennsl used for subscriptions, in order to implement dynamic binding / polymorphism for the syntax highlight strategies. This tucks the implementation behind the `SyntaxHighlighter` type.