### PR TITLE
Switch to using "logs" as the logging framework

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "640bf4194c49658fe04174c1d90b21c2",
+  "checksum": "10cec89139802ac8a01c857b0750ad48",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -966,6 +966,7 @@
         "esy-sdl2@2.0.10004@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/ppx_let@opam:v0.11.0@d6ec0fc1",
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fff65fc424412c0158f42ecae54a55db",
+  "checksum": "640bf4194c49658fe04174c1d90b21c2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -970,7 +970,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@c82ecdb5",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1258,6 +1259,31 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "bench.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.11.0@4aaa7d88": {
@@ -2071,6 +2097,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "bench.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
+        "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:1.13@2381e3c1": {
       "id": "@opam/lambda-term@opam:1.13@2381e3c1",
       "name": "@opam/lambda-term",
@@ -2290,6 +2346,38 @@
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "bench.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/fix@opam:20181206@6f3a1b41": {

--- a/bench.esy.lock/opam/fmt.0.8.8/opam
+++ b/bench.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/bench.esy.lock/opam/logs.0.7.0/opam
+++ b/bench.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/bench.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/bench.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fff65fc424412c0158f42ecae54a55db",
+  "checksum": "640bf4194c49658fe04174c1d90b21c2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -969,7 +969,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@c82ecdb5",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1257,6 +1258,31 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.11.0@4aaa7d88": {
@@ -2070,6 +2096,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
+        "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:1.13@2381e3c1": {
       "id": "@opam/lambda-term@opam:1.13@2381e3c1",
       "name": "@opam/lambda-term",
@@ -2289,6 +2345,38 @@
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/fix@opam:20181206@6f3a1b41": {

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "640bf4194c49658fe04174c1d90b21c2",
+  "checksum": "10cec89139802ac8a01c857b0750ad48",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -965,6 +965,7 @@
         "esy-sdl2@2.0.10004@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/ppx_let@opam:v0.11.0@d6ec0fc1",
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",

--- a/esy.lock/opam/fmt.0.8.8/opam
+++ b/esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/esy.lock/opam/logs.0.7.0/opam
+++ b/esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fff65fc424412c0158f42ecae54a55db",
+  "checksum": "640bf4194c49658fe04174c1d90b21c2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -969,7 +969,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@c82ecdb5",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1257,6 +1258,31 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "integrationtest.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.11.0@4aaa7d88": {
@@ -2071,6 +2097,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "integrationtest.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
+        "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:1.13@2381e3c1": {
       "id": "@opam/lambda-term@opam:1.13@2381e3c1",
       "name": "@opam/lambda-term",
@@ -2290,6 +2346,38 @@
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "integrationtest.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/fix@opam:20181206@6f3a1b41": {

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "640bf4194c49658fe04174c1d90b21c2",
+  "checksum": "10cec89139802ac8a01c857b0750ad48",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -965,6 +965,7 @@
         "esy-sdl2@2.0.10004@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/ppx_let@opam:v0.11.0@d6ec0fc1",
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",

--- a/integrationtest.esy.lock/opam/fmt.0.8.8/opam
+++ b/integrationtest.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/integrationtest.esy.lock/opam/logs.0.7.0/opam
+++ b/integrationtest.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/integrationtest.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/integrationtest.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/package.json
+++ b/package.json
@@ -210,7 +210,8 @@
     "reason-textmate": "^2.1.0",
     "esy-sdl2": "*",
     "@opam/fmt": "^0.8.8",
-    "@opam/logs": "^0.7.0"
+    "@opam/logs": "^0.7.0",
+    "@opam/re": "*"
   },
   "resolutions": {
     "reason-jsonrpc": "github:bryphe/reason-jsonrpc#95f2427",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,9 @@
     "revery": "0.27.0",
     "reason-tree-sitter": "*",
     "reason-textmate": "^2.1.0",
-    "esy-sdl2": "*"
+    "esy-sdl2": "*",
+    "@opam/fmt": "^0.8.8",
+    "@opam/logs": "^0.7.0"
   },
   "resolutions": {
     "reason-jsonrpc": "github:bryphe/reason-jsonrpc#95f2427",

--- a/src/Core/Cli.re
+++ b/src/Core/Cli.re
@@ -48,6 +48,9 @@ let parse = () => {
     [
       ("-f", Unit(Log.enablePrinting), ""),
       ("--nofork", Unit(Log.enablePrinting), ""),
+      ("--debug", Unit(Log.enableDebugLogging), ""),
+      ("--log-file", String(Log.setLogFile), ""),
+      ("--log-filter", String(Log.Namespace.setFilter), ""),
       ("--checkhealth", Unit(HealthCheck.run), ""),
       ("--working-directory", String(setWorkingDirectory), ""),
       ("--extensions-dir", String(setRef(extensionsDir)), ""),

--- a/src/Core/Cli.re
+++ b/src/Core/Cli.re
@@ -57,7 +57,7 @@ let parse = () => {
     "",
   );
 
-  if (! Log.canPrint^) {
+  if (!Log.isPrintingEnabled()) {
     /* On Windows, detach the application from the console if we're not logging to console */
     Utility.freeConsole();
   };

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -96,7 +96,10 @@ module Namespace = {
 };
 
 module DeltaTime = {
-  let pp = (ppf, dt) => Fmt.pf(ppf, "%+5.0fms", dt *. 1000.);
+  let pp = (ppf, dt) =>
+    dt > 10.
+      ? Fmt.pf(ppf, "%+6.2fs", dt) : Fmt.pf(ppf, "%+5.0fms", dt *. 1000.);
+
   let tag = Logs.Tag.def("time", pp);
 };
 

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -122,14 +122,18 @@ let fileReporter =
       | Some(channel) =>
         let ppf = Format.formatter_of_out_channel(channel);
 
-        msgf((~header=?, ~tags as _=?, fmt) => {
+        msgf((~header=?, ~tags=?, fmt) => {
+          let namespace = Option.bind(tags, Tag.find(Namespace.tag));
+
           Format.kfprintf(
             k,
             ppf,
-            "%a@[" ^^ fmt ^^ "@]@.",
+            "%a %a @[" ^^ fmt ^^ "@]@.",
             pp_header,
             (level, header),
-          )
+            Namespace.pp,
+            namespace,
+          );
         });
 
       | None => k()
@@ -173,7 +177,7 @@ let consoleReporter = {
       };
 
       msgf((~header as _=?, ~tags=?, fmt) => {
-        let namespace = Option.bind(tags, Logs.Tag.find(Namespace.tag));
+        let namespace = Option.bind(tags, Tag.find(Namespace.tag));
 
         Format.kfprintf(
           k,

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -250,19 +250,18 @@ let withNamespace = namespace => {
   let logf = (level, msgf) => log(~namespace, level, msgf);
   let log = (level, msg) => logf(level, m => m("%s", msg));
 
-  (
-    (module
-     {
-       let errorf = msgf => logf(Logs.Error, msgf);
-       let error = log(Logs.Error);
-       let warnf = msgf => logf(Logs.Warning, msgf);
-       let warn = log(Logs.Warning);
-       let infof = msgf => logf(Logs.Info, msgf);
-       let info = log(Logs.Info);
-       let debugf = msgf => logf(Logs.Debug, msgf);
-       let debug = log(Logs.Debug);
-     }): (module Logger)
-  );
+  module Log = {
+    let errorf = msgf => logf(Logs.Error, msgf);
+    let error = log(Logs.Error);
+    let warnf = msgf => logf(Logs.Warning, msgf);
+    let warn = log(Logs.Warning);
+    let infof = msgf => logf(Logs.Info, msgf);
+    let info = log(Logs.Info);
+    let debugf = msgf => logf(Logs.Debug, msgf);
+    let debug = log(Logs.Debug);
+  };
+
+  ((module Log): (module Logger));
 };
 
 // init

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -19,7 +19,27 @@ module Option = {
 };
 
 module Constants = {
-  let namespaceStyle = Fmt.(styled(`Fg(`Hi(`Yellow)), string));
+  let colors =
+    Fmt.(
+      [|
+        // `Black
+        `Blue,
+        `Cyan,
+        `Green,
+        `Magenta,
+        `Red,
+        //`White,
+        `Yellow,
+        `Hi(`Black),
+        `Hi(`Blue),
+        `Hi(`Cyan),
+        `Hi(`Green),
+        `Hi(`Magenta),
+        `Hi(`Red),
+        `Hi(`White),
+        `Hi(`Yellow),
+      |]
+    );
 
   module Env = {
     let logFile = "ONI2_LOG_FILE";
@@ -29,10 +49,17 @@ module Constants = {
 
 type msgf('a, 'b) = (format4('a, Format.formatter, unit, 'b) => 'a) => 'b;
 
+let pickColor = i => Constants.colors[i mod Array.length(Constants.colors)];
+
 let namespaceTag = Logs.Tag.def("namespace", Format.pp_print_string);
 
 let pp_namespace = ppf =>
-  Option.iter(Fmt.pf(ppf, "[%a]", Constants.namespaceStyle));
+  Option.iter(namespace => {
+    let color = pickColor(Hashtbl.hash(namespace));
+    let style = Fmt.(styled(`Fg(color), string));
+
+    Fmt.pf(ppf, "[%a]", style, namespace);
+  });
 
 let fileReporter =
   switch (Sys.getenv_opt(Constants.Env.logFile)) {

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -208,7 +208,7 @@ let reporter =
   };
 
 let enablePrinting = () => Logs.set_reporter(reporter);
-let isPrintingEnabled = () => Logs.reporter() === Logs.nop_reporter;
+let isPrintingEnabled = () => Logs.reporter() !== Logs.nop_reporter;
 
 let enableDebugLogging = () =>
   Logs.Src.set_level(Logs.default, Some(Logs.Debug));

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -71,9 +71,12 @@ let enableDebugLogging = () =>
 let isDebugLoggingEnabled = () =>
   Logs.Src.level(Logs.default) == Some(Logs.Debug);
 
-let info = msg => Logs.info(m => m("%s", msg));
-let debug = msgf => Logs.debug(m => m("%s", msgf()));
-let error = msg => Logs.err(m => m("%s", msg));
+let infof = msgf => Logs.info(msgf);
+let info = msg => infof(m => m("%s", msg));
+let debugf = msgf => Logs.debug(msgf);
+let debug = msgf => debugf(m => m("%s", msgf()));
+let errorf = msgf => Logs.err(msgf);
+let error = msg =>errorf(m => m("%s", msg));
 
 let perf = (msg, f) => {
   let startTime = Unix.gettimeofday();

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -4,6 +4,8 @@
  * Simple console logger
  */
 
+type msgf('a, 'b) = (format4('a, Format.formatter, unit, 'b) => 'a) => 'b;
+
 let fileChannel =
   switch (Sys.getenv_opt("ONI2_LOG_FILE")) {
   | Some(v) =>
@@ -71,12 +73,14 @@ let enableDebugLogging = () =>
 let isDebugLoggingEnabled = () =>
   Logs.Src.level(Logs.default) == Some(Logs.Debug);
 
-let infof = msgf => Logs.info(msgf);
+let infof = msgf => Logs.info(m => msgf(m(~header=?None, ~tags=?None)));
 let info = msg => infof(m => m("%s", msg));
-let debugf = msgf => Logs.debug(msgf);
+
+let debugf = msgf => Logs.debug(m => msgf(m(~header=?None, ~tags=?None)));
 let debug = msgf => debugf(m => m("%s", msgf()));
-let errorf = msgf => Logs.err(msgf);
-let error = msg =>errorf(m => m("%s", msg));
+
+let errorf = msgf => Logs.err(m => msgf(m(~header=?None, ~tags=?None)));
+let error = msg => errorf(m => m("%s", msg));
 
 let perf = (msg, f) => {
   let startTime = Unix.gettimeofday();

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -167,7 +167,7 @@ let consoleReporter = {
       };
 
     let style = Fmt.(styled(`Fg(fg), styled(`Bg(bg), pp_level)));
-    Fmt.pf(ppf, "%7a", style, level);
+    Fmt.pf(ppf, "%a", style, level);
   };
 
   Logs.{

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -6,20 +6,20 @@ let isPrintingEnabled: unit => bool;
 let enableDebugLogging: unit => unit;
 let isDebugLoggingEnabled: unit => bool;
 
-let infof: msgf('a, unit) => unit;
 let info: string => unit;
-
-let debugf: msgf('a, unit) => unit;
 let debug: (unit => string) => unit;
-
-let errorf: msgf('a, unit) => unit;
 let error: string => unit;
-
 let perf: (string, unit => 'a) => 'a;
 
 module type Logger = {
+  let errorf: msgf(_, unit) => unit;
+  let error: string => unit;
+  let warnf: msgf(_, unit) => unit;
+  let warn: string => unit;
   let infof: msgf(_, unit) => unit;
   let info: string => unit;
+  let debugf: msgf(_, unit) => unit;
+  let debug: string => unit;
 };
 
 let withNamespace: string => (module Logger);

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -1,0 +1,18 @@
+type msgf('a, 'b) = (format4('a, Format.formatter, unit, 'b) => 'a) => 'b;
+
+let enablePrinting: unit => unit;
+let isPrintingEnabled: unit => bool;
+
+let enableDebugLogging: unit => unit;
+let isDebugLoggingEnabled: unit => bool;
+
+let infof: msgf('a, unit) => unit;
+let info: string => unit;
+
+let debugf: msgf('a, unit) => unit;
+let debug: (unit => string) => unit;
+
+let errorf: msgf('a, unit) => unit;
+let error: string => unit;
+
+let perf: (string, unit => 'a) => 'a;

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -6,26 +6,28 @@ let isPrintingEnabled: unit => bool;
 let enableDebugLogging: unit => unit;
 let isDebugLoggingEnabled: unit => bool;
 
+let setLogFile: string => unit;
+
 let info: string => unit;
 let debug: (unit => string) => unit;
 let error: string => unit;
 let perf: (string, unit => 'a) => 'a;
 
-module Namespace : {
+module Namespace: {
   let isEnabled: string => bool;
 
-  /** 
+  /**
    * setFilter(filters)
-   * 
-   * where `filter` is a comma-separated list of glob patterns to include, 
+   *
+   * where `filter` is a comma-separated list of glob patterns to include,
    * optionally prefixed with a `-` to negate it. A blank string includes
    * everything, and is the default.
-   * 
+   *
    * E.g.
    *   setFilter("Oni2.*, -Revery*")
    */
   let setFilter: string => unit;
-}
+};
 
 module type Logger = {
   let errorf: msgf(_, unit) => unit;

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -11,6 +11,22 @@ let debug: (unit => string) => unit;
 let error: string => unit;
 let perf: (string, unit => 'a) => 'a;
 
+module Namespace : {
+  let isEnabled: string => bool;
+
+  /** 
+   * setFilter(filters)
+   * 
+   * where `filter` is a comma-separated list of glob patterns to include, 
+   * optionally prefixed with a `-` to negate it. A blank string includes
+   * everything, and is the default.
+   * 
+   * E.g.
+   *   setFilter("Oni2.*, -Revery*")
+   */
+  let setFilter: string => unit;
+}
+
 module type Logger = {
   let errorf: msgf(_, unit) => unit;
   let error: string => unit;

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -16,3 +16,10 @@ let errorf: msgf('a, unit) => unit;
 let error: string => unit;
 
 let perf: (string, unit => 'a) => 'a;
+
+module type Logger = {
+  let infof: msgf(_, unit) => unit;
+  let info: string => unit;
+};
+
+let withNamespace: string => (module Logger);

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -16,5 +16,9 @@
         ppx_deriving_yojson.runtime
         reason-jsonrpc
         textmate
+        fmt
+        fmt.tty
+        logs
+        logs.fmt
     )
     (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -20,5 +20,6 @@
         fmt.tty
         logs
         logs.fmt
+        re
     )
     (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -13,6 +13,8 @@ module In = Protocol.IncomingNotifications;
 module Out = Protocol.OutgoingNotifications;
 module Workspace = Protocol.Workspace;
 
+module Log = (val Log.withNamespace("ExtHostClient"));
+
 type t = {transport: ExtHostTransport.t};
 
 type simpleCallback = unit => unit;
@@ -87,12 +89,12 @@ let start =
     | ("MainThreadStatusBar", "$setEntry", args) =>
       In.StatusBar.parseSetEntry(args) |> apply(onStatusBarSetEntry);
       Ok(None);
-    | (s, m, _a) =>
-      Log.error(
-        Printf.sprintf(
+    | (system, method, _a) =>
+      Log.errorf(m => 
+        m(
           "[ExtHostClient] Unhandled message - [%s:%s]: %s",
-          s,
-          m,
+          system,
+          method,
           Yojson.Safe.to_string(`List(_a)),
         ),
       );

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -89,11 +89,11 @@ let start =
     | ("MainThreadStatusBar", "$setEntry", args) =>
       In.StatusBar.parseSetEntry(args) |> apply(onStatusBarSetEntry);
       Ok(None);
-    | (system, method, _a) =>
+    | (scope, method, _argsAsJson) =>
       Log.errorf(m =>
         m(
           "Unhandled message - [%s:%s]: %s",
-          system,
+          scope,
           method,
           Yojson.Safe.to_string(`List(_a)),
         )

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -90,13 +90,13 @@ let start =
       In.StatusBar.parseSetEntry(args) |> apply(onStatusBarSetEntry);
       Ok(None);
     | (system, method, _a) =>
-      Log.errorf(m => 
+      Log.errorf(m =>
         m(
           "[ExtHostClient] Unhandled message - [%s:%s]: %s",
           system,
           method,
           Yojson.Safe.to_string(`List(_a)),
-        ),
+        )
       );
       Ok(None);
     };

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -89,13 +89,13 @@ let start =
     | ("MainThreadStatusBar", "$setEntry", args) =>
       In.StatusBar.parseSetEntry(args) |> apply(onStatusBarSetEntry);
       Ok(None);
-    | (scope, method, _argsAsJson) =>
+    | (scope, method, argsAsJson) =>
       Log.errorf(m =>
         m(
           "Unhandled message - [%s:%s]: %s",
           scope,
           method,
-          Yojson.Safe.to_string(`List(_a)),
+          Yojson.Safe.to_string(`List(argsAsJson)),
         )
       );
       Ok(None);

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -13,7 +13,7 @@ module In = Protocol.IncomingNotifications;
 module Out = Protocol.OutgoingNotifications;
 module Workspace = Protocol.Workspace;
 
-module Log = (val Log.withNamespace("ExtHostClient"));
+module Log = (val Log.withNamespace("Oni2.ExtHostClient"));
 
 type t = {transport: ExtHostTransport.t};
 
@@ -92,7 +92,7 @@ let start =
     | (system, method, _a) =>
       Log.errorf(m =>
         m(
-          "[ExtHostClient] Unhandled message - [%s:%s]: %s",
+          "Unhandled message - [%s:%s]: %s",
           system,
           method,
           Yojson.Safe.to_string(`List(_a)),

--- a/src/Store/FontStoreConnector.re
+++ b/src/Store/FontStoreConnector.re
@@ -7,6 +7,8 @@
 open Oni_Core;
 open Oni_Model;
 
+module Log = (val Log.withNamespace("Oni2.FontStoreConnector"));
+
 let minFontSize = 6;
 let defaultFontFamily = "FiraCode-Regular.ttf";
 let defaultFontSize = 14;
@@ -112,9 +114,7 @@ let start = (~getScaleFactor, ()) => {
                 Utility.executingDirectory ++ defaultFontFamily,
               )
             | Some(v) =>
-              Log.info(
-                "FontStoreConnector::setFont - discovering font: " ++ v,
-              );
+              Log.info("setFont - discovering font: " ++ v);
               Rench.Path.isAbsolute(v)
                 ? (v, v)
                 : {
@@ -125,8 +125,7 @@ let start = (~getScaleFactor, ()) => {
                       v,
                     );
                   Log.info(
-                    "FontStoreConnector::setFont - discovering font at path: "
-                    ++ descriptor.path,
+                    "setFont - discovering font at path: " ++ descriptor.path,
                   );
                   (v, descriptor.path);
                 };
@@ -175,7 +174,7 @@ let start = (~getScaleFactor, ()) => {
       let editorFontSize =
         Configuration.getValue(c => c.editorFontSize, configuration);
 
-      Log.info("FontStoreConnector::synchronizeConfiguration");
+      Log.info("synchronizeConfiguration");
 
       setFont(dispatch, editorFontFamily, editorFontSize);
     });

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -11,6 +11,8 @@ module Model = Oni_Model;
 module State = Model.State;
 module Actions = Model.Actions;
 
+module Log = (val Log.withNamespace("Oni2.InputStoreConnector"));
+
 type captureMode =
   | Normal
   | Wildmenu
@@ -123,11 +125,11 @@ let start =
         | Normal
         | Wildmenu
             when bindingActions == [] && Revery.UI.Focus.focused^ == None =>
-          Log.info("Input::handle - sending raw input: " ++ k);
+          Log.info("handle - sending raw input: " ++ k);
           [Actions.KeyboardInput(k)];
 
         | _ =>
-          Log.info("Input::handle - sending bound actions.");
+          Log.info("handle - sending bound actions.");
           bindingActions;
         };
 
@@ -146,7 +148,7 @@ let start =
   };
 
   switch (window) {
-  | None => Log.info("Input - no window to subscribe to events")
+  | None => Log.info("no window to subscribe to events")
   | Some(window) =>
     let _ignore =
       Revery.Event.subscribe(
@@ -154,8 +156,7 @@ let start =
         keyEvent => {
           let isTextInputActive = isTextInputActive();
           Log.info(
-            "Input - got keydown - text input:"
-            ++ string_of_bool(isTextInputActive),
+            "got keydown - text input:" ++ string_of_bool(isTextInputActive),
           );
           Handler.keyPressToCommand(~isTextInputActive, keyEvent)
           |> keyEventListener;
@@ -166,7 +167,7 @@ let start =
       Revery.Event.subscribe(
         window.onTextInputCommit,
         textEvent => {
-          Log.info("Input - onTextInputCommit: " ++ textEvent.text);
+          Log.info("onTextInputCommit: " ++ textEvent.text);
           keyEventListener(Some(textEvent.text));
         },
       );

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -17,7 +17,10 @@ module Model = Oni_Model;
 
 open Oni_Extensions;
 
-module Log = (val Core.Log.withNamespace("StoreThread"));
+module Log = (val Core.Log.withNamespace("Oni2.StoreThread"));
+module DispatchLog = (
+  val Core.Log.withNamespace("Oni2.StoreThread.dispatch")
+);
 
 let discoverExtensions = (setup: Core.Setup.t, cli: option(Core.Cli.t)) => {
   open Core.Cli;
@@ -42,31 +45,28 @@ let discoverExtensions = (setup: Core.Setup.t, cli: option(Core.Cli.t)) => {
             switch (Core.Filesystem.getExtensionsFolder()) {
             | Ok(p) => Some(p)
             | Error(msg) =>
-              Core.Log.error("Error discovering user extensions: " ++ msg);
+              Log.errorf(m => m("Error discovering user extensions: %s", msg));
               None;
             }
           }
         )
         |> Option.map(p => {
-             Core.Log.info("Searching for user extensions in: " ++ p);
+             Log.infof(m => m("Searching for user extensions in: %s", p));
              p;
            })
         |> Option.map(ExtensionScanner.scan)
         |> Option.value(~default=[]);
 
-      Core.Log.debug(() =>
-        "discoverExtensions - discovered "
-        ++ string_of_int(List.length(userExtensions))
-        ++ " user extensions."
+      Log.debugf(m =>
+        m(
+          "discoverExtensions - discovered %n user extensions.",
+          List.length(userExtensions),
+        )
       );
       [extensions, developmentExtensions, userExtensions] |> List.flatten;
     });
 
-  Core.Log.info(
-    "-- Discovered: "
-    ++ string_of_int(List.length(extensions))
-    ++ " extensions",
-  );
+  Log.infof(m => m("-- Discovered: %n extensions", List.length(extensions)));
 
   extensions;
 };
@@ -218,7 +218,7 @@ let start =
   let rec dispatch = (action: Model.Actions.t) => {
     switch (action) {
     | Tick(_) => () // This gets a bit intense, so ignore it
-    | _ => Log.info("[dispatch]: " ++ Model.Actions.show(action))
+    | _ => DispatchLog.info(Model.Actions.show(action))
     };
 
     let lastState = latestState^;
@@ -245,8 +245,8 @@ let start =
     |> List.filter(e => e != Isolinear.Effect.none)
     |> List.rev
     |> List.iter(e => {
-         Core.Log.debug(() =>
-           "[StoreThread] Running effect: " ++ Isolinear.Effect.getName(e)
+         Log.debugf(m =>
+           m("Running effect: %s", Isolinear.Effect.getName(e))
          );
          Isolinear.Effect.run(e, dispatch);
        });

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -45,7 +45,9 @@ let discoverExtensions = (setup: Core.Setup.t, cli: option(Core.Cli.t)) => {
             switch (Core.Filesystem.getExtensionsFolder()) {
             | Ok(p) => Some(p)
             | Error(msg) =>
-              Log.errorf(m => m("Error discovering user extensions: %s", msg));
+              Log.errorf(m =>
+                m("Error discovering user extensions: %s", msg)
+              );
               None;
             }
           }

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -17,7 +17,7 @@ module Model = Oni_Model;
 
 open Oni_Extensions;
 
-module Log = (val Core.Log.withNamespace("StoreTread"));
+module Log = (val Core.Log.withNamespace("StoreThread"));
 
 let discoverExtensions = (setup: Core.Setup.t, cli: option(Core.Cli.t)) => {
   open Core.Cli;

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -17,6 +17,8 @@ module Model = Oni_Model;
 
 open Oni_Extensions;
 
+module Log = (val Core.Log.withNamespace("StoreTread"));
+
 let discoverExtensions = (setup: Core.Setup.t, cli: option(Core.Cli.t)) => {
   open Core.Cli;
   let extensions =
@@ -216,8 +218,7 @@ let start =
   let rec dispatch = (action: Model.Actions.t) => {
     switch (action) {
     | Tick(_) => () // This gets a bit intense, so ignore it
-    | _ =>
-      Core.Log.info("[StoreThread.dispatch]: " ++ Model.Actions.show(action))
+    | _ => Log.info("[dispatch]: " ++ Model.Actions.show(action))
     };
 
     let lastState = latestState^;

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -12,7 +12,8 @@ module Core = Oni_Core;
 module Input = Oni_Input;
 module Model = Oni_Model;
 module Store = Oni_Store;
-module Log = Core.Log;
+module Log = (val Core.Log.withNamespace("Oni2.Oni2_editor"));
+module ReveryLog = (val Core.Log.withNamespace("Revery"));
 
 let cliOptions = Core.Cli.parse();
 Log.info("Startup: Parsing CLI options complete");
@@ -23,7 +24,7 @@ Log.info("Starting Onivim 2.");
 let init = app => {
   Log.info("Init");
 
-  let _ = Revery.Log.listen((_, msg) => Log.info("[Revery]: " ++ msg));
+  let _ = Revery.Log.listen((_, msg) => ReveryLog.info(msg));
 
   let w =
     App.createWindow(

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -17,6 +17,9 @@ let passthroughString = Arg.String(_ => ());
 let spec = [
   ("-f", Arg.Set(stayAttached), ""),
   ("--nofork", Arg.Set(stayAttached), ""),
+  ("--debug", passthrough, ""),
+  ("--log-file", passthroughString, ""),
+  ("--log-filter", passthroughString, ""),
   ("--checkhealth", passthrough, ""),
   ("--extensions-dir", passthroughString, ""),
   ("--force-device-scale-factor", passthroughFloat, ""),

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0748f36fc410a079f302cb6cd120807a",
+  "checksum": "5b87dc26c58a43fc9aa5e7c9f394f604",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -969,7 +969,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/lwt@opam:4.4.0@0357bb8b", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
         "@opam/camomile@opam:1.0.1@c82ecdb5",
         "@esy-ocaml/reason@github:facebook/reason#474900e@d41d8cd9"
@@ -1257,6 +1258,31 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "test.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.11.0@4aaa7d88": {
@@ -2070,6 +2096,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "test.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.4.0@0357bb8b",
+        "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:1.13@2381e3c1": {
       "id": "@opam/lambda-term@opam:1.13@2381e3c1",
       "name": "@opam/lambda-term",
@@ -2289,6 +2345,38 @@
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "test.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.0@ad1ed40a",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/fix@opam:20181206@6f3a1b41": {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5b87dc26c58a43fc9aa5e7c9f394f604",
+  "checksum": "526964f200af6eb27c02b96fdbaa6891",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.27@d41d8cd9": {
@@ -965,6 +965,7 @@
         "esy-sdl2@2.0.10004@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/ppx_let@opam:v0.11.0@d6ec0fc1",
         "@opam/ppx_deriving_yojson@opam:3.5.1@06a1c37f",
         "@opam/ppx_deriving@opam:4.4@21d6c7a5",

--- a/test.esy.lock/opam/fmt.0.8.8/opam
+++ b/test.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/test.esy.lock/opam/logs.0.7.0/opam
+++ b/test.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/test.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/test.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}


### PR DESCRIPTION
This switches over to using dbuenzli's `logs` library. It's at feature parity and backwards compatible with the old `Log` module, but now also prints in shiny colors!

I've also added some preliminary namespace support using tags as a proof of concept, and I think we should be able to have a namespace hierarchy with both fixed and ad hoc namespaces., filtering and hash-based coloring. I'd like to add that too before merging this, but have to do a bit of research to find a good way to do the filtering first.

- [x] Filtering
- [x] CLI options
- [x] Hash-based coloring of namespaces
- [x] Timing
- [ ] Ad-hoc namespaces?
- [ ] Remove the old non-namespaced logging functions?