### PR TITLE
Bugfix: Show message for install-extension result

### DIFF
--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -15,8 +15,8 @@ let passthroughFloat = Arg.Float(_ => ());
 let passthroughString = Arg.String(_ => ());
 
 let passthroughAndStayAttached = Arg.Set(stayAttached);
-let passthroughFloatAndStayAttached = Arg.Float((_) => stayAttached := true);
-let passthroughStringAndStayAttached = Arg.String((_) => stayAttached := true);
+let passthroughFloatAndStayAttached = Arg.Float(_ => stayAttached := true);
+let passthroughStringAndStayAttached = Arg.String(_ => stayAttached := true);
 
 let spec =
   Arg.align([

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -14,6 +14,10 @@ let passthrough = Arg.Unit(() => ());
 let passthroughFloat = Arg.Float(_ => ());
 let passthroughString = Arg.String(_ => ());
 
+let passthroughAndStayAttached = Arg.Set(stayAttached);
+let passthroughFloatAndStayAttached = Arg.Float((_) => stayAttached := true);
+let passthroughStringAndStayAttached = Arg.String((_) => stayAttached := true);
+
 let spec =
   Arg.align([
     (
@@ -48,12 +52,12 @@ let spec =
     ),
     (
       "--install-extension",
-      passthroughString,
+      passthroughStringAndStayAttached,
       " Install extension by specifying a path to the .vsix file",
     ),
     (
       "--uninstall-extension",
-      passthroughString,
+      passthroughStringAndStayAttached,
       " Uninstall extension by specifying an extension id.",
     ),
     (
@@ -63,7 +67,7 @@ let spec =
     ),
     (
       "--list-extensions",
-      Arg.Set(stayAttached),
+      passthroughAndStayAttached,
       " List the currently installed extensions.",
     ),
     (


### PR DESCRIPTION
Fix #1158

For some of the extension commands, like `--install-extension` and `--uninstall-extension`, we were not sending output to the console.

__Issue:__ We have a 'launcher' process in `Oni2` (mainly for Windows) that spawns the actual editor process - we need to specify when the stdout/stdin pipes should stay 'attached'. If they aren't, then we'll lose the output in the terminal.

__Fix:__ For `--install-extension`, `--uninstall-extension`, and `--list-extensions`, have them stay attached. The `-f` flag can be used to get additional debug logging.