### PR TITLE
Feature: Editor - getTokenAtPosition + underline rendering

### DIFF
--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -267,6 +267,11 @@ module Option = {
     fun
     | Some(x) => x
     | None => None;
+
+  let of_list =
+    fun
+    | [] => None
+    | [hd, ..._] => Some(hd);
 };
 
 module Result = {

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -411,7 +411,7 @@ let%component make =
     );
   };
 
-  let getTokenAtPosition = (~startIndex, ~endIndex, position: Position.t) => {
+  let _getTokenAtPosition = (~startIndex, ~endIndex, position: Position.t) => {
     let lineNumber = position.line |> Index.toInt0;
     let index = position.character |> Index.toInt0;
 
@@ -714,26 +714,26 @@ let%component make =
 
           // TODO:
           // Render underline if we have an available go-to definition
-          /* 
-          let () =
-            getTokenAtPosition(
-              ~startIndex=leftVisibleColumn,
-              ~endIndex=leftVisibleColumn + layout.bufferWidthInCharacters,
-              cursorPosition,
-            )
-            |> Utility.Option.iter((token: BufferViewTokenizer.t) => {
-                 let range =
-                   Range.create(
-                     ~startLine=cursorPosition.line,
-                     ~startCharacter=token.startPosition,
-                     ~endLine=cursorPosition.line,
-                     ~endCharacter=token.endPosition,
-                     (),
-                   );
-                 let () = renderUnderline(~color=token.color, range);
-                 ();
-               });
-           */
+          /*
+           let () =
+             getTokenAtPosition(
+               ~startIndex=leftVisibleColumn,
+               ~endIndex=leftVisibleColumn + layout.bufferWidthInCharacters,
+               cursorPosition,
+             )
+             |> Utility.Option.iter((token: BufferViewTokenizer.t) => {
+                  let range =
+                    Range.create(
+                      ~startLine=cursorPosition.line,
+                      ~startCharacter=token.startPosition,
+                      ~endLine=cursorPosition.line,
+                      ~endCharacter=token.endPosition,
+                      (),
+                    );
+                  let () = renderUnderline(~color=token.color, range);
+                  ();
+                });
+            */
 
           ImmediateList.render(
             ~scrollY,


### PR DESCRIPTION
This is some prepatory work for #1026 - this adds some UI to the editor surface to show underlines when necessary. 

his is turned off for this PR, but with #1026 , we'll bring back the 'renderUnderline' for the tokens when a definition is available at the cursor position.

While going through the EditorSurface code, I've also called out several refactorings: https://github.com/onivim/oni2/projects/10#card-30388562