### PR TITLE
Fixes cursor position for menu dialog with prefixes

### DIFF
--- a/src/Components/Input.re
+++ b/src/Components/Input.re
@@ -276,7 +276,7 @@ let%component make =
 
   let cursor = () => {
     let (startStr, _) =
-      getStringParts(cursorPosition + String.length(prefix), value);
+      getStringParts(cursorPosition + String.length(prefix), displayValue);
     let textWidth = measureTextWidth(startStr);
 
     let offset = textWidth - scrollOffset^;


### PR DESCRIPTION
Code it wasn't counting full input value since that cursor was off to the left for a size of prefix.
![Screenshot from 2020-01-20 15-59-21](https://user-images.githubusercontent.com/7717033/72737999-4ddc0c80-3ba9-11ea-9bc0-bd5669e27036.png)

This fixes this bug. Now cursor
![Screenshot from 2020-01-20 15-59-59](https://user-images.githubusercontent.com/7717033/72738021-5c2a2880-3ba9-11ea-9116-afb12c3ff4b7.png)
 in place: