### PR TITLE
Bugfix: Go-to definition underline not showing up w/ highlight

### DIFF
--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -820,7 +820,6 @@ let%component make =
             ();
           };
 
-
           ImmediateList.render(
             ~scrollY,
             ~rowHeight,

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -729,37 +729,6 @@ let%component make =
                );
              }};
 
-          if (Definition.isAvailable(
-                bufferId,
-                cursorPosition,
-                state.definition,
-              )) {
-            let () =
-              getTokenAtPosition(
-                ~startIndex=leftVisibleColumn,
-                ~endIndex=leftVisibleColumn + layout.bufferWidthInCharacters,
-                cursorPosition,
-              )
-              |> Utility.Option.iter((token: BufferViewTokenizer.t) => {
-                   let range =
-                     Range.{
-                       start:
-                         Location.{
-                           line: cursorPosition.line,
-                           column: token.startPosition,
-                         },
-                       stop:
-                         Location.{
-                           line: cursorPosition.line,
-                           column: token.endPosition,
-                         },
-                     };
-                   let () = renderUnderline(~color=token.color, range);
-                   ();
-                 });
-            ();
-          };
-
           ImmediateList.render(
             ~scrollY,
             ~rowHeight,
@@ -819,6 +788,38 @@ let%component make =
               },
             (),
           );
+
+          if (Definition.isAvailable(
+                bufferId,
+                cursorPosition,
+                state.definition,
+              )) {
+            let () =
+              getTokenAtPosition(
+                ~startIndex=leftVisibleColumn,
+                ~endIndex=leftVisibleColumn + layout.bufferWidthInCharacters,
+                cursorPosition,
+              )
+              |> Utility.Option.iter((token: BufferViewTokenizer.t) => {
+                   let range =
+                     Range.{
+                       start:
+                         Location.{
+                           line: cursorPosition.line,
+                           column: token.startPosition,
+                         },
+                       stop:
+                         Location.{
+                           line: cursorPosition.line,
+                           column: token.endPosition,
+                         },
+                     };
+                   let () = renderUnderline(~color=token.color, range);
+                   ();
+                 });
+            ();
+          };
+
 
           ImmediateList.render(
             ~scrollY,


### PR DESCRIPTION
If there was a highlight (from a document highlight provider) __and__ an available definition - we would draw the highlight on top of the underline, so it wouldn't be visible. We should draw the underline on top of the highlight.