### PR TITLE
Extension - Configuration - Part 1: Initial configuration utilities

### DIFF
--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -781,6 +781,24 @@ module Json = {
     };
   };
 
+  let getKeys = json => {
+    let rec loop = (curr, json) => {
+      switch (json) {
+      | `Assoc(items) =>
+        items
+        |> List.map(item => {
+             let (key, v) = item;
+             let prefix = curr == "" ? key : curr ++ "." ++ key;
+             loop(prefix, v);
+           })
+        |> List.flatten
+      | _ => [curr]
+      };
+    };
+
+    loop("", json);
+  };
+
   let explode_key = String.split_on_char('.');
   /*
    [explode(json)] takes a JSON structure like:

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -747,3 +747,84 @@ module Path = {
 
   let explode = String.split_on_char(Filename.dir_sep.[0]);
 };
+
+module Json = {
+  /*
+    update method adapted from: https://github.com/ocaml-community/yojson/issues/54
+   */
+  let update = (key, f, json) => {
+    let rec update_json_obj =
+      fun
+      | [] =>
+        switch (f(None)) {
+        | None => []
+        | Some(v) => [(key, v)]
+        }
+      | [(k, v) as m, ...tail] as original =>
+        if (String.equal(k, key)) {
+          switch (f(Some(v))) {
+          | None => update_json_obj(tail)
+          | Some(v') =>
+            if (v' == v) {
+              original;
+            } else {
+              [(k, v'), ...tail];
+            }
+          };
+        } else {
+          [m, ...update_json_obj(tail)];
+        };
+
+    switch (json) {
+    | `Assoc(items) => `Assoc(update_json_obj(items))
+    | _ => json
+    };
+  };
+
+  let explode_key = String.split_on_char('.');
+  /*
+   [explode(json)] takes a JSON structure like:
+   [{ "a.b.c": 1}]
+
+   and converts it to:
+   [{"a": { "b": { "c": 1 }}}]
+   */
+
+  let explode = json => {
+    let rec expand_item = (currJson, keys, jsonValue) => {
+      switch (keys) {
+      | [key] => update(key, _ => Some(jsonValue), currJson)
+      | [key, ...remaining] =>
+        update(
+          key,
+          fun
+          | None => Some(expand_item(`Assoc([]), remaining, jsonValue))
+          | Some(json) => Some(expand_item(json, remaining, jsonValue)),
+          currJson,
+        )
+
+      | [] => jsonValue // Shouldn't hit this case...
+      };
+    }
+    and expand_items = items => {
+      List.fold_left(
+        (acc, curr) => {
+          let (key, jsonValue) = curr;
+
+          let explodedKey = explode_key(key);
+          expand_item(acc, explodedKey, loop(jsonValue));
+        },
+        `Assoc([]),
+        items,
+      );
+    }
+    and loop = json => {
+      switch (json) {
+      | `Assoc(items) => expand_items(items)
+      | v => v
+      };
+    };
+
+    loop(json);
+  };
+};

--- a/test/Core/UtilityTests.re
+++ b/test/Core/UtilityTests.re
@@ -31,6 +31,47 @@ describe("dropLast", ({test, _}) => {
   });
 });
 
+describe("JsonUtil", ({describe, _}) => {
+  describe("explode", ({test, _}) => {
+    let explodedAbc =
+      `Assoc([("a", `Assoc([("b", `Assoc([("c", `Int(1))]))]))]);
+    let explodedAbcdef =
+      `Assoc([
+        (
+          "a",
+          `Assoc([
+            ("b", `Assoc([("c", `Int(1)), ("d", `Int(2))])),
+            ("e", `Assoc([("f", `Int(3))])),
+          ]),
+        ),
+      ]);
+
+    test("simple a.b.c case", ({expect, _}) => {
+      let json = `Assoc([("a.b.c", `Int(1))]);
+
+      let result = Json.explode(json);
+      expect.bool(Yojson.Safe.equal(result, explodedAbc)).toBe(true);
+    });
+    test("nested b.c case", ({expect, _}) => {
+      let json = `Assoc([("a", `Assoc([("b.c", `Int(1))]))]);
+
+      let result = Json.explode(json);
+      expect.bool(Yojson.Safe.equal(result, explodedAbc)).toBe(true);
+    });
+    test("multiple subkeys (abcdef)", ({expect, _}) => {
+      let json =
+        `Assoc([
+          ("a.b.c", `Int(1)),
+          ("a.b.d", `Int(2)),
+          ("a.e.f", `Int(3)),
+        ]);
+
+      let result = Json.explode(json);
+      expect.bool(Yojson.Safe.equal(result, explodedAbcdef)).toBe(true);
+    });
+  })
+});
+
 describe("StringUtil", ({describe, _}) => {
   open StringUtil;
 

--- a/test/Core/UtilityTests.re
+++ b/test/Core/UtilityTests.re
@@ -32,20 +32,31 @@ describe("dropLast", ({test, _}) => {
 });
 
 describe("JsonUtil", ({describe, _}) => {
-  describe("explode", ({test, _}) => {
-    let explodedAbc =
-      `Assoc([("a", `Assoc([("b", `Assoc([("c", `Int(1))]))]))]);
-    let explodedAbcdef =
-      `Assoc([
-        (
-          "a",
-          `Assoc([
-            ("b", `Assoc([("c", `Int(1)), ("d", `Int(2))])),
-            ("e", `Assoc([("f", `Int(3))])),
-          ]),
-        ),
-      ]);
+  let explodedAbc =
+    `Assoc([("a", `Assoc([("b", `Assoc([("c", `Int(1))]))]))]);
+  let explodedAbcdef =
+    `Assoc([
+      (
+        "a",
+        `Assoc([
+          ("b", `Assoc([("c", `Int(1)), ("d", `Int(2))])),
+          ("e", `Assoc([("f", `Int(3))])),
+        ]),
+      ),
+    ]);
+  describe("getKeys", ({test, _}) => {
+    test("simple a.b.c case", ({expect, _}) => {
+      let keys = explodedAbc |> Json.getKeys;
 
+      expect.equal(keys, ["a.b.c"]);
+    });
+    test("abcdef case", ({expect, _}) => {
+      let keys = explodedAbcdef |> Json.getKeys;
+
+      expect.equal(keys, ["a.b.c", "a.b.d", "a.e.f"]);
+    });
+  });
+  describe("explode", ({test, _}) => {
     test("simple a.b.c case", ({expect, _}) => {
       let json = `Assoc([("a.b.c", `Int(1))]);
 
@@ -69,7 +80,7 @@ describe("JsonUtil", ({describe, _}) => {
       let result = Json.explode(json);
       expect.bool(Yojson.Safe.equal(result, explodedAbcdef)).toBe(true);
     });
-  })
+  });
 });
 
 describe("StringUtil", ({describe, _}) => {


### PR DESCRIPTION
This is laying the groundwork for handling configuration properly from extensions, which define configuration settings, and wiring them up into the extension host.

When we send configuration updates to the extension host, there are two things we need:
- A list of keys that have changed, with the full-path, like `typescript.suggest.enabled`.
- The fully-expanded configuration, like: ` { "typescript": { "suggest": { "enabled": true } } } `

We're missing both of these pieces today (well, we hard-code them specifically for the typescript / javascript language services - but that doesn't scale to bringing in new extensions).

This adds a couple of utilities that let us expand JSON into the fully-expanded format, and also gather a list of keys. These utilities will enable us to bring in the configuration settings and wire them up to be sent to the extension host.