### PR TITLE
File Explorer performance tweaks

### DIFF
--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -2,6 +2,7 @@ type t = {
   id: int,
   path: string,
   displayName: string,
+  hash: int, // hash of basename, so only comparable locally
   icon: option(IconTheme.IconDefinition.t),
   kind,
   expandedSubtreeSize: int,
@@ -26,21 +27,28 @@ let rec countExpandedSubtree =
   | _ => 1;
 
 let file = (path, ~id, ~icon) => {
-  id,
-  path,
-  displayName: Filename.basename(path),
-  icon,
-  kind: File,
-  expandedSubtreeSize: 1,
-};
-
-let directory = (~isOpen=false, path, ~id, ~icon, ~children) => {
-  let kind = Directory({isOpen, children});
+  let basename = Filename.basename(path);
 
   {
     id,
     path,
-    displayName: Filename.basename(path),
+    displayName: basename,
+    hash: Hashtbl.hash(basename),
+    icon,
+    kind: File,
+    expandedSubtreeSize: 1,
+  }
+};
+
+let directory = (~isOpen=false, path, ~id, ~icon, ~children) => {
+  let kind = Directory({isOpen, children});
+  let basename = Filename.basename(path);
+
+  {
+    id,
+    path,
+    displayName: basename,
+    hash: Hashtbl.hash(basename),
     icon,
     kind,
     expandedSubtreeSize: countExpandedSubtree(kind),

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -37,7 +37,7 @@ let file = (path, ~id, ~icon) => {
     icon,
     kind: File,
     expandedSubtreeSize: 1,
-  }
+  };
 };
 
 let directory = (~isOpen=false, path, ~id, ~icon, ~children) => {
@@ -56,19 +56,22 @@ let directory = (~isOpen=false, path, ~id, ~icon, ~children) => {
 };
 
 let findNodesByLocalPath = (path, tree) => {
-  let pathSegments = path |> String.split_on_char(Filename.dir_sep.[0]);
+  let pathHashes =
+    path
+    |> String.split_on_char(Filename.dir_sep.[0])
+    |> List.map(Hashtbl.hash);
 
   let rec loop = (focusedNodes, children, pathSegments) =>
     switch (pathSegments) {
     | [] => `Success(focusedNodes |> List.rev)
-    | [pathSegment, ...rest] =>
+    | [hash, ...rest] =>
       switch (children) {
       | [] =>
         let last = focusedNodes |> List.hd;
         last.id == tree.id ? `Failed : `Partial(last);
 
       | [node, ...children] =>
-        if (node.displayName == pathSegment) {
+        if (node.hash == hash) {
           let children =
             switch (node.kind) {
             | Directory({children, _}) => children
@@ -82,7 +85,7 @@ let findNodesByLocalPath = (path, tree) => {
     };
 
   switch (tree.kind) {
-  | Directory({children, _}) => loop([tree], children, pathSegments)
+  | Directory({children, _}) => loop([tree], children, pathHashes)
   | File => `Failed
   };
 };

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -3,6 +3,7 @@ type t =
     id: int,
     path: string,
     displayName: string,
+    hash: int, // hash of basename, so only comparable locally
     icon: option(IconTheme.IconDefinition.t),
     kind,
     expandedSubtreeSize: int,

--- a/src/Model/Workspace.re
+++ b/src/Model/Workspace.re
@@ -18,6 +18,6 @@ type t = option(workspace);
 let initial: t = None;
 
 let toRelativePath = (base, path) => {
-  let re = Str.regexp_string(base ++ Filename.dir_sep);
-  Str.replace_first(re, "", path);
+  let base = base == "/" ? base : base ++ Filename.dir_sep;
+  Str.replace_first(Str.regexp_string(base), "", path);
 };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -5,15 +5,17 @@ open Revery.UI;
 
 module Core = Oni_Core;
 
-let toNodePath = (workspace: Workspace.workspace, tree, path) => {
-  let localPath = Workspace.toRelativePath(workspace.workingDirectory, path);
+let toNodePath = (workspace: Workspace.workspace, tree, path) =>
+  Core.Log.perf("FileTreeview.toNodePath", () => {
+    let localPath =
+      Workspace.toRelativePath(workspace.workingDirectory, path);
 
-  switch (FsTreeNode.findNodesByLocalPath(localPath, tree)) {
-  | `Success(nodes) => Some(nodes)
-  | `Partial(_)
-  | `Failed => None
-  };
-};
+    switch (FsTreeNode.findNodesByLocalPath(localPath, tree)) {
+    | `Success(nodes) => Some(nodes)
+    | `Partial(_)
+    | `Failed => None
+    };
+  });
 
 module Styles = {
   open Style;


### PR DESCRIPTION
So far I've just added logging. I'm not sure how to find good test cases for this. A good test case would be a file that's both deep in the hierarchy, is nested in directories with many items and also listed late in those directories.

The worst case I found had `toNodePath` use 2e-05s.

I also found that focus does not work when the workspace is set to root (`/`) though. I need to look into that before I implement the hashing.