### PR TITLE
Search hotkey

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -120,6 +120,7 @@ type t =
   | CopyActiveFilepathToClipboard
   | SearchShow
   | SearchHide
+  | SearchHotkey
   | SearchInput(string, int)
   | SearchStart
   | SearchUpdate([@opaque] list(Ripgrep.Match.t))

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -185,6 +185,7 @@ let start = (getState, contributedCommands) => {
       "workbench.action.gotoSymbol",
       _ => singleActionEffect(QuickmenuShow(DocumentSymbols)),
     ),
+    ("workbench.action.findInFiles", _ => singleActionEffect(SearchHotkey)),
     (
       "workbench.action.openNextRecentlyUsedEditorInGroup",
       _ => singleActionEffect(QuickmenuShow(EditorsPicker)),

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -34,6 +34,16 @@ let start = () => {
         condition: "quickmenuCursorEnd" |> parseExp,
       },
       {
+        key: "<S-C-F>",
+        command: "workbench.action.findInFiles",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
+        key: "<D-S-F>",
+        command: "workbench.action.findInFiles",
+        condition: "editorTextFocus" |> parseExp,
+      },
+      {
         key: "<C-TAB>",
         command: "workbench.action.openNextRecentlyUsedEditorInGroup",
         condition: "editorTextFocus" |> parseExp,

--- a/src/Store/SearchStoreConnector.re
+++ b/src/Store/SearchStoreConnector.re
@@ -36,16 +36,27 @@ let start = () => {
         {...state, searchPane: None},
         Isolinear.Effect.none,
       )
+
     | ActivityBar(Model.ActivityBar.SearchClick) when state.searchPane == None => (
         {...state, searchPane: Some(Model.Search.initial)},
         Isolinear.Effect.none,
       )
+
     | SearchShow => (
         {...state, searchPane: Some(Model.Search.initial)},
         Isolinear.Effect.none,
       )
 
     | SearchHide => ({...state, searchPane: None}, Isolinear.Effect.none)
+
+    | SearchHotkey =>
+      switch (state.searchPane) {
+      | Some(_) => ({...state, searchPane: None}, Isolinear.Effect.none)
+      | None => (
+          {...state, searchPane: Some(Model.Search.initial)},
+          Isolinear.Effect.none,
+        )
+      }
 
     | _ =>
       switch (state.searchPane) {

--- a/src/UI/SearchPane.re
+++ b/src/UI/SearchPane.re
@@ -71,6 +71,7 @@ let make = (~theme, ~uiFont, ~editorFont, ~state: Search.t, ()) => {
       </View>
       <View style=Styles.row>
         <OniInput
+          autofocus=true
           style={Styles.input(~font=uiFont)}
           cursorColor=Colors.gray
           cursorPosition={state.cursorPosition}


### PR DESCRIPTION
Fixes #1054 (At least partially)

Adds a new keybinding to toggle Search, and gives focus to the input when pane is opened. Unfortunately it's not very practical to focus the input outside the view as it would require storing the input ref in the state or a global. So instead the hotkey just toggles the pane. We can revisit this once I've changed the focus mechanism so it's controlled bottom-up.