### PR TITLE
CI/Builds - Support macOS 10.12

### DIFF
--- a/.ci/swap-xcode.yml
+++ b/.ci/swap-xcode.yml
@@ -1,0 +1,11 @@
+# Swap XCode version to 8 for 10.12 support.
+
+steps:
+  - script: env | grep XCODE
+    displayName: 'List Xcode versions'
+  - script: xcodebuild -version
+    displayName: 'List current Xcode version'
+  - script: sudo xcode-select -s $XCODE_8_DEVELOPER_DIR
+    displayName: 'Swap to Xcode8'
+  - script: xcodebuild -version
+    displayName: 'List swapped Xcode version'

--- a/.ci/swap-xcode.yml
+++ b/.ci/swap-xcode.yml
@@ -5,7 +5,7 @@ steps:
     displayName: 'List Xcode versions'
   - script: xcodebuild -version
     displayName: 'List current Xcode version'
-  - script: sudo xcode-select -s /Applications/Xcode_9.0.app
+  - script: sudo xcode-select -s /Applications/Xcode_9.app
     displayName: 'Swap to Xcode8'
   - script: xcodebuild -version
     displayName: 'List swapped Xcode version'

--- a/.ci/swap-xcode.yml
+++ b/.ci/swap-xcode.yml
@@ -6,6 +6,6 @@ steps:
   - script: xcodebuild -version
     displayName: 'List current Xcode version'
   - script: sudo xcode-select -s /Applications/Xcode_9.app
-    displayName: 'Swap to Xcode8'
+    displayName: 'Swap to Xcode9'
   - script: xcodebuild -version
     displayName: 'List swapped Xcode version'

--- a/.ci/swap-xcode.yml
+++ b/.ci/swap-xcode.yml
@@ -1,11 +1,11 @@
-# Swap XCode version to 8 for 10.12 support.
+# Swap XCode version to 9.0 for 10.12 support.
 
 steps:
-  - script: env | grep XCODE
+  - script: ls /Applications/Xcode*
     displayName: 'List Xcode versions'
   - script: xcodebuild -version
     displayName: 'List current Xcode version'
-  - script: sudo xcode-select -s $XCODE_8_DEVELOPER_DIR
+  - script: sudo xcode-select -s /Applications/Xcode_9.0.app
     displayName: 'Swap to Xcode8'
   - script: xcodebuild -version
     displayName: 'List swapped Xcode version'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,6 +97,7 @@ jobs:
   - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
+  - script: env
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/esy-build-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,9 @@ jobs:
   - script: brew update
   - script: brew install libpng ragel
   - script: env
+  - script: xcodebuild -version
+  - script: xcode-select -s $XCODE_8_DEVELOPER_DIR
+  - script: xcodebuild -version
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/esy-build-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
   - script: brew install libpng ragel
   - script: env
   - script: xcodebuild -version
-  - script: xcode-select -s $XCODE_8_DEVELOPER_DIR
+  - script: sudo xcode-select -s $XCODE_8_DEVELOPER_DIR
   - script: xcodebuild -version
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
   - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
+  - template: .ci/swap-xcode.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/esy-check-hygiene.yml
@@ -97,10 +98,7 @@ jobs:
   - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
-  - script: env
-  - script: xcodebuild -version
-  - script: sudo xcode-select -s $XCODE_8_DEVELOPER_DIR
-  - script: xcodebuild -version
+  - template: .ci/swap-xcode.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/esy-build-steps.yml


### PR DESCRIPTION
This is just a test to change the macOS CI to use Xcode 8, which is compatible with macOS 10.12 (to my knowledge). I think this means we'd be compatible with 10.12, though I could be very wrong.

A quick look in my CI looks like there is some build failures over in `esy-sdl2`, so opening just so some people with more understand than me can see.