### PR TITLE
[WIP] feat(language-support): add UI for find-all references

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -105,6 +105,7 @@ type t =
   | QuitBuffer([@opaque] Vim.Buffer.t, bool)
   | Quit(bool)
   | RegisterQuitCleanup(unit => unit)
+  | ReferencesHotKey
   | SearchClearMatchingPair(int)
   | SearchSetMatchingPair(int, Location.t, Location.t)
   | SearchSetHighlights(int, list(Range.t))

--- a/src/Model/Pane.re
+++ b/src/Model/Pane.re
@@ -7,7 +7,8 @@
 [@deriving show({with_path: false})]
 type paneType =
   | Search
-  | Diagnostics;
+  | Diagnostics
+  | References;
 
 type t = {
   activePane: paneType,

--- a/src/Model/Pane.rei
+++ b/src/Model/Pane.rei
@@ -7,7 +7,8 @@
 [@deriving show({with_path: false})]
 type paneType =
   | Search
-  | Diagnostics;
+  | Diagnostics
+  | References;
 
 type t;
 

--- a/src/Model/References.re
+++ b/src/Model/References.re
@@ -12,4 +12,5 @@ let initial: t = [];
 [@deriving show({with_path: false})]
 type actions =
   | Requested
-  | Set([@opaque] list(Ext.LocationWithUri.t));
+  | Available([@opaque] list(Ext.LocationWithUri.t))
+  | NotAvailable;

--- a/src/Store/LanguageFeatureConnector.re
+++ b/src/Store/LanguageFeatureConnector.re
@@ -93,7 +93,11 @@ let start = () => {
           );
 
         Lwt.on_success(promise, result => {
-          dispatch(Actions.References(Model.References.Set(result)))
+          dispatch(Actions.References(Model.References.Available(result)))
+        });
+
+        Lwt.on_failure(promise, _err => {
+          dispatch(Actions.References(Model.References.NotAvailable)) 
         });
       };
 
@@ -117,7 +121,7 @@ let start = () => {
         state,
         findAllReferences(state),
       )
-    | Actions.References(Model.References.Set(references)) => (
+    | Actions.References(Model.References.Available(references)) => (
         {...state, references},
         Isolinear.Effect.none,
       )

--- a/src/Store/LanguageFeatureConnector.re
+++ b/src/Store/LanguageFeatureConnector.re
@@ -97,7 +97,7 @@ let start = () => {
         });
 
         Lwt.on_failure(promise, _err => {
-          dispatch(Actions.References(Model.References.NotAvailable)) 
+          dispatch(Actions.References(Model.References.NotAvailable))
         });
       };
 

--- a/src/Store/PaneReducer.re
+++ b/src/Store/PaneReducer.re
@@ -58,6 +58,16 @@ let openDiagnosticsPane = (state: State.t) => {
   pane: Pane.setOpen(Pane.Diagnostics),
 };
 
+let closeReferencesPane = (state: State.t) => {
+  ...state,
+  pane: Pane.setClosed(state.pane),
+};
+
+let openReferencesPane = (state: State.t) => {
+  ...state,
+  pane: Pane.setOpen(Pane.References),
+};
+
 let diagnosticsPaneReducer = (action, state: State.t) => {
   let isDiagnosticsOpen = Pane.getType(state.pane) == Some(Pane.Diagnostics);
 
@@ -71,6 +81,21 @@ let diagnosticsPaneReducer = (action, state: State.t) => {
   };
 };
 
+let referencesPaneReducer = (action, state: State.t) => {
+  let isReferencesOpen = Pane.getType(state.pane) == Some(Pane.References);
+
+  switch (action, isReferencesOpen) {
+  | (ReferencesHotKey, true) => closeReferencesPane(state)
+  | (ReferencesHotKey, false) => openReferencesPane(state)
+  | (References(References.Available(_)), _openOrClosed) =>
+    openReferencesPane(state)
+  | _ => state
+  };
+};
+
 let reduce = (action: Actions.t, state: State.t) => {
-  state |> searchPaneReducer(action) |> diagnosticsPaneReducer(action);
+  state
+  |> searchPaneReducer(action)
+  |> diagnosticsPaneReducer(action)
+  |> referencesPaneReducer(action);
 };

