### PR TITLE
Dependency: revery -> 1ccda2b; timber -> ae065bb

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "88a0981ef2d41cd6e0d1dcf8b6f46360",
+  "checksum": "eec9070b20e7fa3359d6717652cf5558",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+    "revery@github:revery-ui/revery#1ccda2b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#6a9fbd6",
+      "version": "github:revery-ui/revery#1ccda2b",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#6a9fbd6" ]
+        "source": [ "github:revery-ui/revery#1ccda2b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1067,7 +1067,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+        "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7e5115175531a3601f6dcc2ce272bb16",
+  "checksum": "88a0981ef2d41cd6e0d1dcf8b6f46360",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -71,13 +71,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -118,17 +118,17 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#eeda678@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#eeda678",
+      "version": "github:glennsl/revery#6a9fbd6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#eeda678" ]
+        "source": [ "github:glennsl/revery#6a9fbd6" ]
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -1066,8 +1066,8 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
-        "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
+        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/docs/docs/for-developers/contributing.md
+++ b/docs/docs/for-developers/contributing.md
@@ -47,6 +47,7 @@ The following conventions are used to determine the priority level of log messag
 - __Warn__ if it MIGHT cause unexpected behaviour, but also might not, i.e. it's suspicious, but not a definite problem.
 - __Info__ if it is both understandable AND actionable by the end-user
 - __Debug__ otherwise
+- __Trace__ if the output is overwhelming or just excessively detailed. Namespace filtering is expected at this level
 
 ### Branch Naming
 

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "88a0981ef2d41cd6e0d1dcf8b6f46360",
+  "checksum": "eec9070b20e7fa3359d6717652cf5558",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+    "revery@github:revery-ui/revery#1ccda2b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#6a9fbd6",
+      "version": "github:revery-ui/revery#1ccda2b",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#6a9fbd6" ]
+        "source": [ "github:revery-ui/revery#1ccda2b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1067,7 +1067,7 @@
       "overrides": [],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+        "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7e5115175531a3601f6dcc2ce272bb16",
+  "checksum": "88a0981ef2d41cd6e0d1dcf8b6f46360",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -71,13 +71,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -118,17 +118,17 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#eeda678@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#eeda678",
+      "version": "github:glennsl/revery#6a9fbd6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#eeda678" ]
+        "source": [ "github:glennsl/revery#6a9fbd6" ]
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -1066,8 +1066,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
-        "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
+        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -5,6 +5,7 @@ module Option = Utility.Option;
 module Model = Oni_Model;
 module Store = Oni_Store;
 module Log = (val Core.Log.withNamespace("IntegrationTest"));
+module InitLog = (val Core.Log.withNamespace("IntegrationTest.Init"));
 module TextSynchronization = TextSynchronization;
 module ExtensionHelpers = ExtensionHelpers;
 
@@ -77,14 +78,12 @@ let runTest =
     currentState := v;
   };
 
-  let logInit = s => Log.debug("[INITIALIZATION] " ++ s);
-
-  logInit("Starting store...");
+  InitLog.info("Starting store...");
 
   let configurationFilePath = Filename.temp_file("configuration", ".json");
   let oc = open_out(configurationFilePath);
 
-  logInit("Writing configuration file: " ++ configurationFilePath);
+  InitLog.info("Writing configuration file: " ++ configurationFilePath);
 
   let () =
     configuration
@@ -114,9 +113,9 @@ let runTest =
       (),
     );
 
-  logInit("Store started!");
+  InitLog.info("Store started!");
 
-  logInit("Sending init event");
+  InitLog.info("Sending init event");
 
   dispatch(Model.Actions.Init);
 

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -63,8 +63,8 @@ let runTest =
   };
 
   Printexc.record_backtrace(true);
