### PR TITLE
CI: Add --no-log-colors to validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
   - template: .ci/esy-build-steps.yml
     parameters:
       platform: linux
-  - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
+  - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --no-log-colors --checkhealth
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-build-cache.yml
 

--- a/scripts/windows/validate-release.ps1
+++ b/scripts/windows/validate-release.ps1
@@ -31,5 +31,5 @@ ls D:/
 ls D:/a/1/s
 ls D:/a/1/s/Onivim2
 
-D:/a/1/s/Onivim2/Oni2.exe -f --checkhealth
+D:/a/1/s/Onivim2/Oni2.exe -f --no-log-colors --checkhealth
 


### PR DESCRIPTION
Missed one spot that was still hanging - the `Oni2.exe -f --checkhealth` call line in our windows validation script. This adds `--no-log-colors` to it, too.