### PR TITLE
SCM: Editor diff markers

### DIFF
--- a/bench/lib/EditorDiffMarkersBench.re
+++ b/bench/lib/EditorDiffMarkersBench.re
@@ -1,0 +1,112 @@
+open Oni_Core;
+open Oni_UI;
+open BenchFramework;
+
+// DATA
+
+module Data = {
+  let randomString = () =>
+    String.init(Random.int(100), _ =>
+      Char.chr(Char.code('a') + Random.int(29))
+    );
+
+  let randomBufferLine = () =>
+    BufferLine.make(~indentation=IndentationSettings.default, randomString());
+
+  let lines_10k_a = Array.init(10000, _ => randomString());
+  let lines_10k_b = Array.init(10000, _ => randomString());
+  let lines_100k = Array.init(100000, _ => randomString());
+
+  let buffer_10k_nochanges =
+    Buffer.ofLines(lines_10k_a) |> Buffer.setOriginalLines(lines_10k_a);
+
+  let buffer_10k_randomchanges =
+    Buffer.ofLines(lines_10k_a) |> Buffer.setOriginalLines(lines_10k_b);
+
+  let buffer_10k_onelineoriginal =
+    Buffer.ofLines(lines_10k_a)
+    |> Buffer.setOriginalLines([|randomString()|]);
+
+  let buffer_10k_onelinemodified =
+    Buffer.ofLines([|randomString()|])
+    |> Buffer.setOriginalLines(lines_10k_a);
+
+  let buffer_100k_nochanges =
+    Buffer.ofLines(lines_100k) |> Buffer.setOriginalLines(lines_100k);
+};
+
+// TESTS
+
+module Tests = {
+  let diff_10k_nochanges = () => {
+    let _ = EditorDiffMarkers.generate(Data.buffer_10k_nochanges);
+    ();
+  };
+
+  let diff_10k_randomchanges = () => {
+    let _ = EditorDiffMarkers.generate(Data.buffer_10k_nochanges);
+    ();
+  };
+
+  let diff_10k_onelineoriginal = () => {
+    let _ = EditorDiffMarkers.generate(Data.buffer_10k_onelineoriginal);
+    ();
+  };
+
+  let diff_10k_onelinemodified = () => {
+    let _ = EditorDiffMarkers.generate(Data.buffer_10k_onelinemodified);
+    ();
+  };
+
+  let diff_100k_nochanges = () => {
+    let _ = EditorDiffMarkers.generate(Data.buffer_100k_nochanges);
+    ();
+  };
+};
+
+// PLUMBING
+
+let setup = () => ();
+let options = Reperf.Options.create(~iterations=1000, ());
+
+bench(
+  ~name="EditorDiffMarkers: 10k lines, no changes",
+  ~options,
+  ~setup,
+  ~f=Tests.diff_10k_nochanges,
+  (),
+);
+
+bench(
+  ~name="EditorDiffMarkers: 10k lines, random changes",
+  ~options,
+  ~setup,
+  ~f=Tests.diff_10k_randomchanges,
+  (),
+);
+
+bench(
+  ~name="EditorDiffMarkers: 10k lines, 1 line original",
+  ~options,
+  ~setup,
+  ~f=Tests.diff_10k_onelineoriginal,
+  (),
+);
+
+bench(
+  ~name="EditorDiffMarkers: 10k lines, 1 line modified",
+  ~options,
+  ~setup,
+  ~f=Tests.diff_10k_onelinemodified,
+  (),
+);
+
+let options = Reperf.Options.create(~iterations=100, ());
+
+bench(
+  ~name="EditorDiffMarkers: 100k lines, no changes",
+  ~options,
+  ~setup,
+  ~f=Tests.diff_100k_nochanges,
+  (),
+);

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -143,6 +143,15 @@ function activate(context) {
     };
 
     testSCM.dispose();
