### PR TITLE
CLI: Add CLI options to assist with troubleshooting

### DIFF
--- a/src/Store/SyntaxHighlightingStoreConnector.re
+++ b/src/Store/SyntaxHighlightingStoreConnector.re
@@ -18,136 +18,145 @@ module Protocol = Oni_Syntax.Protocol;
 
 module Log = Core.Log;
 
-let start = (languageInfo: Ext.LanguageInfo.t, setup: Core.Setup.t) => {
+let start =
+    (languageInfo: Ext.LanguageInfo.t, setup: Core.Setup.t, cli: Core.Cli.t) => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
-  let onHighlights = tokenUpdates => {
-    dispatch(Model.Actions.BufferSyntaxHighlights(tokenUpdates));
-  };
-
-  let _syntaxClient =
-    Oni_Syntax_Client.start(
-      ~scheduler=Core.Scheduler.mainThread,
-      ~onHighlights,
-      languageInfo,
-      setup,
-    );
-
-  let getLines = (state: Model.State.t, id: int) => {
-    switch (Model.Buffers.getBuffer(id, state.buffers)) {
-    | None => [||]
-    | Some(v) => Core.Buffer.getLines(v)
+  if (!cli.shouldSyntaxHighlight) {
+    let updater = (state, _action) => (state, Isolinear.Effect.none);
+    (updater, stream);
+  } else {
+    let onHighlights = tokenUpdates => {
+      dispatch(Model.Actions.BufferSyntaxHighlights(tokenUpdates));
     };
-  };
 
-  let getVersion = (state: Model.State.t, id: int) => {
-    switch (Model.Buffers.getBuffer(id, state.buffers)) {
-    | None => (-1)
-    | Some(v) => Core.Buffer.getVersion(v)
-    };
-  };
+    let _syntaxClient =
+      Oni_Syntax_Client.start(
+        ~scheduler=Core.Scheduler.mainThread,
+        ~onHighlights,
+        languageInfo,
+        setup,
+      );
 
-  let bufferEnterEffect = (id: int, fileType) =>
-    Isolinear.Effect.create(~name="syntax.bufferEnter", () => {
-      fileType
-      |> Option.iter(fileType =>
-           Oni_Syntax_Client.notifyBufferEnter(_syntaxClient, id, fileType)
-         )
-    });
-
-  let bufferUpdateEffect =
-      (bufferUpdate: Oni_Core.BufferUpdate.t, lines, maybeScope) =>
-    Isolinear.Effect.create(~name="syntax.bufferUpdate", () => {
-      switch (maybeScope) {
-      | None => ()
-      | Some(scope) =>
-        Oni_Syntax_Client.notifyBufferUpdate(
-          _syntaxClient,
-          bufferUpdate,
-          lines,
-          scope,
-        )
-      }
-    });
-
-  let configurationChangeEffect = (config: Core.Configuration.t) =>
-    Isolinear.Effect.create(~name="syntax.configurationChange", () => {
-      Oni_Syntax_Client.notifyConfigurationChanged(_syntaxClient, config)
-    });
-
-  let themeChangeEffect = theme =>
-    Isolinear.Effect.create(~name="syntax.theme", () => {
-      Oni_Syntax_Client.notifyThemeChanged(_syntaxClient, theme)
-    });
-
-  let visibilityChangedEffect = visibleRanges =>
-    Isolinear.Effect.create(~name="syntax.visibilityChange", () => {
-      Oni_Syntax_Client.notifyVisibilityChanged(_syntaxClient, visibleRanges)
-    });
-
-  let isVersionValid = (updateVersion, bufferVersion) => {
-    bufferVersion != (-1) && updateVersion == bufferVersion;
-  };
-
-  let getScopeForBuffer = (state: Model.State.t, id: int) => {
-    state.buffers
-    |> Model.Buffers.getBuffer(id)
-    |> Option.bind(buf => Core.Buffer.getFileType(buf))
-    |> Option.bind(fileType =>
-         Ext.LanguageInfo.getScopeFromLanguage(languageInfo, fileType)
-       );
-  };
-
-  let updater = (state: Model.State.t, action) => {
-    let default = (state, Isolinear.Effect.none);
-    switch (action) {
-    | Model.Actions.ConfigurationSet(config) => (
-        state,
-        configurationChangeEffect(config),
-      )
-    | Model.Actions.SetTokenTheme(tokenTheme) => (
-        state,
-        themeChangeEffect(tokenTheme),
-      )
-    | Model.Actions.BufferEnter(metadata, fileType) =>
-      let visibleBuffers =
-        Model.EditorVisibleRanges.getVisibleBuffersAndRanges(state);
-
-      let combinedEffects =
-        Isolinear.Effect.batch([
-          visibilityChangedEffect(visibleBuffers),
-          bufferEnterEffect(Vim.BufferMetadata.(metadata.id), fileType),
-        ]);
-
-      (state, combinedEffects);
-    // When the view changes, update our list of visible buffers,
-    // so we know which ones might have pending work!
-    | Model.Actions.EditorGroupAdd(_)
-    | Model.Actions.EditorScroll(_)
-    | Model.Actions.EditorScrollToLine(_)
-    | Model.Actions.EditorScrollToColumn(_)
-    | Model.Actions.AddSplit(_)
-    | Model.Actions.RemoveSplit(_)
-    | Model.Actions.ViewSetActiveEditor(_)
-    //| Model.Actions.BufferEnter(_)
-    | Model.Actions.ViewCloseEditor(_) =>
-      let visibleBuffers =
-        Model.EditorVisibleRanges.getVisibleBuffersAndRanges(state);
-      (state, visibilityChangedEffect(visibleBuffers));
-    // When there is a buffer update, send it over to the syntax highlight
-    // strategy to handle the parsing.
-    | Model.Actions.BufferUpdate(bu) =>
-      let lines = getLines(state, bu.id);
-      let version = getVersion(state, bu.id);
-      let scope = getScopeForBuffer(state, bu.id);
-      if (!isVersionValid(version, bu.version)) {
-        default;
-      } else {
-        (state, bufferUpdateEffect(bu, lines, scope));
+    let getLines = (state: Model.State.t, id: int) => {
+      switch (Model.Buffers.getBuffer(id, state.buffers)) {
+      | None => [||]
+      | Some(v) => Core.Buffer.getLines(v)
       };
-    | _ => default
     };
-  };
 
-  (updater, stream);
+    let getVersion = (state: Model.State.t, id: int) => {
+      switch (Model.Buffers.getBuffer(id, state.buffers)) {
+      | None => (-1)
+      | Some(v) => Core.Buffer.getVersion(v)
+      };
+    };
+
+    let bufferEnterEffect = (id: int, fileType) =>
+      Isolinear.Effect.create(~name="syntax.bufferEnter", () => {
+        fileType
+        |> Option.iter(fileType =>
+             Oni_Syntax_Client.notifyBufferEnter(_syntaxClient, id, fileType)
+           )
+      });
+
+    let bufferUpdateEffect =
+        (bufferUpdate: Oni_Core.BufferUpdate.t, lines, maybeScope) =>
+      Isolinear.Effect.create(~name="syntax.bufferUpdate", () => {
+        switch (maybeScope) {
+        | None => ()
+        | Some(scope) =>
+          Oni_Syntax_Client.notifyBufferUpdate(
+            _syntaxClient,
+            bufferUpdate,
+            lines,
+            scope,
+          )
+        }
+      });
+
+    let configurationChangeEffect = (config: Core.Configuration.t) =>
+      Isolinear.Effect.create(~name="syntax.configurationChange", () => {
+        Oni_Syntax_Client.notifyConfigurationChanged(_syntaxClient, config)
+      });
+
+    let themeChangeEffect = theme =>
+      Isolinear.Effect.create(~name="syntax.theme", () => {
+        Oni_Syntax_Client.notifyThemeChanged(_syntaxClient, theme)
+      });
+
+    let visibilityChangedEffect = visibleRanges =>
+      Isolinear.Effect.create(~name="syntax.visibilityChange", () => {
+        Oni_Syntax_Client.notifyVisibilityChanged(
+          _syntaxClient,
+          visibleRanges,
+        )
+      });
+
+    let isVersionValid = (updateVersion, bufferVersion) => {
+      bufferVersion != (-1) && updateVersion == bufferVersion;
+    };
+
+    let getScopeForBuffer = (state: Model.State.t, id: int) => {
+      state.buffers
+      |> Model.Buffers.getBuffer(id)
+      |> Option.bind(buf => Core.Buffer.getFileType(buf))
+      |> Option.bind(fileType =>
+           Ext.LanguageInfo.getScopeFromLanguage(languageInfo, fileType)
+         );
+    };
+
+    let updater = (state: Model.State.t, action) => {
+      let default = (state, Isolinear.Effect.none);
+      switch (action) {
+      | Model.Actions.ConfigurationSet(config) => (
+          state,
+          configurationChangeEffect(config),
+        )
+      | Model.Actions.SetTokenTheme(tokenTheme) => (
+          state,
+          themeChangeEffect(tokenTheme),
+        )
+      | Model.Actions.BufferEnter(metadata, fileType) =>
+        let visibleBuffers =
+          Model.EditorVisibleRanges.getVisibleBuffersAndRanges(state);
+
+        let combinedEffects =
+          Isolinear.Effect.batch([
+            visibilityChangedEffect(visibleBuffers),
+            bufferEnterEffect(Vim.BufferMetadata.(metadata.id), fileType),
+          ]);
+
+        (state, combinedEffects);
+      // When the view changes, update our list of visible buffers,
+      // so we know which ones might have pending work!
+      | Model.Actions.EditorGroupAdd(_)
+      | Model.Actions.EditorScroll(_)
+      | Model.Actions.EditorScrollToLine(_)
+      | Model.Actions.EditorScrollToColumn(_)
+      | Model.Actions.AddSplit(_)
+      | Model.Actions.RemoveSplit(_)
+      | Model.Actions.ViewSetActiveEditor(_)
+      //| Model.Actions.BufferEnter(_)
+      | Model.Actions.ViewCloseEditor(_) =>
+        let visibleBuffers =
+          Model.EditorVisibleRanges.getVisibleBuffersAndRanges(state);
+        (state, visibilityChangedEffect(visibleBuffers));
+      // When there is a buffer update, send it over to the syntax highlight
+      // strategy to handle the parsing.
+      | Model.Actions.BufferUpdate(bu) =>
+        let lines = getLines(state, bu.id);
+        let version = getVersion(state, bu.id);
+        let scope = getScopeForBuffer(state, bu.id);
+        if (!isVersionValid(version, bu.version)) {
+          default;
+        } else {
+          (state, bufferUpdateEffect(bu, lines, scope));
+        };
+      | _ => default
+      };
+    };
+
+    (updater, stream);
+  };
 };

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -29,6 +29,17 @@ let spec = [
     passthrough,
     "Turn off colors and rich formatting in logs.",
   ),
+  (
+    "--disable-syntax-highlighting",
+    passthrough,
+    "Turn off syntax highlighting.",
+  ),
+  ("--disable-extensions", passthrough, "Turn off extension loading."),
+  (
+    "--disable-configuration",
+    passthrough,
+    "Do not load user configuration (use default configuration).",
+  ),
   ("--checkhealth", passthrough, ""),
   (
     "--install-extension",


### PR DESCRIPTION
This adds a few additional CLI commands:

- `--disable-syntax-highlighting` - don't start up syntax server or do highlight
- `--disable-configuration` - don't load configuration on startup
- `--disable-extensions` - don't load extensions

to assist in troubleshooting.