### PR TITLE
Syntax Highlight Integration Tests

### DIFF
--- a/integration_test/SyntaxHighlightTextMateTest.re
+++ b/integration_test/SyntaxHighlightTextMateTest.re
@@ -1,0 +1,34 @@
+open Oni_Core;
+open Oni_Core.Utility;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// Validate that textmate highlight runs
+runTest(~name="SyntaxHighlightTextMateTest", (dispatch, wait, _runEffects) => {
+  wait(~name="Capture initial state", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  let testFile = getAssetPath("some-test-file.json");
+
+  // Create a buffer
+  dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+  // Wait for highlights to show up
+  wait(~name="Verify we get syntax highlights", (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(Buffer.getId)
+    |> Option.map(bufferId => {
+         let tokens =
+           SyntaxHighlighting.getTokensForLine(
+             state.syntaxHighlighting,
+             bufferId,
+             0,
+           );
+
+         List.length(tokens) > 1;
+       })
+    |> Option.value(~default=false)
+  });
+});

--- a/integration_test/SyntaxHighlightTreesitterTest.re
+++ b/integration_test/SyntaxHighlightTreesitterTest.re
@@ -1,0 +1,42 @@
+open Oni_Core;
+open Oni_Core.Utility;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+let configuration = Some({|
+{ "experimental.treeSitter": true },
+|});
+
+// Validate that treesitter highlight runs
+runTest(
+  ~configuration,
+  ~name="SyntaxHighlightTreesitterTest",
+  (dispatch, wait, _runEffects) => {
+    wait(~name="Capture initial state", (state: State.t) =>
+      state.mode == Vim.Types.Normal
+    );
+
+    let testFile = getAssetPath("some-test-file.json");
+
+    // Create a buffer
+    dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+    // Wait for highlights to show up
+    wait(~name="Verify we get syntax highlights", (state: State.t) => {
+      state
+      |> Selectors.getActiveBuffer
+      |> Option.map(Buffer.getId)
+      |> Option.map(bufferId => {
+           let tokens =
+             SyntaxHighlighting.getTokensForLine(
+               state.syntaxHighlighting,
+               bufferId,
+               0,
+             );
+
+           List.length(tokens) > 1;
+         })
+      |> Option.value(~default=false)
+    });
+  },
+);

--- a/integration_test/SyntaxHighlightTreesitterTest.re
+++ b/integration_test/SyntaxHighlightTreesitterTest.re
@@ -4,7 +4,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 
 let configuration = Some({|
-{ "experimental.treeSitter": true },
+{ "experimental.treeSitter": true }
 |});
 
 // Validate that treesitter highlight runs

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -74,5 +74,6 @@
         VimlConfigurationTest.exe
         ZenModeSingleFileModeTest.exe
         ZenModeSplitTest.exe
+        some-test-file.json
         some-test-file.txt
         ))

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -22,6 +22,8 @@
            RegressionFileModifiedIndicationTest
            RegressionVspEmptyInitialBufferTest
            RegressionVspEmptyExistingBufferTest
+           SyntaxHighlightTextMateTest
+           SyntaxHighlightTreesitterTest
            TickTest
            AddRemoveSplitTest
            TypingBatchedTest
@@ -63,6 +65,8 @@
         RegressionVspEmptyInitialBufferTest.exe
         RegressionVspEmptyExistingBufferTest.exe
         SearchShowClearHighlightsTest.exe
+        SyntaxHighlightTextMateTest.exe
+        SyntaxHighlightTreesitterTest.exe
         AddRemoveSplitTest.exe
         TickTest.exe
         TypingBatchedTest.exe

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -75,6 +75,8 @@ let runTest =
   let configurationFilePath = Filename.temp_file("configuration", ".json");
   let oc = open_out(configurationFilePath);
 
+  logInit("Writing configuration file: " ++ configurationFilePath);
+
   let () =
     configuration
     |> Option.value(~default="{}")

--- a/integration_test/some-test-file.json
+++ b/integration_test/some-test-file.json
@@ -1,0 +1,1 @@
+{ "source": "./package.json", "array": [1, 2, 3] }


### PR DESCRIPTION
This adds some simple, sanity-check syntax highlight tests for both 'TextMate' and 'Treesitter' strategies - to help protect against regressions in #922 