### PR TITLE
Fix up reconciliation of HoverView

### DIFF
--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -25,6 +25,20 @@ let fontAwesomeStyle =
 
 let fontAwesomeIcon = ZedBundled.singleton(UChar.of_int(0xF556));
 
+module Styles = {
+  let bufferView = bufferPixelWidth =>
+    Style.[
+      position(`Absolute),
+      top(0),
+      left(0),
+      width(int_of_float(bufferPixelWidth)),
+      bottom(0),
+    ];
+
+  let bufferViewClipped = bufferPixelWidth =>
+    Style.[overflow(`Hidden), ...bufferView(bufferPixelWidth)];
+};
+
 let renderLineNumber =
     (
       fontFamily: string,
@@ -414,16 +428,6 @@ let%component make =
   let bufferPixelWidth =
     layout.lineNumberWidthInPixels +. layout.bufferWidthInPixels;
 
-  let bufferViewStyle =
-    Style.[
-      position(`Absolute),
-      top(0),
-      left(0),
-      width(int_of_float(bufferPixelWidth)),
-      bottom(0),
-      overflow(`Hidden),
-    ];
-
   let minimapPixelWidth =
     layout.minimapWidthInPixels + Constants.default.minimapPadding * 2;
   let minimapViewStyle =
@@ -552,9 +556,11 @@ let%component make =
 
   <View style ref={node => setElementRef(Some(node))} onDimensionsChanged>
     <View
-      style=bufferViewStyle onMouseUp=editorMouseUp onMouseWheel=scrollSurface>
+      style={Styles.bufferViewClipped(bufferPixelWidth)}
+      onMouseUp=editorMouseUp
+      onMouseWheel=scrollSurface>
       <OpenGL
-        style=bufferViewStyle
+        style={Styles.bufferViewClipped(bufferPixelWidth)}
         render={(transform, _ctx) => {
           let count = lineCount;
           let height = metrics.pixelHeight;
@@ -880,13 +886,15 @@ let%component make =
       </View>
     </View>
     minimapLayout
-    <HoverView x=cursorPixelX y=cursorPixelY state />
-    <CompletionsView
-      x=cursorPixelX
-      y=cursorPixelY
-      lineHeight=fontHeight
-      state
-    />
+    <View style={Styles.bufferView(bufferPixelWidth)}>
+      <HoverView x=cursorPixelX y=cursorPixelY state />
+      <CompletionsView
+        x=cursorPixelX
+        y=cursorPixelY
+        lineHeight=fontHeight
+        state
+      />
+    </View>
     <View style=verticalScrollBarStyle>
       <EditorVerticalScrollbar
         state


### PR DESCRIPTION
__Issue:__ When typing text into a css file, the entire buffer would disappear:

![image](https://user-images.githubusercontent.com/13532591/70165762-4fdd2100-1678-11ea-8a2f-d352198c80fe.png)

__Defect:__ This was specific to just CSS files - I couldn't reproduce it in other file types. It turns out that we were getting diagnostics, and this was causing the `<HoverView />` to show up. The `<HoverView />` was the problematic element - even if we just returned `React.empty`, the buffer would disappear (and all buffers would disappear, because there is another bug where the HoverView is not scoped to a particular buffer).

__Fix:__ It appears this was introduced with the latest Revery bump - we might be a hitting case we didn't hit before in the reconciler, with the correct positioning change. I fixed this by 'nesting' the HoverView a level, which would preserve the root `<View />` for the `<EditorSurface />`. I'm not entirely sure why we'd be losing the editor surface now, though.

With the fix, we now get diagnostics showing w/o losing the buffer:
![image](https://user-images.githubusercontent.com/13532591/70166032-ce39c300-1678-11ea-9dfe-7b5b0ad755e1.png)

(we still have the bug where the hover view is popping up in both places, though!)
