### PR TITLE
CI: Disable log colors completely in Windows

### DIFF
--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -288,11 +288,12 @@ let withNamespace = namespace => {
 };
 
 // init
-let () = if (Sys.win32) {
-  Fmt_tty.setup_std_outputs(~style_renderer=`None, ());
-} else {
-  Fmt_tty.setup_std_outputs(~style_renderer=`Ansi_tty, ());
-}
+let () =
+  if (Sys.win32) {
+    Fmt_tty.setup_std_outputs(~style_renderer=`None, ());
+  } else {
+    Fmt_tty.setup_std_outputs(~style_renderer=`Ansi_tty, ());
+  };
 
 switch (Env.debug, Env.logFile) {
 | (None, None) => Logs.set_level(Some(Logs.Info))

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -216,10 +216,6 @@ let isPrintingEnabled = () => Logs.reporter() !== Logs.nop_reporter;
 let disableColors = () =>
   Fmt_tty.setup_std_outputs(~style_renderer=`None, ());
 
-if (Sys.win32) {
-  disableColors();
-};
-
 let enableDebugLogging = () =>
   Logs.Src.set_level(Logs.default, Some(Logs.Debug));
 let isDebugLoggingEnabled = () =>
@@ -292,7 +288,11 @@ let withNamespace = namespace => {
 };
 
 // init
-let () = Fmt_tty.setup_std_outputs(~style_renderer=`Ansi_tty, ());
+let () = if (Sys.win32) {
+  Fmt_tty.setup_std_outputs(~style_renderer=`None, ());
+} else {
+  Fmt_tty.setup_std_outputs(~style_renderer=`Ansi_tty, ());
+}
 
 switch (Env.debug, Env.logFile) {
 | (None, None) => Logs.set_level(Some(Logs.Info))

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -216,6 +216,10 @@ let isPrintingEnabled = () => Logs.reporter() !== Logs.nop_reporter;
 let disableColors = () =>
   Fmt_tty.setup_std_outputs(~style_renderer=`None, ());
 
+if (Sys.win32) {
+  disableColors();
+}
+
 let enableDebugLogging = () =>
   Logs.Src.set_level(Logs.default, Some(Logs.Debug));
 let isDebugLoggingEnabled = () =>

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -218,7 +218,7 @@ let disableColors = () =>
 
 if (Sys.win32) {
   disableColors();
-}
+};
 
 let enableDebugLogging = () =>
   Logs.Src.set_level(Logs.default, Some(Logs.Debug));


### PR DESCRIPTION
Still seeing hangs on Windows output - this change disables log colors completely. Hopefully this helps make the healthchecks more reliable.