### PR TITLE
CI: Another attempt to remove console colors on windows

### DIFF
--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -202,10 +202,20 @@ let consoleReporter = {
   };
 };
 
+let winConsoleReporter = {
+  Logs.format_reporter(
+    ~app=Format.std_formatter,
+    ~dst=Format.std_formatter,
+    ()
+  );
+};
+
 let reporter =
   Logs.{
     report: (src, level, ~over, k, msgf) => {
-      let kret = consoleReporter.report(src, level, ~over=() => (), k, msgf);
+      let kret = Sys.win32 ? 
+      winConsoleReporter.report(src, level, ~over=() => (), k, msgf)
+      : consoleReporter.report(src, level, ~over=() => (), k, msgf);
       fileReporter.report(src, level, ~over, () => kret, msgf);
     },
   };

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -202,20 +202,26 @@ let consoleReporter = {
   };
 };
 
+// Something is broken with the [consoleReporter] on Windows -
+// it can cause the terminal to hang. This happens on CI, but
+// also reproduces intermittently when run locally.
+// Switching to a simpler formatter solves the issue - but it'd be nice to have our
+// colors back on Windows!
 let winConsoleReporter = {
   Logs.format_reporter(
     ~app=Format.std_formatter,
     ~dst=Format.std_formatter,
-    ()
+    (),
   );
 };
 
 let reporter =
   Logs.{
     report: (src, level, ~over, k, msgf) => {
-      let kret = Sys.win32 ? 
-      winConsoleReporter.report(src, level, ~over=() => (), k, msgf)
-      : consoleReporter.report(src, level, ~over=() => (), k, msgf);
+      let kret =
+        Sys.win32
+          ? winConsoleReporter.report(src, level, ~over=() => (), k, msgf)
+          : consoleReporter.report(src, level, ~over=() => (), k, msgf);
       fileReporter.report(src, level, ~over, () => kret, msgf);
     },
   };


### PR DESCRIPTION
Trying to still resolve the CI hangs for Windows. A couple possibilities:
- An errant color / escape code is causing the terminal to pause and wait for input
- There is still a running process after closing