### PR TITLE
SCM: Add diff algorithm, borrowed from camlp5

### DIFF
--- a/ThirdPartyLicenses.txt
+++ b/ThirdPartyLicenses.txt
@@ -31,6 +31,7 @@ This project incorporates components from the projects listed below. The origina
 24. ocaml-re (https://github.com/ocaml/ocaml-re)
 25. fmt (https://github.com/dbuenzli/fmt)
 26. LaserWave (https://github.com/Jaredk3nt/laserwave)
+27. camlp5 (https://github.com/camlp5/camlp5)
 
 %% FiraCode NOTICES AND INFORMATION BEGIN HERE
 ==============================================
@@ -3203,3 +3204,33 @@ END of LaserWave NOTICES AND INFORMATION
 
 ==============================================
 END of <template> NOTICES AND INFORMATION
+
+- camlp5 is licensed as follows:
+  """
+    * Copyright (c) 2007-2017, INRIA (Institut National de Recherches en
+    * Informatique et Automatique). All rights reserved.
+    * Redistribution and use in source and binary forms, with or without
+    * modification, are permitted provided that the following conditions are met:
+    *
+    *     * Redistributions of source code must retain the above copyright
+    *       notice, this list of conditions and the following disclaimer.
+    *     * Redistributions in binary form must reproduce the above copyright
+    *       notice, this list of conditions and the following disclaimer in the
+    *       documentation and/or other materials provided with the distribution.
+    *     * Neither the name of INRIA, nor the names of its contributors may be
+    *       used to endorse or promote products derived from this software without
+    *       specific prior written permission.
+    *
+    * THIS SOFTWARE IS PROVIDED BY INRIA AND CONTRIBUTORS ``AS IS'' AND
+    * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+    * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+    * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INRIA AND
+    * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+    * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    * SUCH DAMAGE.
+  """

--- a/src/Core/Diff.ml
+++ b/src/Core/Diff.ml
@@ -1,7 +1,35 @@
- 
-(* camlp5r *)
-(* diff.ml,v *)
-(* Copyright (c) INRIA 2007-2017 *)
+(* This file has been adapted from camlp5:
+ * https://github.com/camlp5/camlp5/blob/master/ocaml_src/lib/diff.ml
+ *)
+
+(*
+ * Copyright (c) 2007-2017, INRIA (Institut National de Recherches en
+ * Informatique et Automatique). All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of INRIA, nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY INRIA AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INRIA AND
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *)
 
 (* Parts of Code of GNU diff (analyze.c) translated from C to OCaml
    and adjusted. Basic algorithm described by Eugene W.Myers in:

--- a/src/Core/Diff.ml
+++ b/src/Core/Diff.ml
@@ -7,8 +7,6 @@
    and adjusted. Basic algorithm described by Eugene W.Myers in:
      "An O(ND) Difference Algorithm and Its Variations" *)
 
-     open Versdep;;
-
      exception DiagReturn of int;;
      
      let diag fd bd sh xv yv xoff xlim yoff ylim =
@@ -138,7 +136,7 @@
          (fun i e ->
             try b.(i) <- Hashtbl.find htb e with Not_found -> Hashtbl.add htb e e)
          b;
-       let ai = array_create n 0 in
+       let ai = Array.make n 0 in
        let k =
          let rec loop i k =
            if i = n then k

--- a/src/Core/Diff.ml
+++ b/src/Core/Diff.ml
@@ -1,0 +1,166 @@
+ 
+(* camlp5r *)
+(* diff.ml,v *)
+(* Copyright (c) INRIA 2007-2017 *)
+
+(* Parts of Code of GNU diff (analyze.c) translated from C to OCaml
+   and adjusted. Basic algorithm described by Eugene W.Myers in:
+     "An O(ND) Difference Algorithm and Its Variations" *)
+
+     open Versdep;;
+
+     exception DiagReturn of int;;
+     
+     let diag fd bd sh xv yv xoff xlim yoff ylim =
+       let dmin = xoff - ylim in
+       let dmax = xlim - yoff in
+       let fmid = xoff - yoff in
+       let bmid = xlim - ylim in
+       let odd = (fmid - bmid) land 1 <> 0 in
+       fd.(sh+fmid) <- xoff;
+       bd.(sh+bmid) <- xlim;
+       try
+         let rec loop fmin fmax bmin bmax =
+           let fmin =
+             if fmin > dmin then begin fd.(sh+fmin-2) <- -1; fmin - 1 end
+             else fmin + 1
+           in
+           let fmax =
+             if fmax < dmax then begin fd.(sh+fmax+2) <- -1; fmax + 1 end
+             else fmax - 1
+           in
+           begin let rec loop d =
+             if d < fmin then ()
+             else
+               let tlo = fd.(sh+d-1) in
+               let thi = fd.(sh+d+1) in
+               let x = if tlo >= thi then tlo + 1 else thi in
+               let x =
+                 let rec loop xv yv xlim ylim x y =
+                   if x < xlim && y < ylim && xv x == yv y then
+                     loop xv yv xlim ylim (x + 1) (y + 1)
+                   else x
+                 in
+                 loop xv yv xlim ylim x (x - d)
+               in
+               fd.(sh+d) <- x;
+               if odd && bmin <= d && d <= bmax && bd.(sh+d) <= fd.(sh+d) then
+                 raise (DiagReturn d)
+               else loop (d - 2)
+           in
+             loop fmax
+           end;
+           let bmin =
+             if bmin > dmin then begin bd.(sh+bmin-2) <- max_int; bmin - 1 end
+             else bmin + 1
+           in
+           let bmax =
+             if bmax < dmax then begin bd.(sh+bmax+2) <- max_int; bmax + 1 end
+             else bmax - 1
+           in
+           begin let rec loop d =
+             if d < bmin then ()
+             else
+               let tlo = bd.(sh+d-1) in
+               let thi = bd.(sh+d+1) in
+               let x = if tlo < thi then tlo else thi - 1 in
+               let x =
+                 let rec loop xv yv xoff yoff x y =
+                   if x > xoff && y > yoff && xv (x - 1) == yv (y - 1) then
+                     loop xv yv xoff yoff (x - 1) (y - 1)
+                   else x
+                 in
+                 loop xv yv xoff yoff x (x - d)
+               in
+               bd.(sh+d) <- x;
+               if not odd && fmin <= d && d <= fmax && bd.(sh+d) <= fd.(sh+d) then
+                 raise (DiagReturn d)
+               else loop (d - 2)
+           in
+             loop bmax
+           end;
+           loop fmin fmax bmin bmax
+         in
+         loop fmid fmid bmid bmid
+       with DiagReturn i -> i
+     ;;
+     
+     let diff_loop a ai b bi n m =
+       let fd = Array.make (n + m + 3) 0 in
+       let bd = Array.make (n + m + 3) 0 in
+       let sh = m + 1 in
+       let xvec i = a.(ai.(i)) in
+       let yvec j = b.(bi.(j)) in
+       let chng1 = Array.make (Array.length a) true in
+       let chng2 = Array.make (Array.length b) true in
+       for i = 0 to n - 1 do chng1.(ai.(i)) <- false done;
+       for j = 0 to m - 1 do chng2.(bi.(j)) <- false done;
+       let rec loop xoff xlim yoff ylim =
+         let (xoff, yoff) =
+           let rec loop xoff yoff =
+             if xoff < xlim && yoff < ylim && xvec xoff == yvec yoff then
+               loop (xoff + 1) (yoff + 1)
+             else xoff, yoff
+           in
+           loop xoff yoff
+         in
+         let (xlim, ylim) =
+           let rec loop xlim ylim =
+             if xlim > xoff && ylim > yoff && xvec (xlim - 1) == yvec (ylim - 1)
+             then
+               loop (xlim - 1) (ylim - 1)
+             else xlim, ylim
+           in
+           loop xlim ylim
+         in
+         if xoff = xlim then
+           for y = yoff to ylim - 1 do chng2.(bi.(y)) <- true done
+         else if yoff = ylim then
+           for x = xoff to xlim - 1 do chng1.(ai.(x)) <- true done
+         else
+           let d = diag fd bd sh xvec yvec xoff xlim yoff ylim in
+           let b = bd.(sh+d) in loop xoff b yoff (b - d); loop b xlim (b - d) ylim
+       in
+       loop 0 n 0 m; chng1, chng2
+     ;;
+     
+     (* [make_indexer a b] returns an array of index of items of [a] which
+        are also present in [b]; this way, the main algorithm can skip items
+        which, anyway, are different. This improves the speed much.
+          The same time, this function updates the items of so that all
+        equal items point to the same unique item. All items comparisons in
+        the main algorithm can therefore be done with [==] instead of [=],
+        what can improve speed much. *)
+     let make_indexer a b =
+       let n = Array.length a in
+       let htb = Hashtbl.create (10 * Array.length b) in
+       Array.iteri
+         (fun i e ->
+            try b.(i) <- Hashtbl.find htb e with Not_found -> Hashtbl.add htb e e)
+         b;
+       let ai = array_create n 0 in
+       let k =
+         let rec loop i k =
+           if i = n then k
+           else
+             let k =
+               try
+                 a.(i) <- Hashtbl.find htb a.(i);
+                 (* line found (since "Not_found" not raised) *)
+                 ai.(k) <- i;
+                 k + 1
+               with Not_found -> k
+             in
+             loop (i + 1) k
+         in
+         loop 0 0
+       in
+       Array.sub ai 0 k
+     ;;
+     
+     let f a b =
+       let ai = make_indexer a b in
+       let bi = make_indexer b a in
+       let n = Array.length ai in
+       let m = Array.length bi in diff_loop a ai b bi n m
+     ;;

--- a/src/Core/Diff.mli
+++ b/src/Core/Diff.mli
@@ -1,0 +1,18 @@
+(* camlp5r *)
+(* diff.mli,v *)
+(* Copyright (c) INRIA 2007-2017 *)
+
+(** Differences between two arrays. *)
+
+val f : 'a array -> 'a array -> bool array * bool array;;
+(** [Diff.f a1 a2] returns a couple of two arrays of booleans [(d1, d2)].
+      [d1] has the same size as [a1].
+      [d2] has the same size as [a2].
+      [d1.(i)] is [True] if [a1.(i)] has no corresponding value in [a2].
+      [d2.(i)] is [True] if [a2.(i)] has no corresponding value in [a1].
+      [d1] and [d2] have the same number of values equal to [False].
+    Can be used to write the [diff] program (comparison of two files),
+    the input arrays being the array of lines of each file.
+    Can be used also to compare two strings (they must have been exploded
+    into arrays of chars), or two DNA strings, and so on.
+*)

--- a/src/Core/Diff.mli
+++ b/src/Core/Diff.mli
@@ -1,6 +1,35 @@
-(* camlp5r *)
-(* diff.mli,v *)
-(* Copyright (c) INRIA 2007-2017 *)
+(* This file has been adapted from camlp5:
+ * https://github.com/camlp5/camlp5/blob/master/ocaml_src/lib/diff.mli
+ *)
+
+(*
+ * Copyright (c) 2007-2017, INRIA (Institut National de Recherches en
+ * Informatique et Automatique). All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of INRIA, nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY INRIA AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INRIA AND
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *)
 
 (** Differences between two arrays. *)
 


### PR DESCRIPTION
This adds the diff algorithm from camlp5 directly, instead of the Jane Street derivate because their interface is actually significantly different. This one essentially returns a list of adds and a list of deletes, while the Jane Street one returns a list of pointers to the lines that are the same in both. The former seems much easier to work with to me at least.

I've added a copyright notice and link to the original to the top of each file. Is that sufficient or should I add it to `ThirdPartyLicenses.txt` as well?