### PR TITLE
Windows - CI: Remove powershell health check

### DIFF
--- a/scripts/windows/validate-release.ps1
+++ b/scripts/windows/validate-release.ps1
@@ -31,5 +31,3 @@ ls D:/
 ls D:/a/1/s
 ls D:/a/1/s/Onivim2
 
-D:/a/1/s/Onivim2/Oni2.exe -f --no-log-colors --checkhealth
-


### PR DESCRIPTION
We're seeing hangs in the run of `--checkhealth` when we run in a powershell script:
![image](https://user-images.githubusercontent.com/13532591/71550866-01792480-298f-11ea-9d30-e5aa6599f561.png)

...somehow, we're still getting some colored output / escape codes.

This validation isn't very necessary - we have better validation (via running in `cmd.exe` to regression test #872 ) - we should just leverage that. At least, lets see if that is more reliable.