### PR TITLE
Fix #561 - 'ndd' deletes n^2 lines

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bc6b43d01ff2fcb6521a477737639525",
+  "checksum": "3b8f7ec73446134829f5276132844689",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -307,19 +307,20 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#4919011",
+      "version": "github:onivim/reason-libvim#3782892",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#4919011" ]
+        "source": [ "github:onivim/reason-libvim#3782892" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "libvim@8.10869.26@d41d8cd9",
+        "libvim@8.10869.29@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -542,14 +543,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.26@d41d8cd9": {
-      "id": "libvim@8.10869.26@d41d8cd9",
+    "libvim@8.10869.29@d41d8cd9": {
+      "id": "libvim@8.10869.29@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.26",
+      "version": "8.10869.29",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.26.tgz#sha1:76e56a64a587719bb0dc70ce16c438200e47a38b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.29.tgz#sha1:ef7588b9343ff8434117b6cb12ddcb38634064fd"
         ]
       },
       "overrides": [],
@@ -976,7 +977,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#e2c571e@d41d8cd9",
         "reason-textmate@2.3.0@d41d8cd9", "reason-sdl2@2.10.3012@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bc6b43d01ff2fcb6521a477737639525",
+  "checksum": "3b8f7ec73446134829f5276132844689",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -307,19 +307,20 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#4919011",
+      "version": "github:onivim/reason-libvim#3782892",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#4919011" ]
+        "source": [ "github:onivim/reason-libvim#3782892" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "libvim@8.10869.26@d41d8cd9",
+        "libvim@8.10869.29@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -542,14 +543,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.26@d41d8cd9": {
-      "id": "libvim@8.10869.26@d41d8cd9",
+    "libvim@8.10869.29@d41d8cd9": {
+      "id": "libvim@8.10869.29@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.26",
+      "version": "8.10869.29",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.26.tgz#sha1:76e56a64a587719bb0dc70ce16c438200e47a38b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.29.tgz#sha1:ef7588b9343ff8434117b6cb12ddcb38634064fd"
         ]
       },
       "overrides": [],
@@ -975,7 +976,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#e2c571e@d41d8cd9",
         "reason-textmate@2.3.0@d41d8cd9", "reason-sdl2@2.10.3012@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bc6b43d01ff2fcb6521a477737639525",
+  "checksum": "3b8f7ec73446134829f5276132844689",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -307,19 +307,20 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#4919011",
+      "version": "github:onivim/reason-libvim#3782892",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#4919011" ]
+        "source": [ "github:onivim/reason-libvim#3782892" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "libvim@8.10869.26@d41d8cd9",
+        "libvim@8.10869.29@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -542,14 +543,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.26@d41d8cd9": {
-      "id": "libvim@8.10869.26@d41d8cd9",
+    "libvim@8.10869.29@d41d8cd9": {
+      "id": "libvim@8.10869.29@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.26",
+      "version": "8.10869.29",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.26.tgz#sha1:76e56a64a587719bb0dc70ce16c438200e47a38b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.29.tgz#sha1:ef7588b9343ff8434117b6cb12ddcb38634064fd"
         ]
       },
       "overrides": [],
@@ -975,7 +976,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#e2c571e@d41d8cd9",
         "reason-textmate@2.3.0@d41d8cd9", "reason-sdl2@2.10.3012@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "rench": "github:bryphe/rench#4860ef4",
     "reason-tree-sitter": "github:onivim/reason-tree-sitter#e2c571e",
     "revery": "github:revery-ui/revery#d2fd73b",
-    "reason-libvim": "onivim/reason-libvim#4919011",
+    "reason-libvim": "onivim/reason-libvim#3782892",
     "editor-core-types": "onivim/editor-core-types#16dd98e",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755"
   },

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4f1877d6b8a4f352e5dd646e304a57eb",
+  "checksum": "69a95d46b166f27f1d2ea44a5da171f6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -307,19 +307,20 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#4919011",
+      "version": "github:onivim/reason-libvim#3782892",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#4919011" ]
+        "source": [ "github:onivim/reason-libvim#3782892" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "libvim@8.10869.26@d41d8cd9",
+        "libvim@8.10869.29@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -542,14 +543,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.26@d41d8cd9": {
-      "id": "libvim@8.10869.26@d41d8cd9",
+    "libvim@8.10869.29@d41d8cd9": {
+      "id": "libvim@8.10869.29@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.26",
+      "version": "8.10869.29",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.26.tgz#sha1:76e56a64a587719bb0dc70ce16c438200e47a38b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.29.tgz#sha1:ef7588b9343ff8434117b6cb12ddcb38634064fd"
         ]
       },
       "overrides": [],
@@ -975,7 +976,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",
         "reason-tree-sitter@github:onivim/reason-tree-sitter#e2c571e@d41d8cd9",
         "reason-textmate@2.3.0@d41d8cd9", "reason-sdl2@2.10.3012@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#4919011@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",


### PR DESCRIPTION
This picks up @CrossR 's libvim fix for #561 - fixing an issue where the opcount isn't correct in various situations: https://github.com/onivim/libvim/pull/177

The fix also has a nice set of test cases for various opcount-related functionality, like `2d2d`, `4dd`, etc.

Fixes #561 