### PR TITLE
Fix #1160: Command Palette / Quickopen key bindings not working in some cases

### DIFF
--- a/src/Input/Keybindings.re
+++ b/src/Input/Keybindings.re
@@ -1,6 +1,7 @@
 open Oni_Core;
 
 module List = Utility.List;
+module Result = Utility.Result;
 
 module Keybinding = {
   type t = {
@@ -68,29 +69,12 @@ module Keybinding = {
   };
 };
 
-let empty = [];
-
-type t = list(Keybinding.t);
-
-let of_yojson_with_errors:
-  Yojson.Safe.t => result((list(Keybinding.t), list(string)), string) =
-  json => {
-    let bindingsJson =
-      switch (json) {
-      // Current format:
-      // [ ...bindings ]
-      | `List(bindingsJson) => Ok(bindingsJson)
-      // Legacy format:
-      // { bindings: [ ..bindings. ] }
-      | `Assoc([("bindings", `List(bindingsJson))]) => Ok(bindingsJson)
-      | _ => Error("Unable to parse keybindings - not a JSON array.")
-      };
-
-    switch (bindingsJson) {
-    | Error(msg) => Error(msg)
-    | Ok(bindings) =>
+module Internal = {
+  let of_yojson_with_errors:
+    list(Yojson.Safe.t) => (list(Keybinding.t), list(string)) =
+    bindingsJson => {
       let parsedBindings =
-        bindings
+        bindingsJson
         // Parse each binding
         |> List.map(Keybinding.of_yojson);
 
@@ -116,6 +100,53 @@ let of_yojson_with_errors:
           parsedBindings,
         );
 
-      Ok((bindings, errors));
+      (bindings, errors);
     };
+};
+
+let empty = [];
+
+type t = list(Keybinding.t);
+
+// Old version of keybindings - the legacy format:
+// { bindings: [ ..bindings. ] }
+module Legacy = {
+  let upgrade: list(Keybinding.t) => list(Keybinding.t) =
+    keys => {
+      let upgradeBinding = (binding: Keybinding.t) => {
+        switch (binding.command) {
+        | "quickOpen.open" => {
+            ...binding,
+            command: "workbench.action.quickOpen",
+          }
+        | "commandPalette.open" => {
+            ...binding,
+            command: "workbench.action.showCommands",
+          }
+        | _ => binding
+        };
+      };
+
+      keys |> List.map(upgradeBinding);
+    };
+};
+
+let of_yojson_with_errors = json => {
+  switch (json) {
+  // Current format:
+  // [ ...bindings ]
+  | `List(bindingsJson) =>
+    let res = bindingsJson |> Internal.of_yojson_with_errors;
+    Ok(res);
+  // Legacy format:
+  // { bindings: [ ..bindings. ] }
+  | `Assoc([("bindings", `List(bindingsJson))]) =>
+    let res = bindingsJson |> Internal.of_yojson_with_errors;
+
+    Ok(res)
+    |> Result.map(((bindings, errors)) => {
+         (Legacy.upgrade(bindings), errors)
+       });
+  | _ => Error("Unable to parse keybindings - not a JSON array.")
   };
+};

--- a/test/Input/KeybindingsTests.re
+++ b/test/Input/KeybindingsTests.re
@@ -36,6 +36,19 @@ bindings: [{key: "<F2>", command: "explorer.toggle", when: [["editorTextFocus"]]
 |}
   |> Yojson.Safe.from_string;
 
+let regressionTest1160 =
+  {|
+{
+bindings: [
+  {key: "<C-P>", command: "quickOpen.open", when: [["editorTextFocus"]]},
+  {key: "<D-P>", command: "quickOpen.open", when: [["editorTextFocus"]]},
+  {key: "<S-C-P>", command: "commandPalette.open", when: [["editorTextFocus"]]},
+  {key: "<D-S-P>", command: "commandPalette.open", when: [["editorTextFocus"]]}
+]
+}
+|}
+  |> Yojson.Safe.from_string;
+
 let isOk = v =>
   switch (v) {
   | Ok(_) => true
@@ -53,6 +66,13 @@ let getFirstBinding = v =>
   | Ok(([firstBinding], _)) => firstBinding
   | _ => failwith("No binding found")
   };
+
+let getNthBinding = (~index, v) => {
+  switch (v) {
+  | Ok((bindings, _)) => List.nth(bindings, index)
+  | _ => failwith("No binding found")
+  };
+};
 
 let errorCount = v =>
   switch (v) {
@@ -96,6 +116,29 @@ describe("Keybindings", ({describe, _}) => {
           condition:
             Expression.Or(And(Variable("editorTextFocus"), True), False),
         },
+      );
+    });
+    test("regression test: #1160 (legacy binding)", ({expect}) => {
+      let result = of_yojson_with_errors(regressionTest1160);
+      expect.bool(isOk(result)).toBe(true);
+      expect.int(bindingCount(result)).toBe(4);
+      expect.int(errorCount(result)).toBe(0);
+
+      Keybinding.(
+        {
+          let binding0 = getNthBinding(~index=0, result);
+          let binding1 = getNthBinding(~index=1, result);
+          let binding2 = getNthBinding(~index=2, result);
+          let binding3 = getNthBinding(~index=3, result);
+
+          // Validate quickOpen.open gets upgraded to workbench.action.quickOpen
+          expect.equal(binding0.command, "workbench.action.quickOpen");
+          expect.equal(binding1.command, "workbench.action.quickOpen");
+
+          // Validate commandPalette.open gets upgraded to workbench.action.quickOpen
+          expect.equal(binding2.command, "workbench.action.showCommands");
+          expect.equal(binding3.command, "workbench.action.showCommands");
+        }
       );
     });
   })


### PR DESCRIPTION
__Issue:__ The format of our `keybindings.json` underwent a revamp to be closer in terms of compatibility with VSCode. 

However, in some older versions of Onivim 2, we dropped our default keybindings in a file - these would override the newer defaults, and some of the command names changed. Specifically:
- `quickOpen.open` was changed to `workbench.action.quickOpen`
- `commandPalette.open` was changed to `workbench.action.showCommands`

Fixes #1160 

__Fix:__ The JSON structure of the legacy format is different, so we can detect that case, and run an upgrader to address this change. 
