### PR TITLE
Fix #1221: Clean up version output

### DIFF
--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -55,7 +55,7 @@ let listExtensions = cli => {
 };
 
 let printVersion = _cli => {
-  print_endline("Onivim 2." ++ Core.BuildInfo.version);
+  print_endline("Onivim 2 (" ++ Core.BuildInfo.version ++ ")");
   0;
 };
 

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -81,7 +81,7 @@ let spec =
   ]);
 
 let usage = {|
-Onivim 2 0.2.0
+Onivim 2
 
 Usage:
 


### PR DESCRIPTION
Fix a couple of issues with the version output:
- Change `Onivim2.major.minor.patch` -> `Onivim 2 (major.minor.patch)`. 
- Remove hardcoded version in the 'usage' section.

Fixes #1221 