### PR TITLE
Development / Documentation: Add instructions for working with exthost

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -94,6 +94,32 @@ Once you have a release build created, you can create an `oni2` symlink to point
 Run the following from the `oni2` directory:
 - `./scripts/osx/create-symlink.sh`
 
+## Extension Host
+
+If you want to develop, or debug, the extension host back-end, follow these steps:
+
+### Build the extension host
+
+- Navigate to your home directory (ie, `cd ~` on Linux / OSX, or `cd /` on Windows)
+- `git clone https://github.com/onivim/vscode-exthost`
+- `yarn install`
+- `yarn compile`
+
+> You can use the `yarn watch` command too - this is useful for iterating quickly!
+
+To add logging, use `console.error` - messages on `stderr` will be shown in Onivim's log.
+
+### Testing
+
+You can use the `ONI2_EXTHOST` environment variable to override the default extension host with your local extension host:
+- `ONI2_DEBUG=1 ONI2_EXTHOST=/Users/<your-username>/vscode-exthost esy run -f`
+
+For example, adding the logging here (the [`$executeContributedCommand`](https://github.com/onivim/vscode-exthost/blob/a25f426a04fe427beab7465be660f89a794605b5/src/vs/workbench/api/node/extHostCommands.ts#L165) proxy method)
+![image](https://user-images.githubusercontent.com/13532591/72770589-3013a500-3bb3-11ea-9c24-805bfe1cb7d1.png)
+
+Results in this debug logging:
+![image](https://user-images.githubusercontent.com/13532591/72770508-ea56dc80-3bb2-11ea-96a4-4afefcb282da.png)
+
 # Building the Documentation Website
 
 From the `oni2` directory:

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -115,10 +115,13 @@ You can use the `ONI2_EXTHOST` environment variable to override the default exte
 - `ONI2_DEBUG=1 ONI2_EXTHOST=/Users/<your-username>/vscode-exthost esy run -f`
 
 For example, adding the logging here (the [`$executeContributedCommand`](https://github.com/onivim/vscode-exthost/blob/a25f426a04fe427beab7465be660f89a794605b5/src/vs/workbench/api/node/extHostCommands.ts#L165) proxy method)
+
 ![image](https://user-images.githubusercontent.com/13532591/72770589-3013a500-3bb3-11ea-9c24-805bfe1cb7d1.png)
 
 Results in this debug logging:
-![image](https://user-images.githubusercontent.com/13532591/72770508-ea56dc80-3bb2-11ea-96a4-4afefcb282da.png)
+
+![image](https://user-images.githubusercontent.com/13532591/72770839-ed9e9800-3bb3-11ea-9cb9-317223fb2dbb.png)
+
 
 # Building the Documentation Website
 

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -107,12 +107,12 @@ If you want to develop, or debug, the extension host back-end, follow these step
 
 > You can use the `yarn watch` command too - this is useful for iterating quickly!
 
-To add logging, use `console.error` - messages on `stderr` will be shown in Onivim's log.
+To add logging, use `console.error` - messages on `stderr` will be shown in Onivim's log. (Make sure to turn debug logging on, via `ONI2_DEBUG=1` environment variable or the `--debug` command-line arg).
 
 ### Testing
 
 You can use the `ONI2_EXTHOST` environment variable to override the default extension host with your local extension host:
-- `ONI2_DEBUG=1 ONI2_EXTHOST=/Users/<your-username>/vscode-exthost esy run -f`
+- `ONI2_EXTHOST=/Users/<your-username>/vscode-exthost esy run -f --debug``
 
 For example, adding the logging here (the [`$executeContributedCommand`](https://github.com/onivim/vscode-exthost/blob/a25f426a04fe427beab7465be660f89a794605b5/src/vs/workbench/api/node/extHostCommands.ts#L165) proxy method)
 

--- a/src/Core/Setup.re
+++ b/src/Core/Setup.re
@@ -91,10 +91,13 @@ let getNodeHealthCheckPath = (v: t) => {
 };
 
 let getNodeExtensionHostPath = (v: t) => {
-  getNodeScriptPath(
+  switch (Sys.getenv_opt("ONI2_EXTHOST")) {
+  | Some(extHostPath) => Rench.Path.join(extHostPath, "out/bootstrap-fork.js")
+  | None => getNodeScriptPath(
     ~script="node_modules/vscode-exthost/out/bootstrap-fork.js",
     v,
   );
+  }
 };
 
 let init = () => {

--- a/src/Core/Setup.re
+++ b/src/Core/Setup.re
@@ -92,12 +92,14 @@ let getNodeHealthCheckPath = (v: t) => {
 
 let getNodeExtensionHostPath = (v: t) => {
   switch (Sys.getenv_opt("ONI2_EXTHOST")) {
-  | Some(extHostPath) => Rench.Path.join(extHostPath, "out/bootstrap-fork.js")
-  | None => getNodeScriptPath(
-    ~script="node_modules/vscode-exthost/out/bootstrap-fork.js",
-    v,
-  );
-  }
+  | Some(extHostPath) =>
+    Rench.Path.join(extHostPath, "out/bootstrap-fork.js")
+  | None =>
+    getNodeScriptPath(
+      ~script="node_modules/vscode-exthost/out/bootstrap-fork.js",
+      v,
+    )
+  };
 };
 
 let init = () => {


### PR DESCRIPTION
This adds some documentation describing on how to test / work with the extension host (it's useful to add logging to it when things go wrong!)

Also, when I was testing locally, what I'd often do is remap the `setup.json` to point to my local vscode exthost build. I made that a bit easier in this PR by providing a `ONI2_EXTHOST` env variable that can be used to override this setting - that just needs to point to a `vscode-exthost` folder (should be built, of course!).