--- a/src/UI/PaneView.re
+++ b/src/UI/PaneView.re
@@ -24,6 +24,8 @@ module Styles = {
 let showSearch = _ => GlobalContext.current().dispatch(Actions.SearchHotkey);
 let showProblems = _ =>
   GlobalContext.current().dispatch(Actions.DiagnosticsHotKey);
+let showReferences = _ =>
+  GlobalContext.current().dispatch(Actions.ReferencesHotKey);
 
 let make = (~theme, ~uiFont, ~editorFont, ~state: State.t, ()) => {
   ignore(uiFont);
@@ -43,6 +45,7 @@ let make = (~theme, ~uiFont, ~editorFont, ~state: State.t, ()) => {
              state={state.searchPane}
            />
          | Pane.Diagnostics => <DiagnosticsPane state />
+         | Pane.References => <ReferencesPane state />
          };
        [
          <WindowHandle theme direction=Horizontal />,
@@ -61,6 +64,13 @@ let make = (~theme, ~uiFont, ~editorFont, ~state: State.t, ()) => {
                title="Problems"
                onClick=showProblems
                active={paneType == Pane.Diagnostics}
+             />
+             <PaneTab
+               uiFont
+               theme
+               title="References"
+               onClick=showReferences
+               active={paneType == Pane.References}
              />
            </View>
            <View style=Style.[flexDirection(`Column), flexGrow(1)]>

--- a/src/UI/ReferencesPane.re
+++ b/src/UI/ReferencesPane.re
@@ -1,0 +1,50 @@
+open Revery.UI;
+open Oni_Core;
+open Oni_Model;
+
+module Ext = Oni_Extensions;
+
+module Styles = {
+  let pane = Style.[flexGrow(1), flexDirection(`Row)];
+
+  let noResultsContainer =
+    Style.[flexGrow(1), alignItems(`Center), justifyContent(`Center)];
+
+  let title = (~theme: Theme.t, ~font: UiFont.t) =>
+    Style.[
+      fontFamily(font.fontFile),
+      fontSize(font.fontSize),
+      color(theme.editorForeground),
+      margin(8),
+    ];
+};
+
+let toLocListItem = (locationWithUri: Ext.LocationWithUri.t) => {
+  let {uri, range}: Ext.LocationWithUri.t = locationWithUri;
+  let file = Uri.toFileSystemPath(uri);
+  let location = range.start;
+  LocationListItem.{file, location, text: "", highlight: None};
+};
+
+let make = (~state: State.t, ()) => {
+  let {theme, uiFont, editorFont, _}: State.t = state;
+
+  let items =
+    state.references
+    |> List.map(toLocListItem)
+    |> Array.of_list;
+
+  let innerElement =
+    if (Array.length(items) == 0) {
+      <View style=Styles.noResultsContainer>
+        <Text
+          style={Styles.title(~theme, ~font=uiFont)}
+          text="No references available."
+        />
+      </View>;
+    } else {
+      <LocationListView theme uiFont editorFont items />;
+    };
+
+  <View style=Styles.pane> innerElement </View>;
+};

--- a/src/UI/ReferencesPane.re
+++ b/src/UI/ReferencesPane.re
@@ -29,10 +29,7 @@ let toLocListItem = (locationWithUri: Ext.LocationWithUri.t) => {
 let make = (~state: State.t, ()) => {
   let {theme, uiFont, editorFont, _}: State.t = state;
 
-  let items =
-    state.references
-    |> List.map(toLocListItem)
-    |> Array.of_list;
+  let items = state.references |> List.map(toLocListItem) |> Array.of_list;
 
   let innerElement =
     if (Array.length(items) == 0) {


### PR DESCRIPTION
We actually already have a basic API for find-all references, but we're not surfacing it in the UI anywhere.

This adds a find-all references pane, alongside the other panes we currently have:
![image](https://user-images.githubusercontent.com/13532591/71914067-a634f800-312d-11ea-8395-226c88c082b3.png)

__TODO:__
- [ ] Show line info for a buffer, when available
- [ ] Add shortcut key to toggle showing / hiding
- [ ] Add error notification when references are not available upon request