### PR TITLE
Fix #1045: Only show suggestions in active split

### DIFF
--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -532,6 +532,17 @@ let%component make =
         </View>
       : React.empty;
 
+  let hoverElements = isActiveSplit ?
+    <View style={Styles.bufferViewOverlay(bufferPixelWidth)}>
+      <HoverView x=cursorPixelX y=cursorPixelY state />
+      <CompletionsView
+        x=cursorPixelX
+        y=cursorPixelY
+        lineHeight=fontHeight
+        state
+      />
+    </View> : React.empty;
+    
   /* TODO: Selection! */
   /*let editorMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
     };*/
@@ -939,15 +950,7 @@ let%component make =
       </View>
     </View>
     minimapLayout
-    <View style={Styles.bufferViewOverlay(bufferPixelWidth)}>
-      <HoverView x=cursorPixelX y=cursorPixelY state />
-      <CompletionsView
-        x=cursorPixelX
-        y=cursorPixelY
-        lineHeight=fontHeight
-        state
-      />
-    </View>
+    hoverElements
     <View style=verticalScrollBarStyle>
       <EditorVerticalScrollbar
         state

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -532,17 +532,19 @@ let%component make =
         </View>
       : React.empty;
 
-  let hoverElements = isActiveSplit ?
-    <View style={Styles.bufferViewOverlay(bufferPixelWidth)}>
-      <HoverView x=cursorPixelX y=cursorPixelY state />
-      <CompletionsView
-        x=cursorPixelX
-        y=cursorPixelY
-        lineHeight=fontHeight
-        state
-      />
-    </View> : React.empty;
-    
+  let hoverElements =
+    isActiveSplit
+      ? <View style={Styles.bufferViewOverlay(bufferPixelWidth)}>
+          <HoverView x=cursorPixelX y=cursorPixelY state />
+          <CompletionsView
+            x=cursorPixelX
+            y=cursorPixelY
+            lineHeight=fontHeight
+            state
+          />
+        </View>
+      : React.empty;
+
   /* TODO: Selection! */
   /*let editorMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
     };*/


### PR DESCRIPTION
Fixes #1045 

We should only be showing suggestions and the other hover elements in the _active_ split - currently, they'd show in all splits with the same buffer.