### PR TITLE
Dependency: vscode-exthost -> 1.33.5

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -3,6 +3,8 @@
 steps:
   - script: npm install -g esy@0.6.0
     displayName: 'Install Esy: npm install -g esy@0.6.0'
+  - script: npm install -g node-gyp
+    displayName: 'Install node-gyp: npm install -g node-gyp'
   - script: esy install
     displayName: 'Install Dependencies: esy install'
   - script: esy bootstrap

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -3,8 +3,6 @@
 steps:
   - script: npm install -g esy@0.6.0
     displayName: 'Install Esy: npm install -g esy@0.6.0'
-  - script: npm install -g node-gyp
-    displayName: 'Install node-gyp: npm install -g node-gyp'
   - script: esy install
     displayName: 'Install Dependencies: esy install'
   - script: esy bootstrap

--- a/.ci/js-build-steps.yml
+++ b/.ci/js-build-steps.yml
@@ -1,5 +1,7 @@
 # Cross-platform set of build steps for building esy projects	
 
 steps:	
+  - script: npm install -g node-gyp
+    displayName: 'js deps: install node-gyp'
   - script: node install-node-deps.js --prod	
     displayName: 'js deps: npm install --prod'

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -47,6 +47,7 @@ esy build
 ### Install node dependencies
 
 ```sh
+npm install -g node-gyp
 node install-node-deps.js
 ```
 

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
-    "vscode-exthost": "1.33.4",
+    "vscode-exthost": "1.33.5",
     "yauzl": "^2.5.1"
   },
   "jest": {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -42,6 +42,18 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+nan@2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
+  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+
+node-pty@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.8.1.tgz#94b457bec013e7a09b8d9141f63b0787fa25c23f"
+  integrity sha512-j+/g0Q5dR+vkELclpJpz32HcS3O/3EdPSGPvDXJZVJQLCvgG0toEbfmymxAEyQyZEpaoKHAcoL+PvKM+4N9nlw==
+  dependencies:
+    nan "2.12.1"
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -67,13 +79,14 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-vscode-exthost@1.33.4:
-  version "1.33.4"
-  resolved "https://registry.yarnpkg.com/vscode-exthost/-/vscode-exthost-1.33.4.tgz#f076ef6f753b46f1d3ea6c3cb121ee5eb89f9efd"
-  integrity sha512-V6hikfsZTgwqNITMpwoYwxkoJq99UmX1xZm0AquxHcKKfcksGql5k1dg0jQe7SyLNp0LEW9WhZUIbZIRwSNCkA==
+vscode-exthost@1.33.5:
+  version "1.33.5"
+  resolved "https://registry.yarnpkg.com/vscode-exthost/-/vscode-exthost-1.33.5.tgz#ac7ef28d34d82f30f067064b129e56c144a4e63d"
+  integrity sha512-9snPG1ZxytO0HFmkqItRt3W6SGDhZ1JIUsIYXYQ2eKu5jx/NSow3/SYJJhFzsRqtLfbx9gL/6AWh50Vz62llog==
   dependencies:
     graceful-fs "4.1.11"
     iconv-lite "0.4.23"
+    node-pty "0.8.1"
     semver "^5.5.0"
     vscode-jsonrpc "4.0.0"
 


### PR DESCRIPTION
This brings in vscode-exthost@1.33.5, in preparation for wiring up the terminal service APIs

__TODO:__
- [x] Add `node-gyp` to build install steps