### PR TITLE
Implement and use immutable queue for Ripgrep and FilterJob

### DIFF
--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -110,13 +110,11 @@ module RipgrepProcessingJob = {
         queue;
       };
 
-    let isDone = Queue.length(pending.queue) == 0;
-
-    if (isDone) {
+    if (Queue.isEmpty(pending.queue)) {
       pending.onComplete();
     };
 
-    (isDone, {...pending, queue}, completed);
+    (Queue.isEmpty(pending.queue), {...pending, queue}, completed);
   };
 
   let create = (~onUpdate, ~onComplete) => {

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -2,6 +2,7 @@ open Rench;
 
 module Time = Revery_Core.Time;
 module List = Utility.List;
+module Queue = Utility.Queue;
 
 module Match = {
   module Log = (val Log.withNamespace("Oni2.Ripgrep.Match"));
@@ -87,7 +88,7 @@ module RipgrepProcessingJob = {
   type pendingWork = {
     onUpdate: list(string) => unit,
     onComplete: unit => unit,
-    queue: Queue.t(Bytes.t) // WARNING: mutable data structure
+    queue: Queue.t(Bytes.t),
   };
 
   let pendingWorkPrinter = pending =>
@@ -96,21 +97,26 @@ module RipgrepProcessingJob = {
   type t = Job.t(pendingWork, unit);
 
   let doWork = (pending, completed) => {
-    switch (Queue.take(pending.queue)) {
-    | exception Queue.Empty => ()
-    | bytes =>
-      let items =
-        bytes |> Bytes.to_string |> String.trim |> String.split_on_char('\n');
-      pending.onUpdate(items);
-    };
+    let queue =
+      switch (Queue.pop(pending.queue)) {
+      | (None, queue) => queue
+      | (Some(bytes), queue) =>
+        let items =
+          bytes
+          |> Bytes.to_string
+          |> String.trim
+          |> String.split_on_char('\n');
+        pending.onUpdate(items);
+        queue;
+      };
 
-    let isDone = Queue.is_empty(pending.queue);
+    let isDone = Queue.length(pending.queue) == 0;
 
     if (isDone) {
       pending.onComplete();
     };
 
-    (isDone, pending, completed);
+    (isDone, {...pending, queue}, completed);
   };
 
   let create = (~onUpdate, ~onComplete) => {
@@ -120,15 +126,15 @@ module RipgrepProcessingJob = {
       ~name="RipgrepProcessingJob",
       ~pendingWorkPrinter,
       ~budget=Time.ms(2),
-      {onUpdate, onComplete, queue: Queue.create()},
+      {onUpdate, onComplete, queue: Queue.empty},
     );
   };
 
   let queueWork = (bytes: Bytes.t, currentJob: t) => {
     Job.map(
       (pending, completed) => {
-        Queue.push(bytes, pending.queue);
-        (false, pending, completed);
+        let queue = Queue.push(bytes, pending.queue);
+        (false, {...pending, queue}, completed);
       },
       currentJob,
     );

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -526,7 +526,7 @@ module StringUtil = {
   };
 };
 
-module Queue: {
+module type Queue = {
   type t('a);
 
   let empty: t(_);
@@ -537,7 +537,9 @@ module Queue: {
   let pop: t('a) => (option('a), t('a));
   let take: (int, t('a)) => (list('a), t('a));
   let toList: t('a) => list('a);
-} = {
+};
+
+module Queue: Queue = {
   type t('a) = {
     front: list('a),
     rear: list('a), // reversed
@@ -595,7 +597,8 @@ module Queue: {
 };
 
 module ChunkyQueue: {
-  include (module type of Queue);
+  include Queue;
+
   let pushChunk: (list('a), t('a)) => t('a);
   let pushReversedChunk: (list('a), t('a)) => t('a);
 } = {

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -531,6 +531,7 @@ module Queue: {
 
   let empty: t(_);
   let length: t('a) => int;
+  let isEmpty: t('a) => bool;
   let push: ('a, t('a)) => t('a);
   let pushFront: ('a, t('a)) => t('a);
   let pop: t('a) => (option('a), t('a));
@@ -545,7 +546,8 @@ module Queue: {
 
   let empty = {front: [], rear: [], length: 0};
 
-  let length = q => q.length;
+  let length = queue => queue.length;
+  let isEmpty = queue => queue.length == 0;
 
   let push = (item, queue) => {
     ...queue,
@@ -605,7 +607,8 @@ module ChunkyQueue: {
 
   let empty = {front: [], rear: Queue.empty, length: 0};
 
-  let length = q => q.length;
+  let length = queue => queue.length;
+  let isEmpty = queue => queue.length == 0;
 
   let push = (item, queue) => {
     ...queue,

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -525,3 +525,70 @@ module StringUtil = {
     };
   };
 };
+
+module Queue : {
+  type t('a);
+
+  let empty: t(_);
+  let length: t('a) => int;
+  let push: ('a, t('a)) => t('a);
+  let pushFront: ('a, t('a)) => t('a);
+  let pop: t('a) => (option('a), t('a));
+  let toList: t('a) => list('a);
+} = {
+  type t('a) = {
+    front: list('a),
+    rear: list('a), // reversed
+    length: int
+  };
+
+  let empty = {
+    front: [],
+    rear: [],
+    length: 0
+  };
+
+  let length = q =>
+    q.length;
+
+  let push = (item, queue) => {
+    ...queue,
+    rear: [item, ...queue.rear],
+    length: queue.length + 1
+  };
+
+  let pushFront = (item, queue) => {
+    ...queue,
+    front: [item, ...queue.front],
+    length: queue.length + 1
+  };
+
+  let pop = queue => {
+    let queue =
+      if (queue.front == []) {
+        {
+          ...queue,
+          front: List.rev(queue.rear),
+          rear: []
+        }
+      } else {
+        queue
+      };
+
+    switch (queue.front) {
+    | [item, ...tail] => (
+      Some(item),
+      {
+        ...queue,
+        front: tail,
+        length: queue.length - 1
+      }
+    )
+    | [] =>
+      (None, queue)
+    }
+  };
+
+  let toList = ({front, rear, _}) =>
+    front @ List.rev(rear)
+}

--- a/src/Model/FilterJob.re
+++ b/src/Model/FilterJob.re
@@ -53,20 +53,17 @@ module Make = (Config: Config) => {
 
   module CompletedWork = {
     type t = {
-      allFiltered: list(Config.item),
-      // If the allFiltered list is still huge,
-      // we take a subset prior to sorting to display in the UI
-      // The 'ui' filtered should be the main item for the UI to use
-      uiFiltered: list(Filter.result(Config.item)),
+      filtered: list(Config.item),
+      ranked: list(Filter.result(Config.item)),
     };
 
-    let initial = {allFiltered: [], uiFiltered: []};
+    let initial = {filtered: [], ranked: []};
 
-    let toString = ({allFiltered, uiFiltered}) =>
+    let toString = ({filtered, ranked}) =>
       Printf.sprintf(
-        "- Completed Work\n -- allFiltered: %n -- uiFiltered: %n",
-        List.length(allFiltered),
-        List.length(uiFiltered),
+        "- Completed Work\n -- filtered: %n -- ranked: %n",
+        List.length(filtered),
+        List.length(ranked),
       );
   };
 
@@ -74,11 +71,7 @@ module Make = (Config: Config) => {
 
   /* [addItems] is a helper for `Job.map` that updates the job when the query has changed */
   let updateQuery =
-      (
-        filter,
-        pending: PendingWork.t,
-        {allFiltered, uiFiltered}: CompletedWork.t,
-      ) => {
+      (filter, pending: PendingWork.t, {filtered, ranked}: CompletedWork.t) => {
     // TODO: Optimize - for now, if the query changes, just clear the completed work
     // However, there are several ways we could improve this:
     // - If the query is just a stricter version... we could add the filter items back to completed
@@ -87,8 +80,7 @@ module Make = (Config: Config) => {
     let explodedFilter = Zed_utf8.explode(filter);
     let shouldLower = filter == String.lowercase_ascii(filter);
 
-    let currentMatches =
-      Utility.firstk(Constants.maxItemsToFilter, allFiltered);
+    let currentMatches = Utility.firstk(Constants.maxItemsToFilter, filtered);
 
     // If the new query matches the old one... we can re-use results
     if (pending.filter != ""
@@ -98,23 +90,23 @@ module Make = (Config: Config) => {
 
       let newCompletedWork =
         CompletedWork.{
-          allFiltered:
+          filtered:
             List.filter(
               item =>
                 Filter.fuzzyMatches(
                   explodedFilter,
                   format(item, ~shouldLower),
                 ),
-              allFiltered,
+              filtered,
             ),
-          uiFiltered:
+          ranked:
             List.filter(
               (Filter.{item, _}) =>
                 Filter.fuzzyMatches(
                   explodedFilter,
                   format(item, ~shouldLower),
                 ),
-              uiFiltered,
+              ranked,
             ),
         };
 
@@ -146,47 +138,46 @@ module Make = (Config: Config) => {
   let doActualWork =
       (
         {queue, shouldLower, filter, explodedFilter, _} as pendingWork: PendingWork.t,
-        {allFiltered, _}: CompletedWork.t,
+        {filtered, _}: CompletedWork.t,
       ) => {
     // Take out the items to process this frame
     let (items, queue) = Queue.take(Constants.itemsPerFrame, queue);
 
     // Do a first filter pass to check if the item satisifies the regex
-    let allFiltered =
+    let filtered =
       List.fold_left(
-        (completed, item) => {
+        (acc, item) => {
           let name = format(item, ~shouldLower);
 
           if (Filter.fuzzyMatches(explodedFilter, name)) {
-            [item, ...completed];
+            [item, ...acc];
           } else {
-            completed;
+            acc;
           };
         },
-        allFiltered,
+        filtered,
         items,
       );
 
     // Rank a limited nuumber of filtered items
-    let uiFiltered =
-      allFiltered
+    let ranked =
+      filtered
       |> Utility.firstk(Constants.maxItemsToFilter)
       |> Filter.rank(filter, format);
 
     (
       Queue.isEmpty(queue),
       {...pendingWork, queue},
-      CompletedWork.{allFiltered, uiFiltered},
+      CompletedWork.{filtered, ranked},
     );
   };
 
   /* [doWork] is run each frame until the work is completed! */
   let doWork = (pending: PendingWork.t, completed) =>
     if (pending.filter == "") {
-      let allFiltered = pending.allItems |> Queue.toList;
-      let uiFiltered =
-        allFiltered |> List.map(item => Filter.{highlight: [], item});
-      (true, pending, CompletedWork.{allFiltered, uiFiltered});
+      let filtered = pending.allItems |> Queue.toList;
+      let ranked = filtered |> List.map(item => Filter.{highlight: [], item});
+      (true, pending, CompletedWork.{filtered, ranked});
     } else {
       doActualWork(pending, completed);
     };

--- a/src/Store/FilterSubscription.re
+++ b/src/Store/FilterSubscription.re
@@ -54,7 +54,7 @@ module Make = (JobConfig: Oni_Model.FilterJob.Config) => {
             switch (Hashtbl.find_opt(jobs, id)) {
             | Some({job, _} as state) when !Job.isComplete(job) =>
               let job = Job.tick(job);
-              let items = Job.getCompletedWork(job).uiFiltered;
+              let items = Job.getCompletedWork(job).ranked;
               let progress = Job.getProgress(job);
               dispatch(onUpdate(items, ~progress));
               Hashtbl.replace(jobs, id, {...state, job});

--- a/test/Core/UtilityTests.re
+++ b/test/Core/UtilityTests.re
@@ -218,7 +218,7 @@ describe("StringUtil", ({describe, _}) => {
   });
 });
 
-describe("Queue", ({describe, _}) => {
+let testQueue = (describe: Rely.Describe.describeFn(_), module Queue: Queue) => {
   describe("length", ({test, _}) => {
     test("empty", ({expect}) => {
       let q = Queue.empty;
@@ -417,6 +417,56 @@ describe("Queue", ({describe, _}) => {
 
       expect.list(items).toEqual([1, 2]);
       expect.list(Queue.toList(q)).toEqual([3, 4]);
+    });
+  });
+};
+
+describe("Queue", ({describe, _}) => {
+  testQueue(describe, (module Queue))
+});
+
+describe("ChunkyQueue", ({describe, _}) => {
+  testQueue(describe, (module ChunkyQueue));
+
+  module Queue = ChunkyQueue;
+
+  describe("pushChunk", ({test, _}) => {
+    test("empty", ({expect}) => {
+      let q = Queue.empty |> Queue.pushChunk([]);
+
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("singleton", ({expect}) => {
+      let q = Queue.empty |> Queue.pushChunk([42]);
+
+      expect.list(Queue.toList(q)).toEqual([42]);
+    });
+
+    test("chunk", ({expect}) => {
+      let q = Queue.empty |> Queue.pushChunk([1, 2, 3, 4]);
+
+      expect.list(Queue.toList(q)).toEqual([4, 3, 2, 1]);
+    });
+  });
+
+  describe("pushReversedChunk", ({test, _}) => {
+    test("empty", ({expect}) => {
+      let q = Queue.empty |> Queue.pushReversedChunk([]);
+
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("singleton", ({expect}) => {
+      let q = Queue.empty |> Queue.pushReversedChunk([42]);
+
+      expect.list(Queue.toList(q)).toEqual([42]);
+    });
+
+    test("chunk", ({expect}) => {
+      let q = Queue.empty |> Queue.pushReversedChunk([1, 2, 3, 4]);
+
+      expect.list(Queue.toList(q)).toEqual([1, 2, 3, 4]);
     });
   });
 });

--- a/test/Core/UtilityTests.re
+++ b/test/Core/UtilityTests.re
@@ -217,3 +217,206 @@ describe("StringUtil", ({describe, _}) => {
     });
   });
 });
+
+describe("Queue", ({describe, _}) => {
+  describe("length", ({test, _}) => {
+    test("empty", ({expect}) => {
+      let q = Queue.empty;
+
+      expect.int(Queue.length(q)).toBe(0);
+    });
+
+    test("push 1", ({expect}) => {
+      let q = Queue.empty |> Queue.push(42);
+
+      expect.int(Queue.length(q)).toBe(1);
+    });
+
+    test("push 4", ({expect}) => {
+      let q =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.push(3)
+        |> Queue.push(4);
+
+      expect.int(Queue.length(q)).toBe(4);
+    });
+
+    test("pop empty", ({expect}) => {
+      let (_, q) = Queue.empty |> Queue.pop;
+
+      expect.int(Queue.length(q)).toBe(0);
+    });
+
+    test("push 1 + pop", ({expect}) => {
+      let (_, q) = Queue.empty |> Queue.push(42) |> Queue.pop;
+
+      expect.int(Queue.length(q)).toBe(0);
+    });
+
+    test("push 4 + pop", ({expect}) => {
+      let (_, q) =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.push(3)
+        |> Queue.push(4)
+        |> Queue.pop;
+
+      expect.int(Queue.length(q)).toBe(3);
+    });
+
+    test("take empty", ({expect}) => {
+      let (_, q) = Queue.empty |> Queue.take(5);
+
+      expect.int(Queue.length(q)).toBe(0);
+    });
+  });
+
+  describe("isEmpty", ({test, _}) => {
+    test("empty", ({expect}) => {
+      let q = Queue.empty;
+
+      expect.bool(Queue.isEmpty(q)).toBe(true);
+    });
+
+    test("push 1", ({expect}) => {
+      let q = Queue.empty |> Queue.push(42);
+
+      expect.bool(Queue.isEmpty(q)).toBe(false);
+    });
+  });
+
+  describe("push", ({test, _}) => {
+    test("push 1", ({expect}) => {
+      let q = Queue.empty |> Queue.push(42);
+
+      expect.list(Queue.toList(q)).toEqual([42]);
+    });
+
+    test("push 4", ({expect}) => {
+      let q =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.push(3)
+        |> Queue.push(4);
+
+      expect.list(Queue.toList(q)).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe("pushFront", ({test, _}) => {
+    test("pushFront 1", ({expect}) => {
+      let q = Queue.empty |> Queue.pushFront(42);
+
+      expect.list(Queue.toList(q)).toEqual([42]);
+    });
+
+    test("pushFront 4", ({expect}) => {
+      let q =
+        Queue.empty
+        |> Queue.pushFront(1)
+        |> Queue.pushFront(2)
+        |> Queue.pushFront(3)
+        |> Queue.pushFront(4);
+
+      expect.list(Queue.toList(q)).toEqual([4, 3, 2, 1]);
+    });
+
+    test("push 2 + pushFront 2", ({expect}) => {
+      let q =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.pushFront(3)
+        |> Queue.pushFront(4);
+
+      expect.list(Queue.toList(q)).toEqual([4, 3, 1, 2]);
+    });
+  });
+
+  describe("pop", ({test, _}) => {
+    test("pop empty", ({expect}) => {
+      let (maybeItem, q) = Queue.empty |> Queue.pop;
+
+      expect.equal(maybeItem, None);
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("push 1 + pop", ({expect}) => {
+      let (maybeItem, q) = Queue.empty |> Queue.push(42) |> Queue.pop;
+
+      expect.equal(maybeItem, Some(42));
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("push 4 + pop", ({expect}) => {
+      let (maybeItem, q) =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.push(3)
+        |> Queue.push(4)
+        |> Queue.pop;
+
+      expect.equal(maybeItem, Some(1));
+      expect.list(Queue.toList(q)).toEqual([2, 3, 4]);
+    });
+
+    test("push 1 + pop 2", ({expect}) => {
+      let (maybeItem, q) = Queue.empty |> Queue.push(42) |> Queue.pop;
+
+      expect.equal(maybeItem, Some(42));
+      expect.list(Queue.toList(q)).toEqual([]);
+
+      let (maybeItem, q) = Queue.pop(q);
+
+      expect.equal(maybeItem, None);
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+  });
+
+  describe("take", ({test, _}) => {
+    test("take empty", ({expect}) => {
+      let (items, q) = Queue.empty |> Queue.take(5);
+
+      expect.list(items).toEqual([]);
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("push 1 + take 5", ({expect}) => {
+      let (items, q) = Queue.empty |> Queue.push(42) |> Queue.take(5);
+
+      expect.list(items).toEqual([42]);
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("push 4 + take 5", ({expect}) => {
+      let (items, q) =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.push(3)
+        |> Queue.push(4)
+        |> Queue.take(5);
+
+      expect.list(items).toEqual([1, 2, 3, 4]);
+      expect.list(Queue.toList(q)).toEqual([]);
+    });
+
+    test("push 4 + take 2", ({expect}) => {
+      let (items, q) =
+        Queue.empty
+        |> Queue.push(1)
+        |> Queue.push(2)
+        |> Queue.push(3)
+        |> Queue.push(4)
+        |> Queue.take(2);
+
+      expect.list(items).toEqual([1, 2]);
+      expect.list(Queue.toList(q)).toEqual([3, 4]);
+    });
+  });
+});

--- a/test/Model/FilterJobTest.re
+++ b/test/Model/FilterJobTest.re
@@ -30,9 +30,8 @@ describe("FilterJob", ({describe, _}) => {
         |> Job.map(FilterJob.updateQuery("pref"))
         |> runToCompletion;
 
-      let uiFilteredLength =
-        List.length(Job.getCompletedWork(job).uiFiltered);
-      expect.int(uiFilteredLength).toBe(1);
+      let rankedLength = List.length(Job.getCompletedWork(job).ranked);
+      expect.int(rankedLength).toBe(1);
     });
 
     test("updating query should not reset items", ({expect, _}) => {
@@ -52,7 +51,7 @@ describe("FilterJob", ({describe, _}) => {
         |> Job.map(FilterJob.updateQuery("abce"));
 
       // We should have results without needing to do another iteration of work
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abcde"]);
     });
@@ -72,7 +71,7 @@ describe("FilterJob", ({describe, _}) => {
         |> Job.doWork
         |> Job.doWork;
 
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abcde", "abcd"]);
     });
@@ -96,7 +95,7 @@ describe("FilterJob", ({describe, _}) => {
         |> Job.doWork
         |> Job.doWork;
 
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abcde", "abcd"]);
     });
@@ -111,21 +110,21 @@ describe("FilterJob", ({describe, _}) => {
         |> Job.map(FilterJob.updateQuery("abc"))
         |> runToCompletion;
 
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abc"]);
 
       let job =
         job |> Job.map(FilterJob.updateQuery("abd")) |> runToCompletion;
 
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abd"]);
 
       let job =
         job |> Job.map(FilterJob.updateQuery("ab")) |> runToCompletion;
 
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abd", "abc"]);
     });
@@ -142,7 +141,7 @@ describe("FilterJob", ({describe, _}) => {
         |> Job.map(FilterJob.updateQuery("abc"))
         |> runToCompletion;
 
-      let filtered = Job.getCompletedWork(job).allFiltered;
+      let filtered = Job.getCompletedWork(job).filtered;
       let names = List.map((item: Actions.menuItem) => item.name, filtered);
       expect.list(names).toEqual(["abcd"]);
     });


### PR DESCRIPTION
Performance-wise the only significant difference is that adding items takes twice as long because the length of each chunk is computed twice, inside each of the queues it is added too. Previously it could be computed once since the total count was dealt with separately.

TODO:
- [x] add tests