### PR TITLE
Windows: Point installer / shortcut to Oni2_editor.exe

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,4 +216,8 @@ jobs:
   - script: |
       set PATH=%PATH%;D:/a/1/s/Onivim2
       Oni2.exe -f --no-log-colors --checkhealth
-    displayName: "Oni2.exe - run installed"
+    displayName: "Oni2.exe -f --no-log-colors --checkhealth (run installed)"
+  - script: |
+      set PATH=%PATH%;D:/a/1/s/Onivim2
+      Oni2_editor.exe -f --version
+    displayName: "Oni2_editor.exe - -f --version (run installed)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,3 @@ jobs:
       set PATH=%PATH%;D:/a/1/s/Onivim2
       Oni2.exe -f --no-log-colors --checkhealth
     displayName: "Oni2.exe -f --no-log-colors --checkhealth (run installed)"
-  - script: |
-      set PATH=%PATH%;D:/a/1/s/Onivim2
-      Oni2_editor.exe -f --version
-    displayName: "Oni2_editor.exe - -f --version (run installed)"

--- a/scripts/windows/BuildSetupTemplate.js
+++ b/scripts/windows/BuildSetupTemplate.js
@@ -20,7 +20,7 @@ const packageJsonContents = fs.readFileSync(path.join(__dirname, "..", "..", "pa
 const packageMeta = JSON.parse(packageJsonContents)
 const { version, name } = packageMeta
 const prodName = packageMeta.build.productName
-const executableName = `Oni2.exe`
+const executableName = `Oni2_editor.exe`
 const pathVariable = "{app}"
 const appIcon = `${pathVariable}\\oni2.ico`
 


### PR DESCRIPTION
Simpler / lower risk fix than #1241 and #1248 - just point the installer + shortcut to 'Oni2_editor.exe'. Should be transparent to the user, running `Oni2.exe` still works as expected.