### PR TITLE
[docs] Add reminder to run `esy @test install` before `esy @test run`

### DIFF
--- a/docs/docs/for-developers/architecture.md
+++ b/docs/docs/for-developers/architecture.md
@@ -73,7 +73,7 @@ We have two classes of tests - _unit tests_ and _integration tests_.
 
 ### Unit Tests
 
-Unit tests live in the `test` folder and be can be run via `esy '@test' run`. 
+Unit tests live in the `test` folder and be can be run via `esy '@test' run`, but remember to run `esy '@test' install` initially to install the test dependencies. 
 
 We organize our tests 1-to-1 with the `src` code - for example, test cases for `src/editor/Core/LineNumber.re` would live in `test/Core/LineNumberTests.re`.
 


### PR DESCRIPTION
Many seem understandably confused by the bad error message when running `esy @test run` without first running `esy @test install`, so a reminder in the docs seems like a good idea.