### PR TITLE
File explorer focus

### DIFF
--- a/src/Core/BufferUpdate.re
+++ b/src/Core/BufferUpdate.re
@@ -7,7 +7,7 @@ type t = {
   id: int,
   startLine: Index.t,
   endLine: Index.t,
-  lines: array(string),
+  lines: [@opaque] array(string),
   version: int,
 };
 

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -9,8 +9,9 @@ type t = {
 
 [@deriving show({with_path: false})]
 type action =
-  | TreeUpdated([@opaque] FsTreeNode.t)
-  | NodeUpdated(int, [@opaque] FsTreeNode.t)
+  | TreeLoaded([@opaque] FsTreeNode.t)
+  | NodeLoaded(int, [@opaque] FsTreeNode.t)
+  | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t);
 
 module ExplorerId =

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -134,6 +134,6 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
 let initial = {
   tree: None,
   isOpen: true,
-  focus: None,
   scrollOffset: `Start(0.),
+  focus: None,
 };

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -4,6 +4,7 @@ open Oni_Core;
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
+  scrollOffset: float,
   focus: option(string) // path
 };
 
@@ -12,7 +13,8 @@ type action =
   | TreeLoaded([@opaque] FsTreeNode.t)
   | NodeLoaded(int, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
-  | NodeClicked([@opaque] FsTreeNode.t);
+  | NodeClicked([@opaque] FsTreeNode.t)
+  | ScrollOffsetChanged(float);
 
 module ExplorerId =
   UniqueId.Make({});
@@ -129,4 +131,4 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
   );
 };
 
-let initial = {tree: None, isOpen: true, focus: None};
+let initial = {tree: None, isOpen: true, focus: None, scrollOffset: 0.};

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -4,6 +4,7 @@ open Oni_Core;
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
+  focus: option(string) // path
 };
 
 [@deriving show({with_path: false})]
@@ -127,4 +128,4 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
   );
 };
 
-let initial = {tree: None, isOpen: true};
+let initial = {tree: None, isOpen: true, focus: None};

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -4,7 +4,7 @@ open Oni_Core;
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
-  scrollOffset: float,
+  scrollOffset: [ | `Start(float) | `Middle(float)],
   focus: option(string) // path
 };
 
@@ -14,7 +14,7 @@ type action =
   | NodeLoaded(int, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
-  | ScrollOffsetChanged(float);
+  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)]);
 
 module ExplorerId =
   UniqueId.Make({});
@@ -131,4 +131,9 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
   );
 };
 
-let initial = {tree: None, isOpen: true, focus: None, scrollOffset: 0.};
+let initial = {
+  tree: None,
+  isOpen: true,
+  focus: None,
+  scrollOffset: `Start(0.),
+};

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -1,6 +1,7 @@
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
+  focus: option(string) // path
 };
 
 [@deriving show]

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -6,9 +6,10 @@ type t = {
 
 [@deriving show]
 type action =
-  | TreeUpdated(FsTreeNode.t)
-  | NodeUpdated(int, FsTreeNode.t)
-  | NodeClicked(FsTreeNode.t);
+  | TreeLoaded([@opaque] FsTreeNode.t)
+  | NodeLoaded(int, [@opaque] FsTreeNode.t)
+  | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
+  | NodeClicked([@opaque] FsTreeNode.t);
 
 let initial: t;
 

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -1,7 +1,7 @@
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
-  scrollOffset: float,
+  scrollOffset: [ | `Start(float) | `Middle(float)],
   focus: option(string) // path
 };
 
@@ -11,7 +11,7 @@ type action =
   | NodeLoaded(int, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
-  | ScrollOffsetChanged(float);
+  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)]);
 
 let initial: t;
 

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -1,6 +1,7 @@
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
+  scrollOffset: float,
   focus: option(string) // path
 };
 
