### PR TITLE
Perf - Editor: Scope colorization of line to active view

### DIFF
--- a/src/Model/BufferLineColorizer.re
+++ b/src/Model/BufferLineColorizer.re
@@ -40,11 +40,10 @@ let create =
     switch (tokens) {
     | [] => ()
     | [hd, ...tail] =>
-
       let adjIndex = hd.index - startIndex;
 
       let pos = ref(start);
-      
+
       while (pos^ >= adjIndex && pos^ >= 0 && pos^ < length) {
         tokenColorArray[pos^] = hd;
         decr(pos);
@@ -53,7 +52,7 @@ let create =
         ();
       } else {
         f(tail, pos^);
-      }
+      };
     };
 
   let (selectionStart, selectionEnd) =
@@ -70,13 +69,14 @@ let create =
   f(tokenColors, length - 1);
 
   i => {
-    let colorIndex = if (i < startIndex) {
-      tokenColorArray[0];
-    } else if (i > endIndex) {
-      tokenColorArray[Array.length(tokenColorArray) - 1];
-    } else {
-      tokenColorArray[i - startIndex];
-    };
+    let colorIndex =
+      if (i < startIndex) {
+        tokenColorArray[0];
+      } else if (i >= endIndex) {
+        tokenColorArray[Array.length(tokenColorArray) - 1];
+      } else {
+        tokenColorArray[i - startIndex];
+      };
 
     let matchingPair =
       switch (matchingPair) {

--- a/src/Model/BufferLineColorizer.re
+++ b/src/Model/BufferLineColorizer.re
@@ -14,19 +14,20 @@ let create =
     (
       ~startIndex,
       ~endIndex,
-      theme: Theme.t,
+      ~defaultBackgroundColor: Color.t,
+      ~defaultForegroundColor: Color.t,
+      ~selectionHighlights: option(Range.t),
+      ~selectionColor: Color.t,
+      ~matchingPair: option(int),
+      ~searchHighlights: list(Range.t),
+      ~searchHighlightColor: Color.t,
       tokenColors: list(ColorizedToken.t),
-      selection: option(Range.t),
-      defaultBackgroundColor: Color.t,
-      selectionColor: Color.t,
-      matchingPair: option(int),
-      searchHighlightRanges: list(Range.t),
     ) => {
   let defaultToken2 =
     ColorizedToken.create(
       ~index=0,
       ~backgroundColor=defaultBackgroundColor,
-      ~foregroundColor=theme.editorForeground,
+      ~foregroundColor=defaultForegroundColor,
       (),
     );
 
@@ -56,7 +57,7 @@ let create =
     };
 
   let (selectionStart, selectionEnd) =
-    switch (selection) {
+    switch (selectionHighlights) {
     | Some(range) =>
       let start = Index.toZeroBased(range.start.column);
       let stop = Index.toZeroBased(range.stop.column);
@@ -93,10 +94,10 @@ let create =
     };
 
     let isSearchHighlight =
-      List.exists(doesSearchIntersect, searchHighlightRanges);
+      List.exists(doesSearchIntersect, searchHighlights);
 
     let backgroundColor =
-      isSearchHighlight ? theme.editorFindMatchBackground : backgroundColor;
+      isSearchHighlight ? searchHighlightColor : backgroundColor;
 
     let color = colorIndex.foregroundColor;
     (backgroundColor, color);

--- a/src/Model/BufferLineColorizer.rei
+++ b/src/Model/BufferLineColorizer.rei
@@ -25,7 +25,8 @@ type t = int => tokenColor;
  */
 let create:
   (
-    int,
+    ~startIndex: int,
+    ~endIndex: int,
     Theme.t,
     list(ColorizedToken.t),
     option(Range.t),

--- a/src/Model/BufferLineColorizer.rei
+++ b/src/Model/BufferLineColorizer.rei
@@ -27,12 +27,13 @@ let create:
   (
     ~startIndex: int,
     ~endIndex: int,
-    Theme.t,
+    ~defaultBackgroundColor: Color.t,
+    ~defaultForegroundColor: Color.t, // theme.editorForeground
+    ~selectionHighlights: option(Range.t),
+    ~selectionColor:Color.t,
+    ~matchingPair: option(int),
+    ~searchHighlights: list(Range.t),
+    ~searchHighlightColor: Color.t, // theme.editorFindMatchBackground
     list(ColorizedToken.t),
-    option(Range.t),
-    Color.t,
-    Color.t,
-    option(int),
-    list(Range.t)
   ) =>
   t;

--- a/src/Model/BufferLineColorizer.rei
+++ b/src/Model/BufferLineColorizer.rei
@@ -30,10 +30,10 @@ let create:
     ~defaultBackgroundColor: Color.t,
     ~defaultForegroundColor: Color.t, // theme.editorForeground
     ~selectionHighlights: option(Range.t),
-    ~selectionColor:Color.t,
+    ~selectionColor: Color.t,
     ~matchingPair: option(int),
     ~searchHighlights: list(Range.t),
     ~searchHighlightColor: Color.t, // theme.editorFindMatchBackground
-    list(ColorizedToken.t),
+    list(ColorizedToken.t)
   ) =>
   t;

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -399,13 +399,14 @@ let%component make =
         BufferLineColorizer.create(
           ~startIndex,
           ~endIndex,
-          state.theme,
+          ~defaultBackgroundColor=defaultBackground,
+          ~defaultForegroundColor=theme.editorForeground,
+          ~selectionHighlights=selection,
+          ~selectionColor=theme.editorSelectionBackground,
+          ~matchingPair=matchingPairIndex,
+          ~searchHighlights=highlights,
+          ~searchHighlightColor=theme.editorFindMatchBackground,
           tokenColors2,
-          selection,
-          defaultBackground,
-          theme.editorSelectionBackground,
-          matchingPairIndex,
-          highlights,
         );
 
       BufferViewTokenizer.tokenize(

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -397,7 +397,8 @@ let%component make =
 
       let colorizer =
         BufferLineColorizer.create(
-          ZedBundled.length(line),
+          ~startIndex,
+          ~endIndex,
           state.theme,
           tokenColors2,
           selection,

--- a/test/Model/BufferLineColorizerTests.re
+++ b/test/Model/BufferLineColorizerTests.re
@@ -1,0 +1,66 @@
+open Oni_Core;
+open TestFramework;
+open Revery;
+
+module BufferLineColorizer = Oni_Model.BufferLineColorizer;
+
+let basicColorizer =
+  BufferLineColorizer.create(
+    ~defaultBackgroundColor=Colors.black,
+    ~defaultForegroundColor=Colors.white,
+    ~selectionHighlights=None,
+    ~selectionColor=Colors.yellow,
+    ~matchingPair=None,
+    ~searchHighlights=[],
+    ~searchHighlightColor=Colors.orange,
+  );
+
+// Still needs ~startIndex, ~endIndex, and tokenColors
+
+let backgroundColor = Colors.black;
+let basicTokens = [
+  ColorizedToken.create(
+    ~index=1,
+    ~backgroundColor,
+    ~foregroundColor=Colors.green,
+    (),
+  ),
+  ColorizedToken.create(
+    ~index=5,
+    ~backgroundColor,
+    ~foregroundColor=Colors.red,
+    (),
+  ),
+  ColorizedToken.create(
+    ~index=10,
+    ~backgroundColor,
+    ~foregroundColor=Colors.blue,
+    (),
+  ),
+];
+
+describe("BufferLineColorizer", ({test, _}) => {
+  test("base case - cover all tokens", ({expect, _}) => {
+    let colorize = basicColorizer(~startIndex=0, ~endIndex=11, basicTokens);
+
+    let (_, color0) = colorize(0);
+    let (_, color2) = colorize(2);
+    let (_, color6) = colorize(6);
+    let (_, color11) = colorize(11);
+
+    expect.equal(color0, Colors.white);
+    expect.equal(color2, Colors.green);
+    expect.equal(color6, Colors.red);
+    expect.equal(color11, Colors.blue);
+  });
+
+  test("out of bounds", ({expect, _}) => {
+    let colorize = basicColorizer(~startIndex=4, ~endIndex=6, basicTokens);
+
+    let (_, color0) = colorize(0);
+    let (_, color11) = colorize(11);
+
+    expect.equal(color0, Colors.green);
+    expect.equal(color11, Colors.red);
+  });
+});


### PR DESCRIPTION
__Issue:__ The way we figured out the 'colorization' state of tokens was very efficient. 

Previously, we'd create an `Array.t` _the entire length of the line_ - and then apply syntax coloring to each cell of the array. This is problematic, and wasteful, for large lines - we only care about colorizing within the visible view.

This change scopes this colorization process to just the visible size of the line, which is very helpful for large lines.

A further improvement would be to not require the `List.rev(..)` of the tokens, but we should have #922 come in prior to that, as #922 changes the shape of the syntax highlight model.

