### PR TITLE
File Explorer Keyboard Navigation - Part 1

### DIFF
--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -254,6 +254,24 @@ module RangeUtil = {
     };
 };
 
+module ArrayEx = {
+  exception Found(int);
+
+  let findIndex = (predicate, array) =>
+    try(
+      {
+        for (i in 0 to Array.length(array) - 1) {
+          if (predicate(array[i])) {
+            raise(Found(i));
+          };
+        };
+        None;
+      }
+    ) {
+    | Found(i) => Some(i)
+    };
+};
+
 // TODO: Remove after 4.08 upgrade
 module List = {
   include List;

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -701,3 +701,15 @@ module ChunkyQueue: {
   let toList = ({front, rear, _}) =>
     front @ (Queue.toList(rear) |> List.concat);
 };
+
+module Path = {
+  // Not very robust path-handling utilities.
+  // TODO: Make good
+
+  let toRelative = (~base, path) => {
+    let base = base == "/" ? base : base ++ Filename.dir_sep;
+    Str.replace_first(Str.regexp_string(base), "", path);
+  };
+
+  let explode = String.split_on_char(Filename.dir_sep.[0]);
+};

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -6,7 +6,7 @@ type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float)],
-  focus: option(string) // path
+  active: option(string) // path
 };
 
 [@deriving show({with_path: false})]
@@ -136,5 +136,5 @@ let initial = {
   tree: None,
   isOpen: true,
   scrollOffset: `Start(0.),
-  focus: None,
+  active: None,
 };

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -1,4 +1,3 @@
-open Revery;
 open Oni_Core;
 open Oni_Extensions;
 
@@ -13,15 +12,12 @@ type t = {
 [@deriving show({with_path: false})]
 type action =
   | TreeLoaded([@opaque] FsTreeNode.t)
-  | NodeLoaded(int, [@opaque] FsTreeNode.t)
-  | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
+  | NodeLoaded(string, [@opaque] FsTreeNode.t)
+  | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
   | FocusPrev
   | FocusNext;
-
-module ExplorerId =
-  UniqueId.Make({});
 
 let getFileIcon = (languageInfo, iconTheme, filePath) => {
   let fileIcon =
@@ -82,7 +78,6 @@ let getFilesAndFolders = (~ignored, cwd, getIcon) => {
   let rec getDirContent = (~loadChildren=false, cwd) => {
     let toFsTreeNode = file => {
       let path = Filename.concat(cwd, file);
-      let id = ExplorerId.getUniqueId();
 
       if (isDirectory(path)) {
         let%lwt children =
@@ -97,10 +92,11 @@ let getFilesAndFolders = (~ignored, cwd, getIcon) => {
             Lwt.return([]);
           };
 
-        FsTreeNode.directory(path, ~id, ~icon=getIcon(path), ~children)
-        |> Lwt.return;
+        Lwt.return(
+          FsTreeNode.directory(path, ~icon=getIcon(path), ~children)
+        )
       } else {
-        FsTreeNode.file(path, ~id, ~icon=getIcon(path)) |> Lwt.return;
+        FsTreeNode.file(path, ~icon=getIcon(path)) |> Lwt.return;
       };
     };
 
@@ -119,7 +115,6 @@ let getFilesAndFolders = (~ignored, cwd, getIcon) => {
 };
 
 let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
-  let id = ExplorerId.getUniqueId();
   let getIcon = getFileIcon(languageInfo, iconTheme);
   let children =
     getFilesAndFolders(~ignored, cwd, getIcon)
@@ -128,7 +123,6 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
 
   FsTreeNode.directory(
     cwd,
-    ~id,
     ~icon=getIcon(cwd),
     ~children,
     ~isOpen=true,

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -7,7 +7,7 @@ type t = {
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float)],
   active: option(string), // path
-  focus: option(int), // node id
+  focus: option(string) // node id
 };
 
 [@deriving show({with_path: false})]
@@ -16,7 +16,9 @@ type action =
   | NodeLoaded(int, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
-  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)]);
+  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
+  | FocusPrev
+  | FocusNext;
 
 module ExplorerId =
   UniqueId.Make({});
@@ -138,4 +140,5 @@ let initial = {
   isOpen: true,
   scrollOffset: `Start(0.),
   active: None,
+  focus: None,
 };

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -93,8 +93,8 @@ let getFilesAndFolders = (~ignored, cwd, getIcon) => {
           };
 
         Lwt.return(
-          FsTreeNode.directory(path, ~icon=getIcon(path), ~children)
-        )
+          FsTreeNode.directory(path, ~icon=getIcon(path), ~children),
+        );
       } else {
         FsTreeNode.file(path, ~icon=getIcon(path)) |> Lwt.return;
       };
