### PR TITLE
File Explorer - scroll to follow focus + spring + minor refactor

### DIFF
--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -13,10 +13,10 @@ type t = {
 
 [@deriving show({with_path: false})]
 type action =
-  | TreeLoaded([@opaque] FsTreeNode.t)
-  | NodeLoaded(string, [@opaque] FsTreeNode.t)
-  | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
-  | NodeClicked([@opaque] FsTreeNode.t)
+  | TreeLoaded(FsTreeNode.t)
+  | NodeLoaded(FsTreeNode.t)
+  | FocusNodeLoaded(FsTreeNode.t)
+  | NodeClicked(FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
   | KeyboardInput(string);
 

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -6,7 +6,7 @@ module Log = (val Log.withNamespace("Oni2.Model.FileExplorer"));
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
-  scrollOffset: [ | `Start(float) | `Middle(float)],
+  scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(string), // path
   focus: option(string) // path
 };
@@ -17,7 +17,7 @@ type action =
   | NodeLoaded(string, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
-  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
+  | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
   | KeyboardInput(string);
 
 let getFileIcon = (languageInfo, iconTheme, filePath) => {

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -3,7 +3,7 @@ open Oni_Extensions;
 type t = {
   tree: option(FsTreeNode.t),
   isOpen: bool,
-  scrollOffset: [ | `Start(float) | `Middle(float)],
+  scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(string), // path
   focus: option(string) // path
 };
@@ -14,7 +14,7 @@ type action =
   | NodeLoaded(string, [@opaque] FsTreeNode.t)
   | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
   | NodeClicked([@opaque] FsTreeNode.t)
-  | ScrollOffsetChanged([ | `Start(float) | `Middle(float)])
+  | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
   | KeyboardInput(string);
 
 let initial: t;

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -10,10 +10,10 @@ type t = {
 
 [@deriving show]
 type action =
-  | TreeLoaded([@opaque] FsTreeNode.t)
-  | NodeLoaded(string, [@opaque] FsTreeNode.t)
-  | FocusNodeLoaded(string, [@opaque] FsTreeNode.t)
-  | NodeClicked([@opaque] FsTreeNode.t)
+  | TreeLoaded(FsTreeNode.t)
+  | NodeLoaded(FsTreeNode.t)
+  | FocusNodeLoaded(FsTreeNode.t)
+  | NodeClicked(FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
   | KeyboardInput(string);
 

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -203,12 +203,12 @@ let nextExpandedNode = (path, tree) =>
   };
 
 // Counts the number of expanded nodes before the node specified by the given path
-let expandedIndex = (tree, path) => {
-  let rec loop = (node, path) =>
-    switch (path) {
+let expandedIndex = (path, tree) => {
+  let rec loop = (node, pathHashes) =>
+    switch (pathHashes) {
     | [] => `Found(0)
-    | [focus, ...focusTail] =>
-      if (!equals(focus, node)) {
+    | [hash, ...pathTail] =>
+      if (node.hash != hash) {
         `NotFound(node.expandedSubtreeSize);
       } else {
         switch (node.kind) {
@@ -220,7 +220,7 @@ let expandedIndex = (tree, path) => {
             switch (children) {
             | [] => `NotFound(count)
             | [child, ...childTail] =>
-              switch (loop(child, focusTail)) {
+              switch (loop(child, pathTail)) {
               | `Found(subtreeCount) => `Found(count + subtreeCount)
               | `NotFound(subtreeCount) =>
                 loopChildren(count + subtreeCount, childTail)
@@ -232,7 +232,7 @@ let expandedIndex = (tree, path) => {
       }
     };
 
-  switch (loop(tree, path)) {
+  switch (loop(tree, _pathHashes(~base=Filename.dirname(tree.path), path))) {
   | `Found(count) => Some(count)
   | `NotFound(_) => None
   };

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -253,11 +253,11 @@ let update = (~tree, ~updater, targetPath) => {
   loop(tree);
 };
 
-let updateNodesInPath = (~tree, ~updater, nodes) => {
-  let rec loop = (nodes, node) =>
-    switch (nodes) {
-    | [{hash, kind, _}, ...rest] when hash == node.hash =>
-      switch (kind) {
+let updateNodesInPath = (updater, path, tree) => {
+  let rec loop = (pathHashes, node) =>
+    switch (pathHashes) {
+    | [hash, ...rest] when hash == node.hash =>
+      switch (node.kind) {
       | Directory({children, _} as dir) =>
         let newChildren = List.map(loop(rest), children);
         let newNode =
@@ -277,7 +277,7 @@ let updateNodesInPath = (~tree, ~updater, nodes) => {
     | _ => node
     };
 
-  loop(nodes, tree);
+  loop(_pathHashes(~base=Filename.dirname(tree.path), path), tree);
 };
 
 let toggleOpen =

--- a/src/Model/FsTreeNode.re
+++ b/src/Model/FsTreeNode.re
@@ -208,7 +208,7 @@ let expandedIndex = (tree, path) => {
     switch (path) {
     | [] => `Found(0)
     | [focus, ...focusTail] =>
-      if (equals(focus, node)) {
+      if (!equals(focus, node)) {
         `NotFound(node.expandedSubtreeSize);
       } else {
         switch (node.kind) {

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -33,7 +33,7 @@ let findByPath: (string, t) => option(t);
 let prevExpandedNode: (string, t) => option(t);
 let nextExpandedNode: (string, t) => option(t);
 
-let expandedIndex: (t, list(t)) => option(int);
+let expandedIndex: (string, t) => option(int);
 
 let update: (~tree: t, ~updater: t => t, string) => t;
 let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -1,3 +1,4 @@
+[@deriving show]
 type t =
   pri {
     path: string,

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -35,8 +35,7 @@ let nextExpandedNode: (string, t) => option(t);
 
 let expandedIndex: (string, t) => option(int);
 
-let update: (~tree: t, ~updater: t => t, string) => t;
-let updateNodesInPath: (~tree: t, ~updater: t => t, list(t)) => t;
+let updateNodesInPath: (t => t, string, t) => t;
 let toggleOpen: t => t;
 let setOpen: t => t;
 

--- a/src/Model/FsTreeNode.rei
+++ b/src/Model/FsTreeNode.rei
@@ -35,6 +35,7 @@ let nextExpandedNode: (string, t) => option(t);
 
 let expandedIndex: (string, t) => option(int);
 
+let replace: (~replacement: t, t) => t;
 let updateNodesInPath: (t => t, string, t) => t;
 let toggleOpen: t => t;
 let setOpen: t => t;

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -106,7 +106,7 @@ let start = () => {
   let replaceNode = (path, node, state: State.t) =>
     switch (state.fileExplorer.tree) {
     | Some(tree) =>
-      setTree(FsTreeNode.update(path, ~tree, ~updater=_ => node), state)
+      setTree(FsTreeNode.replace(~replacement=node, tree), state)
     | None => state
     };
 

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -61,13 +61,8 @@ let revealPath = (path, state: State.t) => {
       )
 
     // Open ALL the nodes (in the path)!
-    | `Success(nodes) =>
-      let tree =
-        FsTreeNode.updateNodesInPath(
-          ~tree,
-          nodes,
-          ~updater=FsTreeNode.setOpen,
-        );
+    | `Success(_) =>
+      let tree = FsTreeNode.updateNodesInPath(FsTreeNode.setOpen, path, tree);
       let offset =
         switch (FsTreeNode.expandedIndex(path, tree)) {
         | Some(offset) => `Middle(float(offset))

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -56,7 +56,7 @@ let revealPath = (path, state: State.t) => {
           state.iconTheme,
           state.configuration,
           ~onComplete=node =>
-          Actions.FileExplorer(FocusNodeLoaded(lastNode.path, node))
+          Actions.FileExplorer(FocusNodeLoaded(node))
         ),
       )
 
@@ -103,7 +103,7 @@ let start = () => {
     });
   };
 
-  let replaceNode = (path, node, state: State.t) =>
+  let replaceNode = (node, state: State.t) =>
     switch (state.fileExplorer.tree) {
     | Some(tree) =>
       setTree(FsTreeNode.replace(~replacement=node, tree), state)
@@ -117,7 +117,7 @@ let start = () => {
       (state |> setActive(Some(node.path)), openFileByPathEffect(path))
 
     | {kind: Directory({isOpen, _}), _} => (
-        replaceNode(node.path, FsTreeNode.toggleOpen(node), state),
+        replaceNode(FsTreeNode.toggleOpen(node), state),
         isOpen
           ? Isolinear.Effect.none
           : Effects.load(
@@ -126,7 +126,7 @@ let start = () => {
               state.iconTheme,
               state.configuration,
               ~onComplete=newNode =>
-              Actions.FileExplorer(NodeLoaded(node.path, newNode))
+              Actions.FileExplorer(NodeLoaded(newNode))
             ),
       )
     };
@@ -135,15 +135,12 @@ let start = () => {
     switch (action) {
     | TreeLoaded(tree) => (setTree(tree, state), Isolinear.Effect.none)
 
-    | NodeLoaded(path, node) => (
-        replaceNode(path, node, state),
-        Isolinear.Effect.none,
-      )
+    | NodeLoaded(node) => (replaceNode(node, state), Isolinear.Effect.none)
 
-    | FocusNodeLoaded(path, node) =>
+    | FocusNodeLoaded(node) =>
       switch (state.fileExplorer.active) {
       | Some(activePath) =>
-        state |> replaceNode(path, node) |> revealPath(activePath)
+        state |> replaceNode(node) |> revealPath(activePath)
 
       | None => (state, Isolinear.Effect.none)
       }

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -69,7 +69,7 @@ let revealPath = (path, state: State.t) => {
           ~updater=FsTreeNode.setOpen,
         );
       let offset =
-        switch (FsTreeNode.expandedIndex(tree, nodes)) {
+        switch (FsTreeNode.expandedIndex(path, tree)) {
         | Some(offset) => `Middle(float(offset))
         | None => state.fileExplorer.scrollOffset
         };
@@ -88,14 +88,9 @@ let revealFocus =
   updateFileExplorer(state => {
     switch (state.focus, state.tree) {
     | (Some(focus), Some(tree)) =>
-      switch (FsTreeNode.findNodesByPath(focus, tree)) {
-      | `Success(nodes) =>
-        switch (FsTreeNode.expandedIndex(tree, nodes)) {
-        | Some(index) => {...state, scrollOffset: `Reveal(index)}
-        | None => state
-        }
-      | `Partial(_)
-      | `Failed => state
+      switch (FsTreeNode.expandedIndex(focus, tree)) {
+      | Some(index) => {...state, scrollOffset: `Reveal(index)}
+      | None => state
       }
 
     | _ => state


### PR DESCRIPTION
This implements scrolling to follow focus, and does so using a spring. It also refactors a few FsTreeNode functions to be more consistent with he rest, using string paths instead of node paths.

The scrolling logic has become a bit complicated, but could be simplified a bit with a spring hook that included a setter. It would also be nice to have a way to do "hard" transitions, like when scrolling with the mouse wheel, as it currently feels a bit sluggish.