### PR TITLE
Warn when closing window with unsaved changes

### DIFF
--- a/src/Components/MessageBox.re
+++ b/src/Components/MessageBox.re
@@ -1,0 +1,77 @@
+open Oni_Core;
+
+open Revery.UI;
+open Revery.UI.Components;
+
+type action('msg) = {
+  label: string,
+  msg: 'msg,
+};
+
+module Styles = {
+  open Style;
+
+  let container = (~theme: Theme.t) => [backgroundColor(theme.background)];
+
+  let message = [padding(10)];
+
+  let messageText = (~theme: Theme.t, ~font: UiFont.t) => [
+    fontFamily(font.fontFile),
+    color(theme.foreground),
+    backgroundColor(theme.editorBackground),
+    fontSize(14),
+  ];
+
+  let actions = [flexDirection(`Row)];
+
+  let buttonOuter = (~isHovered, ~theme: Theme.t) => [
+    isHovered
+      ? backgroundColor(theme.menuSelectionBackground)
+      : backgroundColor(theme.editorBackground),
+    flexGrow(1),
+  ];
+
+  let buttonInner = [padding(10)];
+
+  let buttonText = (~isHovered, ~theme: Theme.t, ~font: UiFont.t) => [
+    fontFamily(font.fontFile),
+    color(theme.foreground),
+    isHovered
+      ? backgroundColor(theme.menuSelectionBackground)
+      : backgroundColor(theme.editorBackground),
+    fontSize(14),
+    alignSelf(`Center),
+  ];
+};
+
+let%component button = (~text, ~onClick, ~theme, ~font, ()) => {
+  let%hook (isHovered, setHovered) = Hooks.state(false);
+
+  <Clickable onClick style={Styles.buttonOuter(~theme, ~isHovered)}>
+    <View
+      onMouseOver={_ => setHovered(_ => true)}
+      onMouseOut={_ => setHovered(_ => false)}
+      style=Styles.buttonInner>
+      <Text style={Styles.buttonText(~isHovered, ~theme, ~font)} text />
+    </View>
+  </Clickable>;
+};
+
+let make = (~message, ~theme, ~font, ~actions, ~onAction, ()) =>
+  <View style={Styles.container(~theme)}>
+    <View style=Styles.message>
+      <Text style={Styles.messageText(~theme, ~font)} text=message />
+    </View>
+    <View style=Styles.actions>
+      {actions
+       |> List.map(action =>
+            <button
+              text={action.label}
+              onClick={() => onAction(action.msg)}
+              theme
+              font
+            />
+          )
+       |> React.listToElement}
+    </View>
+  </View>;

