### PR TITLE
Debug: Write a 'crash log' whenever Onivim 2 crashes - so it is more actionable

### DIFF
--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -297,7 +297,12 @@ Env.filter |> Option.iter(Namespace.setFilter);
 
 let writeExceptionLog = (e, bt) => {
   let oc = Stdlib.open_out("onivim2-crash.log");
-  Printf.fprintf(oc, "%s:\n%s", Printexc.to_string(e), Printexc.raw_backtrace_to_string(bt));
+  Printf.fprintf(
+    oc,
+    "%s:\n%s",
+    Printexc.to_string(e),
+    Printexc.raw_backtrace_to_string(bt),
+  );
   Stdlib.close_out(oc);
 };
 
@@ -317,6 +322,6 @@ if (isDebugLoggingEnabled()) {
 } else {
   // Even if we're not debugging.... at least emit the exception
   Printexc.set_uncaught_exception_handler((e, bt) => {
-     writeExceptionLog(e, bt);
+    writeExceptionLog(e, bt)
   });
-}
+};


### PR DESCRIPTION
When a crash occurs in the OCaml code, even if logging isn't enabled, we'll write an `onivim2-crash.log` file - at least giving the exception message, which can give us an idea of the class of error.