### PR TITLE
Bugfix - Logging: Hook up '--debug' to also provide stacktraces

### DIFF
--- a/src/Core/Cli.re
+++ b/src/Core/Cli.re
@@ -79,7 +79,7 @@ let parse =
     [
       ("-f", Unit(Timber.App.enablePrinting), ""),
       ("--nofork", Unit(Timber.App.enablePrinting), ""),
-      ("--debug", Unit(Timber.App.enableDebugLogging), ""),
+      ("--debug", Unit(CoreLog.enableDebugLogging), ""),
       ("--no-log-colors", Unit(Timber.App.disableColors), ""),
       ("--disable-extensions", Unit(disableExtensionLoading), ""),
       ("--disable-configuration", Unit(disableLoadConfiguration), ""),

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -33,7 +33,8 @@ let writeExceptionLog = (e, bt) => {
   Stdlib.close_out(oc);
 };
 
-if (isDebugLoggingEnabled()) {
+let enableDebugLogging = () => {
+  Timber.App.enableDebugLogging();
   module Log = (val withNamespace("Oni2.Exception"));
 
   Log.debug("Recording backtraces");
@@ -49,6 +50,10 @@ if (isDebugLoggingEnabled()) {
     flush_all();
     writeExceptionLog(e, bt);
   });
+};
+
+if (Timber.isDebugLoggingEnabled()) {
+  enableDebugLogging();
 } else {
   // Even if we're not debugging.... at least emit the exception
   Printexc.set_uncaught_exception_handler((e, bt) => {

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -16,4 +16,5 @@ module type Logger = {
   let fn: (string, 'a => 'b, 'a) => 'b;
 };
 
+let enableDebugLogging: unit => unit;
 let withNamespace: string => (module Logger);


### PR DESCRIPTION
In investigating the logs for #1185 , I saw that the '--debug' flag was being passed, but we weren't actually get stack traces, like would be expected.

It turns out that we are only recording backtraces if the environment variable is set on initialization (`ONI2_DEBUG=1`). If the `--debug` flag is set, we don't actually call `record_backtrace`.

This updates our logic so that, if either the environment variable is set (ie, `Timber.isDebugLoggingEnabled()` is true to start), or if the `--debug` flag is passed - we'll run `Printexc.record_backtrace` so we can get a better exception message.