### PR TITLE
Fix #1169 / #992 - Command+W should close current window

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3b8f7ec73446134829f5276132844689",
+  "checksum": "74ade899f69f85c086abca508f18f207",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -278,7 +278,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
@@ -766,15 +766,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10005@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10005@d41d8cd9",
+    "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9": {
+      "id": "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10005",
+      "version": "github:revery-ui/esy-sdl2#b63892b",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10005.tgz#sha1:adfb34d5cb0c5a7886c04e63bfef6dc15eda5942"
-        ]
+        "source": [ "github:revery-ui/esy-sdl2#b63892b" ]
       },
       "overrides": [],
       "dependencies": [],
@@ -980,7 +978,8 @@
         "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
+        "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1b8137cbda59f0bbc4838d8e7310cd94",
+  "checksum": "74ade899f69f85c086abca508f18f207",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -278,7 +278,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
-        "esy-sdl2@link:../esy-sdl2",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
@@ -766,11 +766,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@link:../esy-sdl2": {
-      "id": "esy-sdl2@link:../esy-sdl2",
+    "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9": {
+      "id": "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "link:../esy-sdl2",
-      "source": { "type": "link", "path": "../esy-sdl2" },
+      "version": "github:revery-ui/esy-sdl2#b63892b",
+      "source": {
+        "type": "install",
+        "source": [ "github:revery-ui/esy-sdl2#b63892b" ]
+      },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -974,7 +977,8 @@
         "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
-        "esy-sdl2@link:../esy-sdl2", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
+        "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3b8f7ec73446134829f5276132844689",
+  "checksum": "1b8137cbda59f0bbc4838d8e7310cd94",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -278,7 +278,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9",
+        "esy-sdl2@link:../esy-sdl2",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
@@ -766,16 +766,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10005@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10005@d41d8cd9",
+    "esy-sdl2@link:../esy-sdl2": {
+      "id": "esy-sdl2@link:../esy-sdl2",
       "name": "esy-sdl2",
-      "version": "2.0.10005",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10005.tgz#sha1:adfb34d5cb0c5a7886c04e63bfef6dc15eda5942"
-        ]
-      },
+      "version": "link:../esy-sdl2",
+      "source": { "type": "link", "path": "../esy-sdl2" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -979,7 +974,7 @@
         "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "esy-sdl2@link:../esy-sdl2", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3b8f7ec73446134829f5276132844689",
+  "checksum": "74ade899f69f85c086abca508f18f207",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -278,7 +278,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
@@ -766,15 +766,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10005@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10005@d41d8cd9",
+    "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9": {
+      "id": "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10005",
+      "version": "github:revery-ui/esy-sdl2#b63892b",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10005.tgz#sha1:adfb34d5cb0c5a7886c04e63bfef6dc15eda5942"
-        ]
+        "source": [ "github:revery-ui/esy-sdl2#b63892b" ]
       },
       "overrides": [],
       "dependencies": [],
@@ -979,7 +977,8 @@
         "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
+        "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "reason-libvim": "onivim/reason-libvim#3782892",
     "editor-core-types": "onivim/editor-core-types#16dd98e",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
-    "esy-sdl2": "link:../esy-sdl2"
+    "esy-sdl2": "revery-ui/esy-sdl2#b63892b"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",

--- a/package.json
+++ b/package.json
@@ -235,7 +235,8 @@
     "revery": "github:revery-ui/revery#d2fd73b",
     "reason-libvim": "onivim/reason-libvim#3782892",
     "editor-core-types": "onivim/editor-core-types#16dd98e",
-    "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755"
+    "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
+    "esy-sdl2": "link:../esy-sdl2"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -179,11 +179,7 @@ let start = () => {
         command: "workbench.actions.view.problems",
         condition: Expression.True,
       },
-      {
-        key: "<D-W>",
-        command: "view.closeEditor",
-        condition: Expression.True,
-      },
+      {key: "<D-W>", command: "view.closeEditor", condition: Expression.True},
     ];
 
   let reloadConfigOnWritePost = (~configPath, dispatch) => {

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -179,6 +179,11 @@ let start = () => {
         command: "workbench.actions.view.problems",
         condition: Expression.True,
       },
+      {
+        key: "<D-W>",
+        command: "view.closeEditor",
+        condition: Expression.True,
+      },
     ];
 
   let reloadConfigOnWritePost = (~configPath, dispatch) => {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "69a95d46b166f27f1d2ea44a5da171f6",
+  "checksum": "e044e73a039abef91fc25c8de94fc274",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -278,7 +278,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.2@ee59a0be", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
@@ -766,15 +766,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10005@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10005@d41d8cd9",
+    "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9": {
+      "id": "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10005",
+      "version": "github:revery-ui/esy-sdl2#b63892b",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10005.tgz#sha1:adfb34d5cb0c5a7886c04e63bfef6dc15eda5942"
-        ]
+        "source": [ "github:revery-ui/esy-sdl2#b63892b" ]
       },
       "overrides": [],
       "dependencies": [],
@@ -979,7 +977,8 @@
         "reason-libvim@github:onivim/reason-libvim#3782892@d41d8cd9",
         "reason-jsonrpc@github:bryphe/reason-jsonrpc#95f2427@d41d8cd9",
         "ocaml@4.7.1004@d41d8cd9", "isolinear@2.2.0@d41d8cd9",
-        "esy-sdl2@2.0.10005@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "esy-sdl2@github:revery-ui/esy-sdl2#b63892b@d41d8cd9",
+        "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#16dd98e@d41d8cd9",
         "axios@0.19.0@d41d8cd9", "@reason-native/rely@1.3.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",


### PR DESCRIPTION
__Issue:__ Pressing `Cmd+W` closes the entire app. This is problematic because in OSX, `Cmd+W` generally closes the active tab. Breaks muscle memory!

__Defect:__ In `SDL2`, there is a default menu handler set up for closing a window. We don't currently override or set the menu, so this gets used - and it breaks our ability to hook in and add 'user-space' handling of the menu.

__Fix:__ The full fix will be to define our own application menu in Revery, but since we don't have that yet - this disables the 'Close' menu item in SDL2 (https://github.com/revery-ui/esy-sdl2/pull/8) and adds a handler for `Cmd+W` to close the active editor.

Fixes #1169 and #992 