+
+    const textContentProvider = {
+        provideTextDocumentContent: (uri) => {
+            console.error("CONTENT!");
+            return "Hello. This is content.";
+        }
+    };
+    let disposable = vscode.workspace.registerTextDocumentContentProvider('foo', textContentProvider)
+    disposable.dispose();
 }
 
 // this method is called when your extension is deactivated

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -14,6 +14,8 @@ type t = {
   modified: bool,
   version: int,
   lines: array(BufferLine.t),
+  originalUri: option(Uri.t),
+  originalLines: option(array(string)),
   indentation: option(IndentationSettings.t),
   syntaxHighlightingEnabled: bool,
   lastUsed: float,
@@ -33,6 +35,8 @@ let ofLines = (~id=0, rawLines: array(string)) => {
     fileType: None,
     modified: false,
     lines,
+    originalUri: None,
+    originalLines: None,
     indentation: None,
     syntaxHighlightingEnabled: true,
     lastUsed: 0.,
@@ -48,6 +52,8 @@ let ofMetadata = (metadata: Vim.BufferMetadata.t) => {
   modified: metadata.modified,
   fileType: None,
   lines: [||],
+  originalUri: None,
+  originalLines: None,
   indentation: None,
   syntaxHighlightingEnabled: true,
   lastUsed: 0.,
@@ -72,6 +78,15 @@ let getLine = (line: int, buffer: t) => {
 };
 
 let getLines = (buffer: t) => buffer.lines |> Array.map(BufferLine.raw);
+
+let getOriginalUri = buffer => buffer.originalUri;
+let setOriginalUri = (uri, buffer) => {...buffer, originalUri: Some(uri)};
+
+let getOriginalLines = buffer => buffer.originalLines;
+let setOriginalLines = (lines, buffer) => {
+  ...buffer,
+  originalLines: Some(lines),
+};
 
 let getVersion = (buffer: t) => buffer.version;
 let setVersion = (version: int, buffer: t) => {...buffer, version};

--- a/src/Core/Buffer.rei
+++ b/src/Core/Buffer.rei
@@ -21,6 +21,12 @@ let getLine: (int, t) => BufferLine.t;
 let getLines: t => array(string);
 let getNumberOfLines: t => int;
 
+let getOriginalUri: t => option(Uri.t);
+let setOriginalUri: (Uri.t, t) => t;
+
+let getOriginalLines: t => option(array(string));
+let setOriginalLines: (array(string), t) => t;
+
 let getVersion: t => int;
 let setVersion: (int, t) => t;
 

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -19,6 +19,7 @@ module ConfigurationTransformer = ConfigurationTransformer;
 module ConfigurationValues = ConfigurationValues;
 module Constants = Constants;
 module Cursor = Cursor;
+module Diff = Diff;
 module EditorFont = EditorFont;
 module EditorSize = EditorSize;
 module EnvironmentVariables = Kernel.EnvironmentVariables;

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -42,6 +42,14 @@ let getDefaults = uiTheme =>
   | _ => dark
   };
 
+type editorGutter = {
+  background: Color.t,
+  modifiedBackground: Color.t,
+  addedBackground: Color.t,
+  deletedBackground: Color.t,
+  commentRangeForeground: Color.t,
+};
+
 type t = {
   background: Color.t,
   foreground: Color.t,
@@ -102,6 +110,9 @@ type t = {
   sneakBackground: Color.t,
   sneakForeground: Color.t,
   sneakHighlight: Color.t,
+  editorGutterModifiedBackground: Color.t,
+  editorGutterAddedBackground: Color.t,
+  editorGutterDeletedBackground: Color.t,
 };
 
 let default: t = {
@@ -164,6 +175,9 @@ let default: t = {
   sneakBackground: Colors.red,
   sneakForeground: Colors.white,
   sneakHighlight: Colors.white,
+  editorGutterModifiedBackground: Color.hex("#0C7D9D"),
+  editorGutterAddedBackground: Color.hex("#587C0C"),
+  editorGutterDeletedBackground: Color.hex("#94151B"),
 };
 
 let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -32,9 +32,14 @@ type msg =
       hasQuickDiffProvider: option(bool),
       count: option(int),
       commitTemplate: option(string),
-    });
-// acceptInputCommand: option(_),
-// statusBarCommands: option(_),
+    })
+  // acceptInputCommand: option(_),
+  // statusBarCommands: option(_),
+  | RegisterTextContentProvider({
+      handle: int,
+      scheme: string,
+    })
+  | UnregisterTextContentProvider({handle: int});
 
 type unitCallback = unit => unit;
 let noop = () => ();
@@ -200,6 +205,22 @@ let start =
             features |> member("commitTemplate") |> to_string_option,
         }),
       );
+      Ok(None);
+
+    | (
+        "MainThreadDocumentContentProviders",
+        "$registerTextContentProvider",
+        [`Int(handle), `String(scheme)],
+      ) =>
+      dispatch(RegisterTextContentProvider({handle, scheme}));
+      Ok(None);
+
+    | (
+        "MainThreadDocumentContentProviders",
+        "$unregisterTextContentProvider",
+        [`Int(handle)],
+      ) =>
+      dispatch(UnregisterTextContentProvider({handle: handle}));
       Ok(None);
 
     | (scope, method, argsAsJson) =>

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -376,6 +376,20 @@ let provideReferences = (id, uri, position, client) => {
   promise;
 };
 
+let provideTextDocumentContent = (id, uri, client) => {
+  let promise =
+    ExtHostTransport.request(
+      ~msgType=MessageType.requestJsonArgsWithCancellation,
+      client,
+      Out.DocumentContent.provideTextDocumentContent(id, uri),
+      fun
+      | `String(content) => content
+      | json =>
+        failwith("Unexpected response: " ++ Yojson.Safe.to_string(json)),
+    );
+  promise;
+};
+
 let send = (client, msg) => ExtHostTransport.send(client, msg);
 
 let close = client => ExtHostTransport.close(client);

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -356,6 +356,18 @@ let provideDocumentSymbols = (id, uri, client) => {
   promise;
 };
 
+let provideOriginalResource = (id, uri, client) => {
+  let promise =
+    ExtHostTransport.request(
+      ~msgType=MessageType.requestJsonArgsWithCancellation,
+      client,
+      Out.SCM.provideOriginalResource(id, uri),
+      json =>
+      Core.Uri.of_yojson(json) |> Utility.Result.get_ok
+    );
+  promise;
+};
+
 let provideReferences = (id, uri, position, client) => {
   let f = (json: Yojson.Safe.t) => {
     let default: list(LocationWithUri.t) = [];

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -76,6 +76,7 @@ let provideDocumentHighlights:
   Lwt.t(list(Protocol.DocumentHighlight.t));
 let provideDocumentSymbols:
   (int, Core.Uri.t, t) => Lwt.t(list(DocumentSymbol.t));
+let provideOriginalResource: (int, Core.Uri.t, t) => Lwt.t(Core.Uri.t);
 let provideReferences:
   (int, Core.Uri.t, Protocol.OneBasedPosition.t, t) =>
   Lwt.t(list(LocationWithUri.t));

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -17,9 +17,14 @@ type msg =
       hasQuickDiffProvider: option(bool),
       count: option(int),
       commitTemplate: option(string),
-    });
-// acceptInputCommand: option(_),
-// statusBarCommands: option(_),
+    })
+  // acceptInputCommand: option(_),
+  // statusBarCommands: option(_),
+  | RegisterTextContentProvider({
+      handle: int,
+      scheme: string,
+    })
+  | UnregisterTextContentProvider({handle: int});
 
 type unitCallback = unit => unit;
 

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -79,5 +79,6 @@ let provideDocumentSymbols:
 let provideReferences:
   (int, Core.Uri.t, Protocol.OneBasedPosition.t, t) =>
   Lwt.t(list(LocationWithUri.t));