@@ -121,12 +121,7 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
     |> Lwt_main.run
     |> List.sort(sortByLoweredDisplayName);
 
-  FsTreeNode.directory(
-    cwd,
-    ~icon=getIcon(cwd),
-    ~children,
-    ~isOpen=true,
-  );
+  FsTreeNode.directory(cwd, ~icon=getIcon(cwd), ~children, ~isOpen=true);
 };
 
 let initial = {

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -16,6 +16,7 @@ type action =
   | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
+  | Select
   | FocusPrev
   | FocusNext;
 

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -6,7 +6,8 @@ type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float)],
-  active: option(string) // path
+  active: option(string), // path
+  focus: option(int), // node id
 };
 
 [@deriving show({with_path: false})]

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -4,7 +4,8 @@ type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float)],
-  active: option(string) // path
+  active: option(string), // path
+  focus: option(int), // node id
 };
 
 [@deriving show]

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -15,6 +15,7 @@ type action =
   | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
+  | Select
   | FocusPrev
   | FocusNext;
 

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -11,8 +11,8 @@ type t = {
 [@deriving show]
 type action =
   | TreeLoaded([@opaque] FsTreeNode.t)
-  | NodeLoaded(int, [@opaque] FsTreeNode.t)
-  | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
+  | NodeLoaded(string, [@opaque] FsTreeNode.t)
+  | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
   | FocusPrev

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -5,7 +5,7 @@ type t = {
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float)],
   active: option(string), // path
-  focus: option(int), // node id
+  focus: option(string) // node id
 };
 
 [@deriving show]
@@ -14,7 +14,9 @@ type action =
   | NodeLoaded(int, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(int, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
-  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)]);
+  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
+  | FocusPrev
+  | FocusNext;
 
 let initial: t;
 

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -4,7 +4,7 @@ type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float)],
-  focus: option(string) // path
+  active: option(string) // path
 };
 
 [@deriving show]

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -90,6 +90,37 @@ let findNodesByLocalPath = (path, tree) => {
   };
 };
 
