### PR TITLE
Bugfix: Remove stray log

### DIFF
--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -70,7 +70,6 @@ let cliOptions =
       1;
     },
   );
-Log.info("Startup: Parsing CLI options complete");
 if (cliOptions.syntaxHighlightService) {
   Oni_Syntax_Server.start();
 } else {


### PR DESCRIPTION
Noticed a stray log prior to initializing the syntax server - we override the logging strategy in the syntax server to not write to a file (for now), so we want to defer logging until after initialization.

We should probably enforce this more strictly...