### PR TITLE
Fix stack overflow crashes with a large number of search results

### DIFF
--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -2,6 +2,7 @@ open Rench;
 
 module Time = Revery_Core.Time;
 module List = Utility.List;
+module ListEx = Utility.ListEx;
 module Queue = Utility.Queue;
 
 module Match = {
@@ -243,7 +244,7 @@ let findInFiles =
     items => {
       items
       |> List.filter_map(Match.fromJsonString)
-      |> List.concat  // TODO: This causes a stack overflow
+      |> ListEx.safeConcat
       |> onUpdate
     },
     onComplete,

--- a/src/Core/Utility.re
+++ b/src/Core/Utility.re
@@ -300,6 +300,12 @@ module List = {
   };
 };
 
+module ListEx = {
+  let safeConcat = lists => lists |> List.fold_left(List.append, []);
+
+  let safeMap = (f, list) => list |> List.rev |> List.rev_map(f);
+};
+
 // TODO: Remove after 4.08 upgrade
 module Option = {
   let map = f =>
@@ -743,7 +749,7 @@ module ChunkyQueue: {
     };
 
   let toList = ({front, rear, _}) =>
-    front @ (Queue.toList(rear) |> List.concat);
+    front @ (Queue.toList(rear) |> ListEx.safeConcat);
 };
 
 module Path = {

--- a/src/UI/SearchPane.re
+++ b/src/UI/SearchPane.re
@@ -4,6 +4,8 @@ open Revery.UI;
 open Oni_Core;
 open Oni_Model;
 
+module ListEx = Utility.ListEx;
+
 module Styles = {
   let searchPane = (~theme: Theme.t) =>
     Style.[
@@ -62,7 +64,8 @@ let matchToLocListItem = (hit: Ripgrep.Match.t) =>
   };
 
 let make = (~theme, ~uiFont, ~editorFont, ~isFocused, ~state: Search.t, ()) => {
-  let items = state.hits |> List.map(matchToLocListItem) |> Array.of_list;
+  let items =
+    state.hits |> ListEx.safeMap(matchToLocListItem) |> Array.of_list;
 
   <View style={Styles.searchPane(~theme)}>
     <View style={Styles.queryPane(~theme)}>

--- a/test/Core/UtilityTests.re
+++ b/test/Core/UtilityTests.re
@@ -270,6 +270,61 @@ describe("StringUtil", ({describe, _}) => {
   });
 });
 
+describe("ListEx.safeMap", ({test, _}) => {
+  test("empty", ({expect}) =>
+    expect.list(ListEx.safeMap(x => x, [])).toEqual([])
+  );
+
+  test("one", ({expect}) =>
+    expect.list(ListEx.safeMap(x => x, [1])).toEqual([1])
+  );
+
+  test("many", ({expect}) => {
+    expect.list(ListEx.safeMap(x => x, [1, 2, 3])).toEqual([1, 2, 3])
+  });
+
+  test("int_to_string", ({expect}) => {
+    expect.list(ListEx.safeMap(string_of_int, [1, 2, 3])).toEqual([
+      "1",
+      "2",
+      "3",
+    ])
+  });
+});
+
+describe("ListEx.safeConcat", ({test, _}) => {
+  test("empty", ({expect}) =>
+    expect.list(ListEx.safeConcat([])).toEqual([])
+  );
+
+  test("one of one", ({expect}) =>
+    expect.list(ListEx.safeConcat([[1]])).toEqual([1])
+  );
+
+  test("one of many", ({expect}) => {
+    expect.list(ListEx.safeConcat([[1, 2, 3]])).toEqual([1, 2, 3])
+  });
+
+  test("many of one", ({expect}) => {
+    expect.list(ListEx.safeConcat([[1], [2], [3]])).toEqual([1, 2, 3])
+  });
+
+  test("many of many", ({expect}) => {
+    expect.list(ListEx.safeConcat([[1, 2, 3], [4, 5, 6], [7, 8, 9]])).
+      toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+    ])
+  });
+});
+
 let testQueue = (describe: Rely.Describe.describeFn(_), module Queue: Queue) => {
   describe("length", ({test, _}) => {
     test("empty", ({expect}) => {


### PR DESCRIPTION
Fixes #1113. Stack Overflows be gone.

I had to provide stack-safe implementations of both `List.concat` and `List.map`. It also still seems to lock up after a few hundred thousand search results. Perhaps we should impose some kind of limit, like vscode does. Not sure what exactly their limit is as it seems to vary by query, but it seems to be in the range of 25,000-50,000.