### PR TITLE
Fix #1156 - Welcome screen overflows

### DIFF
--- a/src/UI/PaneView.re
+++ b/src/UI/PaneView.re
@@ -17,6 +17,7 @@ module Styles = {
       flexDirection(`Column),
       height(225),
       borderTop(~color=theme.sideBarBackground, ~width=1),
+      backgroundColor(theme.editorBackground),
     ];
 };
 

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -4,6 +4,7 @@
  * Component for the 'welcome' experience
  */
 
+open Revery;
 open Revery.UI;
 open Oni_Model;
 open Oni_Core;
@@ -19,6 +20,7 @@ module Styles = {
       flexDirection(`Column),
       justifyContent(`Center),
       alignItems(`Center),
+      overflow(`Hidden)
     ];
 
   let titleText = (~theme: Theme.t, ~font: UiFont.t) =>
@@ -67,7 +69,8 @@ module KeyBindingView = {
       justifyContent(`Center),
       alignItems(`Center),
       height(25),
-      width(300),
+      maxWidth(300),
+      minWidth(150),
     ];
 
     let commandText = (~theme: Theme.t, ~fontFile, ~fontSize) => [

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -4,7 +4,6 @@
  * Component for the 'welcome' experience
  */
 
-open Revery;
 open Revery.UI;
 open Oni_Model;
 open Oni_Core;

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -20,7 +20,7 @@ module Styles = {
       flexDirection(`Column),
       justifyContent(`Center),
       alignItems(`Center),
-      overflow(`Hidden)
+      overflow(`Hidden),
     ];
 
   let titleText = (~theme: Theme.t, ~font: UiFont.t) =>


### PR DESCRIPTION
This adds `overflow(Hidden)` to the welcome screen container. This might be something we want more generally across all the 'buffer renderers', as we add them.

In addition, a couple small tweaks:
- Adds a `backgroundColor` to the bottom pane
- Adds some dynamic sizing to the keybindings - so they collapse a bit as the view gets smaller. It's still not ideal when the window is very small, but in that case, we could consider hiding them.

Fixes #1156 