### PR TITLE
Bugfix: Health-check flakiness

### DIFF
--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -24,12 +24,17 @@ let checks = [
   (
     "Verify node dependencies",
     (setup: Setup.t) => {
-      Oni_Extensions.NodeTask.run(~scheduler=Scheduler.immediate, ~setup, 
-      "check-health.js")
+      Oni_Extensions.NodeTask.run(
+        ~scheduler=Scheduler.immediate,
+        ~setup,
+        "check-health.js",
+      )
       |> Utility.LwtUtil.sync
-      |> fun 
-      | Ok(_) => true
-      | Error(_) => false;
+      |> (
+        fun
+        | Ok(_) => true
+        | Error(_) => false
+      );
     },
   ),
   (

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -22,25 +22,14 @@ let checks = [
     (setup: Setup.t) => Sys.file_exists(setup.nodePath),
   ),
   (
-    "Verify node executable can execute simple script",
-    (setup: Setup.t) => {
-      let ret =
-        Rench.ChildProcess.spawnSync(
-          setup.nodePath,
-          [|"-e", "console.log(\"test\")"|],
-        );
-      ret.stdout |> String.trim |> String.equal("test");
-    },
-  ),
-  (
     "Verify node dependencies",
     (setup: Setup.t) => {
-      let ret =
-        Rench.ChildProcess.spawnSync(
-          setup.nodePath,
-          [|Setup.getNodeHealthCheckPath(setup)|],
-        );
-      ret.stdout |> String.trim |> String.equal("Success!");
+      Oni_Extensions.NodeTask.run(~scheduler=Scheduler.immediate, ~setup, 
+      "check-health.js")
+      |> Utility.LwtUtil.sync
+      |> fun 
+      | Ok(_) => true
+      | Error(_) => false;
     },
   ),
   (


### PR DESCRIPTION
A couple of the `node` health-checks were failing intermittently in Windows. This is an attempt to refactor to use our `NodeTask` API (which should be reliable - we are using it to run various node scripts) to compare the reliability.