### PR TITLE
Extensions - Configuration - Part 2: Parse configuration info

### DIFF
--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -114,6 +114,11 @@ let resultToException = r => {
   };
 };
 
+let tryToResult = (~msg, f) =>
+  try(Ok(f())) {
+  | _exn => Error(msg)
+  };
+
 type commandLineCompletionMeet = {
   prefix: string,
   position: int,

--- a/src/Extensions/ExtensionContributions.re
+++ b/src/Extensions/ExtensionContributions.re
@@ -41,8 +41,6 @@ module Configuration = {
   let of_yojson_exn = json => {
     Yojson.Safe.(
       {
-        prerr_endline("Starting parse: " ++ Yojson.Safe.to_string(json));
-
         let parseConfigSection = json => {
           let properties = Util.member("properties", json) |> Util.to_assoc;
           properties


### PR DESCRIPTION
This change implements parsing / reading of the `configuration` section of VSCode extensions.

We need this to be able to provide the extension host with the appropriate set of defaults on initialization (and later, the metadata can be used to provide an improved configuration experience).