### PR TITLE
Dependency: timber -> ae5de6c

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5b85266aef1239526c9e4443a98e1a9b",
+  "checksum": "c934e30e80a1778c41929f473b2197a7",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -58,13 +58,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#37ffa07",
+      "version": "github:glennsl/timber#ae5de6c",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#37ffa07" ]
+        "source": [ "github:glennsl/timber#ae5de6c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -115,7 +115,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -985,7 +985,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery@github:revery-ui/revery#7ede78a@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5b85266aef1239526c9e4443a98e1a9b",
+  "checksum": "c934e30e80a1778c41929f473b2197a7",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -58,13 +58,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#37ffa07",
+      "version": "github:glennsl/timber#ae5de6c",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#37ffa07" ]
+        "source": [ "github:glennsl/timber#ae5de6c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -115,7 +115,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -985,7 +985,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery@github:revery-ui/revery#7ede78a@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5b85266aef1239526c9e4443a98e1a9b",
+  "checksum": "c934e30e80a1778c41929f473b2197a7",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -58,13 +58,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#37ffa07",
+      "version": "github:glennsl/timber#ae5de6c",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#37ffa07" ]
+        "source": [ "github:glennsl/timber#ae5de6c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -115,7 +115,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -985,7 +985,7 @@
       },
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery@github:revery-ui/revery#7ede78a@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "editor-core-types": "onivim/editor-core-types#16dd98e",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-sdl2": "revery-ui/esy-sdl2#b63892b",
-    "timber": "glennsl/timber#37ffa07"
+    "timber": "glennsl/timber#ae5de6c"
   },
   "devDependencies": {
     "ocaml": "~4.7.0",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7048ec2bfb5967a838f2d84e4d723705",
+  "checksum": "8630bd3f5e6c3e82cc286577d293df06",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "xmldom@0.1.31@d41d8cd9": {
@@ -58,13 +58,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#37ffa07",
+      "version": "github:glennsl/timber#ae5de6c",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#37ffa07" ]
+        "source": [ "github:glennsl/timber#ae5de6c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -115,7 +115,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -985,7 +985,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
         "revery@github:revery-ui/revery#7ede78a@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",


### PR DESCRIPTION
In addition to using native printf to avoid crashing on Windows, this:
- appends to the log file, so multiple processes can safely log to the same file. An optional `truncate` argument can be passed to `setLogFile`, which the main process can use to start from scratch each time.
- timestamp added to the log file header
- uses black foreground for all log levels, since that seems to be most legible with normal terminal colors