### PR TITLE
Various quickmenu bugfixes

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -76,6 +76,7 @@ type t =
   | QuickmenuUpdateRipgrepProgress(progress)
   | QuickmenuUpdateFilterProgress([@opaque] array(menuItem), progress)
   | QuickmenuSearch(string)
+  | QuickmenuMaybeLoseFocus
   | QuickmenuClose
   | ListFocus(int)
   | ListFocusUp

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -28,6 +28,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
     Isolinear.Effect.createWithDispatch(~name="quickmenu.selectItem", dispatch => {
       let action = item.command();
       dispatch(action);
+      dispatch(Actions.QuickmenuMaybeLoseFocus);
     });
 
   let executeVimCommandEffect =
@@ -260,7 +261,6 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
       )
 
     | ListSelect =>
-      Revery_UI.Focus.loseFocus(); // TODO: Remove once revery-ui/revery#412 has been fixed
       switch (state) {
       | Some({variant: Wildmenu(_), _}) => (None, executeVimCommandEffect)
 
@@ -271,7 +271,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
         }
 
       | _ => (state, Isolinear.Effect.none)
-      };
+      }
 
     | ListSelectBackground =>
       switch (state) {
@@ -285,6 +285,14 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
 
       | _ => (state, Isolinear.Effect.none)
       }
+
+    // Triggered by selectItemEffect in order to lose focus iff the item command
+    // has resulted in the menu being closed
+    | QuickmenuMaybeLoseFocus =>
+      if (state == None) {
+        Revery_UI.Focus.loseFocus(); // TODO: Remove once revery-ui/revery#412 has been fixed
+      };
+      (state, Isolinear.Effect.none);
 
     | QuickmenuClose =>
       Revery_UI.Focus.loseFocus(); // TODO: Remove once revery-ui/revery#412 has been fixed

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -13,6 +13,7 @@ module Animation = Model.Animation;
 module Quickmenu = Model.Quickmenu;
 module Utility = Core.Utility;
 module ExtensionContributions = Oni_Extensions.ExtensionContributions;
+module Log = (val Core.Log.withNamespace("Oni2.QuickmenuStore"));
 
 let prefixFor: Vim.Types.cmdlineType => string =
   fun
@@ -377,7 +378,7 @@ let subscriptions = ripgrep => {
 
           dispatch(Actions.QuickmenuUpdateRipgrepProgress(Loading));
         },
