### PR TITLE
Fix off-by-one bug in the visual range integration

### DIFF
--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -231,11 +231,11 @@ let start =
           Range.{
             start: {
               ...range.start,
-              column: Index.(range.start.column + 1),
+              column: range.start.column,
             },
             stop: {
               ...range.stop,
-              column: Index.(range.stop.column + 1),
+              column: range.stop.column,
             },
           },
         );


### PR DESCRIPTION
When using either characterwise visual mode (`v`) or blockwise visual mode (`<c-v>`), the selection highlights would be off by one column. 