+let findByLocalPath = (path, tree) => {
+  let pathSegments = path |> String.split_on_char(Filename.dir_sep.[0]);
+
+  let rec loop = (node, children, pathSegments) =>
+    switch (pathSegments) {
+    | [] => Some(node)
+    | [pathSegment, ...rest] =>
+      switch (children) {
+      | [] =>
+        None
+
+      | [node, ...children] =>
+        if (node.displayName == pathSegment) {
+          let children =
+            switch (node.kind) {
+            | Directory({children, _}) => children
+            | File => []
+            };
+          loop(node, children, rest);
+        } else {
+          loop(node, children, pathSegments);
+        }
+      }
+    };
+
+  switch (tree.kind) {
+  | Directory({children, _}) => loop(tree, children, pathSegments)
+  | File => None
+  };
+};
+
 let update = (~tree, ~updater, nodeId) => {
   let rec loop =
     fun

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -1,6 +1,7 @@
 open Oni_Core;
 
 module ArrayEx = Utility.ArrayEx;
+module Path = Utility.Path;
 
 type t = {
   path: string,
@@ -59,10 +60,10 @@ let directory = (~isOpen=false, path, ~icon, ~children) => {
 let equals = (a, b) => a.hash == b.hash && a.path == b.path;
 
 let findNodesByPath = (path, tree) => {
-  let path = Workspace.toRelativePath(tree.path, path);
   let pathHashes =
     path
-    |> String.split_on_char(Filename.dir_sep.[0])
+    |> Path.toRelative(~base=tree.path)
+    |> Path.explode
     |> List.map(Hashtbl.hash);
 
   let rec loop = (focusedNodes, children, pathSegments) =>
@@ -99,10 +100,10 @@ let findNodesByPath = (path, tree) => {
 };
 
 let findByPath = (path, tree) => {
-  let path = Workspace.toRelativePath(tree.path, path);
   let pathHashes =
     path
-    |> String.split_on_char(Filename.dir_sep.[0])
+    |> Path.toRelative(~base=tree.path)
+    |> Path.explode
     |> List.map(Hashtbl.hash);
 
   let rec loop = (node, children, pathHashes) =>

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -1,3 +1,7 @@
+open Oni_Core;
+
+module ArrayEx = Utility.ArrayEx;
+
 type t = {
   id: int,
   path: string,
@@ -55,7 +59,8 @@ let directory = (~isOpen=false, path, ~id, ~icon, ~children) => {
   };
 };
 
-let findNodesByLocalPath = (path, tree) => {
+let findNodesByPath = (path, tree) => {
+  let path = Workspace.toRelativePath(tree.path, path);
   let pathHashes =
     path
     |> String.split_on_char(Filename.dir_sep.[0])
@@ -90,7 +95,8 @@ let findNodesByLocalPath = (path, tree) => {
   };
 };
 
-let findByLocalPath = (path, tree) => {
+let findByPath = (path, tree) => {
+  let path = Workspace.toRelativePath(tree.path, path);
   let pathSegments = path |> String.split_on_char(Filename.dir_sep.[0]);
 
   let rec loop = (node, children, pathSegments) =>
@@ -98,8 +104,7 @@ let findByLocalPath = (path, tree) => {
     | [] => Some(node)
     | [pathSegment, ...rest] =>
       switch (children) {
-      | [] =>
-        None
+      | [] => None
 
       | [node, ...children] =>
         if (node.displayName == pathSegment) {
@@ -120,6 +125,82 @@ let findByLocalPath = (path, tree) => {
   | File => None
   };
 };
+
+let prevExpandedNode = (path, tree) =>
+  switch (findNodesByPath(path, tree)) {
+  | `Success(nodePath) =>
+    switch (List.rev(nodePath)) {
+    // Has a parent, and therefore also siblings
+    | [focus, {kind: Directory({children, _}), _} as parent, ..._] =>
+      let children = children |> Array.of_list;
+      let index = children |> ArrayEx.findIndex(child => child.id == focus.id);
+
+      switch (index) {
+      // is first child
+      | Some(index) when index == 0 => Some(parent)
+
+      | Some(index) =>
+        switch (children[index - 1]) {
+        // is open directory with at least one child
+        | {
+            kind: Directory({isOpen: true, children: [_, ..._] as children}),
+            _,
+          } =>
+          let children = children |> Array.of_list;
+          let lastChild = children[Array.length(children) - 1];
+          Some(lastChild);
+
+        | prev => Some(prev)
+        }
+
+      | None => None // is not a child of its parent (?!)
+      };
+    | _ => None // has neither parent or siblings
+    }
+  | `Partial(_)
+  | `Failed => None // path does not exist in this ree
+  };
+
+let nextExpandedNode = (path, tree) =>
+  switch (findNodesByPath(path, tree)) {
+  | `Success(nodePath) =>
+    let rec loop = revNodePath =>
+      switch (revNodePath) {
+      | [
+          focus,
+          ...[{kind: Directory({children, _}), _}, ..._] as ancestors,
+        ] =>
+        let children = children |> Array.of_list;
+        let index =
+          children |> ArrayEx.findIndex(child => child.id == focus.id);
+
+        switch (index) {
+        // is last child
+        | Some(index) when index == Array.length(children) - 1 =>
+          loop(ancestors)
+
+        | Some(index) =>
+          let next = children[index + 1];
+          Some(next);
+
+        | None => None // is not a child of its parent (?!)
+        };
+      | _ => None // has neither parent or siblings
+      };
+
+    switch (List.rev(nodePath)) {
+    // Focus is open directory with at least one child
+    | [
+        {kind: Directory({isOpen: true, children: [firstChild, ..._]}), _},
+        ..._,
+      ] =>
+      Some(firstChild)
+    | revNodePath => loop(revNodePath)
+    };
+
+  | `Partial(_)
+  | `Failed => None // path does not exist in this tree
+  };
 
 let update = (~tree, ~updater, nodeId) => {
   let rec loop =

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -73,10 +73,10 @@ let findNodesByPath = (path, tree) => {
       | [] =>
         let last = List.hd(focusedNodes);
         if (equals(last, tree)) {
-          `Failed
+          `Failed;
         } else {
           `Partial(last);
-        }
+        };
 
       | [node, ...children] =>
         if (node.hash == hash) {

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -97,17 +97,20 @@ let findNodesByPath = (path, tree) => {
 
 let findByPath = (path, tree) => {
   let path = Workspace.toRelativePath(tree.path, path);
-  let pathSegments = path |> String.split_on_char(Filename.dir_sep.[0]);
+  let pathHashes =
+    path
+    |> String.split_on_char(Filename.dir_sep.[0])
+    |> List.map(Hashtbl.hash);
 
-  let rec loop = (node, children, pathSegments) =>
-    switch (pathSegments) {
+  let rec loop = (node, children, pathHashes) =>
+    switch (pathHashes) {
     | [] => Some(node)
-    | [pathSegment, ...rest] =>
+    | [hash, ...rest] =>
       switch (children) {
       | [] => None
 
       | [node, ...children] =>
-        if (node.displayName == pathSegment) {
+        if (node.hash == hash) {
           let children =
             switch (node.kind) {
             | Directory({children, _}) => children
@@ -115,13 +118,13 @@ let findByPath = (path, tree) => {
             };
           loop(node, children, rest);
         } else {
-          loop(node, children, pathSegments);
+          loop(node, children, pathHashes);
         }
       }
     };
 
   switch (tree.kind) {
-  | Directory({children, _}) => loop(tree, children, pathSegments)
+  | Directory({children, _}) => loop(tree, children, pathHashes)
   | File => None
   };
 };

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -28,9 +28,12 @@ let directory:
   ) =>
   t;
 
-let findNodesByLocalPath:
+let findNodesByPath:
   (string, t) => [ | `Success(list(t)) | `Partial(t) | `Failed];
-let findByLocalPath: (string, t) => option(t);
+let findByPath: (string, t) => option(t);
+
+let prevExpandedNode: (string, t) => option(t);
+let nextExpandedNode: (string, t) => option(t);
 
 let update: (~tree: t, ~updater: t => t, int) => t;
 let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -30,6 +30,7 @@ let directory:
 
 let findNodesByLocalPath:
   (string, t) => [ | `Success(list(t)) | `Partial(t) | `Failed];
+let findByLocalPath: (string, t) => option(t);
 
 let update: (~tree: t, ~updater: t => t, int) => t;
 let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -1,6 +1,5 @@
 type t =
   pri {
-    id: int,
     path: string,
     displayName: string,
     hash: int, // hash of basename, so only comparable locally
@@ -17,12 +16,11 @@ and kind =
       })
     | File;
 
-let file: (string, ~id: int, ~icon: option(IconTheme.IconDefinition.t)) => t;
+let file: (string, ~icon: option(IconTheme.IconDefinition.t)) => t;
 let directory:
   (
     ~isOpen: bool=?,
     string,
-    ~id: int,
     ~icon: option(IconTheme.IconDefinition.t),
     ~children: list(t)
   ) =>
@@ -35,10 +33,12 @@ let findByPath: (string, t) => option(t);
 let prevExpandedNode: (string, t) => option(t);
 let nextExpandedNode: (string, t) => option(t);
 
-let update: (~tree: t, ~updater: t => t, int) => t;
+let update: (~tree: t, ~updater: t => t, string) => t;
 let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;
 let toggleOpen: t => t;
 let setOpen: t => t;
+
+let equals: (t, t) => bool;
 
 module Model: {
   type nonrec t = t;

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -33,6 +33,8 @@ let findByPath: (string, t) => option(t);
 let prevExpandedNode: (string, t) => option(t);
 let nextExpandedNode: (string, t) => option(t);
 
+let expandedIndex: (t, list(t)) => option(int);
+
 let update: (~tree: t, ~updater: t => t, string) => t;
 let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;
 let toggleOpen: t => t;

--- a/src/Model/Workspace.re
+++ b/src/Model/Workspace.re
@@ -16,8 +16,3 @@ type workspace = {
 type t = option(workspace);
 
 let initial: t = None;
-
-let toRelativePath = (base, path) => {
-  let base = base == "/" ? base : base ++ Filename.dir_sep;
-  Str.replace_first(Str.regexp_string(base), "", path);
-};

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -26,41 +26,6 @@ module Effects = {
   };
 };
 
-// Counts the number of axpanded nodes before the node specified by the given path
-let nodeOffsetByPath = (tree, path) => {
-  let rec loop = (node, path) =>
-    switch (path) {
-    | [] => `Found(0)
-    | [focus, ...focusTail] =>
-      if (FsTreeNode.equals(focus, node)) {
-        `NotFound(node.expandedSubtreeSize);
-      } else {
-        switch (node.kind) {
-        | Directory({isOpen: false, _})
-        | File => `Found(0)
-
-        | Directory({isOpen: true, children}) =>
-          let rec loopChildren = (count, children) =>
-            switch (children) {
-            | [] => `NotFound(count)
-            | [child, ...childTail] =>
-              switch (loop(child, focusTail)) {
-              | `Found(subtreeCount) => `Found(count + subtreeCount)
-              | `NotFound(subtreeCount) =>
-                loopChildren(count + subtreeCount, childTail)
-              }
-            };
-          loopChildren(1, children);
-        };
-      }
-    };
-
-  switch (loop(tree, path)) {
-  | `Found(count) => Some(count)
-  | `NotFound(_) => None
-  };
-};
-
 let updateFileExplorer = (updater, state) =>
   State.{...state, fileExplorer: updater(state.fileExplorer)};
 let setTree = (tree, state) =>
@@ -104,7 +69,7 @@ let revealPath = (state: State.t, path) => {
           ~updater=FsTreeNode.setOpen,
         );
       let offset =
-        switch (nodeOffsetByPath(tree, nodes)) {
+        switch (FsTreeNode.expandedIndex(tree, nodes)) {
         | Some(offset) => `Middle(float(offset))
         | None => state.fileExplorer.scrollOffset
         };

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -148,9 +148,9 @@ let start = () => {
 
     | FocusNodeLoaded(path, node) =>
       switch (state.fileExplorer.active) {
-      | Some(path) =>
+      | Some(activePath) =>
         let state = replaceNode(path, node, state);
-        revealPath(state, path);
+        revealPath(state, activePath);
       | None => (state, Isolinear.Effect.none)
       }
 

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -69,6 +69,8 @@ let setOpen = (isOpen, state) =>
   updateFileExplorer(s => {...s, isOpen}, state);
 let setActive = (maybePath, state) =>
   updateFileExplorer(s => {...s, active: maybePath}, state);
+let setFocus = (maybeId, state) =>
+  updateFileExplorer(s => {...s, focus: maybeId}, state);
 let setScrollOffset = (scrollOffset, state) =>
   updateFileExplorer(s => {...s, scrollOffset}, state);
 
@@ -150,8 +152,11 @@ let start = () => {
       }
 
     | NodeClicked(node) =>
+      let state = 
+        state
       // Set active here to avoid scrolling in BufferEnter
-      let state = setActive(Some(node.path), state);
+        |> setActive(Some(node.path))
+        |> setFocus(Some(node.id));
 
       switch (node) {
       | {kind: File, path, _} => (state, openFileByPathEffect(path))

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -67,8 +67,8 @@ let setTree = (tree, state) =>
   updateFileExplorer(s => {...s, tree: Some(tree)}, state);
 let setOpen = (isOpen, state) =>
   updateFileExplorer(s => {...s, isOpen}, state);
-let setFocus = (focus, state) =>
-  updateFileExplorer(s => {...s, focus}, state);
+let setActive = (maybePath, state) =>
+  updateFileExplorer(s => {...s, active: maybePath}, state);
 let setScrollOffset = (scrollOffset, state) =>
   updateFileExplorer(s => {...s, scrollOffset}, state);
 
@@ -144,14 +144,14 @@ let start = () => {
     | NodeLoaded(id, node) => (replaceNode(id, node), Isolinear.Effect.none)
 
     | FocusNodeLoaded(id, node) =>
-      switch (state.fileExplorer.focus) {
+      switch (state.fileExplorer.active) {
       | Some(path) => revealPath(replaceNode(id, node), path)
       | None => (state, Isolinear.Effect.none)
       }
 
     | NodeClicked(node) =>
-      // Set focus here to avoid scrolling in BufferEnter
-      let state = setFocus(Some(node.path), state);
+      // Set active here to avoid scrolling in BufferEnter
+      let state = setActive(Some(node.path), state);
 
       switch (node) {
       | {kind: File, path, _} => (state, openFileByPathEffect(path))
@@ -212,8 +212,8 @@ let start = () => {
 
       | BufferEnter({filePath, _}, _) =>
         switch (state.fileExplorer) {
-        | {focus, _} when focus != filePath =>
-          let state = setFocus(filePath, state);
+        | {active, _} when active != filePath =>
+          let state = setActive(filePath, state);
           switch (filePath) {
           | Some(path) => revealPath(state, path)
           | None => (state, Isolinear.Effect.none)

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -12,6 +12,7 @@ module Actions = Model.Actions;
 module Animation = Model.Animation;
 module Quickmenu = Model.Quickmenu;
 module Utility = Core.Utility;
+module Path = Utility.Path;
 module ExtensionContributions = Oni_Extensions.ExtensionContributions;
 module Log = (val Core.Log.withNamespace("Oni2.QuickmenuStore"));
 
@@ -69,7 +70,7 @@ let start = (themeInfo: Model.ThemeInfo.t) => {
            Some(
              Actions.{
                category: None,
-               name: Model.Workspace.toRelativePath(currentDirectory, path),
+               name: Path.toRelative(~base=currentDirectory, path),
                command: () => {
                  Model.Actions.OpenFileByPath(path, None, None);
                },
@@ -375,7 +376,7 @@ let subscriptions = ripgrep => {
     let stringToCommand = (languageInfo, iconTheme, fullPath) =>
       Actions.{
         category: None,
-        name: Model.Workspace.toRelativePath(directory, fullPath),
+        name: Path.toRelative(~base=directory, fullPath),
         command: () => Model.Actions.OpenFileByPath(fullPath, None, None),
         icon:
           Model.FileExplorer.getFileIcon(languageInfo, iconTheme, fullPath),

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -11,7 +11,7 @@ let make = (~state: State.t, ()) => {
 
   switch (state.fileExplorer) {
   | {tree: None, _} => React.empty
-  | {tree: Some(tree), active, _} =>
-    <FileTreeView state active onNodeClick tree />
+  | {tree: Some(tree), active, focus, _} =>
+    <FileTreeView state active focus onNodeClick tree />
   };
 };

--- a/src/UI/FileExplorerView.re
+++ b/src/UI/FileExplorerView.re
@@ -11,7 +11,7 @@ let make = (~state: State.t, ()) => {
 
   switch (state.fileExplorer) {
   | {tree: None, _} => React.empty
-  | {tree: Some(tree), focus, _} =>
-    <FileTreeView state focus onNodeClick tree />
+  | {tree: Some(tree), active, _} =>
+    <FileTreeView state active onNodeClick tree />
   };
 };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -1,3 +1,4 @@
+open Oni_Core;
 open Oni_Model;
 
 open Revery;
@@ -24,7 +25,7 @@ module Styles = {
 
   let item = [flexDirection(`Row), alignItems(`Center)];
 
-  let text = (~fg, ~font: Core.UiFont.t) => [
+  let text = (~fg, ~font: UiFont.t) => [
     fontSize(font.fontSize),
     fontFamily(font.fontFile),
     color(fg),
@@ -49,7 +50,7 @@ let setiIcon = (~icon, ~fontSize as size, ~fg, ()) => {
   />;
 };
 
-let nodeView = (~font: Core.UiFont.t, ~fg, ~node: FsTreeNode.t, ()) => {
+let nodeView = (~font: UiFont.t, ~fg, ~node: FsTreeNode.t, ()) => {
   let icon = () =>
     switch (node.icon) {
     | Some(icon) =>
@@ -95,8 +96,8 @@ let make =
 
   let fg = state.theme.sideBarForeground;
 
-  let focus =
-    switch (focus, state.workspace) {
+  let active =
+    switch (active, state.workspace) {
     | (Some(path), Some(workspace)) => toNodePath(workspace, tree, path)
     | _ => None
     };
@@ -112,7 +113,7 @@ let make =
       scrollOffset
       onScrollOffsetChange
       tree
-      focus
+      active
       theme
       itemHeight=22
       onClick=onNodeClick>

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -131,10 +131,18 @@ let%component make =
 
   let onKeyDown = (event: NodeEvents.keyEventParams) => {
     switch (event.keycode) {
+    // Enter
+    | v when v == 13 =>
+      GlobalContext.current().dispatch(Actions.FileExplorer(Select))
+
+    // arrow up
     | v when v == 1073741906 =>
       GlobalContext.current().dispatch(Actions.FileExplorer(FocusPrev))
+
+    // arrow down
     | v when v == 1073741905 =>
       GlobalContext.current().dispatch(Actions.FileExplorer(FocusNext))
+
     | _ => ()
     };
   };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -142,11 +142,7 @@ let%component make =
   <View
     onKeyDown style=Styles.container ref={ref => setContainerRef(Some(ref))}>
     <TreeView
-      scrollOffset
-      onScrollOffsetChange
-      tree
-      itemHeight=22
-      onClick=onNodeClick>
+      scrollOffset onScrollOffsetChange tree itemHeight=22 onClick=onNodeClick>
       ...{node =>
         <nodeView
           isFocus={Some(node.path) == focus}

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -118,18 +118,6 @@ let%component make =
   [@warning "-27"]
   let State.{theme, uiFont as font, _} = state;
 
-  let fg = state.theme.sideBarForeground;
-
-  let active =
-    active
-    |> Option.bind(path => FsTreeNode.findByPath(path, tree))
-    |> Option.map((node: FsTreeNode.t) => node.id);
-
-  let focus =
-    focus
-    |> Option.bind(path => FsTreeNode.findByPath(path, tree))
-    |> Option.map((node: FsTreeNode.t) => node.id);
-
   let FileExplorer.{scrollOffset, _} = state.fileExplorer;
   let onScrollOffsetChange = offset =>
     GlobalContext.current().dispatch(
@@ -162,8 +150,8 @@ let%component make =
       onClick=onNodeClick>
       ...{node =>
         <nodeView
-          isFocus={Some(node.id) == focus}
-          isActive={Some(node.id) == active}
+          isFocus={Some(node.path) == focus}
+          isActive={Some(node.path) == active}
           font
           theme
           node

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -145,7 +145,6 @@ let%component make =
       scrollOffset
       onScrollOffsetChange
       tree
-      theme
       itemHeight=22
       onClick=onNodeClick>
       ...{node =>

--- a/src/UI/LocationListView.re
+++ b/src/UI/LocationListView.re
@@ -6,6 +6,7 @@ open Oni_Core;
 open Oni_Model;
 
 module Option = Utility.Option;
+module Path = Utility.Path;
 
 // TODO: move to Revery
 let getFontAdvance = (fontFile, fontSize) => {
@@ -84,7 +85,7 @@ let item =
   let locationText =
     Printf.sprintf(
       "%s:%n - ",
-      Workspace.toRelativePath(workingDirectory, item.file),
+      Path.toRelative(~base=workingDirectory, item.file),
       Index.toOneBased(item.location.line),
     );
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -53,13 +53,13 @@ module Styles = {
     bottom(0),
   ];
 
-  let item = (~itemHeight, ~isFocused, ~theme: Theme.t) => [
+  let item = (~itemHeight, ~isActive, ~theme: Theme.t) => [
     height(itemHeight),
     cursor(Revery.MouseCursors.pointer),
     flexDirection(`Row),
     overflow(`Hidden),
     backgroundColor(
-      isFocused ? theme.menuSelectionBackground : Colors.transparentWhite,
+      isActive ? theme.menuSelectionBackground : Colors.transparentWhite,
     ),
   ];
 
@@ -91,7 +91,7 @@ module Make = (Model: TreeModel) => {
   let rec nodeView =
           (
             ~renderContent,
-            ~focus,
+            ~active,
             ~itemHeight,
             ~clipRange as (clipStart, clipEnd),
             ~onClick,
@@ -101,8 +101,8 @@ module Make = (Model: TreeModel) => {
           ) => {
     let subtreeSize = Model.expandedSubtreeSize(node);
 
-    let (isFocused, childFocus) =
-      switch (focus) {
+    let (isActive, descendantActive) =
+      switch (active) {
       | Some([last]) when last == node => (true, None)
       | Some([head, ...tail]) when head == node => (false, Some(tail))
       | Some(_) => (false, None)
@@ -115,7 +115,7 @@ module Make = (Model: TreeModel) => {
     let item = (~arrow, ()) =>
       <Clickable
         onClick={() => onClick(node)}
-        style={Styles.item(~itemHeight, ~isFocused, ~theme)}>
+        style={Styles.item(~itemHeight, ~isActive, ~theme)}>
         <arrow />
         {renderContent(node)}
       </Clickable>;
@@ -127,7 +127,7 @@ module Make = (Model: TreeModel) => {
           let element =
             <nodeView
               renderContent
-              focus=childFocus
+              active=descendantActive
               itemHeight
               clipRange=(clipStart - count, clipEnd - count)
               onClick
@@ -173,7 +173,7 @@ module Make = (Model: TreeModel) => {
   let%component make =
                 (
                   ~children as renderContent,
-                  ~focus: option(list(Model.t)),
+                  ~active: option(list(Model.t)),
                   ~itemHeight,
                   ~initialRowsToRender=10,
                   ~onClick,
@@ -266,7 +266,7 @@ module Make = (Model: TreeModel) => {
         <View style={Styles.content(~scrollTop)}>
           <nodeView
             renderContent
-            focus
+            active
             itemHeight
             clipRange
             onClick

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -101,8 +101,7 @@ module Make = (Model: TreeModel) => {
 
     let item = (~arrow, ()) =>
       <Clickable
-        onClick={() => onClick(node)}
-        style={Styles.item(~itemHeight)}>
+        onClick={() => onClick(node)} style={Styles.item(~itemHeight)}>
         <arrow />
         {renderContent(node)}
       </Clickable>;
@@ -247,13 +246,7 @@ module Make = (Model: TreeModel) => {
       onMouseWheel=scroll>
       <View style={Styles.viewport(~showScrollbar)}>
         <View style={Styles.content(~scrollTop)}>
-          <nodeView
-            renderContent
-            itemHeight
-            clipRange
-            onClick
-            node=tree
-          />
+          <nodeView renderContent itemHeight clipRange onClick node=tree />
         </View>
       </View>
       {showScrollbar ? <scrollbar /> : React.empty}

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -53,14 +53,11 @@ module Styles = {
     bottom(0),
   ];
 
-  let item = (~itemHeight, ~isActive, ~theme: Theme.t) => [
+  let item = (~itemHeight, ~theme: Theme.t) => [
     height(itemHeight),
     cursor(Revery.MouseCursors.pointer),
     flexDirection(`Row),
     overflow(`Hidden),
-    backgroundColor(
-      isActive ? theme.menuSelectionBackground : Colors.transparentWhite,
-    ),
   ];
 
   let placeholder = (~height) => [Style.height(height)];
@@ -91,7 +88,6 @@ module Make = (Model: TreeModel) => {
   let rec nodeView =
           (
             ~renderContent,
-            ~active,
             ~itemHeight,
             ~clipRange as (clipStart, clipEnd),
             ~onClick,
@@ -101,21 +97,13 @@ module Make = (Model: TreeModel) => {
           ) => {
     let subtreeSize = Model.expandedSubtreeSize(node);
 
-    let (isActive, descendantActive) =
-      switch (active) {
-      | Some([last]) when last == node => (true, None)
-      | Some([head, ...tail]) when head == node => (false, Some(tail))
-      | Some(_) => (false, None)
-      | _ => (false, None)
-      };
-
     let placeholder = (~size, ()) =>
       <View style={Styles.placeholder(~height=size * itemHeight)} />;
 
     let item = (~arrow, ()) =>
       <Clickable
         onClick={() => onClick(node)}
-        style={Styles.item(~itemHeight, ~isActive, ~theme)}>
+        style={Styles.item(~itemHeight, ~theme)}>
         <arrow />
         {renderContent(node)}
       </Clickable>;
@@ -127,7 +115,6 @@ module Make = (Model: TreeModel) => {
           let element =
             <nodeView
               renderContent
-              active=descendantActive
               itemHeight
               clipRange=(clipStart - count, clipEnd - count)
               onClick
@@ -173,7 +160,6 @@ module Make = (Model: TreeModel) => {
   let%component make =
                 (
                   ~children as renderContent,
-                  ~active: option(list(Model.t)),
                   ~itemHeight,
                   ~initialRowsToRender=10,
                   ~onClick,
@@ -266,7 +252,6 @@ module Make = (Model: TreeModel) => {
         <View style={Styles.content(~scrollTop)}>
           <nodeView
             renderContent
-            active
             itemHeight
             clipRange
             onClick

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -53,7 +53,7 @@ module Styles = {
     bottom(0),
   ];
 
-  let item = (~itemHeight, ~theme: Theme.t) => [
+  let item = (~itemHeight) => [
     height(itemHeight),
     cursor(Revery.MouseCursors.pointer),
     flexDirection(`Row),
@@ -92,7 +92,6 @@ module Make = (Model: TreeModel) => {
             ~clipRange as (clipStart, clipEnd),
             ~onClick,
             ~node,
-            ~theme,
             (),
           ) => {
     let subtreeSize = Model.expandedSubtreeSize(node);
@@ -103,7 +102,7 @@ module Make = (Model: TreeModel) => {
     let item = (~arrow, ()) =>
       <Clickable
         onClick={() => onClick(node)}
-        style={Styles.item(~itemHeight, ~theme)}>
+        style={Styles.item(~itemHeight)}>
         <arrow />
         {renderContent(node)}
       </Clickable>;
@@ -119,7 +118,6 @@ module Make = (Model: TreeModel) => {
               clipRange=(clipStart - count, clipEnd - count)
               onClick
               node=child
-              theme
             />;
 
           loop(
@@ -167,7 +165,6 @@ module Make = (Model: TreeModel) => {
                   ~onScrollOffsetChange:
                      [ | `Start(float) | `Middle(float)] => unit=_ => (),
                   ~tree,
-                  ~theme,
                   (),
                 ) => {
     let%hook (outerRef, setOuterRef) = Hooks.ref(None);
@@ -256,7 +253,6 @@ module Make = (Model: TreeModel) => {
             clipRange
             onClick
             node=tree
-            theme
           />
         </View>
       </View>


### PR DESCRIPTION
This implements basic keyboard navigation (up arrow/down arrow) and selection (enter) _within_ the file explorer. There's no way to use the keyboard to focus the file explorer, however, so it's not very useful for end-users yet. And because of the mechanism used to capture keyboard input it also blocks all keybindings. But it's useful for testing keyboard input and relatively self-contained, so I'm submitting this now to try to keep PRs manageable.

Addresses #528 