### PR TITLE
Docs - Update Docs/CLI Help Text.

### DIFF
--- a/docs/docs/configuration/extensions.md
+++ b/docs/docs/configuration/extensions.md
@@ -1,0 +1,45 @@
+---
+id: extensions
+title: extensions
+sidebar_label: VSCode Extensions
+---
+
+Onivim is capable of loading VSCode extensions. The current capabilities of the
+extension host can be found [here](https://github.com/onivim/oni2/issues/1058).
+
+## Installing extensions
+
+Onivim has two ways of installing VSCode extensions currently, though in the future this
+will be expanded to include an in-editor experience.
+
+Extensions by default are installed in the following folders:
+
+ - `~/.config/oni2/extensions` - Linux/macOS
+ - `%LOCALAPPDATA%/oni2/extensions` - Windows
+
+This can be overridden with the `--extensions-dir` command line flag however.
+
+### Installing `vsix` files
+
+The Onivim command line executable has a `--install-extension` flag, that can be given a
+path to a `.vsix` file like so:
+
+```sh
+oni2 --install-extension /path/to/some-extension.vsix
+```
+
+> __NOTE:__ Currently, `oni2` is only added to the user's `PATH` on Windows. Find instructions on adding it to your `PATH` on macOS and Linux over [here](./../using-onivim/command-line.md).
+
+### Installing manually from a GitHub repo
+
+If a `.vsix` file can not be found, the alternative way of installing a VSCode extension
+is to download the extension manually into the extension folder.
+
+```sh
+cd $ONI2_CONFIG_DIR/extensions
+git clone https://github.com/thomaspink/vscode-github-theme.git
+```
+
+## Listing extensions
+
+The currently installed extensions are listed in the editor, in the extensions panel.

--- a/docs/docs/configuration/extensions.md
+++ b/docs/docs/configuration/extensions.md
@@ -1,6 +1,6 @@
 ---
 id: extensions
-title: extensions
+title: VSCode Extensions
 sidebar_label: VSCode Extensions
 ---
 
@@ -15,7 +15,7 @@ will be expanded to include an in-editor experience.
 Extensions by default are installed in the following folders:
 
  - `~/.config/oni2/extensions` - Linux/macOS
- - `%LOCALAPPDATA%/oni2/extensions` - Windows
+ - `%LOCALAPPDATA%/Oni2/extensions` - Windows
 
 This can be overridden with the `--extensions-dir` command line flag however.
 
@@ -30,7 +30,7 @@ oni2 --install-extension /path/to/some-extension.vsix
 
 > __NOTE:__ Currently, `oni2` is only added to the user's `PATH` on Windows. Find instructions on adding it to your `PATH` on macOS and Linux over [here](./../using-onivim/command-line.md).
 
-### Installing manually from a GitHub repo
+### Installing manually
 
 If a `.vsix` file can not be found, the alternative way of installing a VSCode extension
 is to download the extension manually into the extension folder.
@@ -43,3 +43,4 @@ git clone https://github.com/thomaspink/vscode-github-theme.git
 ## Listing extensions
 
 The currently installed extensions are listed in the editor, in the extensions panel.
+Alternatively, this can be achieved with the `--list-extensions` command line flag.

--- a/docs/docs/using-onivim/command-line.md
+++ b/docs/docs/using-onivim/command-line.md
@@ -21,12 +21,17 @@ alias oni2='/Applications/Onivim2.app/Contents/MacOS/Oni2'
 This should be added to one of the shell files that is loaded on shell start up, such as
 the `.bashrc` or equivalent for other shells.
 
+> __NOTE:__ It is currently preferable to alias `oni2`, rather than adding a symlink to it.
+
 ### Getting help
 
 Launching `oni2` with the `--help` flag should give a brief outline on all command line
 flags.
 
 ### Extension Management
+
+A more in detail explanation of the VSCode extension management can be found
+[here](./../configuration/extensions.md).
 
 By default, user extension are loaded from the following paths:
 
@@ -77,6 +82,6 @@ oni2 -f --checkhealth
 
 ### Miscellaneous
 
-- `-force-device-scale-factor` overrides the current scaling. 
+- `-force-device-scale-factor` overrides the current scaling.
 
 > Example: `oni2 --force-device-scale-factor 2`

--- a/docs/docs/using-onivim/command-line.md
+++ b/docs/docs/using-onivim/command-line.md
@@ -6,13 +6,31 @@ sidebar_label: Command Line
 
 ## Command Line Interface
 
+The `oni2` command line executable is currently only added to the user's `PATH` on
+Windows. However, it can be added manually by updating the `PATH` environment variable
+to point to the folder where the `oni2` executable lives, or adding an alias to `oni2`:
+
+```sh
+# Linux
+alias oni2="${HOME}/path/to/Onivim2-x86_64.AppImage"
+
+# macOS
+alias oni2='/Applications/Onivim2.app/Contents/MacOS/Oni2'
+```
+
+This should be added to one of the shell files that is loaded on shell start up, such as
+the `.bashrc` or equivalent for other shells.
+
 ### Getting help
+
+Launching `oni2` with the `--help` flag should give a brief outline on all command line
+flags.
 
 ### Extension Management
 
 By default, user extension are loaded from the following paths:
 
-- Windows: `%LOCALAPPDATA%/Oni2/extensions` 
+- Windows: `%LOCALAPPDATA%/Oni2/extensions`
 - OSX & Linux: `~/.config/oni2/extensions`
 
 This can be overridden via the `--extensions-dir`, like:

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -14,7 +14,8 @@
     ],
     "Configuration": [
       "configuration/settings",
-      "configuration/key-bindings"
+      "configuration/key-bindings",
+      "configuration/extensions"
     ],
     "For Developers": [
       "for-developers/architecture",

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -7,48 +7,70 @@
 let stayAttached = ref(false);
 
 let version = () => {
-  print_endline("Onivim 2 0.0.0");
+  print_endline("Onivim 2 0.2.0");
 };
 
 let passthrough = Arg.Unit(() => ());
 let passthroughFloat = Arg.Float(_ => ());
 let passthroughString = Arg.String(_ => ());
 
-let spec = [
-  ("-f", Arg.Set(stayAttached), "Stay attached to the foreground terminal"),
-  (
-    "--nofork",
-    Arg.Set(stayAttached),
-    "Stay attached to the foreground termina",
-  ),
-  ("--debug", passthrough, ""),
-  ("--log-file", passthroughString, "Specify a file to output logs"),
-  ("--log-filter", passthroughString, "Filter log output"),
-  (
-    "--no-log-colors",
-    passthrough,
-    "Turn off colors and rich formatting in logs.",
-  ),
-  ("--checkhealth", passthrough, ""),
-  (
-    "--install-extension",
-    passthroughString,
-    "Install extension by specifying a path to the .vsix file",
-  ),
-  (
-    "--uninstall-extension",
-    passthroughString,
-    "Uninstall extension by specifying an extension id.",
-  ),
-  ("--extensions-dir", passthroughString, ""),
-  ("--list-extensions", Arg.Set(stayAttached), ""),
-  ("--force-device-scale-factor", passthroughFloat, ""),
-  ("--working-directory", passthrough, ""),
-  ("-version", Arg.Unit(version), "Print version"),
-];
+let spec =
+  Arg.align([
+    (
+      "-f",
+      Arg.Set(stayAttached),
+      " Stay attached to the foreground terminal.",
+    ),
+    (
+      "--nofork",
+      Arg.Set(stayAttached),
+      " Stay attached to the foreground terminal.",
+    ),
+    ("--debug", passthrough, " Enable debug logging."),
+    ("--log-file", passthroughString, " Specify a file for the output logs."),
+    ("--log-filter", passthroughString, " Filter log output."),
+    (
+      "--no-log-colors",
+      passthrough,
+      " Turn off colors and rich formatting in logs.",
+    ),
+    ("--checkhealth", passthrough, " Check the health of the Oni2 editor."),
+    (
+      "--install-extension",
+      passthroughString,
+      " Install extension by specifying a path to the .vsix file",
+    ),
+    (
+      "--uninstall-extension",
+      passthroughString,
+      " Uninstall extension by specifying an extension id.",
+    ),
+    (
+      "--extensions-dir",
+      passthroughString,
+      " The folder to store/load VSCode extensions.",
+    ),
+    (
+      "--list-extensions",
+      Arg.Set(stayAttached),
+      " List the currently installed extensions.",
+    ),
+    (
+      "--force-device-scale-factor",
+      passthroughFloat,
+      " Force the DPI scaling for the editor.",
+    ),
+    (
+      "--working-directory",
+      passthrough,
+      " Set the current working for Oni2.",
+    ),
+    ("--version", Arg.Unit(version), " Print version information."),
+    ("-v", Arg.Unit(version), " Print version information."),
+  ]);
 
 let usage = {|
-Onivim 2
+Onivim 2 0.2.0
 
 Usage:
 


### PR DESCRIPTION
Some of the docs are a bit duplicated between CLI/Extensions. Arguably for a flagship feature, I think we should have a distinct page for extensions, so this can hopefully be the start of that.

I also updated the CLI flag text and added it for every flag, such that they show up, and aligned them all.