### PR TITLE
CI: Add --no-log-colors to missed windows health check

### DIFF
--- a/scripts/windows/validate-release.ps1
+++ b/scripts/windows/validate-release.ps1
@@ -11,7 +11,7 @@ Write-Host "** Validating .zip package **"
 Expand-Archive -Path $env:SYSTEM_ARTIFACTSDIRECTORY/Release_Windows/Onivim2-$SHORT_COMMIT_ID.zip -DestinationPath _unpacked/
 ls _unpacked
 $env:ONI2_DEBUG=1
-./_unpacked/win32/Oni2.exe -f --checkhealth
+./_unpacked/win32/Oni2.exe -f --no-log-colors --checkhealth
 
 Write-Host "** Validating .exe installer **"
 rm -r _unpacked


### PR DESCRIPTION
Looking at the CI failure for #1087 (<https://dev.azure.com/onivim/oni2/_build/results?buildId=8227&view=logs&j=16afaa31-88f2-57dc-4c6f-57177f9c64fc&t=11c2e412-6171-5c8e-1aae-001304ca28f3>), I realized there was still another place I missed `--no-log-colors` for Windows in #1078 and #1079.

This fixes the remaining spot so hopefully no more hangs of that class in CI.