### PR TITLE
Fix #1272: Evaluate experimental.viml commands in correct order

### DIFF
--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -6,6 +6,7 @@
 open Kernel;
 open ConfigurationValues;
 open LineNumber;
+open Utility;
 
 let parseBool = json =>
   switch (json) {
@@ -29,13 +30,10 @@ let parseFloat = json =>
 let parseStringList = json => {
   switch (json) {
   | `List(items) =>
-    List.fold_left(
-      (accum, item) =>
-        switch (item) {
-        | `String(v) => [v, ...accum]
-        | _ => accum
-        },
-      [],
+    List.filter_map(
+      fun
+      | `String(v) => Some(v)
+      | _ => None,
       items,
     )
   | `String(v) => [v]

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -89,7 +89,7 @@ let default = {
   workbenchStatusBarVisible: true,
   workbenchIconTheme: "vs-seti",
   workbenchTreeIndent: 2,
-  filesExclude: ["node_modules", "_esy"],
+  filesExclude: ["_esy", "node_modules"],
   uiShadows: true,
   uiZoom: 1.0,
   vimUseSystemClipboard: {

--- a/test/Core/ConfigurationParserTests.re
+++ b/test/Core/ConfigurationParserTests.re
@@ -195,6 +195,22 @@ describe("ConfigurationParser", ({test, describe, _}) => {
     };
   });
 
+  test("list of strings", ({expect}) => {
+    let configuration = {|
+     { "experimental.viml": ["first thing", "second thing", "third thing"] }
+     |};
+
+    switch (ConfigurationParser.ofString(configuration)) {
+    | Ok(v) =>
+      expect.list(Configuration.getValue(c => c.experimentalVimL, v)).toEqual([
+        "first thing",
+        "second thing",
+        "third thing",
+      ])
+    | Error(_) => expect.bool(false).toBe(true)
+    };
+  });
+
   test("resiliency tests", ({expect}) => {
     let trailingCommaInObject = {|
       { "editor.rulers": [120, 80], }


### PR DESCRIPTION
This was due to a bug in parseStringList in ConfigurationParser. This
also affected `files.exclude`.