### PR TITLE
Fix #1071: Empty editor split

### DIFF
--- a/src/Model/WindowTree.re
+++ b/src/Model/WindowTree.re
@@ -109,7 +109,11 @@ let rec removeSplit = (id, currentTree) =>
       children
       |> List.map(child => removeSplit(id, child))
       |> List.filter(filterEmpty);
-    Parent(direction, newChildren);
+
+    if (List.length(newChildren) > 0)
+    Parent(direction, newChildren) 
+    else
+    Empty
   | Leaf(split) when split.id == id => Empty
   | Leaf(_) as leaf => leaf
   | Empty => Empty

--- a/src/Model/WindowTree.re
+++ b/src/Model/WindowTree.re
@@ -110,10 +110,11 @@ let rec removeSplit = (id, currentTree) =>
       |> List.map(child => removeSplit(id, child))
       |> List.filter(filterEmpty);
 
-    if (List.length(newChildren) > 0)
-    Parent(direction, newChildren) 
-    else
-    Empty
+    if (List.length(newChildren) > 0) {
+      Parent(direction, newChildren);
+    } else {
+      Empty;
+    };
   | Leaf(split) when split.id == id => Empty
   | Leaf(_) as leaf => leaf
   | Empty => Empty

--- a/test/Model/WindowTreeTests.re
+++ b/test/Model/WindowTreeTests.re
@@ -6,7 +6,35 @@ module WindowTree = Oni_Model.WindowTree;
 
 open WindowTree;
 
-describe("WindowTreeTests", ({describe, _}) =>
+describe("WindowTreeTests", ({describe, _}) => {
+  describe("removeSplit", ({test, _}) => {
+    test("empty parent splits are removed", ({expect, _}) => {
+      let splits = WindowTree.empty;
+
+      let split1 = createSplit(~editorGroupId=1, ());
+      let split2 = createSplit(~editorGroupId=2, ());
+      let split3 = createSplit(~editorGroupId=2, ());
+      let split4 = createSplit(~editorGroupId=1, ());
+
+      let splits =
+        splits
+        |> addSplit(~target=None, Vertical, split1)
+        |> addSplit(~target=Some(split1.id), Vertical, split2)
+        |> addSplit(~target=Some(split2.id), Horizontal, split3)
+        |> addSplit(~target=Some(split1.id), Horizontal, split4);
+
+      let newSplits =
+        splits
+        |> removeSplit(split4.id)
+        |> removeSplit(split3.id)
+        |> removeSplit(split2.id);
+
+      expect.equal(
+        newSplits,
+        Parent(Vertical, [Parent(Horizontal, [Leaf(split1)])]),
+      );
+    })
+  });
   describe("addSplit", ({test, _}) => {
     test("add vertical split", ({expect}) => {
       let splits = WindowTree.empty;
@@ -77,8 +105,8 @@ describe("WindowTreeTests", ({describe, _}) =>
         true,
       );
     });
-  })
-);
+  });
+});
 
 describe("rotateForward", ({test, _}) => {
   test("simple tree", ({expect}) => {


### PR DESCRIPTION
Fixes #1071 

__Issue:__ In certain cases, the editor surface wouldn't expand to fill up the available space after removing a split.

__Defect:__ When a split is removed, we filter out all the 'empty' splits. However, there was a case missed - if, after filtering, a parent has 0 children, we'd leave it around (and it would take up space) - but that should be removed too.

__Fix:__ Remove parent with 0 children after filtering.