### PR TITLE
CI: Move --no-log-colors before checkhealth

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
   - script: dir
     workingDirectory: _release/win32
     displayName: 'check directory contents'
-  - script: Oni2.exe -f --checkhealth --no-log-colors
+  - script: Oni2.exe -f --no-log-colors --checkhealth
     workingDirectory: _release/win32
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-win.yml
@@ -213,5 +213,5 @@ jobs:
   # but we need to check from the command prompt, too via %PATH% - for #872
   - script: |
       set PATH=%PATH%;D:/a/1/s/Onivim2
-      Oni2.exe -f --checkhealth --no-log-colors
+      Oni2.exe -f --no-log-colors --checkhealth
     displayName: "Oni2.exe - run installed"


### PR DESCRIPTION
It looks like we were still getting colored output on CI, with the command:
```
Oni2.exe -f --checkhealth --no-log-colors
```

With the way the CLI parsing is done - the health check was being run before applying the `--no-log-colors`. In #1065 , the CLI parsing will be fixed to apply all the arguments prior to running commands like health-check. But in the short-term, this puts `--no-colors` before `--checkhealth` to unblock CI builds.

