### PR TITLE
[docs] Add installation page back in the sidebar

### DIFF
--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -2,6 +2,7 @@
   "docs": {
     "Getting Started": [
       "getting-started/why-onivim",
+      "getting-started/installation",
       "getting-started/vim-differences",
       "getting-started/modal-editing-101"
     ],


### PR DESCRIPTION
It was removed in #905 for non-obvious reasons, possibly unintentional.