@@ -9,7 +10,8 @@ type action =
   | TreeLoaded([@opaque] FsTreeNode.t)
   | NodeLoaded(int, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
-  | NodeClicked([@opaque] FsTreeNode.t);
+  | NodeClicked([@opaque] FsTreeNode.t)
+  | ScrollOffsetChanged(float);
 
 let initial: t;
 

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -47,6 +47,38 @@ let directory = (~isOpen=false, path, ~id, ~icon, ~children) => {
   };
 };
 
+let findNodesByLocalPath = (path, tree) => {
+  let pathSegments = path |> String.split_on_char(Filename.dir_sep.[0]);
+
+  let rec loop = (focusedNodes, children, pathSegments) =>
+    switch (pathSegments) {
+    | [] => `Success(focusedNodes |> List.rev)
+    | [pathSegment, ...rest] =>
+      switch (children) {
+      | [] =>
+        let last = focusedNodes |> List.hd;
+        last.id == tree.id ? `Failed : `Partial(last);
+
+      | [node, ...children] =>
+        if (node.displayName == pathSegment) {
+          let children =
+            switch (node.kind) {
+            | Directory({children, _}) => children
+            | File => []
+            };
+          loop([node, ...focusedNodes], children, rest);
+        } else {
+          loop(focusedNodes, children, pathSegments);
+        }
+      }
+    };
+
+  switch (tree.kind) {
+  | Directory({children, _}) => loop([tree], children, pathSegments)
+  | File => `Failed
+  };
+};
+
 let update = (~tree, ~updater, nodeId) => {
   let rec update = tree => {
     switch (tree) {

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -132,7 +132,7 @@ let toggleOpen =
 
 let setOpen =
   fun
-  | {kind: Directory({isOpen, children}), _} as node => {
+  | {kind: Directory({children, _}), _} as node => {
       let kind = Directory({isOpen: true, children});
 
       {...node, kind, expandedSubtreeSize: countExpandedSubtree(kind)};

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -27,6 +27,9 @@ let directory:
   ) =>
   t;
 
+let findNodesByLocalPath:
+  (string, t) => [ | `Success(list(t)) | `Partial(t) | `Failed];
+
 let update: (~tree: t, ~updater: t => t, int) => t;
 let toggleOpenState: t => t;
 

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -31,7 +31,9 @@ let findNodesByLocalPath:
   (string, t) => [ | `Success(list(t)) | `Partial(t) | `Failed];
 
 let update: (~tree: t, ~updater: t => t, int) => t;
-let toggleOpenState: t => t;
+let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;
+let toggleOpen: t => t;
+let setOpen: t => t;
 
 module Model: {
   type nonrec t = t;

--- a/src/Model/Workspace.re
+++ b/src/Model/Workspace.re
@@ -16,3 +16,8 @@ type workspace = {
 type t = option(workspace);
 
 let initial: t = None;
+
+let toRelativePath = (base, path) => {
+  let re = Str.regexp_string(base ++ Filename.dir_sep);
+  Str.replace_first(re, "", path);
+};

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -111,7 +111,7 @@ let start = () => {
     | NodeLoaded(id, node) => (replaceNode(id, node), Isolinear.Effect.none)
 
     | FocusNodeLoaded(id, node) =>
-      openFoldersInPath(replaceNode(id, node), state.fileExplorer.focus);
+      openFoldersInPath(replaceNode(id, node), state.fileExplorer.focus)
 
     | NodeClicked(node) =>
       switch (node) {

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -148,6 +148,18 @@ let start = () => {
           },
           Isolinear.Effect.none,
         )
+      | BufferEnter({filePath, _}, _) => {
+          (
+            {
+              ...state,
+              fileExplorer: {
+                ...state.fileExplorer,
+                focus: filePath,
+              },
+            },
+            eff,
+          );
+        }
 
       | Actions.FileExplorer(action) => updater(state, action)
       | _ => (state, Isolinear.Effect.none),

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -131,6 +131,16 @@ let start = () => {
               ),
         )
       }
+    | ScrollOffsetChanged(scrollOffset) => (
+        {
+          ...state,
+          fileExplorer: {
+            ...state.fileExplorer,
+            scrollOffset,
+          },
+        },
+        Isolinear.Effect.none,
+      )
     };
   };
 

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -31,8 +31,8 @@ let nodeOffsetByPath = (tree, path) => {
   let rec loop = (node: FsTreeNode.t, path) =>
     switch (path) {
     | [] => failwith("Well, this is awkward (ie. unreachable)")
-    | [focus, ...focusTail] =>
-      if (focus != node) {
+    | [(focus: FsTreeNode.t), ...focusTail] =>
+      if (focus.id != node.id) {
         `NotFound(node.expandedSubtreeSize);
       } else {
         switch (node.kind) {

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -221,7 +221,7 @@ let start = () => {
         )
       | BufferEnter({filePath, _}, _) =>
         switch (state.fileExplorer) {
-        | {tree: Some(tree), focus, _} when focus != filePath =>
+        | {focus, _} when focus != filePath =>
           let state = setFocus(filePath, state);
           switch (filePath) {
           | Some(path) => revealPath(state, path)

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -75,8 +75,7 @@ let setScrollOffset = (scrollOffset, state) =>
 let revealPath = (state: State.t, path) => {
   switch (state.fileExplorer.tree, state.workspace) {
   | (Some(tree), Some({workingDirectory, _})) =>
-    let re = Str.regexp_string(workingDirectory ++ Filename.dir_sep);
-    let localPath = path |> Str.replace_first(re, "");
+    let localPath = Workspace.toRelativePath(workingDirectory, path);
 
     switch (FsTreeNode.findNodesByLocalPath(localPath, tree)) {
     // Nothing to do
@@ -182,7 +181,7 @@ let start = () => {
   (
     (state: State.t, action: Actions.t) =>
       switch (action) {
-      // TODO: Should be handle by a more general init mechanism
+      // TODO: Should be handled by a more general init mechanism
       | Init =>
         let cwd = Rench.Environment.getWorkingDirectory();
         let newState = {

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -5,7 +5,7 @@
  */
 
 module Core = Oni_Core;
-module Option = Oni_Core.Utility.Option;
+module Option = Core.Utility.Option;
 module Model = Oni_Model;
 
 module Actions = Model.Actions;
@@ -49,12 +49,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
     });
 
   let makeBufferCommands = (languageInfo, iconTheme, buffers) => {
-    let currentDirectory = Rench.Environment.getWorkingDirectory();
-
-    let getDisplayPath = (fullPath, dir) => {
-      let re = Str.regexp_string(dir ++ Filename.dir_sep);
-      Str.replace_first(re, "", fullPath);
-    };
+    let currentDirectory = Rench.Environment.getWorkingDirectory(); // TODO: This should be workspace-relative
 
     buffers
     |> Core.IntMap.to_seq
@@ -74,9 +69,9 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
            Some(
              Actions.{
                category: None,
-               name: getDisplayPath(path, currentDirectory),
+               name: Model.Workspace.toRelativePath(currentDirectory, path),
                command: () => {
-                 Oni_Model.Actions.OpenFileByPath(path, None, None);
+                 Model.Actions.OpenFileByPath(path, None, None);
                },
                icon:
                  Oni_Model.FileExplorer.getFileIcon(
@@ -363,14 +358,12 @@ let subscriptions = ripgrep => {
   };
 
   let ripgrep = (languageInfo, iconTheme) => {
-    let directory = Rench.Environment.getWorkingDirectory();
-    let re = Str.regexp_string(directory ++ Filename.dir_sep);
-    let getDisplayPath = fullPath => Str.replace_first(re, "", fullPath);
+    let directory = Rench.Environment.getWorkingDirectory(); // TODO: This should be workspace-relative
 
     let stringToCommand = (languageInfo, iconTheme, fullPath) =>
       Actions.{
         category: None,
-        name: getDisplayPath(fullPath),
+        name: Model.Workspace.toRelativePath(directory, fullPath),
         command: () => Model.Actions.OpenFileByPath(fullPath, None, None),
         icon:
           Model.FileExplorer.getFileIcon(languageInfo, iconTheme, fullPath),

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -794,25 +794,22 @@ let start =
       ();
     });
 
-  let updater = (state: State.t, action) => {
+  let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
-    | Actions.ConfigurationSet(configuration) => (
+    | ConfigurationSet(configuration) => (
         state,
         synchronizeViml(configuration),
       )
-    | Actions.Command("editor.action.clipboardPasteAction") => (
+    | Command("editor.action.clipboardPasteAction") => (
         state,
         pasteIntoEditorAction,
       )
-    | Actions.Command("insertBestCompletion") => (
-        state,
-        applyCompletion(state),
-      )
-    | Actions.Command("undo") => (state, undoEffect)
-    | Actions.Command("redo") => (state, redoEffect)
-    | Actions.ListFocusUp
-    | Actions.ListFocusDown
-    | Actions.ListFocus(_) =>
+    | Command("insertBestCompletion") => (state, applyCompletion(state))
+    | Command("undo") => (state, undoEffect)
+    | Command("redo") => (state, redoEffect)
+    | ListFocusUp
+    | ListFocusDown
+    | ListFocus(_) =>
       // IFFY: Depends on the ordering of "updater"s>
       let eff =
         switch (state.quickmenu) {
@@ -824,34 +821,28 @@ let start =
         };
       (state, eff);
 
-    | Actions.Init => (state, initEffect)
-    | Actions.OpenFileByPath(path, direction, location) => (
+    | Init => (state, initEffect)
+    | OpenFileByPath(path, direction, location) => (
         state,
         openFileByPathEffect(path, direction, location),
       )
-    | Actions.BufferEnter(_)
-    | Actions.SetEditorFont(_)
-    | Actions.WindowSetActive(_, _)
-    | Actions.EditorGroupSetSize(_, _) => (
-        state,
-        synchronizeEditorEffect(state),
-      )
-    | Actions.BufferSetIndentation(_, indent) => (
+    | BufferEnter(_)
+    | SetEditorFont(_)
+    | WindowSetActive(_, _)
+    | EditorGroupSetSize(_, _) => (state, synchronizeEditorEffect(state))
+    | BufferSetIndentation(_, indent) => (
         state,
         synchronizeIndentationEffect(indent),
       )
-    | Actions.ViewSetActiveEditor(_) => (
-        state,
-        synchronizeEditorEffect(state),
-      )
-    | Actions.ViewCloseEditor(_) => (state, synchronizeEditorEffect(state))
-    | Actions.KeyboardInput(s) => (state, inputEffect(s))
-    | Actions.CopyActiveFilepathToClipboard => (
+    | ViewSetActiveEditor(_) => (state, synchronizeEditorEffect(state))
+    | ViewCloseEditor(_) => (state, synchronizeEditorEffect(state))
+    | KeyboardInput(s) => (state, inputEffect(s))
+    | CopyActiveFilepathToClipboard => (
         state,
         copyActiveFilepathToClipboardEffect,
       )
 
-    | Actions.VimDirectoryChanged(directory) =>
+    | VimDirectoryChanged(directory) =>
       let newState = {
         ...state,
         workspace:
@@ -868,6 +859,8 @@ let start =
             state.languageInfo,
             state.iconTheme,
             state.configuration,
+            ~onComplete=tree =>
+            Actions.FileExplorer(TreeLoaded(tree))
           ),
           TitleStoreConnector.Effects.updateTitle(newState),
         ]),

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -10,8 +10,8 @@ let make = (~state: State.t, ()) => {
     );
 
   switch (state.fileExplorer) {
-  | {tree: None} => React.empty
-  | {tree: Some(tree), focus} =>
+  | {tree: None, _} => React.empty
+  | {tree: Some(tree), focus, _} =>
     <FileTreeView state focus onNodeClick title="Explorer" tree />
   };
 };

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -9,8 +9,9 @@ let make = (~state: State.t, ()) => {
       FileExplorer(FileExplorer.NodeClicked(node)),
     );
 
-  switch (state.fileExplorer.tree) {
-  | None => React.empty
-  | Some(tree) => <FileTreeView state onNodeClick title="Explorer" tree />
+  switch (state.fileExplorer) {
+  | {tree: None} => React.empty
+  | {tree: Some(tree), focus} =>
+    <FileTreeView state focus onNodeClick title="Explorer" tree />
   };
 };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -1,4 +1,3 @@
-open Oni_Core;
 open Oni_Model;
 
 open Revery;
@@ -63,7 +62,7 @@ let setiIcon = (~icon, ~fontSize as size, ~fg, ()) => {
   />;
 };
 
-let nodeView = (~font: Core.UiFont.t, ~fg, ~bg, ~node: FsTreeNode.t, ()) => {
+let nodeView = (~font: Core.UiFont.t, ~fg, ~node: FsTreeNode.t, ()) => {
   let icon = () =>
     switch (node.icon) {
     | Some(icon) =>
@@ -135,7 +134,7 @@ let make =
       theme
       itemHeight=22
       onClick=onNodeClick>
-      ...{node => <nodeView font bg fg node />}
+      ...{node => <nodeView font fg node />}
     </TreeView>
   </View>;
 };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -116,11 +116,24 @@ let make =
     | _ => None
     };
 
+  let FileExplorer.{scrollOffset, _} = state.fileExplorer;
+  let onScrollOffsetChange = offset =>
+    GlobalContext.current().dispatch(
+      FileExplorer(ScrollOffsetChanged(offset)),
+    );
+
   <View style=Styles.container>
     <View style={Styles.heading(theme)}>
       <Text text=title style={Styles.title(~fg, ~bg, ~font)} />
     </View>
-    <TreeView tree focus theme itemHeight=22 onClick=onNodeClick>
+    <TreeView
+      scrollOffset
+      onScrollOffsetChange
+      tree
+      focus
+      theme
+      itemHeight=22
+      onClick=onNodeClick>
       ...{node => <nodeView font bg fg node />}
     </TreeView>
   </View>;

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -1,9 +1,20 @@
+open Oni_Core;
 open Oni_Model;
 
 open Revery;
 open Revery.UI;
 
 module Core = Oni_Core;
+
+let toNodePath = (workspace: Workspace.workspace, tree, path) => {
+  let localPath = Workspace.toRelativePath(workspace.workingDirectory, path);
+
+  switch (FsTreeNode.findNodesByLocalPath(localPath, tree)) {
+  | `Success(nodes) => Some(nodes)
+  | `Partial(_)
+  | `Failed => None
+  };
+};
 
 module Styles = {
   open Style;
@@ -102,17 +113,7 @@ let make =
 
   let focus =
     switch (focus, state.workspace) {
-    | (Some(path), Some(workspace)) =>
-      let re =
-        Str.regexp_string(workspace.workingDirectory ++ Filename.dir_sep);
-      let localPath = path |> Str.replace_first(re, "");
-
-      switch (FsTreeNode.findNodesByLocalPath(localPath, tree)) {
-      | `Success(nodes) => Some(nodes)
-      | `Partial(_)
-      | `Failed => None
-      };
-
+    | (Some(path), Some(workspace)) => toNodePath(workspace, tree, path)
     | _ => None
     };
 

--- a/src/UI/LocationListView.re
+++ b/src/UI/LocationListView.re
@@ -65,9 +65,7 @@ let item =
       ~item: LocationListItem.t,
       (),
     ) => {
-  let directory = Rench.Environment.getWorkingDirectory();
-  let re = Str.regexp_string(directory ++ Filename.dir_sep);
-  let getDisplayPath = fullPath => Str.replace_first(re, "", fullPath);
+  let workingDirectory = Rench.Environment.getWorkingDirectory(); // TODO: This should be workspace-relative
 
   let onClick = () => {
     GlobalContext.current().dispatch(
@@ -80,7 +78,7 @@ let item =
   let locationText =
     Printf.sprintf(
       "%s:%n - ",
-      getDisplayPath(item.file),
+      Workspace.toRelativePath(workingDirectory, item.file),
       Index.toOneBased(item.location.line),
     );
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -213,6 +213,8 @@ module Make = (Model: TreeModel) => {
                   ~itemHeight,
                   ~initialRowsToRender=10,
                   ~onClick,
+                  ~scrollOffset=?,
+                  ~onScrollOffsetChange=_=>(),
                   ~tree,
                   ~theme,
                   (),
@@ -228,6 +230,16 @@ module Make = (Model: TreeModel) => {
       };
 
     let%hook (scrollTop, setScrollTop) = Hooks.state(0);
+    let setScrollTop = callback =>
+      setScrollTop(scrollTop => {
+        let newScrollTop = callback(scrollTop);
+        onScrollOffsetChange(float(newScrollTop) /. float(itemHeight));
+        newScrollTop;
+      });
+    let scrollTop =
+      scrollOffset
+        |> Option.map(offset => int_of_float(offset *. float(itemHeight)))
+        |> Option.value(~default=scrollTop);
 
     let count = Model.expandedSubtreeSize(tree);
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -3,7 +3,6 @@ open Revery.UI;
 open Revery.UI.Components;
 
 open Oni_Core;
-open Oni_Model;
 
 module Option = Utility.Option;
 
@@ -106,7 +105,7 @@ module Make = (Model: TreeModel) => {
       switch (focus) {
       | Some([last]) when last == node => (true, None)
       | Some([head, ...tail]) when head == node => (false, Some(tail))
-      | Some(v) => (false, None)
+      | Some(_) => (false, None)
       | _ => (false, None)
       };
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -214,7 +214,7 @@ module Make = (Model: TreeModel) => {
                   ~initialRowsToRender=10,
                   ~onClick,
                   ~scrollOffset=?,
-                  ~onScrollOffsetChange=_=>(),
+                  ~onScrollOffsetChange=_ => (),
                   ~tree,
                   ~theme,
                   (),
@@ -238,8 +238,8 @@ module Make = (Model: TreeModel) => {
       });
     let scrollTop =
       scrollOffset
-        |> Option.map(offset => int_of_float(offset *. float(itemHeight)))
-        |> Option.value(~default=scrollTop);
+      |> Option.map(offset => int_of_float(offset *. float(itemHeight)))
+      |> Option.value(~default=scrollTop);
 
     let count = Model.expandedSubtreeSize(tree);
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -55,7 +55,9 @@ module Styles = {
     cursor(Revery.MouseCursors.pointer),
     flexDirection(`Row),
     overflow(`Hidden),
-    backgroundColor(isFocused ? theme.menuSelectionBackground : Colors.transparentWhite),
+    backgroundColor(
+      isFocused ? theme.menuSelectionBackground : Colors.transparentWhite,
+    ),
   ];
 
   let placeholder = (~height) => [Style.height(height)];


### PR DESCRIPTION
This highlights the current buffer in the file explorer, opens all directories in the path to the current buffer and scrolls the view so it's visible. You'd think this would be pretty straight forward, but unfortunately it is not.

One issues is that the path to the current buffer might only be partially loaded. We therefore need to traverse the tree until encountering an unloaded directory, load that asynchronously, wait for the result and then try again. This works fine as it is now, but is a bit complicated.

Another issue is that it should only scroll to the focused item on `BufferEnter`, but currently does so whenever the focus changes AND even just when opening a directory since that updates the tree including node ids and hence causes comparison of the node path to fail. The root issue here is that the scroll position is kept in the `TreeView` component, but the `BufferEnter` event happens outside it. The only solution I've found so far is to move the scroll position out of the component and into the `FileExplorer` model, but since we need pixel precision and only the component knows about that, we need to store the position as a float with whole numbers representing the start of an item, and compute the pixel position from that. We might also want to reuse node ids so tree comparison doesn't break down, although if the scroll position is moved out I don't think we need this here at least.

A third issue is that there seems to be some blocking on `BufferEnter`, causing a delay in updating the explorer until the editor has finished loading and rendering.

There's also room for performance improvement here if needed by using hashing instead of direct string comparison, for example, but unless it's really needed I think this is complicated enough as it is.