-  Timber.App.enablePrinting();
-  Timber.App.enableDebugLogging();
+  Timber.App.enable();
+  Timber.App.setLevel(Timber.Level.trace);
 
   Log.info("Starting test... Working directory: " ++ Sys.getcwd());
 

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "88a0981ef2d41cd6e0d1dcf8b6f46360",
+  "checksum": "eec9070b20e7fa3359d6717652cf5558",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+    "revery@github:revery-ui/revery#1ccda2b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#6a9fbd6",
+      "version": "github:revery-ui/revery#1ccda2b",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#6a9fbd6" ]
+        "source": [ "github:revery-ui/revery#1ccda2b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1067,7 +1067,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+        "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7e5115175531a3601f6dcc2ce272bb16",
+  "checksum": "88a0981ef2d41cd6e0d1dcf8b6f46360",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -71,13 +71,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -118,17 +118,17 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#eeda678@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#eeda678",
+      "version": "github:glennsl/revery#6a9fbd6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#eeda678" ]
+        "source": [ "github:glennsl/revery#6a9fbd6" ]
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -1066,8 +1066,8 @@
       },
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
-        "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
+        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -240,13 +240,13 @@
     "@opam/merlin-extend": "0.4",
     "rench": "github:bryphe/rench#4860ef4",
     "reason-tree-sitter": "github:onivim/reason-tree-sitter#e2c571e",
-    "revery": "github:revery-ui/revery#eeda678",
+    "revery": "glennsl/revery#6a9fbd6",
     "reason-libvim": "onivim/reason-libvim#3782892",
     "editor-core-types": "onivim/editor-core-types#16dd98e",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-sdl2": "revery-ui/esy-sdl2#b63892b",
     "esy-skia": "revery-ui/esy-skia#91b10c9",
-    "timber": "glennsl/timber#ae5de6c",
+    "timber": "glennsl/timber#ae065bb",
     "yarn-pkg-config": "esy-ocaml/yarn-pkg-config#db3a0b6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "@opam/merlin-extend": "0.4",
     "rench": "github:bryphe/rench#4860ef4",
     "reason-tree-sitter": "github:onivim/reason-tree-sitter#e2c571e",
-    "revery": "glennsl/revery#6a9fbd6",
+    "revery": "revery-ui/revery#1ccda2b",
     "reason-libvim": "onivim/reason-libvim#3782892",
     "editor-core-types": "onivim/editor-core-types#16dd98e",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",