--- a/src/Components/MessageBox.re
+++ b/src/Components/MessageBox.re
@@ -13,13 +13,9 @@ module Styles = {
 
   let container = (~theme: Theme.t) => [backgroundColor(theme.background)];
 
-  let message = [padding(10)];
-
-  let messageText = (~theme: Theme.t, ~font: UiFont.t) => [
-    fontFamily(font.fontFile),
-    color(theme.foreground),
-    backgroundColor(theme.editorBackground),
-    fontSize(14),
+  let message = [
+    padding(20),
+    paddingBottom(30) // I don't know why this is needed, but it is
   ];
 
   let actions = [flexDirection(`Row)];
@@ -57,11 +53,9 @@ let%component button = (~text, ~onClick, ~theme, ~font, ()) => {
   </Clickable>;
 };
 
-let make = (~message, ~theme, ~font, ~actions, ~onAction, ()) =>
+let make = (~children as message, ~theme, ~font, ~actions, ~onAction, ()) =>
   <View style={Styles.container(~theme)}>
-    <View style=Styles.message>
-      <Text style={Styles.messageText(~theme, ~font)} text=message />
-    </View>
+    <View style=Styles.message> message </View>
     <View style=Styles.actions>
       {actions
        |> List.map(action =>

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -126,6 +126,10 @@ type t =
   | Sneak(Sneak.action)
   | PaneTabClicked(Pane.paneType)
   | VimDirectoryChanged(string)
+  | WindowCloseBlocked
+  | WindowCloseDiscardConfirmed
+  | WindowCloseSaveAllConfirmed
+  | WindowCloseCanceled
   // "Internal" effect action, see TitleStoreConnector
   | SetTitle(string)
   | Noop

--- a/src/Model/Buffers.re
+++ b/src/Model/Buffers.re
@@ -44,24 +44,17 @@ let isModifiedByPath = (buffers: t, filePath: string) => {
   );
 };
 
-let ofBufferOpt = (f, buffer) => {
-  switch (buffer) {
-  | None => None
-  | Some(b) => Some(f(b))
-  };
-};
-
 let applyBufferUpdate = bufferUpdate =>
-  ofBufferOpt(buffer => Buffer.update(buffer, bufferUpdate));
+  Option.map(buffer => Buffer.update(buffer, bufferUpdate));
 
 let setIndentation = indent =>
-  ofBufferOpt(buffer => Buffer.setIndentation(indent, buffer));
+  Option.map(buffer => Buffer.setIndentation(indent, buffer));
 
 let disableSyntaxHighlighting =
-  ofBufferOpt(buffer => Buffer.disableSyntaxHighlighting(buffer));
+  Option.map(buffer => Buffer.disableSyntaxHighlighting(buffer));
 
 let setModified = modified =>
-  ofBufferOpt(buffer => Buffer.setModified(modified, buffer));
+  Option.map(buffer => Buffer.setModified(modified, buffer));
 
 let reduce = (state: t, action: Actions.t) => {
   switch (action) {

--- a/src/Model/Modal.re
+++ b/src/Model/Modal.re
@@ -1,0 +1,2 @@
+type t =
+  | UnsavedBuffersWarning;

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -54,6 +54,7 @@ type t = {
   pane: Pane.t,
   searchPane: Feature_Search.model,
   focus: Focus.stack,
+  modal: option(Modal.t),
 };
 
 let create: unit => t =
@@ -102,4 +103,5 @@ let create: unit => t =
     pane: Pane.initial,
     searchPane: Feature_Search.initial,
     focus: Focus.initial,
+    modal: None,
   };

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -226,6 +226,19 @@ let start =
 
   latestRunEffects := Some(runEffects);
 
+  Option.iter(
+    window =>
+      Revery.Window.setCanQuitCallback(window, () =>
+        if (Model.Buffers.anyModified(latestState^.buffers)) {
+          dispatch(Model.Actions.WindowCloseBlocked);
+          false;
+        } else {
+          true;
+        }
+      ),
+    window,
+  );
+
   let editorEventStream =
     Isolinear.Stream.map(storeStream, ((state, action)) =>
       switch (action) {

--- a/src/UI/Modals.re
+++ b/src/UI/Modals.re
@@ -1,0 +1,98 @@
+open Revery;
+open Revery.UI;
+
+open Oni_Core;
+open Utility;
+open Oni_Model;
+open Oni_Components;
+open Actions;
+
+module Styles = {
+  open Style;
+
+  let overlay = [
+    backgroundColor(Color.hex("#0004")),
+    position(`Absolute),
+    top(0),
+    left(0),
+    right(0),
+    bottom(0),
+    alignItems(`Center),
+    justifyContent(`Center),
+    overflow(`Hidden),
+    flexDirection(`Column),
+    pointerEvents(`Allow),
+  ];
+
+  let text = (~theme: Theme.t, ~font: UiFont.t) => [
+    fontFamily(font.fontFile),
+    color(theme.editorForeground),
+    backgroundColor(theme.editorBackground),
+    fontSize(14),
+  ];
+
+  let files = [padding(10)];
+
+  let file = (~theme: Theme.t, ~font: UiFont.t) => [
+    fontFamily(font.fontFile),
+    color(theme.foreground),
+    backgroundColor(theme.editorBackground),
+    fontSize(14),
+  ];
+};
+
+let unsavedBufferWarning =
+    (~workingDirectory, ~buffers, ~theme, ~uiFont as font, ()) => {
+  let modifiedFiles =
+    buffers
+    |> IntMap.to_seq
+    |> Seq.map(snd)
+    |> Seq.filter(Buffer.isModified)
+    |> Seq.map(Buffer.getFilePath)
+    |> List.of_seq
+    |> OptionEx.values
+    |> List.map(
+         Path.toRelative(~base=Option.value(workingDirectory, ~default="")),
+       );
+
+  <MessageBox
+    actions=MessageBox.[
+      {label: "Discard Changes", msg: WindowCloseDiscardConfirmed},
+      {label: "Cancel", msg: WindowCloseCanceled},
+      {label: "Save All", msg: WindowCloseSaveAllConfirmed},
+    ]
+    onAction={GlobalContext.current().dispatch}
+    theme
+    font>
+    <Text
+      style={Styles.text(~theme, ~font)}
+      text="You have unsaved changes in the following files:"
+    />
+    <View style=Styles.files>
+      {modifiedFiles
+       |> List.map(text => <Text style={Styles.file(~theme, ~font)} text />)
+       |> React.listToElement}
+    </View>
+    <Text
+      style={Styles.text(~theme, ~font)}
+      text="Would you like to to save them before closing?"
+    />
+  </MessageBox>;
+};
+
+let make = (~state: State.t, ()) => {
+  let State.{theme, uiFont, buffers, workspace, _} = state;
+  let workingDirectory =
+    Option.map(ws => ws.Workspace.workingDirectory, workspace);
+
+  switch (state.modal) {
+  | None => React.empty
+  | Some(modal) =>
+    <View style=Styles.overlay>
+      {switch (modal) {
+       | UnsavedBuffersWarning =>
+         <unsavedBufferWarning workingDirectory buffers theme uiFont />
+       }}
+    </View>
+  };
+};

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -9,34 +9,42 @@ open Revery.UI;
 open Oni_Model;
 
 module Styles = {
-  let root = (background, foreground) =>
-    Style.[
-      backgroundColor(background),
-      color(foreground),
-      position(`Absolute),
-      top(0),
-      left(0),
-      right(0),
-      bottom(0),
-      justifyContent(`Center),
-      alignItems(`Stretch),
-    ];
+  open Style;
 
-  let surface = Style.[flexGrow(1), flexDirection(`Row)];
+  let root = (background, foreground) => [
+    backgroundColor(background),
+    color(foreground),
+    position(`Absolute),
+    top(0),
+    left(0),
+    right(0),
+    bottom(0),
+    justifyContent(`Center),
+    alignItems(`Stretch),
+  ];
+
+  let surface = [flexGrow(1), flexDirection(`Row)];
 
   let workspace = Style.[flexGrow(1), flexDirection(`Column)];
 
-  let statusBar = statusBarHeight =>
-    Style.[
-      backgroundColor(Color.hex("#21252b")),
-      height(statusBarHeight),
-      justifyContent(`Center),
-      alignItems(`Center),
-    ];
+  let statusBar = statusBarHeight => [
+    backgroundColor(Color.hex("#21252b")),
+    height(statusBarHeight),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
 };
 
 let make = (~state: State.t, ()) => {
-  let State.{theme, configuration, uiFont, editorFont, sideBar, zenMode, _} = state;
+  let State.{
+        theme,
+        configuration,
+        uiFont as font,
+        editorFont,
+        sideBar,
+        zenMode,
+        _,
+      } = state;
 
   let statusBarVisible =
     Selectors.getActiveConfigurationValue(state, c =>
@@ -98,13 +106,13 @@ let make = (~state: State.t, ()) => {
          switch (quickmenu.variant) {
          | Wildmenu(_) => <WildmenuView theme configuration state=quickmenu />
 
-         | _ =>
-           <QuickmenuView theme configuration state=quickmenu font=uiFont />
+         | _ => <QuickmenuView theme configuration state=quickmenu font />
          }
        }}
       <KeyDisplayerView state />
     </Overlay>
     statusBar
+    <Modals state />
     <Overlay> <SneakView state /> </Overlay>
   </View>;
 };

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -161,7 +161,7 @@ if (cliOptions.syntaxHighlightService) {
     let setVsync = vsync => Window.setVsync(w, vsync);
 
     let quit = code => {
-      App.quit(~code, app);
+      App.quit(~askNicely=false, ~code, app);
     };
 
     Log.debug("Startup: Starting StoreThread");


### PR DESCRIPTION
![2020-01-20-124655_413x233_scrot](https://user-images.githubusercontent.com/5207036/72724234-0c386b00-3b83-11ea-9561-b43d0deeff3a.png)

Fixes #610

The message is a bit unbalanced, both visually and in terms of "scanability". It would be better to lead with a very short question summarizing the decision to be made, and then expand on it. We can tweak this later though, but it would be nice to have rich text support to be able to more easily to so.

A neat keyboard interface is planned for a subsequent PR.