+let provideTextDocumentContent: (int, Core.Uri.t, t) => Lwt.t(string);
 let send: (t, Yojson.Safe.t) => unit;
 let close: t => unit;

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -679,6 +679,15 @@ module OutgoingNotifications = {
       );
   };
 
+  module SCM = {
+    let provideOriginalResource = (handle: int, resource: Uri.t) =>
+      _buildNotification(
+        "ExtHostSCM",
+        "$provideOriginalResource",
+        `List([`Int(handle), Uri.to_yojson(resource)]),
+      );
+  };
+
   module Workspace = {
     [@deriving yojson({strict: false, exn: true})]
     type workspaceInfo = {

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -602,6 +602,15 @@ module OutgoingNotifications = {
     };
   };
 
+  module DocumentContent = {
+    let provideTextDocumentContent = (handle: int, resource: Uri.t) =>
+      _buildNotification(
+        "ExtHostDocumentContentProviders",
+        "$provideTextDocumentContent",
+        `List([`Int(handle), Uri.to_yojson(resource)]),
+      );
+  };
+
   module ExtensionService = {
     let activateByEvent = (event: string) => {
       _buildNotification(

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -136,6 +136,11 @@ type t =
   | WindowCloseDiscardConfirmed
   | WindowCloseSaveAllConfirmed
   | WindowCloseCanceled
+  | NewTextContentProvider({
+      handle: int,
+      scheme: string,
+    })
+  | LostTextContentProvider({handle: int})
   | Modal(Modal.msg)
   // "Internal" effect action, see TitleStoreConnector
   | SetTitle(string)

--- a/src/Model/SCM.re
+++ b/src/Model/SCM.re
@@ -49,4 +49,12 @@ type msg =
   | CommitTemplateChanged({
       handle: int,
       template: string,
+    })
+  | GotOriginalUri({
+      bufferId: int,
+      uri: Uri.t,
+    })
+  | GotOriginalContent({
+      bufferId: int,
+      lines: [@opaque] array(string),
     });

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -58,6 +58,7 @@ type t = {
   searchPane: Feature_Search.model,
   focus: Focus.stack,
   modal: option(Modal.t(Actions.t)),
+  textContentProviders: list((int, string)),
 };
 
 let create: unit => t =
@@ -109,4 +110,5 @@ let create: unit => t =
     searchPane: Feature_Search.initial,
     focus: Focus.initial,
     modal: None,
+    textContentProviders: [],
   };

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -463,6 +463,54 @@ let start = (extensions, setup: Setup.t) => {
       )
     });
 
