### PR TITLE
Make relative extension path absolute.

### DIFF
--- a/src/ExtensionManagement/Oni_ExtensionManagement.re
+++ b/src/ExtensionManagement/Oni_ExtensionManagement.re
@@ -7,25 +7,32 @@ module Log = (val Log.withNamespace("Oni2.ExtensionManagement"));
 let install: (~extensionFolder: string, ~extensionPath: string) => Lwt.t(unit) =
   (~extensionFolder, ~extensionPath) => {
     let setup = Setup.init();
+    let extensionName = Rench.Path.filename(extensionPath);
+
+    let absoluteExtensionPath = if (Rench.Path.isAbsolute(extensionPath)) {
+      extensionPath
+    } else {
+      Rench.Path.join(Rench.Environment.getWorkingDirectory(), extensionPath);
+    };
 
     Log.infof(m =>
-      m("Installing extension %s to %s", extensionPath, extensionFolder)
+      m("Installing extension %s to %s", extensionName, extensionFolder)
     );
 
     let promise: Lwt.t(unit) =
       NodeTask.run(
         ~name="Install",
         ~setup,
-        ~args=[extensionPath, extensionFolder],
+        ~args=[absoluteExtensionPath, extensionFolder],
         "install-extension.js",
       );
 
     Lwt.on_success(promise, () => {
-      Log.infof(m => m("Successfully installed extension: %s", extensionPath))
+      Log.infof(m => m("Successfully installed extension: %s", extensionName))
     });
 
     Lwt.on_failure(promise, _ => {
-      Log.errorf(m => m("Unable to install extension: %s", extensionPath))
+      Log.errorf(m => m("Unable to install extension: %s", extensionName))
     });
     promise;
   };

--- a/src/ExtensionManagement/Oni_ExtensionManagement.re
+++ b/src/ExtensionManagement/Oni_ExtensionManagement.re
@@ -9,11 +9,15 @@ let install: (~extensionFolder: string, ~extensionPath: string) => Lwt.t(unit) =
     let setup = Setup.init();
     let extensionName = Rench.Path.filename(extensionPath);
 
-    let absoluteExtensionPath = if (Rench.Path.isAbsolute(extensionPath)) {
-      extensionPath
-    } else {
-      Rench.Path.join(Rench.Environment.getWorkingDirectory(), extensionPath);
-    };
+    let absoluteExtensionPath =
+      if (Rench.Path.isAbsolute(extensionPath)) {
+        extensionPath;
+      } else {
+        Rench.Path.join(
+          Rench.Environment.getWorkingDirectory(),
+          extensionPath,
+        );
+      };
 
     Log.infof(m =>
       m("Installing extension %s to %s", extensionName, extensionFolder)


### PR DESCRIPTION
Should fix most of the common issues people have when trying to install an extension with a relative path.