### PR TITLE
CI: Fix hang for Windows when running integration tests / health check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
   - script: dir
     workingDirectory: _release/win32
     displayName: 'check directory contents'
-  - script: Oni2.exe -f --checkhealth
+  - script: Oni2.exe -f --checkhealth --no-log-colors
     workingDirectory: _release/win32
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-win.yml
@@ -213,5 +213,5 @@ jobs:
   # but we need to check from the command prompt, too via %PATH% - for #872
   - script: |
       set PATH=%PATH%;D:/a/1/s/Onivim2
-      Oni2.exe -f --checkhealth 
+      Oni2.exe -f --checkhealth --no-log-colors
     displayName: "Oni2.exe - run installed"

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -55,6 +55,12 @@ let runTest =
       ~name="AnonymousTest",
       test: testCallback,
     ) => {
+
+  // Disable colors on windows to prevent hanging on CI
+  if (Sys.win32) {
+    Log.disableColors();
+  }
+
   Printexc.record_backtrace(true);
   Log.enablePrinting();
   Log.enableDebugLogging();

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -55,11 +55,10 @@ let runTest =
       ~name="AnonymousTest",
       test: testCallback,
     ) => {
-
   // Disable colors on windows to prevent hanging on CI
   if (Sys.win32) {
     Log.disableColors();
-  }
+  };
 
   Printexc.record_backtrace(true);
   Log.enablePrinting();

--- a/src/Core/Cli.re
+++ b/src/Core/Cli.re
@@ -52,6 +52,7 @@ let parse = (~checkHealth) => {
       ("-f", Unit(Log.enablePrinting), ""),
       ("--nofork", Unit(Log.enablePrinting), ""),
       ("--debug", Unit(Log.enableDebugLogging), ""),
+      ("--no-log-colors", Unit(Log.disableColors), ""),
       ("--log-file", String(Log.setLogFile), ""),
       ("--log-filter", String(Log.Namespace.setFilter), ""),
       ("--checkhealth", Unit(checkHealth), ""),

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -213,6 +213,9 @@ let reporter =
 let enablePrinting = () => Logs.set_reporter(reporter);
 let isPrintingEnabled = () => Logs.reporter() !== Logs.nop_reporter;
 
+let disableColors = () =>
+  Fmt_tty.setup_std_outputs(~style_renderer=`None, ());
+
 let enableDebugLogging = () =>
   Logs.Src.set_level(Logs.default, Some(Logs.Debug));
 let isDebugLoggingEnabled = () =>

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -1,5 +1,7 @@
 type msgf('a, 'b) = (format4('a, Format.formatter, unit, 'b) => 'a) => 'b;
 
+let disableColors: unit => unit;
+
 let enablePrinting: unit => unit;
 let isPrintingEnabled: unit => bool;
 

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -18,6 +18,11 @@ let spec = [
   ("-f", Arg.Set(stayAttached), ""),
   ("--nofork", Arg.Set(stayAttached), ""),
   ("--debug", passthrough, ""),
+  (
+    "--no-log-colors",
+    passthrough,
+    "Turn off colors and rich formatting in logs.",
+  ),
   ("--log-file", passthroughString, ""),
   ("--log-filter", passthroughString, ""),
   ("--checkhealth", passthrough, ""),


### PR DESCRIPTION
__Issue:__ There seems to be a hang on Windows intermittently when running the integration tests & health checks on CI.

I can actually reproduce it locally with `esy '@integrationtest' run` in Powershell. It seems there are some errant term codes that cause the console to expect input even after the processes end. This might be a combination of the colorization + some threaded output we get from the syntax server.

In any case, turning off the colors fixes the hang for me locally, so I added a CLI option `--no-log-colors` and use it for the health checks, and turned off colored output for the integration tests on Windows.