### PR TITLE
Fix #1019 - ExtHost / Windows: Diagnostics not showing on windows

### DIFF
--- a/integration_test/LanguageCssTest.re
+++ b/integration_test/LanguageCssTest.re
@@ -59,26 +59,23 @@ runTestWithInput(
 
   input("a");
 
-  // TODO: Fix diagnostics on Windows!
-  if (!Sys.win32) {
-    // Should get an error diagnostic
-    wait(
-      ~timeout=30.0,
-      ~name=
-        "Validate a diagnostic showed up, since our current input is erroneous",
-      (state: State.t) => {
-        let bufferOpt = Selectors.getActiveBuffer(state);
+  // Should get an error diagnostic
+  wait(
+    ~timeout=30.0,
+    ~name=
+      "Validate a diagnostic showed up, since our current input is erroneous",
+    (state: State.t) => {
+      let bufferOpt = Selectors.getActiveBuffer(state);
 
-        switch (bufferOpt) {
-        | Some(buffer) =>
-          let diags =
-            Model.Diagnostics.getDiagnostics(state.diagnostics, buffer);
-          List.length(diags) > 0;
-        | _ => false
-        };
-      },
-    );
-  };
+      switch (bufferOpt) {
+      | Some(buffer) =>
+        let diags =
+          Model.Diagnostics.getDiagnostics(state.diagnostics, buffer);
+        List.length(diags) > 0;
+      | _ => false
+      };
+    },
+  );
 
   // Should've also gotten some completions...
   wait(

--- a/integration_test/LanguageTypeScriptTest.re
+++ b/integration_test/LanguageTypeScriptTest.re
@@ -56,26 +56,23 @@ runTestWithInput(
 
   input("w");
 
-  // TODO: Fix diagnostics on Windows!
-  if (!Sys.win32) {
-    // Should get an error diagnostic
-    wait(
-      ~timeout=30.0,
-      ~name=
-        "Validate a diagnostic showed up, since our current input is erroneous",
-      (state: State.t) => {
-        let bufferOpt = Selectors.getActiveBuffer(state);
+  // Should get an error diagnostic
+  wait(
+    ~timeout=30.0,
+    ~name=
+      "Validate a diagnostic showed up, since our current input is erroneous",
+    (state: State.t) => {
+      let bufferOpt = Selectors.getActiveBuffer(state);
 
-        switch (bufferOpt) {
-        | Some(buffer) =>
-          let diags =
-            Model.Diagnostics.getDiagnostics(state.diagnostics, buffer);
-          List.length(diags) > 0;
-        | _ => false
-        };
-      },
-    );
-  };
+      switch (bufferOpt) {
+      | Some(buffer) =>
+        let diags =
+          Model.Diagnostics.getDiagnostics(state.diagnostics, buffer);
+        List.length(diags) > 0;
+      | _ => false
+      };
+    },
+  );
 
   // Should've also gotten some completions...
   wait(

--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -46,8 +46,67 @@ type t = {
   path: string,
 };
 
-let fromMemory = (path: string) => {scheme: Scheme.Memory, path};
-let fromPath = (path: string) => {scheme: Scheme.File, path};
+let _slash = "/";
+let _slashChar = '/';
+
+let aCode = Char.code('A');
+let zCode = Char.code('Z');
+
+let _isDriveLetter = (candidate: Char.t) => {
+  Char.code(candidate) >= aCode && Char.code(candidate) <= zCode;
+};
+
+let _normalizePath = (scheme: Scheme.t, path: string) => {
+  switch (scheme) {
+  | File =>
+    let pathLen = String.length(path);
+    if (pathLen > 1) {
+      let firstLetter = path.[0];
+      let secondCharacter = path.[1];
+      if (_isDriveLetter(firstLetter) && secondCharacter == ':') {
+        let firstLetterString =
+          String.make(1, Char.lowercase_ascii(firstLetter));
+        firstLetterString ++ ":" ++ String.sub(path, 2, pathLen - 2);
+      } else {
+        path;
+      };
+    } else {
+      path;
+    };
+  | _ => path
+  };
+};
+
+// Port over https://github.com/onivim/vscode-exthost/blob/952a57d2205aba6cabfd277d15787ace3b07f7ba/src/vs/base/common/uri.ts#L75
+// VSCode uses a slash-character as the default base - so a windows-path
+// like C:/test gets stored as /C:test
+let _addSlash = (scheme: Scheme.t, path: string) => {
+  switch (scheme) {
+  | Https
+  | Http
+  | File =>
+    if (String.length(path) == 0) {
+      _slash;
+    } else if (path.[0] != _slashChar) {
+      _slash ++ path;
+    } else {
+      path;
+    }
+  | Memory => path
+  };
+};
+
+let _referenceResolution = (scheme: Scheme.t, path: string) => {
+  path |> _normalizePath(scheme) |> _addSlash(scheme);
+};
+
+let fromScheme = (~scheme: Scheme.t, path: string) => {
+  scheme,
+  path: _referenceResolution(scheme, path),
+};
+
+let fromMemory = fromScheme(~scheme=Scheme.Memory);
+let fromPath = fromScheme(~scheme=Scheme.File);
 
 let toString = (uri: t) => {
   Scheme.toString(uri.scheme) ++ "://" ++ uri.path;

--- a/src/Core/Uri.rei
+++ b/src/Core/Uri.rei
@@ -1,8 +1,9 @@
 module Scheme: {
-  type t;
-
-  let file: t;
-  let memory: t;
+  type t =
+    | File
+    | Http
+    | Https
+    | Memory;
 
   let toString: t => string;
 

--- a/test/Core/UriTests.re
+++ b/test/Core/UriTests.re
@@ -20,6 +20,12 @@ let okOrFail = v =>
   };
 
 describe("Uri", ({describe, _}) => {
+  describe("toString", ({test, _}) => {
+    test("adds slash for windows-style path", ({expect, _}) => {
+      let uri = Uri.fromPath("C:/test");
+      expect.string(Uri.toString(uri)).toEqual("file:///c:/test");
+    })
+  });
   describe("JSON", ({test, _}) => {
     test("parses with scheme as string", ({expect, _}) => {
       let scheme =
@@ -33,5 +39,5 @@ describe("Uri", ({describe, _}) => {
 
       expect.bool(scheme == Uri.Scheme.Memory).toBe(true);
     });
-  })
+  });
 });

--- a/test/Core/UriTests.re
+++ b/test/Core/UriTests.re
@@ -25,13 +25,13 @@ describe("Uri", ({describe, _}) => {
       let scheme =
         Uri.of_yojson(uriSchemeStringJSON) |> okOrFail |> Uri.getScheme;
 
-      expect.bool(scheme == Uri.Scheme.file).toBe(true);
+      expect.bool(scheme == Uri.Scheme.File).toBe(true);
     });
     test("parses with scheme as array", ({expect, _}) => {
       let scheme =
         Uri.of_yojson(uriSchemeArrayJSON) |> okOrFail |> Uri.getScheme;
 
-      expect.bool(scheme == Uri.Scheme.memory).toBe(true);
+      expect.bool(scheme == Uri.Scheme.Memory).toBe(true);
     });
   })
 });

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -7,16 +7,15 @@ open TestFramework;
 open ExtensionClientHelper;
 open ExtHostProtocol;
 
-// Windows extension 
-let normalizeExpectedPath = (path) => {
-  // Windows does a normalization of slashes in the ext host...
+let normalizeExpectedPath = path =>
+  // Windows does a normalization of slashes in the ext host... we need to match this logic
+  // for our verification. For example, if we send it a path like /root/test.txt, it'll send us
+  // back \\root\\test.txt
   if (Sys.win32) {
-    path
-    |> Str.global_replace(Str.regexp_string("/"), "\\");
+    path |> String.split_on_char('/') |> String.concat("\\");
   } else {
-    path
-  }
-};
+    path;
+  };
 
 describe("ExtHostClient", ({describe, _}) => {
   describe("activation", ({test, _}) => {
@@ -115,7 +114,10 @@ describe("ExtHostClient", ({describe, _}) => {
 
       let didGetOpenMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "/root/test.txt" |> normalizeExpectedPath)
+          String.equal(
+            info.filename,
+            "/root/test.txt" |> normalizeExpectedPath,
+          )
           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
         );
 
@@ -152,13 +154,19 @@ describe("ExtHostClient", ({describe, _}) => {
 
       let didGetOpenMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "/root/test.txt" |> normalizeExpectedPath)
+          String.equal(
+            info.filename,
+            "/root/test.txt" |> normalizeExpectedPath,
+          )
           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
         );
 
       let didGetUpdateMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "/root/test.txt" |> normalizeExpectedPath)
+          String.equal(
+            info.filename,
+            "/root/test.txt" |> normalizeExpectedPath,
+          )
           && String.equal(
                info.messageType,
                "workspace.onDidChangeTextDocument",

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -104,7 +104,7 @@ describe("ExtHostClient", ({describe, _}) => {
 
       let didGetOpenMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "test.txt")
+          String.equal(info.filename, "/root/test.txt")
           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
         );
 
@@ -118,7 +118,7 @@ describe("ExtHostClient", ({describe, _}) => {
           ExtHostClient.addDocument(
             createInitialDocumentModel(
               ~lines=["Hello world"],
-              ~path="test.txt",
+              ~path="/root/test.txt",
               (),
             ),
             client,
@@ -141,13 +141,13 @@ describe("ExtHostClient", ({describe, _}) => {
 
       let didGetOpenMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "test.txt")
+          String.equal(info.filename, "/root/test.txt")
           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
         );
 
       let didGetUpdateMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "test.txt")
+          String.equal(info.filename, "/root/test.txt")
           && String.equal(
                info.messageType,
                "workspace.onDidChangeTextDocument",
@@ -168,7 +168,7 @@ describe("ExtHostClient", ({describe, _}) => {
           ExtHostClient.addDocument(
             createInitialDocumentModel(
               ~lines=["hello", "world"],
-              ~path="test.txt",
+              ~path="/root/test.txt",
               (),
             ),
             client,
@@ -198,7 +198,7 @@ describe("ExtHostClient", ({describe, _}) => {
               (),
             );
           ExtHostClient.updateDocument(
-            Uri.fromPath("test.txt"),
+            Uri.fromPath("/root/test.txt"),
             modelChangedEvent,
             true,
             client,

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -7,6 +7,17 @@ open TestFramework;
 open ExtensionClientHelper;
 open ExtHostProtocol;
 
+// Windows extension 
+let normalizeExpectedPath = (path) => {
+  // Windows does a normalization of slashes in the ext host...
+  if (Sys.win32) {
+    path
+    |> Str.global_replace(Str.regexp_string("/"), "\\");
+  } else {
+    path
+  }
+};
+
 describe("ExtHostClient", ({describe, _}) => {
   describe("activation", ({test, _}) => {
     test("activates by language", ({expect}) => {
@@ -104,7 +115,7 @@ describe("ExtHostClient", ({describe, _}) => {
 
       let didGetOpenMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "/root/test.txt")
+          String.equal(info.filename, "/root/test.txt" |> normalizeExpectedPath)
           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
         );
 
@@ -141,13 +152,13 @@ describe("ExtHostClient", ({describe, _}) => {
 
       let didGetOpenMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "/root/test.txt")
+          String.equal(info.filename, "/root/test.txt" |> normalizeExpectedPath)
           && String.equal(info.messageType, "workspace.onDidOpenTextDocument")
         );
 
       let didGetUpdateMessage = () =>
         doesInfoMessageMatch(messages, info =>
-          String.equal(info.filename, "/root/test.txt")
+          String.equal(info.filename, "/root/test.txt" |> normalizeExpectedPath)
           && String.equal(
                info.messageType,
                "workspace.onDidChangeTextDocument",


### PR DESCRIPTION
__Issue:__ There was a discrepancy in the way we were serializing Uris on Windows, and the way the VSCode extension host handles them.

In particular, the VSCode extension host expects a slash prefix - we were sending paths like `C:/test.css`, but the VSCode extension host expected them as `/C:/test.css`. This meant that the URIs we sent VSCode for buffer enter / updates, and then the URIs we'd receive for diagnostics would be out-of-sync. So we'd get them, but when we'd go to look them u p, the URls wouldn't match.

__Fix:__ Use the same convention as the VSCode exthost - always prefix with a `/` character, and ensure the drive letter is lowercase.

Fixes #1019 