--- a/src/Core/Cli.re
+++ b/src/Core/Cli.re
@@ -96,8 +96,8 @@ let parse =
 
   Arg.parse(
     [
-      ("-f", Unit(Timber.App.enablePrinting), ""),
-      ("--nofork", Unit(Timber.App.enablePrinting), ""),
+      ("-f", Unit(Timber.App.enable), ""),
+      ("--nofork", Unit(Timber.App.enable), ""),
       ("--debug", Unit(CoreLog.enableDebugLogging), ""),
       ("--version", printVersion |> runAndExitUnit, ""),
       ("--no-log-colors", Unit(Timber.App.disableColors), ""),
@@ -128,7 +128,7 @@ let parse =
     "",
   );
 
-  if (CoreLog.isPrintingEnabled() || needsConsole^) {
+  if (Timber.App.isEnabled() || needsConsole^) {
     /* On Windows, we need to create a console instance if possible */
     Revery.App.initConsole();
   };

--- a/src/Core/Cli.re
+++ b/src/Core/Cli.re
@@ -98,7 +98,8 @@ let parse =
     [
       ("-f", Unit(Timber.App.enable), ""),
       ("--nofork", Unit(Timber.App.enable), ""),
-      ("--debug", Unit(CoreLog.enableDebugLogging), ""),
+      ("--debug", Unit(CoreLog.enableDebug), ""),
+      ("--trace", Unit(CoreLog.enableTrace), ""),
       ("--version", printVersion |> runAndExitUnit, ""),
       ("--no-log-colors", Unit(Timber.App.disableColors), ""),
       ("--disable-extensions", Unit(disableExtensionLoading), ""),

--- a/src/Core/Job.re
+++ b/src/Core/Job.re
@@ -91,7 +91,7 @@ let tick = (~budget=None, v: t('p, 'c)) => {
   let current = ref(v);
   let iterations = ref(0);
 
-  Log.debug("Starting " ++ v.name);
+  Log.trace("Starting " ++ v.name);
   while (Unix.gettimeofday() -. startTime < budget && !current^.isComplete) {
     current := doWork(current^);
     incr(iterations);
@@ -99,7 +99,7 @@ let tick = (~budget=None, v: t('p, 'c)) => {
 
   let endTime = Unix.gettimeofday();
 
-  Log.debugf(m =>
+  Log.tracef(m =>
     m(
       "%s ran %i iterations for %fs",
       v.name,
@@ -108,7 +108,7 @@ let tick = (~budget=None, v: t('p, 'c)) => {
     )
   );
 
-  Log.debugf(m => m("Detailed report: %s", show(v)));
+  Log.tracef(m => m("Detailed report: %s", show(v)));
 
   current^;
 };

--- a/src/Core/Kernel/Log.re
+++ b/src/Core/Kernel/Log.re
@@ -35,7 +35,7 @@ let writeExceptionLog = (e, bt) => {
   Stdlib.close_out(oc);
 };
 
-let enableDebugLogging = () => {
+let enableDebug = () => {
   Timber.App.setLevel(Timber.Level.debug);
   module Log = (val withNamespace("Oni2.Exception"));
 
@@ -54,8 +54,13 @@ let enableDebugLogging = () => {
   });
 };
 
+let enableTrace = () => {
+  enableDebug();
+  Timber.App.setLevel(Timber.Level.trace);
+};
+
 if (Timber.App.isLevelEnabled(Timber.Level.debug)) {
-  enableDebugLogging();
+  enableDebug();
 } else {
   // Even if we're not debugging.... at least emit the exception
   Printexc.set_uncaught_exception_handler((e, bt) => {

--- a/src/Core/Kernel/Log.re
+++ b/src/Core/Kernel/Log.re
@@ -1,5 +1,3 @@
-include Timber;
-
 // TODO: Remove after 4.08
 module Option = {
   let iter = f =>
@@ -7,6 +5,10 @@ module Option = {
     | Some(x) => f(x)
     | None => ();
 };
+
+include Timber.Log;
+
+module type Logger = Timber.Logger;
 
 module Env = {
   let logFile = Sys.getenv_opt("ONI2_LOG_FILE");
@@ -34,7 +36,7 @@ let writeExceptionLog = (e, bt) => {
 };
 
 let enableDebugLogging = () => {
-  Timber.App.enableDebugLogging();
+  Timber.App.setLevel(Timber.Level.debug);
   module Log = (val withNamespace("Oni2.Exception"));
 
   Log.debug("Recording backtraces");
@@ -52,7 +54,7 @@ let enableDebugLogging = () => {
   });
 };
 
-if (Timber.isDebugLoggingEnabled()) {
+if (Timber.App.isLevelEnabled(Timber.Level.debug)) {
   enableDebugLogging();
 } else {
   // Even if we're not debugging.... at least emit the exception

--- a/src/Core/Kernel/Log.rei
+++ b/src/Core/Kernel/Log.rei
@@ -1,8 +1,4 @@
-let isPrintingEnabled: unit => bool;
-let isDebugLoggingEnabled: unit => bool;
-
 let perf: (string, unit => 'a) => 'a;
-let fn: (string, 'a => 'b, 'a) => 'b;
 
 module type Logger = {
   let errorf: Timber.msgf(_, unit) => unit;
@@ -13,8 +9,11 @@ module type Logger = {
   let info: string => unit;
   let debugf: Timber.msgf(_, unit) => unit;
   let debug: string => unit;
-  let fn: (string, 'a => 'b, 'a) => 'b;
+  let tracef: Timber.msgf(_, unit) => unit;
+  let trace: string => unit;
+  let fn: (string, 'a => 'b, ~pp: 'b => string=?, 'a) => 'b;
 };
 
-let enableDebugLogging: unit => unit;
 let withNamespace: string => (module Logger);
+
+let enableDebugLogging: unit => unit;

--- a/src/Core/Kernel/Log.rei
+++ b/src/Core/Kernel/Log.rei
@@ -16,4 +16,5 @@ module type Logger = {
 
 let withNamespace: string => (module Logger);
 
-let enableDebugLogging: unit => unit;
+let enableDebug: unit => unit;
+let enableTrace: unit => unit;

--- a/src/Extensions/ExtHostTransport.re
+++ b/src/Extensions/ExtHostTransport.re
@@ -136,7 +136,7 @@ let start =
     };
 
   let handleReply = (reqId: int, payload: Yojson.Safe.t) => {
-    Log.debugf(m =>
+    Log.tracef(m =>
       m("Reply ID: %d payload: %s\n", reqId, Yojson.Safe.to_string(payload))
     );
     switch (Hashtbl.find_opt(replyIdToResolver, reqId)) {

--- a/src/Feature/Search/SearchSubscription.re
+++ b/src/Feature/Search/SearchSubscription.re
@@ -24,7 +24,7 @@ module Make = (Config: {type action;}) => {
           ~params as {directory, query, ripgrep, onUpdate, onCompleted},
           ~dispatch: _,
         ) => {
-      Log.debug("Starting " ++ id);
+      Log.info("Starting " ++ id);
 
       let dispose =
         ripgrep.Ripgrep.findInFiles(

--- a/src/Input/Expression.re
+++ b/src/Input/Expression.re
@@ -42,7 +42,7 @@ let evaluate = (v: t, getValue) => {
 
   let ret = eval(v);
 
-  Log.debugf(m =>
+  Log.tracef(m =>
     m("Expression %s evaluated to: %s", toString(v), ret ? "true" : "false")
   );
 

--- a/src/Input/Handler.re
+++ b/src/Input/Handler.re
@@ -47,7 +47,7 @@ let keyCodeToVimString = (keycode, keyString) => {
 let keyPressToString =
     (~isTextInputActive, ~altKey, ~shiftKey, ~ctrlKey, ~superKey, keycode) => {
   let keyString = Revery.Key.Keycode.getName(keycode);
-  Log.debug("keyPressToString - key name: " ++ keyString);
+  Log.trace("keyPressToString - key name: " ++ keyString);
 
   let keyString =
     if (!shiftKey && String.length(keyString) == 1) {
@@ -56,7 +56,7 @@ let keyPressToString =
       keyString;
     };
 
-  Log.debugf(m => m("Processing keycode: %i|%s", keycode, keyString));
+  Log.tracef(m => m("Processing keycode: %i|%s", keycode, keyString));
 
   let vimString = keyCodeToVimString(keycode, keyString);
   let vimStringLength =
@@ -89,11 +89,11 @@ let keyPressToString =
 
       let ret = Zed_utf8.length(s) > 1 ? "<" ++ s ++ ">" : s;
 
-      Log.debug("Sending key: " ++ ret);
+      Log.trace("Sending key: " ++ ret);
       Some(ret);
     };
   } else {
-    Log.debug("Key blocked: " ++ keyString);
+    Log.trace("Key blocked: " ++ keyString);
     None;
   };
 };

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -322,7 +322,7 @@ let start = (extensions, setup: Setup.t) => {
       (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
     switch (bm.filePath, fileType) {
     | (Some(fp), Some(ft)) =>
-      Log.debug("Creating model for filetype: " ++ ft);
+      Log.trace("Creating model for filetype: " ++ ft);
       Some(
         Protocol.ModelAddedDelta.create(
           ~uri=Uri.fromPath(fp),

--- a/src/Store/FilterSubscription.re
+++ b/src/Store/FilterSubscription.re
@@ -79,7 +79,7 @@ module Make = (JobConfig: Oni_Model.FilterJob.Config) => {
       switch (Hashtbl.find_opt(jobs, id)) {
       | Some({job, _} as state) when query != job.pendingWork.filter =>
         // Query changed
-        Log.debug("Updating " ++ id ++ " with query: " ++ query);
+        Log.tracef(m => m("Updating %s with query: %s", id, query));
 
         let job = Job.map(FilterJob.updateQuery(query), job);
         Hashtbl.replace(jobs, id, {...state, job});

--- a/src/Store/FontStoreConnector.re
+++ b/src/Store/FontStoreConnector.re
@@ -17,7 +17,7 @@ let requestId = ref(0);
 
 let loadAndValidateEditorFont =
     (~onSuccess, ~onError, ~requestId: int, scaleFactor, fullPath, fontSize) => {
-  Log.debugf(m =>
+  Log.tracef(m =>
     m("loadAndValidateEditorFont path: %s | size: %i", fullPath, fontSize)
   );
 
@@ -32,7 +32,7 @@ let loadAndValidateEditorFont =
       let firstShape = shapedText[0];
       let secondShape = shapedText[1];
 
-      Log.debugf(m =>
+      Log.tracef(m =>
         m("glyph1: %i glyph2: %i", firstShape.glyphId, secondShape.glyphId)
       );
 
@@ -162,14 +162,14 @@ let start = (~getScaleFactor, ()) => {
 
   let synchronizeConfiguration = (configuration: Configuration.t) =>
     Isolinear.Effect.createWithDispatch(~name="windows.syncConfig", dispatch => {
+      Log.trace("synchronizeConfiguration");
+
       // TODO
       let editorFontFamily =
         Configuration.getValue(c => c.editorFontFamily, configuration);
 
       let editorFontSize =
         Configuration.getValue(c => c.editorFontSize, configuration);
-
-      Log.debug("synchronizeConfiguration");
 
       setFont(dispatch, editorFontFamily, editorFontSize);
     });

--- a/src/Store/RipgrepSubscription.re
+++ b/src/Store/RipgrepSubscription.re
@@ -32,7 +32,7 @@ module Provider = {
         ~directory,
         ~onUpdate,
         ~onComplete=() => {
-          Log.info("Ripgrep completed.");
+          Log.debug("Ripgrep completed.");
           dispatch(onComplete());
         },
       );

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -275,7 +275,7 @@ let start =
         | v => v
         };
 
-      Log.debug("Vim.Window.onSplit: " ++ buf);
+      Log.trace("Vim.Window.onSplit: " ++ buf);
 
       let command =
         switch (splitType) {
@@ -290,7 +290,7 @@ let start =
 
   let _ =
     Vim.Window.onMovement((movementType, _count) => {
-      Log.debug("Vim.Window.onMovement");
+      Log.trace("Vim.Window.onMovement");
       let currentState = getState();
 
       let move = moveFunc => {

--- a/src/Syntax/TextmateTokenizerJob.re
+++ b/src/Syntax/TextmateTokenizerJob.re
@@ -113,7 +113,7 @@ let doWork = (pending: pendingWork, completed: completedWork) => {
       | Some(v) => Some(v.scopeStack)
       };
 
-    Log.debugf(m => m("Tokenizing line: %i", currentLine));
+    Log.tracef(m => m("Tokenizing line: %i", currentLine));
 
     // Get new tokens & scopes
     let (tokens, scopes) =

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -155,12 +155,12 @@ let start =
 
           | ServerToClient.EchoReply(result) =>
             scheduler(() =>
-              ClientLog.debugf(m =>
+              ClientLog.tracef(m =>
                 m("got message from channel: |%s|", result)
               )
             )
 
-          | ServerToClient.Log(msg) => scheduler(() => ServerLog.debug(msg))
+          | ServerToClient.Log(msg) => scheduler(() => ServerLog.trace(msg))
 
           | ServerToClient.Closing =>
             scheduler(() => ServerLog.debug("Closing"))
@@ -171,7 +171,7 @@ let start =
           | ServerToClient.TokenUpdate(tokens) =>
             scheduler(() => {
               onHighlights(tokens);
-              ClientLog.debug("Tokens applied");
+              ClientLog.trace("Tokens applied");
             })
           };
         };
@@ -209,7 +209,7 @@ let start =
 let notifyBufferEnter = (v: t, bufferId: int, fileType: string) => {
   let message: Oni_Syntax.Protocol.ClientToServer.t =
     Oni_Syntax.Protocol.ClientToServer.BufferEnter(bufferId, fileType);
-  ClientLog.debug("Sending bufferUpdate notification...");
+  ClientLog.trace("Sending bufferUpdate notification...");
   write(v, message);
 };
 
@@ -231,12 +231,12 @@ let healthCheck = (v: t) => {
 
 let notifyBufferUpdate =
     (v: t, bufferUpdate: BufferUpdate.t, lines: array(string), scope) => {
-  ClientLog.debug("Sending bufferUpdate notification...");
+  ClientLog.trace("Sending bufferUpdate notification...");
   write(v, Protocol.ClientToServer.BufferUpdate(bufferUpdate, lines, scope));
 };
 
 let notifyVisibilityChanged = (v: t, visibility) => {
-  ClientLog.debug("Sending visibleRangesChanged notification...");
+  ClientLog.trace("Sending visibleRangesChanged notification...");
   write(v, Protocol.ClientToServer.VisibleRangesChanged(visibility));
 };
 

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -557,7 +557,7 @@ let%component make =
     };*/
 
   let editorMouseUp = (evt: NodeEvents.mouseButtonEventParams) => {
-    Log.debug("editorMouseUp");
+    Log.trace("editorMouseUp");
 
     switch (elementRef) {
     | None => ()
@@ -577,8 +577,8 @@ let%component make =
         );
 
       if (line < numberOfLines) {
-        Log.debugf(m => m("  topVisibleLine is %i", topVisibleLine));
-        Log.debugf(m => m("  setPosition (%i, %i)", line + 1, col));
+        Log.tracef(m => m("  topVisibleLine is %i", topVisibleLine));
+        Log.tracef(m => m("  setPosition (%i, %i)", line + 1, col));
 
         let cursor =
           Vim.Cursor.create(

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -27,6 +27,7 @@ let spec =
       " Stay attached to the foreground terminal.",
     ),
     ("--debug", passthrough, " Enable debug logging."),
+    ("--trace", passthrough, " Enable trace logging."),
     ("--log-file", passthroughString, " Specify a file for the output logs."),
     ("--log-filter", passthroughString, " Filter log output."),
     (

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3a35b92386effc889a92266d100a2de5",
+  "checksum": "5942212a4a0bd717e12a0af71f89383a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -71,13 +71,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -118,17 +118,17 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#eeda678@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#eeda678",
+      "version": "github:glennsl/revery#6a9fbd6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#eeda678" ]
+        "source": [ "github:glennsl/revery#6a9fbd6" ]
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
@@ -1066,8 +1066,8 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
-        "revery@github:revery-ui/revery#eeda678@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
+        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5942212a4a0bd717e12a0af71f89383a",
+  "checksum": "5bf69942494c91f78c7d270d66f456ad",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#6a9fbd6@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+    "revery@github:revery-ui/revery#1ccda2b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#6a9fbd6",
+      "version": "github:revery-ui/revery#1ccda2b",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#6a9fbd6" ]
+        "source": [ "github:revery-ui/revery#1ccda2b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1067,7 +1067,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:glennsl/revery#6a9fbd6@d41d8cd9",
+        "revery@github:revery-ui/revery#1ccda2b@d41d8cd9",
         "rench@github:bryphe/rench#4860ef4@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",


### PR DESCRIPTION
This updates both Revery and timber, since the timber API has breaking changes. Depends on https://github.com/revery-ui/revery/pull/731.

Adds a new trace log level, and a new CLI option to enable it: `--trace`