-      ~onCompleted=() => Actions.QuickmenuUpdateRipgrepProgress(Complete),
+      ~onComplete=() => Actions.QuickmenuUpdateRipgrepProgress(Complete),
     );
   };
 

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -180,11 +180,11 @@ let start =
       ~updater=
         Isolinear.Updater.combine([
           Isolinear.Updater.ofReducer(Reducer.reduce),
+          quickmenuUpdater,
           vimUpdater,
           syntaxUpdater,
           extHostUpdater,
           fontUpdater,
-          quickmenuUpdater,
           configurationUpdater,
           keyBindingsUpdater,
           commandUpdater,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -314,7 +314,7 @@ let start =
       let endLine =
         if (isFull) {
           maybeBuffer
-          |> Option.map(b => Buffer.getNumberOfLines(b) + 1)
+          |> Option.map(b => Core.Buffer.getNumberOfLines(b) + 1)
           |> Option.value(~default=update.startLine);
         } else {
           update.endLine;
@@ -340,7 +340,8 @@ let start =
       // The fix really belongs in reason-libvim - we should always be trust the order we get from the updates,
       // and any of this filtering or manipulation of updates should be handled and tested there.
       let shouldApply =
-        Option.map(Buffer.shouldApplyUpdate(bu), maybeBuffer) != Some(false);
+        Option.map(Core.Buffer.shouldApplyUpdate(bu), maybeBuffer)
+        != Some(false);
 
       if (shouldApply) {
         dispatch(Actions.BufferUpdate(bu));

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -13,7 +13,7 @@ open Oni_Model;
 
 module Extensions = Oni_Extensions;
 
-module Log = Core.Log;
+module Log = (val Core.Log.withNamespace("Oni2.VimStore"));
 module Zed_utf8 = Core.ZedBundled;
 
 let start =
@@ -93,7 +93,7 @@ let start =
         | Info => ("INFO", Actions.Info)
         };
 
-      Log.info("Message -" ++ priorityString ++ " [" ++ t ++ "]: " ++ msg);
+      Log.infof(m => m("Message - %s [%s]: %s", priorityString, t, msg));
 
       dispatch(
         ShowNotification(
@@ -131,7 +131,7 @@ let start =
 
   let _ =
     Vim.Buffer.onFilenameChanged(meta => {
-      Log.info("Buffer metadata changed: " ++ string_of_int(meta.id));
+      Log.infof(m => m("Buffer metadata changed: %n", meta.id));
       let meta = {
         ...meta,
         /*
@@ -153,12 +153,7 @@ let start =
 
   let _ =
     Vim.Buffer.onModifiedChanged((id, modified) => {
-      Log.info(
-        "Buffer metadata changed: "
-        ++ string_of_int(id)
-        ++ " | "
-        ++ string_of_bool(modified),
-      );
+      Log.infof(m => m("Buffer metadata changed: %n | %b", id, modified));
       dispatch(Actions.BufferSetModified(id, modified));
     });
 
@@ -305,9 +300,8 @@ let start =
 
   let _ =
     Vim.Buffer.onUpdate(update => {
-      open Oni_Core;
       open Vim.BufferUpdate;
-      Log.info("Vim - Buffer update: " ++ string_of_int(update.id));
+      Log.infof(m => m("Vim - Buffer update: %n", update.id));
       open State;
 
       let isFull = update.endLine == (-1);
@@ -330,8 +324,8 @@ let start =
         Core.BufferUpdate.create(
           ~id=update.id,
           ~isFull,
-          ~startLine=Index.OneBasedIndex(update.startLine),
-          ~endLine=Index.OneBasedIndex(endLine),
+          ~startLine=Core.Index.OneBasedIndex(update.startLine),
+          ~endLine=Core.Index.OneBasedIndex(endLine),
           ~lines=update.lines,
           ~version=update.version,
           (),
@@ -367,12 +361,13 @@ let start =
   let isCompleting = ref(false);
 
   let checkCommandLineCompletions = () => {
-    Log.info("VimStoreConnector::checkCommandLineCompletions");
+    Log.info("checkCommandLineCompletions");
     let completions = Vim.CommandLine.getCompletions();
-    Log.info(
-      "VimStoreConnector::checkCommandLineCompletions - got "
-      ++ string_of_int(Array.length(completions))
-      ++ " completions.",
+    Log.infof(m =>
+      m(
+        "checkCommandLineCompletions - got %n completions.",
+        Array.length(completions),
+      )
     );
     let items =
       Array.map(
@@ -508,7 +503,7 @@ let start =
                dispatch(Actions.EditorScrollToLine(id, newTopLine - 1));
                dispatch(Actions.EditorScrollToColumn(id, newLeftColumn));
              });
-        Log.debug(() => "VimStoreConnector - handled key: " ++ key);
+        Log.debug("handled key: " ++ key);
       }
     );
 

--- a/src/UI/FlatList.re
+++ b/src/UI/FlatList.re
@@ -11,19 +11,7 @@ open Revery_UI_Components;
 module Utility = Oni_Core.Utility;
 
 // TODO: Remove after 4.08 upgrade
-module Option = {
-  let map = f =>
-    fun
-    | Some(x) => Some(f(x))
-    | None => None;
-
-  let value = (~default) =>
-    fun
-    | Some(x) => x
-    | None => default;
-
-  let some = x => Some(x);
-};
+module Option = Utility.Option;
 
 type renderFunction = int => React.element(React.node);
 
@@ -36,42 +24,40 @@ module Constants = {
 };
 
 module Styles = {
-  let container = (~height as h) =>
-    Style.[
-      position(`Relative),
-      top(0),
-      left(0),
-      height(h),
-      overflow(`Hidden),
-      flexGrow(1),
-    ];
+  open Style;
 
-  let slider =
-    Style.[
-      position(`Absolute),
-      right(0),
-      top(0),
-      bottom(0),
-      width(Constants.scrollBarThickness),
-    ];
+  let container = (~isHeightEstimated, ~height) => [
+    position(`Relative),
+    top(0),
+    left(0),
+    isHeightEstimated ? bottom(0) : Style.height(height),
+    overflow(`Hidden),
+    flexGrow(1),
+  ];
 
-  let viewport = (~isScrollbarVisible) =>
-    Style.[
-      position(`Absolute),
-      top(0),
-      left(0),
-      bottom(0),
-      right(isScrollbarVisible ? 0 : Constants.scrollBarThickness),
-    ];
+  let slider = [
+    position(`Absolute),
+    right(0),
+    top(0),
+    bottom(0),
+    width(Constants.scrollBarThickness),
+  ];
 
-  let item = (~offset, ~rowHeight) =>
-    Style.[
-      position(`Absolute),
-      top(offset),
-      left(0),
-      right(0),
-      height(rowHeight),
-    ];
+  let viewport = (~isScrollbarVisible) => [
+    position(`Absolute),
+    top(0),
+    left(0),
+    bottom(0),
+    right(isScrollbarVisible ? 0 : Constants.scrollBarThickness),
+  ];
+
+  let item = (~offset, ~rowHeight) => [
+    position(`Absolute),
+    top(offset),
+    left(0),
+    right(0),
+    height(rowHeight),
+  ];
 };
 
 let render = (~menuHeight, ~rowHeight, ~count, ~scrollTop, ~renderItem) =>
@@ -205,7 +191,10 @@ let%component make =
     |> React.listToElement;
 
   <View
-    style={Styles.container(~height=min(menuHeight, count * rowHeight))}
+    style={Styles.container(
+      ~isHeightEstimated=outerRef == None,
+      ~height=min(menuHeight, count * rowHeight),
+    )}
     ref=setOuterRef
     onMouseWheel=scroll>
     <View

--- a/src/UI/OniInput.re
+++ b/src/UI/OniInput.re
@@ -168,10 +168,11 @@ let%component make =
   let%hook (textRef, setTextRef) = Hooks.ref(None);
   let%hook (scrollOffset, _setScrollOffset) = Hooks.state(ref(0));
 
-  let value = prefix ++ Option.value(value, ~default=state.value);
-  let showPlaceholder = value == "";
+  let value = Option.value(value, ~default=state.value);
   let cursorPosition =
     Option.value(cursorPosition, ~default=state.cursorPosition);
+  let displayValue = prefix ++ value;
+  let showPlaceholder = displayValue == "";
 
   module Styles = {
     open Style;
@@ -242,7 +243,7 @@ let%component make =
 
   let () = {
     let cursorOffset =
-      measureTextWidth(String.sub(value, 0, cursorPosition));
+      measureTextWidth(String.sub(displayValue, 0, cursorPosition));
 
     switch (Option.bind(r => r#getParent(), textRef)) {
     | Some(containerNode) =>
@@ -377,7 +378,7 @@ let%component make =
   let text = () =>
     <Text
       ref={node => setTextRef(Some(node))}
-      text={showPlaceholder ? placeholder : value}
+      text={showPlaceholder ? placeholder : displayValue}
       style=Styles.text
     />;
 


### PR DESCRIPTION
Bugs fixed:

- Input prefix multiplied like rabbits. Caused by not properly distinguishing between the actual value and the value to display, which should include the prefix.

- Filtered items where duplicated. Caused by the FilterJob revamp earlier today, although I still don't understand how it could have worked before without this fix either.

- Ripgrep seemed to never complete, causing the loading animation to animate forever and ever. Root cause was that `onComplete` was called when the ripgrep process had completed, but the processing still hadn't, triggering further `onUpdate` calls that set the state to `Loading`.

- FlatList was overflowing its container when displaying many items initially. Caused by the initial height estimation overriding the later measurement. It now uses the estimation only to calculate which items to render, not to set the height of the container.

- Input lost focus when a submenu, such as the theme picker, was selected. Caused by `loseFocus` being called on `ListSelect`, but since the menu, due to reconciliation,  is never removed and remounted `focus` wasn't being called when opening the submenu. Fixed by adding a very hacky `QuickmenuMaybeLoseFocus` action that checks whether `state.quickmenu` is `None` and calls `loseFocus` only after the selected item's command has been dispatched and the state updated.

- Wildmenu completion out of sync. This was caused by an ordering issue between updaters where VimStore applied the completion before QuickmenuStore had updated the focus. This was originally fixed in https://github.com/onivim/oni2/pull/858/commits/44a3f453440254bc649405199ea094a93c12536b, but seems to have been lost in some rebase.

Addresses parts of #1017