### PR TITLE
Sort Ctrl+Tab menu by MRU

### DIFF
--- a/src/Model/Buffer.re
+++ b/src/Model/Buffer.re
@@ -15,6 +15,7 @@ type t = {
   lines: array(string),
   indentation: option(IndentationSettings.t),
   syntaxHighlightingEnabled: bool,
+  lastUsed: float,
 };
 
 let show = _ => "TODO";
@@ -28,6 +29,7 @@ let ofLines = (lines: array(string)) => {
   lines,
   indentation: None,
   syntaxHighlightingEnabled: true,
+  lastUsed: 0.,
 };
 
 let empty = ofLines([||]);
@@ -41,17 +43,16 @@ let ofMetadata = (metadata: Vim.BufferMetadata.t) => {
   lines: [||],
   indentation: None,
   syntaxHighlightingEnabled: true,
+  lastUsed: 0.,
 };
 
 let getFilePath = (buffer: t) => buffer.filePath;
-
 let setFilePath = (filePath: option(string), buffer) => {
   ...buffer,
   filePath,
 };
 
 let getFileType = (buffer: t) => buffer.fileType;
-
 let setFileType = (fileType: option(string), buffer: t) => {
   ...buffer,
   fileType,
@@ -60,16 +61,16 @@ let setFileType = (fileType: option(string), buffer: t) => {
 let getId = (buffer: t) => buffer.id;
 
 let getLine = (buffer: t, line: int) => buffer.lines[line];
-
 let getLines = (buffer: t) => buffer.lines;
 
 let getVersion = (buffer: t) => buffer.version;
-
 let setVersion = (version: int, buffer: t) => {...buffer, version};
 
 let isModified = (buffer: t) => buffer.modified;
-
 let setModified = (modified: bool, buffer: t) => {...buffer, modified};
+
+let stampLastUsed = buffer => {...buffer, lastUsed: Unix.gettimeofday()};
+let getLastUsed = buffer => buffer.lastUsed;
 
 let isSyntaxHighlightingEnabled = (buffer: t) =>
   buffer.syntaxHighlightingEnabled;

--- a/src/Model/Buffer.rei
+++ b/src/Model/Buffer.rei
@@ -13,6 +13,8 @@ let show: t => string;
 let ofLines: array(string) => t;
 let ofMetadata: Vim.BufferMetadata.t => t;
 
+let getId: t => int;
+let getUri: t => Uri.t;
 let getFilePath: t => option(string);
 let setFilePath: (option(string), t) => t;
 let getFileType: t => option(string);
@@ -20,21 +22,23 @@ let setFileType: (option(string), t) => t;
 let getLine: (t, int) => string;
 let getLineLength: (t, int) => int;
 let getLines: t => array(string);
+let getNumberOfLines: t => int;
 
 let getVersion: t => int;
 let setVersion: (int, t) => t;
 
-let getUri: t => Uri.t;
-let getId: t => int;
-let getNumberOfLines: t => int;
 let isModified: t => bool;
-let isSyntaxHighlightingEnabled: t => bool;
+let setModified: (bool, t) => t;
 
 let isIndentationSet: t => bool;
 let setIndentation: (IndentationSettings.t, t) => t;
 let getIndentation: t => option(IndentationSettings.t);
-let setModified: (bool, t) => t;
+
+let isSyntaxHighlightingEnabled: t => bool;
 let disableSyntaxHighlighting: t => t;
+
+let stampLastUsed: t => t;
+let getLastUsed: t => float;
 
 let shouldApplyUpdate: (BufferUpdate.t, t) => bool;
 let update: (t, BufferUpdate.t) => t;

--- a/src/Model/FilterJob.re
+++ b/src/Model/FilterJob.re
@@ -193,9 +193,9 @@ module Make = (Config: Config) => {
     | Some((isCompleted, pendingWork, completedWork)) =>
       /* As a last pass, run the filter to sort / score filtered items if under a certain length */
       let uiFiltered =
-          completedWork
-          |> Utility.firstk(maxItemsToFilter)
-          |> Filter.rank(p.filter, format);
+        completedWork
+        |> Utility.firstk(maxItemsToFilter)
+        |> Filter.rank(p.filter, format);
 
       (isCompleted, pendingWork, {allFiltered: completedWork, uiFiltered});
     };
@@ -204,12 +204,12 @@ module Make = (Config: Config) => {
   let doWork = (pending, completed) =>
     if (pending.filter == "") {
       let allFiltered = List.concat(pending.allItems);
-      let uiFiltered = allFiltered |> List.map(item => Filter.{highlight: [], item});
+      let uiFiltered =
+        allFiltered |> List.map(item => Filter.{highlight: [], item});
       (true, pending, {allFiltered, uiFiltered});
     } else {
       doActualWork(pending, completed);
-    }
-
+    };
 
   let progressReporter = (p: pendingWork, _) => {
     let toFilter = float_of_int(List.length(p.itemsToFilter));

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -56,9 +56,17 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
 
     buffers
     |> Core.IntMap.to_seq
-    |> Seq.filter_map(element => {
-         let (_, buffer) = element;
-
+    |> Seq.map(snd)
+    |> List.of_seq
+    // Sort by most recerntly used
+    |> List.fast_sort((a, b) =>
+         -
+           Float.compare(
+             Model.Buffer.getLastUsed(a),
+             Model.Buffer.getLastUsed(b),
+           )
+       )
+    |> Utility.List.filter_map(buffer => {
          switch (Model.Buffer.getFilePath(buffer)) {
          | Some(path) =>
            Some(
@@ -78,9 +86,9 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
              },
            )
          | None => None
-         };
+         }
        })
-    |> Array.of_seq;
+    |> Array.of_list;
   };
 
   let menuUpdater =


### PR DESCRIPTION
This addresses a few issues from #1017:

- Sorting Ctrl+Tab menu by MRU
- Initial "flickering" in Ctrl+Tab and Ctrl/Cmd+Shift+P menus

The flickering issue was caused by FilterProcessingJob reversing the items while processing them because it uses lists instead of queues when processing. The fix here is just to bypass filtering entirely if there's no filter. Note however when a filter is applied, this will still cause similarly ranked items to appear in reverse order. Probably not an issue in practice, but might be worth considering using a queue here anyway to alleviate it.

Note also that this doesn't fix the non-determinism of the Ctrl/Cmd+P menu. That definitely does need to use a queue during processing.