### PR TITLE
Fix #1070: Crash when running ':e ~/some/directory' in OSX build

### DIFF
--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -30,7 +30,7 @@ module Effects = {
 let nodeOffsetByPath = (tree, path) => {
   let rec loop = (node: FsTreeNode.t, path) =>
     switch (path) {
-    | [] => failwith("Well, this is awkward (ie. unreachable)")
+    | [] => `NotFound(0)
     | [(focus: FsTreeNode.t), ...focusTail] =>
       if (focus.id != node.id) {
         `NotFound(node.expandedSubtreeSize);

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -30,7 +30,7 @@ module Effects = {
 let nodeOffsetByPath = (tree, path) => {
   let rec loop = (node: FsTreeNode.t, path) =>
     switch (path) {
-    | [] => `NotFound(0)
+    | [] => `Found(0)
     | [(focus: FsTreeNode.t), ...focusTail] =>
       if (focus.id != node.id) {
         `NotFound(node.expandedSubtreeSize);


### PR DESCRIPTION
Fixes #1070 - a crash when trying to edit a directory.

It's a bit of a mystery why we are hitting this case in packaged builds, but _not_ in development builds / running the executable directly.

This prevents the crash, but the focus behavior is not correct (it doesn't actually focus the directory). 