+  let getOriginalUri = (bufferId, path, providers: list(SCM.Provider.t)) =>
+    Isolinear.Effect.createWithDispatch(~name="scm.getOriginalUri", dispatch => {
+      // Try our luck with every provider. If several returns Last-Writer-Wins
+      // TODO: Is there a better heuristic? Perhaps use rootUri to choose the "nearest" provider?
+      providers
+      |> List.iter((provider: SCM.Provider.t) => {
+           let promise =
+             ExtHostClient.provideOriginalResource(
+               provider.handle,
+               Uri.fromPath(path),
+               extHostClient,
+             );
+
+           Lwt.on_success(promise, uri =>
+             dispatch(Actions.SCM(SCM.GotOriginalUri({bufferId, uri})))
+           );
+         })
+    });
+
+  let getOriginalContent = (bufferId, uri, providers) =>
+    Isolinear.Effect.createWithDispatch(
+      ~name="scm.getOriginalSourceLines", dispatch => {
+      let scheme = uri |> Uri.getScheme |> Uri.Scheme.toString;
+      providers
+      |> List.find_opt(((_, providerScheme)) => providerScheme == scheme)
+      |> Option.iter(provider => {
+           let (handle, _) = provider;
+           let promise =
+             ExtHostClient.provideTextDocumentContent(
+               handle,
+               uri,
+               extHostClient,
+             );
+
+           Lwt.on_success(
+             promise,
+             content => {
+               let lines =
+                 content |> Str.(split(regexp_string("\n"))) |> Array.of_list;
+
+               dispatch(
+                 Actions.SCM(SCM.GotOriginalContent({bufferId, lines})),
+               );
+             },
+           );
+         });
+    });
+
   let updater = (state: State.t, action) =>
     switch (action) {
     | Actions.Init => (
@@ -488,10 +536,18 @@ let start = (extensions, setup: Setup.t) => {
         changeWorkspaceEffect(path),
       )
 
-    | Actions.BufferEnter(bm, fileTypeOpt) => (
-        state,
-        sendBufferEnterEffect(bm, fileTypeOpt),
-      )
+    | Actions.BufferEnter(metadata, fileTypeOpt) =>
+      let eff =
+        switch (metadata.filePath) {
+        | Some(path) =>
+          Isolinear.Effect.batch([
+            sendBufferEnterEffect(metadata, fileTypeOpt),
+            getOriginalUri(metadata.id, path, state.scm.providers),
+          ])
+
+        | None => sendBufferEnterEffect(metadata, fileTypeOpt)
+        };
+      (state, eff);
 
     | Actions.NewTextContentProvider({handle, scheme}) => (
         {
@@ -595,6 +651,32 @@ let start = (extensions, setup: Setup.t) => {
                 state.scm.providers,
               ),
           },
+        },
+        Isolinear.Effect.none,
+      )
+
+    | Actions.SCM(SCM.GotOriginalUri({bufferId, uri})) => (
+        {
+          ...state,
+          buffers:
+            IntMap.update(
+              bufferId,
+              Option.map(Buffer.setOriginalUri(uri)),
+              state.buffers,
+            ),
+        },
+        getOriginalContent(bufferId, uri, state.textContentProviders),
+      )
+
+    | Actions.SCM(SCM.GotOriginalContent({bufferId, lines})) => (
+        {
+          ...state,
+          buffers:
+            IntMap.update(
+              bufferId,
+              Option.map(Buffer.setOriginalLines(lines)),
+              state.buffers,
+            ),
         },
         Isolinear.Effect.none,
       )

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -291,8 +291,10 @@ let start = (extensions, setup: Setup.t) => {
     switch (msg) {
     | RegisterSourceControl({handle, id, label, rootUri}) =>
       dispatch(Actions.SCM(SCM.NewProvider({handle, id, label, rootUri})))
+
     | UnregisterSourceControl({handle}) =>
       dispatch(Actions.SCM(SCM.LostProvider({handle: handle})))
+
     | UpdateSourceControl({
         handle,
         hasQuickDiffProvider,
@@ -317,6 +319,12 @@ let start = (extensions, setup: Setup.t) => {
           ),
         commitTemplate,
       );
+
+    | RegisterTextContentProvider({handle, scheme}) =>
+      dispatch(NewTextContentProvider({handle, scheme}))
+
+    | UnregisterTextContentProvider({handle}) =>
+      dispatch(LostTextContentProvider({handle: handle}))
     };
 
   let onOutput = Log.info;
@@ -483,6 +491,29 @@ let start = (extensions, setup: Setup.t) => {
     | Actions.BufferEnter(bm, fileTypeOpt) => (
         state,
         sendBufferEnterEffect(bm, fileTypeOpt),
+      )
+
+    | Actions.NewTextContentProvider({handle, scheme}) => (
+        {
+          ...state,
+          textContentProviders: [
+            (handle, scheme),
+            ...state.textContentProviders,
+          ],
+        },
+        Isolinear.Effect.none,
+      )
+
+    | Actions.LostTextContentProvider({handle}) => (
+        {
+          ...state,
+          textContentProviders:
+            List.filter(
+              ((h, _)) => h != handle,
+              state.textContentProviders,
+            ),
+        },
+        Isolinear.Effect.none,
       )
 
     | Actions.SCM(SCM.NewProvider({handle, id, label, rootUri})) => (

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -501,7 +501,7 @@ let start = (extensions, setup: Setup.t) => {
              promise,
              content => {
                let lines =
-                 content |> Str.(split(regexp_string("\n"))) |> Array.of_list;
+                 content |> Str.(split(regexp("\r?\n"))) |> Array.of_list;
 
                dispatch(
                  Actions.SCM(SCM.GotOriginalContent({bufferId, lines})),

--- a/src/UI/EditorDiffMarkers.re
+++ b/src/UI/EditorDiffMarkers.re
@@ -1,0 +1,123 @@
+open Oni_Core;
+open Utility;
+
+open Revery.Draw;
+
+[@deriving show({with_path: false})]
+type t = array(marker)
+
+and marker =
+  | Modified
+  | Added
+  | DeletedBefore
+  | DeletedAfter
+  | Unmodified;
+
+let generate = buffer =>
+  buffer
+  |> Buffer.getOriginalLines
+  |> Option.map(originalLines => {
+       let (adds, deletes) = Diff.f(Buffer.getLines(buffer), originalLines);
+
+       let shift = ref(0); // the offset between matching lines in deletes vs adds; ie. deletes[i + shift] == adds[i]
+       let markers =
+         Array.mapi(
+           (i, added) => {
+             let deleted = {
+               let j = i + shift^;
+               j >= Array.length(deletes) ? false : deletes[j];
+             };
+
+             switch (added, deleted) {
+             | (true, true) => Modified
+
+             | (true, false) =>
+               decr(shift);
+               Added;
+
+             | (false, true) =>
+               incr(shift);
+               while (i
+                      + shift^ < Array.length(deletes)
+                      && deletes[i + shift^]) {
+                 incr(shift);
+               };
+               DeletedBefore;
+
+             | (false, false) => Unmodified
+             };
+           },
+           adds,
+         );
+
+       if (Array.length(deletes) - shift^ - 1 > Array.length(adds)) {
+         markers[Array.length(markers) - 1] = (
+           switch (markers[Array.length(markers) - 1]) {
+           | Modified
+           | Added => Modified
+
+           | DeletedBefore
+           | DeletedAfter
+           | Unmodified => DeletedAfter
+           }
+         );
+       };
+
+       markers;
+     });
+
+let renderMarker =
+    (~x, ~y, ~rowHeight, ~width, ~transform, ~theme: Theme.t, marker) => {
+  let (y, height) =
+    switch (marker) {
+    | Modified
+    | Added => (y, rowHeight)
+    | DeletedBefore => (y -. width /. 2., width)
+    | DeletedAfter => (y +. rowHeight -. width /. 2., width)
+    | Unmodified => failwith("unreachable")
+    };
+
+  let color =
+    switch (marker) {
+    | Modified => theme.editorGutterModifiedBackground
+    | Added => theme.editorGutterAddedBackground
+    | DeletedBefore => theme.editorGutterDeletedBackground
+    | DeletedAfter => theme.editorGutterDeletedBackground
+    | Unmodified => failwith("unreachable")
+    };
+
+  Shapes.drawRect(~transform, ~x, ~y, ~height, ~width, ~color, ());
+};
+
+let render =
+    (
+      ~scrollY,
+      ~rowHeight,
+      ~x,
+      ~height,
+      ~width,
+      ~count,
+      ~transform,
+      ~theme,
+      markers,
+    ) =>
+  ImmediateList.render(
+    ~scrollY,
+    ~rowHeight,
+    ~height,
+    ~count,
+    ~render=
+      (i, y) =>
+        if (markers[i] != Unmodified) {
+          renderMarker(
+            ~x,
+            ~y,
+            ~rowHeight,
+            ~width,
+            ~transform,
+            ~theme,
+            markers[i],
+          );
+        },
+    (),
+  );

--- a/src/UI/EditorDiffMarkers.re
+++ b/src/UI/EditorDiffMarkers.re
@@ -17,18 +17,24 @@ let generate = buffer =>
   buffer
   |> Buffer.getOriginalLines
   |> Option.map(originalLines => {
+       // `adds` is an array of bools the length of the current lines array where `true` indicates the line is added
+       // `deletes` is an array of bools the length of the originall lines array where `true` indicates the line has been deleted
        let (adds, deletes) = Diff.f(Buffer.getLines(buffer), originalLines);
 
-       let shift = ref(0); // the offset between matching lines in deletes vs adds; ie. deletes[i + shift] == adds[i]
+       // shift is he offset between lines that should match up at the current index;
+       // ie. `deletes[i + shift] == adds[i]`
+       let shift = ref(0);
+
+       let isDeleted = i => {
+         i < Array.length(deletes) && deletes[i];
+       };
+
+       // create a new marker array by mapping over `adds` while also taking the
+       // corresponding flag in `deletes` into account
        let markers =
          Array.mapi(
-           (i, added) => {
-             let deleted = {
-               let j = i + shift^;
-               j >= Array.length(deletes) ? false : deletes[j];
-             };
-
-             switch (added, deleted) {
+           (i, isAdded) =>
+             switch (isAdded, isDeleted(i + shift^)) {
              | (true, true) => Modified
 
              | (true, false) =>
@@ -37,19 +43,19 @@ let generate = buffer =>
 
              | (false, true) =>
                incr(shift);
-               while (i
-                      + shift^ < Array.length(deletes)
-                      && deletes[i + shift^]) {
+               // skip over subsequent deletes to line up `shift` with the next non-deleted line
+               // the skipped over deletes will be represented by the first
+               while (isDeleted(i + shift^)) {
                  incr(shift);
                };
                DeletedBefore;
 
              | (false, false) => Unmodified
-             };
-           },
+             },
            adds,
          );
 
+       // if there are deleted lines past the end of the current document, mark the last lines as having deletes afterwards, or being modified
        if (Array.length(deletes) - shift^ - 1 > Array.length(adds)) {
          markers[Array.length(markers) - 1] = (
            switch (markers[Array.length(markers) - 1]) {

--- a/src/UI/EditorDiffMarkers.rei
+++ b/src/UI/EditorDiffMarkers.rei
@@ -11,6 +11,7 @@ and marker =
   | Unmodified;
 
 let generate: Buffer.t => option(t);
+
 let render:
   (
     ~scrollY: float,

--- a/src/UI/EditorDiffMarkers.rei
+++ b/src/UI/EditorDiffMarkers.rei
@@ -1,0 +1,26 @@
+open Oni_Core;
+
+[@deriving show]
+type t = array(marker)
+
+and marker =
+  | Modified
+  | Added
+  | DeletedBefore
+  | DeletedAfter
+  | Unmodified;
+
+let generate: Buffer.t => option(t);
+let render:
+  (
+    ~scrollY: float,
+    ~rowHeight: float,
+    ~x: float,
+    ~height: float,
+    ~width: float,
+    ~count: int,
+    ~transform: Reglm.Mat4.t,
+    ~theme: Theme.t,
+    t
+  ) =>
+  unit;

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -20,6 +20,7 @@ module Option = Utility.Option;
 module Constants = {
   include Constants;
 
+  let diffMarkersMaxLineCount = 2000;
   let diffMarkerWidth = 3.;
   let gutterMargin = 3.;
 };
@@ -511,7 +512,9 @@ let%component make =
   let ranges = Selection.getRanges(editor.selection, buffer);
   let selectionRanges = Range.toHash(ranges);
 
-  let diffMarkers = EditorDiffMarkers.generate(buffer);
+  let diffMarkers =
+    lineCount < Constants.diffMarkersMaxLineCount
+      ? EditorDiffMarkers.generate(buffer) : None;
 
   let minimapLayout =
     isMinimapShown

--- a/src/UI/EditorSurface.re
+++ b/src/UI/EditorSurface.re
@@ -15,6 +15,14 @@ open Oni_Core.CamomileBundled.Camomile;
 open Oni_Model;
 
 module Log = (val Log.withNamespace("Oni2.UI.EditorSurface"));
+module Option = Utility.Option;
+
+module Constants = {
+  include Constants;
+
+  let diffMarkerWidth = 3.;
+  let gutterMargin = 3.;
+};
 
 /* Set up some styles */
 let textHeaderStyle =
@@ -79,7 +87,7 @@ let renderLineNumber =
       ? 0.
       : lineNumberWidth
         /. 2.
-        -. float_of_int(String.length(lineNumber))
+        -. float(String.length(lineNumber))
         *. fontWidth
         /. 2.;
 
@@ -114,7 +122,7 @@ let renderSpaces =
   let yOffset = fontHeight /. 2. -. 1.;
 
   while (i^ < count) {
-    let iF = float_of_int(i^);
+    let iF = float(i^);
     let xPos = x +. fontWidth *. iF;
 
     Shapes.drawRect(
@@ -152,7 +160,7 @@ let renderTokens =
     let x =
       lineNumberWidth
       +. fontWidth
-      *. float_of_int(Index.toZeroBased(token.startPosition))
+      *. float(Index.toZeroBased(token.startPosition))
       -. xF;
     let y = yF;
 
@@ -242,6 +250,9 @@ let%component make =
         )
       : 0.0;
 
+  let gutterWidth =
+    lineNumberWidth +. Constants.diffMarkerWidth +. Constants.gutterMargin;
+
   let fontHeight = state.editorFont.measuredHeight;
   let fontWidth = state.editorFont.measuredWidth;
   let fontFamily = state.editorFont.fontFile;
@@ -278,9 +289,8 @@ let%component make =
     };
 
   let bufferPositionToPixel = (line, char) => {
-    let x =
-      float_of_int(char) *. fontWidth -. editor.scrollX +. lineNumberWidth;
-    let y = float_of_int(line) *. fontHeight -. editor.scrollY;
+    let x = float(char) *. fontWidth -. editor.scrollX +. gutterWidth;
+    let y = float(line) *. fontHeight -. editor.scrollY;
     (x, y);
   };
 
@@ -297,18 +307,14 @@ let%component make =
   let cursorPixelY =
     int_of_float(
       fontHeight
-      *. float_of_int(Index.toZeroBased(cursorPosition.line))
+      *. float(Index.toZeroBased(cursorPosition.line))
       -. editor.scrollY
       +. 0.5,
     );
 
   let cursorPixelX =
     int_of_float(
-      lineNumberWidth
-      +. fontWidth
-      *. float_of_int(cursorOffset)
-      -. editor.scrollX
-      +. 0.5,
+      gutterWidth +. fontWidth *. float(cursorOffset) -. editor.scrollX +. 0.5,
     );
 
   let cursorStyle =
@@ -332,8 +338,8 @@ let%component make =
           c => c.editorMinimapMaxColumn,
           state.configuration,
         ),
-      ~pixelWidth=float_of_int(metrics.pixelWidth),
-      ~pixelHeight=float_of_int(metrics.pixelHeight),
+      ~pixelWidth=float(metrics.pixelWidth),
+      ~pixelHeight=float(metrics.pixelHeight),
       ~isMinimapShown,
       ~characterWidth=state.editorFont.measuredWidth,
       ~characterHeight=state.editorFont.measuredHeight,
@@ -462,9 +468,7 @@ let%component make =
     Style.[
       position(`Absolute),
       top(0),
-      left(
-        int_of_float(bufferPixelWidth +. float_of_int(minimapPixelWidth)),
-      ),
+      left(int_of_float(bufferPixelWidth +. float(minimapPixelWidth))),
       width(Constants.default.scrollBarThickness),
       backgroundColor(theme.scrollbarSliderBackground),
       bottom(0),
@@ -507,6 +511,8 @@ let%component make =
   let ranges = Selection.getRanges(editor.selection, buffer);
   let selectionRanges = Range.toHash(ranges);
 
+  let diffMarkers = EditorDiffMarkers.generate(buffer);
+
   let minimapLayout =
     isMinimapShown
       ? <View style=minimapViewStyle onMouseWheel=scrollMinimap>
@@ -523,6 +529,8 @@ let%component make =
               layout.bufferWidthInCharacters,
             )}
             selection=selectionRanges
+            diffMarkers
+            theme
           />
         </View>
       : React.empty;
@@ -565,7 +573,7 @@ let%component make =
         Editor.pixelPositionToLineColumn(
           editor,
           metrics,
-          relX -. lineNumberWidth,
+          relX -. gutterWidth,
           relY,
         );
 
@@ -608,13 +616,13 @@ let%component make =
           /* Draw background for cursor line */
           Shapes.drawRect(
             ~transform,
-            ~x=lineNumberWidth,
+            ~x=gutterWidth,
             ~y=
               fontHeight
-              *. float_of_int(Index.toZeroBased(cursorPosition.line))
+              *. float(Index.toZeroBased(cursorPosition.line))
               -. editor.scrollY,
             ~height=fontHeight,
-            ~width=float_of_int(metrics.pixelWidth) -. lineNumberWidth,
+            ~width=float(metrics.pixelWidth) -. gutterWidth,
             ~color=theme.editorLineHighlightBackground,
             (),
           );
@@ -625,8 +633,8 @@ let%component make =
               ~transform,
               ~x=fst(bufferPositionToPixel(0, ruler)),
               ~y=0.0,
-              ~height=float_of_int(metrics.pixelHeight),
-              ~width=float_of_int(1),
+              ~height=float(metrics.pixelHeight),
+              ~width=1.,
               ~color=theme.editorRulerForeground,
               (),
             );
@@ -656,20 +664,17 @@ let%component make =
              Shapes.drawRect(
                ~transform,
                ~x=
-                 lineNumberWidth
-                 +. float_of_int(startOffset)
-                 *. fontWidth
-                 -. halfOffset,
+                 gutterWidth +. float(startOffset) *. fontWidth -. halfOffset,
                ~y=
                  fontHeight
-                 *. float_of_int(Index.toZeroBased(r.start.line))
+                 *. float(Index.toZeroBased(r.start.line))
                  -. editor.scrollY
                  -. halfOffset
                  +. (fontHeight -. 2.),
                ~height=1.,
                ~width=
                  offset
-                 +. max(float_of_int(endOffset - startOffset), 1.0)
+                 +. max(float(endOffset - startOffset), 1.0)
                  *. fontWidth,
                ~color,
                (),
@@ -700,19 +705,19 @@ let%component make =
                Shapes.drawRect(
                  ~transform,
                  ~x=
-                   lineNumberWidth
-                   +. float_of_int(startOffset)
+                   gutterWidth
+                   +. float(startOffset)
                    *. fontWidth
                    -. halfOffset,
                  ~y=
                    fontHeight
-                   *. float_of_int(Index.toZeroBased(r.start.line))
+                   *. float(Index.toZeroBased(r.start.line))
                    -. editor.scrollY
                    -. halfOffset,
                  ~height=fontHeight +. offset,
                  ~width=
                    offset
-                   +. max(float_of_int(endOffset - startOffset), 1.0)
+                   +. max(float(endOffset - startOffset), 1.0)
                    *. fontWidth,
                  ~color,
                  (),
@@ -722,7 +727,7 @@ let%component make =
           ImmediateList.render(
             ~scrollY,
             ~rowHeight,
-            ~height=float_of_int(height),
+            ~height=float(height),
             ~count,
             ~render=
               (item, _offset) => {
@@ -813,7 +818,7 @@ let%component make =
           ImmediateList.render(
             ~scrollY,
             ~rowHeight,
-            ~height=float_of_int(height),
+            ~height=float(height),
             ~count,
             ~render=
               (item, offset) => {
@@ -841,7 +846,7 @@ let%component make =
                     fontSize,
                     fontWidth,
                     fontHeight,
-                    lineNumberWidth,
+                    gutterWidth,
                     theme,
                     tokens,
                     editor.scrollX,
@@ -857,14 +862,14 @@ let%component make =
             (),
           );
 
-          /* Draw background for line numbers */
           if (showLineNumbers) {
+            /* Draw background for line numbers */
             Shapes.drawRect(
               ~transform,
               ~x=0.,
               ~y=0.,
               ~width=lineNumberWidth,
-              ~height=float_of_int(height),
+              ~height=float(height),
               ~color=theme.editorLineNumberBackground,
               (),
             );
@@ -872,44 +877,55 @@ let%component make =
             ImmediateList.render(
               ~scrollY,
               ~rowHeight,
-              ~height=float_of_int(height),
+              ~height=float(height),
               ~count,
               ~render=
-                (item, offset) => {
-                  let _ =
-                    renderLineNumber(
-                      fontFamily,
-                      fontSize,
-                      fontWidth,
-                      item,
-                      lineNumberWidth,
-                      theme,
-                      Configuration.getValue(
-                        c => c.editorLineNumbers,
-                        state.configuration,
-                      ),
-                      cursorLine,
-                      offset,
-                      transform,
-                    );
-                  ();
-                },
+                (item, offset) =>
+                  renderLineNumber(
+                    fontFamily,
+                    fontSize,
+                    fontWidth,
+                    item,
+                    lineNumberWidth,
+                    theme,
+                    Configuration.getValue(
+                      c => c.editorLineNumbers,
+                      state.configuration,
+                    ),
+                    cursorLine,
+                    offset,
+                    transform,
+                  ),
               (),
             );
           };
 
-          let renderIndentGuides =
+          Option.iter(
+            EditorDiffMarkers.render(
+              ~scrollY,
+              ~rowHeight,
+              ~x=lineNumberWidth,
+              ~height=float(height),
+              ~width=Constants.diffMarkerWidth,
+              ~count,
+              ~transform,
+              ~theme,
+            ),
+            diffMarkers,
+          );
+
+          let shouldRenderIndentGuides =
             Configuration.getValue(
               c => c.editorRenderIndentGuides,
               state.configuration,
             );
-          let showActive =
+          let shouldShowActive =
             Configuration.getValue(
               c => c.editorHighlightActiveIndentGuide,
               state.configuration,
             );
 
-          if (renderIndentGuides) {
+          if (shouldRenderIndentGuides) {
             switch (activeBuffer) {
             | None => ()
             | Some(buffer) =>
@@ -924,7 +940,7 @@ let%component make =
                 ~theme=state.theme,
                 ~indentationSettings=indentation,
                 ~bufferPositionToPixel,
-                ~showActive,
+                ~showActive=shouldShowActive,
                 (),
               )
             };

--- a/src/UI/Oni_UI.re
+++ b/src/UI/Oni_UI.re
@@ -6,6 +6,7 @@
 
 module Dock = Dock;
 module GlobalContext = GlobalContext;
+module EditorDiffMarkers = EditorDiffMarkers;
 module EditorSurface = EditorSurface;
 module FileExplorerView = FileExplorerView;
 module Root = Root;

--- a/src/UI/dune
+++ b/src/UI/dune
@@ -1,7 +1,7 @@
 (library
     (name Oni_UI)
     (public_name Oni2.ui)
-    (preprocess (pps brisk-reconciler.ppx))
+    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show))
     (libraries 
         str
         bigarray
@@ -15,4 +15,5 @@
         Rench
         Revery
         editor-core-types
+        ppx_deriving.runtime
     ))

--- a/test/OniUnitTestRunner.re
+++ b/test/OniUnitTestRunner.re
@@ -1,6 +1,7 @@
 Oni_Core_Test.TestFramework.cli();
 Oni_Input_Test.TestFramework.cli();
 Oni_Model_Test.TestFramework.cli();
+Oni_UI_Test.TestFramework.cli();
 Oni_Extensions_Test.TestFramework.cli();
 Oni_ExtensionManagement_Test.TestFramework.cli();
 Oni_Syntax_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerUI.re
+++ b/test/OniUnitTestRunnerUI.re
@@ -1,0 +1,1 @@
+Oni_UI_Test.TestFramework.cli();

--- a/test/UI/EditorDiffMarkersTest.re
+++ b/test/UI/EditorDiffMarkersTest.re
@@ -1,0 +1,243 @@
+/* open Oni_Core; */
+open TestFramework;
+
+module Buffer = Oni_Core.Buffer;
+module EditorDiffMarkers = Oni_UI.EditorDiffMarkers;
+
+describe("EditorDiffMarkers", ({describe, _}) => {
+  describe("generate", ({test, _}) => {
+    test("single added", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "b", ".", "c", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.(
+          [|Unmodified, Unmodified, Added, Unmodified, Unmodified|]
+        );
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("block added", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "b", ".", ".", ".", "c", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.(
+          [|
+            Unmodified,
+            Unmodified,
+            Added,
+            Added,
+            Added,
+            Unmodified,
+            Unmodified,
+          |]
+        );
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("single deleted", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "b", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.([|Unmodified, Unmodified, DeletedBefore|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("block deleted from beginning", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"c", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected = EditorDiffMarkers.([|DeletedBefore, Unmodified|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("block deleted from end", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "b"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected = EditorDiffMarkers.([|Unmodified, DeletedAfter|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("single modified", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "b", "C", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.([|Unmodified, Unmodified, Modified, Unmodified|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("block modified", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "B", "C", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.([|Unmodified, Modified, Modified, Unmodified|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("add + modify", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", ".", "B", "c", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.(
+          [|Unmodified, Modified, Added, Unmodified, Unmodified|]
+        );
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("delete + modify", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [|"a", "C", "d"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.([|Unmodified, Modified, DeletedBefore|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("delete + add + delete", ({expect}) => {
+      let was = [|"a", "b", "c", "d", "e", "f", "g"|];
+      let now = [|"a", "c", ".", "d", "f", "g"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.(
+          [|
+            Unmodified,
+            DeletedBefore,
+            Added,
+            Unmodified,
+            DeletedBefore,
+            Unmodified,
+          |]
+        );
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("delete block + add + delete", ({expect}) => {
+      let was = [|"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"|];
+      let now = [|"a", "d", ".", "e", "h", "i", "j"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.(
+          [|
+            Unmodified,
+            DeletedBefore,
+            Added,
+            Unmodified,
+            DeletedBefore,
+            Unmodified,
+            Unmodified,
+          |]
+        );
+
+      switch (actual) {
+      | Some(actual) =>
+        // Printf.printf("\n%s\n%!", EditorDiffMarkers.show(actual));
+        expect.array(actual).toEqual(expected);
+      | None => failwith("unreachable")
+      };
+    });
+
+    test("delete + add + delete block", ({expect}) => {
+      let was = [|"a", "b", "c", "d", "e", "f", "g", "h"|];
+      let now = [|"a", "c", ".", "d", "g", "h"|];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected =
+        EditorDiffMarkers.(
+          [|
+            Unmodified,
+            DeletedBefore,
+            Added,
+            Unmodified,
+            DeletedBefore,
+            Unmodified,
+          |]
+        );
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+  })
+});

--- a/test/UI/EditorDiffMarkersTest.re
+++ b/test/UI/EditorDiffMarkersTest.re
@@ -210,7 +210,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       switch (actual) {
       | Some(actual) =>
         // Printf.printf("\n%s\n%!", EditorDiffMarkers.show(actual));
-        expect.array(actual).toEqual(expected);
+        expect.array(actual).toEqual(expected)
       | None => failwith("unreachable")
       };
     });

--- a/test/UI/TestFramework.re
+++ b/test/UI/TestFramework.re
@@ -1,0 +1,4 @@
+include Rely.Make({
+  let config =
+    Rely.TestFrameworkConfig.initialize({snapshotDir: "", projectDir: ""});
+});

--- a/test/UI/dune
+++ b/test/UI/dune
@@ -1,0 +1,5 @@
+(library
+    (name Oni_UI_Test)
+    (library_flags (-linkall -g))
+    (modules (:standard))
+    (libraries Oni2.core Oni2.ui rely.lib))

--- a/test/dune
+++ b/test/dune
@@ -10,6 +10,7 @@
         Oni_ExtensionManagement_Test
         Oni_Input_Test
         Oni_Model_Test
+        Oni_UI_Test
         Oni_Syntax_Test
             ))
 
@@ -44,6 +45,13 @@
         Oni_Core_Test
         Oni_Model_Test
             ))
+
+(executable
+    (name OniUnitTestRunnerUI)
+    (public_name OniUnitTestRunnerUI)
+    (modules OniUnitTestRunnerUI)
+    (package OniUnitTestRunner)
+    (libraries Oni_UI_Test))
 
 (executable
     (name OniUnitTestRunnerCI)


### PR DESCRIPTION
![2020-01-26-083805_668x310_scrot](https://user-images.githubusercontent.com/5207036/73132158-4e482d80-4017-11ea-8b6f-21d21f820052.png)

Part of the SCM extension integration, this adds diff makers to the editor and minimap showing the changes made to the current file relative to its checked-in or staged counterpart.

This implementation differ from vscode's in that they show the whole block as modified if there are both additions and deletions overlapping in said, while this implementation is more granular in a sense, showing a line as modified only if there's both an addition and deletion on that line, and otherwise treating them as stand-alone additons and deletions. For example, in the above screenshot. the deletion at the end of the first block would not be present in vscode.

This is functionally ready to be merged, although there;s still plenty of room for improvement:

- [ ] Find a good heuristic for choosing SCM provider
- [ ] Update original content when changed (ie. on staging or commit). As far as I can tell there is no notification from the git extension of this happening, and since it's a git uri it's not straightforward to use fswatch on it either.
- [ ] Investigate and improve heuristics of diff algorithm, in particular with regards to alignment of code blocks.
- [ ] Render an arrow marker for deletion, to make it more visible. I don't think this is possible with the current drawing primitives however (unless we use a font icon I guess). We might want to wait until skia has dropped for this one.
- [ ] Improve performance (although from what I can tell the impact is negligible in normal use cases)
  - [ ] Adapt diff algorithm to BufferLine interface to avoid allocation of an extra array
  - [ ] Generate markers only on buffer enter and update, rather than on every render
  - [ ] Generate markers asynchronously or time-sliced