### PR TITLE
SCM: File Explorer decorations

### DIFF
--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -35,6 +35,7 @@ module LineNumber = LineNumber;
 module Log = Kernel.Log;
 module Ripgrep = Ripgrep;
 module Scheduler = Scheduler;
+module SCMDecoration = SCMDecoration;
 module Setup = Setup;
 module ShellUtility = ShellUtility;
 module StringMap = Kernel.StringMap;

--- a/src/Core/SCMDecoration.re
+++ b/src/Core/SCMDecoration.re
@@ -1,0 +1,8 @@
+[@deriving show]
+type t = {
+  handle: int, // provider handle
+  tooltip: string,
+  letter: string,
+  color: string, // TODO: ThemeColor.t?
+  source: string,
+};

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -76,6 +76,12 @@ type t = {
   editorFindMatchHighlightBackground: Color.t,
   editorIndentGuideBackground: Color.t,
   editorIndentGuideActiveBackground: Color.t,
+  listActiveSelectionBackground: Color.t,
+  listActiveSelectionForeground: Color.t,
+  listFocusBackground: Color.t,
+  listFocusForeground: Color.t,
+  listHoverBackground: Color.t,
+  listHoverForeground: Color.t,
   menuBackground: Color.t,
   menuForeground: Color.t,
   menuSelectionBackground: Color.t,
@@ -140,6 +146,12 @@ let default: t = {
   editorOverviewRulerBracketMatchForeground: Color.hex("#A0A0A0"),
   editorActiveLineNumberForeground: Color.hex("#737984"),
   editorSelectionBackground: Color.hex("#687595"),
+  listActiveSelectionBackground: Color.hex("#495162"),
+  listActiveSelectionForeground: Color.hex("#FFFFFF"),
+  listFocusBackground: Color.hex("#495162"),
+  listFocusForeground: Color.hex("#FFFFFF"),
+  listHoverBackground: Color.hex("#495162"),
+  listHoverForeground: Color.hex("#FFFFFF"),
   scrollbarSliderBackground: Color.rgba(0., 0., 0., 0.2),
   scrollbarSliderActiveBackground: Color.hex("#2F3440"),
   editorIndentGuideBackground: Color.hex("#3b4048"),
@@ -393,6 +405,36 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     editorSuggestWidgetBorder,
     editorSuggestWidgetHighlightForeground,
     editorSuggestWidgetSelectedBackground,
+    listActiveSelectionBackground:
+      getColor(
+        defaultBackground,
+        ["list.activeSelectionBackground", "menu.selectionBackground"],
+      ),
+    listActiveSelectionForeground:
+      getColor(
+        defaultForeground,
+        ["list.activeSelectionForeground", "menu.foreground"],
+      ),
+    listFocusBackground:
+      getColor(
+        defaultBackground,
+        ["list.focusBackground", "menu.selectionBackground"],
+      ),
+    listFocusForeground:
+      getColor(
+        defaultForeground,
+        ["list.focusForeground", "menu.foreground"],
+      ),
+    listHoverBackground:
+      getColor(
+        defaultBackground,
+        ["list.hoverBackground", "menu.selectionBackground"],
+      ),
+    listHoverForeground:
+      getColor(
+        defaultForeground,
+        ["list.hoverForeground", "menu.foreground"],
+      ),
     menuBackground,
     menuForeground,
     menuSelectionBackground,

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -473,3 +473,16 @@ let getColorsForMode = (theme: t, mode: Vim.Mode.t) => {
 
   (background, foreground);
 };
+
+let getCustomColor = (color, _theme) =>
+  switch (color) {
+  | "gitDecoration.addedResourceForeground" => Some(Color.hex("#81b88b"))
+  | "gitDecoration.modifiedResourceForeground" => Some(Color.hex("#E2C08D"))
+  | "gitDecoration.deletedResourceForeground" => Some(Color.hex("#c74e39"))
+  | "gitDecoration.untrackedResourceForeground" => Some(Color.hex("#73C991"))
+  | "gitDecoration.ignoredResourceForeground" => Some(Color.hex("#8C8C8C"))
+  | "gitDecoration.conflictingResourceForeground" =>
+    Some(Color.hex("#6c6cc4"))
+  | "gitDecoration.submoduleResourceForeground" => Some(Color.hex("#8db9e2"))
+  | _ => None
+  };

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -44,7 +44,11 @@ type msg =
       handle: int,
       label: string,
     })
-  | UnregisterDecorationProvider({handle: int});
+  | UnregisterDecorationProvider({handle: int})
+  | DecorationsDidChange({
+      handle: int,
+      uris: list(Uri.t),
+    });
 
 type unitCallback = unit => unit;
 let noop = () => ();
@@ -244,6 +248,19 @@ let start =
       dispatch(UnregisterDecorationProvider({handle: handle}));
       Ok(None);
 
+    | (
+        "MainThreadDecorations",
+        "$onDidChange",
+        [`Int(handle), `List(resources)],
+      ) =>
+      let uris =
+        resources
+        |> List.filter_map(json =>
+             Uri.of_yojson(json) |> Utility.Result.to_option
+           );
+      dispatch(DecorationsDidChange({handle, uris}));
+      Ok(None);
+
     | (scope, method, argsAsJson) =>
       Log.warnf(m =>
         m(
@@ -317,6 +334,46 @@ let provideCompletions = (id, uri, position, client) => {
       f,
     );
   promise;
+};
+
+let provideDecorations = (handle, uri, client) => {
+  let decodeItem =
+    fun
+    | (
+        _requestId,
+        `List([
+          `Int(_),
+          `Bool(_),
+          `String(tooltip),
+          `String(letter),
+          `Assoc([("id", `String(color))]),
+          `String(source),
+        ]),
+      ) =>
+      Some(SCMDecoration.{handle, tooltip, letter, color, source})
+    | (_, json) => {
+        Log.error("Unexpected data: " ++ Yojson.Safe.to_string(json));
+        None;
+      };
+
+  ExtHostTransport.request(
+    ~msgType=MessageType.requestJsonArgsWithCancellation,
+    client,
+    Out.Decorations.provideDecorations(handle, uri),
+    json =>
+    switch (json) {
+    | `Assoc(items) => items |> List.filter_map(decodeItem)
+
+    | _ =>
+      failwith(
+        Printf.sprintf(
+          "Unexpected response from provideDecorations for %s: \n  %s",
+          Uri.toString(uri),
+          Yojson.Safe.to_string(json),
+        ),
+      )
+    }
+  );
 };
 
 let provideDefinition = (id, uri, position, client) => {

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -39,7 +39,12 @@ type msg =
       handle: int,
       scheme: string,
     })
-  | UnregisterTextContentProvider({handle: int});
+  | UnregisterTextContentProvider({handle: int})
+  | RegisterDecorationProvider({
+      handle: int,
+      label: string,
+    })
+  | UnregisterDecorationProvider({handle: int});
 
 type unitCallback = unit => unit;
 let noop = () => ();
@@ -221,6 +226,22 @@ let start =
         [`Int(handle)],
       ) =>
       dispatch(UnregisterTextContentProvider({handle: handle}));
+      Ok(None);
+
+    | (
+        "MainThreadDecorations",
+        "$registerDecorationProvider",
+        [`Int(handle), `String(label)],
+      ) =>
+      dispatch(RegisterDecorationProvider({handle, label}));
+      Ok(None);
+
+    | (
+        "MainThreadDecorations",
+        "$unregisterDecorationProvider",
+        [`Int(handle)],
+      ) =>
+      dispatch(UnregisterDecorationProvider({handle: handle}));
       Ok(None);
 
     | (scope, method, argsAsJson) =>

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -29,7 +29,11 @@ type msg =
       handle: int,
       label: string,
     })
-  | UnregisterDecorationProvider({handle: int});
+  | UnregisterDecorationProvider({handle: int})
+  | DecorationsDidChange({
+      handle: int,
+      uris: list(Core.Uri.t),
+    });
 
 type unitCallback = unit => unit;
 
@@ -73,6 +77,8 @@ let updateDocument:
 let provideCompletions:
   (int, Core.Uri.t, Protocol.OneBasedPosition.t, t) =>
   Lwt.t(option(list(Protocol.SuggestionItem.t)));
+let provideDecorations:
+  (int, Core.Uri.t, t) => Lwt.t(list(Core.SCMDecoration.t));
 let provideDefinition:
   (int, Core.Uri.t, Protocol.OneBasedPosition.t, t) =>
   Lwt.t(Protocol.DefinitionLink.t);

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -24,7 +24,12 @@ type msg =
       handle: int,
       scheme: string,
     })
-  | UnregisterTextContentProvider({handle: int});
+  | UnregisterTextContentProvider({handle: int})
+  | RegisterDecorationProvider({
+      handle: int,
+      label: string,
+    })
+  | UnregisterDecorationProvider({handle: int});
 
 type unitCallback = unit => unit;
 

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -548,6 +548,23 @@ module OutgoingNotifications = {
     };
   };
 
+  module Decorations = {
+    let provideDecorations = (handle: int, uri: Uri.t) =>
+      _buildNotification(
+        "ExtHostDecorations",
+        "$provideDecorations",
+        `List([
+          `List([
+            `Assoc([
+              ("id", `Int(0)),
+              ("handle", `Int(handle)),
+              ("uri", Uri.to_yojson(uri)),
+            ]),
+          ]),
+        ]),
+      );
+  };
+
   module Documents = {
     let acceptModelChanged =
         (uri: Uri.t, modelChangedEvent: ModelChangedEvent.t, isDirty: bool) => {

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -8,7 +8,8 @@ type t = {
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(string), // path
-  focus: option(string) // path
+  focus: option(string), // path
+  decorations: StringMap.t(list(SCMDecoration.t)),
 };
 
 [@deriving show({with_path: false})]
@@ -19,6 +20,15 @@ type action =
   | NodeClicked(FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
   | KeyboardInput(string);
+
+let initial = {
+  tree: None,
+  isOpen: true,
+  scrollOffset: `Start(0.),
+  active: None,
+  focus: None,
+  decorations: StringMap.empty,
+};
 
 let getFileIcon = (languageInfo, iconTheme, filePath) => {
   let fileIcon =
@@ -120,12 +130,4 @@ let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
     |> List.sort(sortByLoweredDisplayName);
 
   FsTreeNode.directory(cwd, ~icon=getIcon(cwd), ~children, ~isOpen=true);
-};
-
-let initial = {
-  tree: None,
-  isOpen: true,
-  scrollOffset: `Start(0.),
-  active: None,
-  focus: None,
 };

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -1,3 +1,4 @@
+open Oni_Core;
 open Oni_Extensions;
 
 type t = {
@@ -5,7 +6,8 @@ type t = {
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(string), // path
-  focus: option(string) // path
+  focus: option(string), // path
+  decorations: StringMap.t(list(SCMDecoration.t)),
 };
 
 [@deriving show]

--- a/src/Model/SCM.re
+++ b/src/Model/SCM.re
@@ -24,10 +24,21 @@ module Provider = {
   };
 };
 
-[@deriving show({with_path: false})]
-type t = {providers: list(Provider.t)};
+module DecorationProvider = {
+  [@deriving show({with_path: false})]
+  type t = {
+    handle: int,
+    label: string,
+  };
+};
 
-let initial = {providers: []};
+[@deriving show({with_path: false})]
+type t = {
+  providers: list(Provider.t),
+  decorationProviders: list(DecorationProvider.t),
+};
+
+let initial = {providers: [], decorationProviders: []};
 
 [@deriving show({with_path: false})]
 type msg =
@@ -57,4 +68,9 @@ type msg =
   | GotOriginalContent({
       bufferId: int,
       lines: [@opaque] array(string),
-    });
+    })
+  | NewDecorationProvider({
+      handle: int,
+      label: string,
+    })
+  | LostDecorationProvider({handle: int});

--- a/src/Model/SCM.re
+++ b/src/Model/SCM.re
@@ -73,4 +73,13 @@ type msg =
       handle: int,
       label: string,
     })
-  | LostDecorationProvider({handle: int});
+  | LostDecorationProvider({handle: int})
+  | DecorationsChanged({
+      handle: int,
+      uris: list(Uri.t),
+    })
+  | GotDecorations({
+      handle: int,
+      uri: Uri.t,
+      decorations: list(SCMDecoration.t),
+    });

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -11,7 +11,6 @@ open Oni_Core;
 open Oni_Model;
 open Utility;
 
-module Uri = Oni_Core.Uri;
 module Log = (val Log.withNamespace("Oni2.Extension.ClientStore"));
 
 open Oni_Extensions;
@@ -328,6 +327,12 @@ let start = (extensions, setup: Setup.t) => {
 
     | UnregisterTextContentProvider({handle}) =>
       dispatch(LostTextContentProvider({handle: handle}))
+
+    | RegisterDecorationProvider({handle, label}) =>
+      dispatch(Actions.SCM(SCM.NewDecorationProvider({handle, label})))
+
+    | UnregisterDecorationProvider({handle}) =>
+      dispatch(Actions.SCM(SCM.LostDecorationProvider({handle: handle})))
     };
 
   let onOutput = Log.info;
@@ -579,6 +584,7 @@ let start = (extensions, setup: Setup.t) => {
         {
           ...state,
           scm: {
+            ...state.scm,
             providers: [
               SCM.Provider.{
                 handle,
@@ -601,6 +607,7 @@ let start = (extensions, setup: Setup.t) => {
         {
           ...state,
           scm: {
+            ...state.scm,
             providers:
               List.filter(
                 (it: SCM.Provider.t) => it.handle != handle,
@@ -615,6 +622,7 @@ let start = (extensions, setup: Setup.t) => {
         {
           ...state,
           scm: {
+            ...state.scm,
             providers:
               List.map(
                 (it: SCM.Provider.t) =>
@@ -631,6 +639,7 @@ let start = (extensions, setup: Setup.t) => {
         {
           ...state,
           scm: {
+            ...state.scm,
             providers:
               List.map(
                 (it: SCM.Provider.t) =>
@@ -646,6 +655,7 @@ let start = (extensions, setup: Setup.t) => {
         {
           ...state,
           scm: {
+            ...state.scm,
             providers:
               List.map(
                 (it: SCM.Provider.t) =>
@@ -680,6 +690,35 @@ let start = (extensions, setup: Setup.t) => {
               Option.map(Buffer.setOriginalLines(lines)),
               state.buffers,
             ),
+        },
+        Isolinear.Effect.none,
+      )
+
+    | Actions.SCM(SCM.NewDecorationProvider({handle, label})) => (
+        {
+          ...state,
+          scm: {
+            ...state.scm,
+            decorationProviders: [
+              SCM.DecorationProvider.{handle, label},
+              ...state.scm.decorationProviders,
+            ],
+          },
+        },
+        Isolinear.Effect.none,
+      )
+
+    | Actions.SCM(SCM.LostDecorationProvider({handle})) => (
+        {
+          ...state,
+          scm: {
+            ...state.scm,
+            decorationProviders:
+              List.filter(
+                (it: SCM.DecorationProvider.t) => it.handle != handle,
+                state.scm.decorationProviders,
+              ),
+          },
         },
         Isolinear.Effect.none,
       )

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -550,7 +550,10 @@ let start = (extensions, setup: Setup.t) => {
 
     | Actions.BufferUpdate(bu) => (
         state,
-        modelChangedEffect(state.buffers, bu),
+        Isolinear.Effect.batch([
+          modelChangedEffect(state.buffers, bu),
+          executeContributedCommandEffect("git.refresh"),
+        ]),
       )
 
     | Actions.CommandExecuteContributed(cmd) => (

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -6,6 +6,7 @@ open Revery.UI;
 
 module FontAwesome = Oni_Components.FontAwesome;
 module FontIcon = Oni_Components.FontIcon;
+module Option = Utility.Option;
 
 module Styles = {
   open Style;
@@ -42,16 +43,25 @@ module Styles = {
     ),
   ];
 
-  let text = (~isFocus, ~isActive, ~theme: Theme.t, ~font: UiFont.t) => [
+  let text =
+      (~isFocus, ~isActive, ~decoration, ~theme: Theme.t, ~font: UiFont.t) => [
     fontSize(11),
     fontFamily(font.fontFile),
     color(
-      if (isFocus) {
-        theme.listFocusForeground;
-      } else if (isActive) {
-        theme.listActiveSelectionForeground;
-      } else {
-        theme.foreground;
+      switch (
+        Option.bind(decoration, (decoration: SCMDecoration.t) =>
+          Theme.getCustomColor(decoration.color, theme)
+        )
+      ) {
+      | Some(color) => color
+      | None =>
+        if (isFocus) {
+          theme.listFocusForeground;
+        } else if (isActive) {
+          theme.listActiveSelectionForeground;
+        } else {
+          theme.foreground;
+        }
       },
     ),
     marginLeft(10),
@@ -82,6 +92,7 @@ let nodeView =
       ~font: UiFont.t,
       ~theme: Theme.t,
       ~node: FsTreeNode.t,
+      ~decorations=[],
       (),
     ) => {
   let icon = () =>
@@ -108,9 +119,18 @@ let nodeView =
     | _ => <icon />
     };
 
+  let decoration =
+    switch (decorations) {
+    | [last, ..._] => Some(last)
+    | [] => None
+    };
+
   <View style={Styles.item(~isFocus, ~isActive, ~theme)}>
     <icon />
-    <Text text style={Styles.text(~isFocus, ~isActive, ~theme, ~font)} />
+    <Text
+      text={node.displayName}
+      style={Styles.text(~isFocus, ~isActive, ~decoration, ~theme, ~font)}
+    />
   </View>;
 };
 
@@ -137,15 +157,19 @@ let make =
   <View style=Styles.container>
     <TreeView
       scrollOffset onScrollOffsetChange tree itemHeight=22 onClick=onNodeClick>
-      ...{node =>
+      ...{node => {
+        let decorations =
+          StringMap.find_opt(node.path, state.fileExplorer.decorations);
+
         <nodeView
           isFocus={Some(node.path) == focus}
           isActive={Some(node.path) == active}
           font
           theme
           node
-        />
-      }
+          ?decorations
+        />;
+      }}
     </TreeView>
   </View>;
 };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -27,19 +27,33 @@ module Styles = {
     height(Constants.default.tabHeight),
   ];
 
-  let item = (~isFocus, ~theme: Theme.t) => [
+  let item = (~isFocus, ~isActive, ~theme: Theme.t) => [
     flexDirection(`Row),
     flexGrow(1),
     alignItems(`Center),
     backgroundColor(
-      isFocus ? theme.menuSelectionBackground : theme.sideBarBackground,
+      if (isFocus) {
+        theme.listFocusBackground;
+      } else if (isActive) {
+        theme.listActiveSelectionBackground;
+      } else {
+        Colors.transparentWhite;
+      },
     ),
   ];
 
-  let text = (~isActive, ~theme: Theme.t, ~font: UiFont.t) => [
+  let text = (~isFocus, ~isActive, ~theme: Theme.t, ~font: UiFont.t) => [
     fontSize(11),
     fontFamily(font.fontFile),
-    color(isActive ? theme.oniNormalModeBackground : theme.sideBarForeground),
+    color(
+      if (isFocus) {
+        theme.listFocusForeground;
+      } else if (isActive) {
+        theme.listActiveSelectionForeground;
+      } else {
+        theme.foreground;
+      },
+    ),
     marginLeft(10),
     marginVertical(2),
     textWrap(TextWrapping.NoWrap),
@@ -94,12 +108,9 @@ let nodeView =
     | _ => <icon />
     };
 
-  <View style={Styles.item(~isFocus, ~theme)}>
+  <View style={Styles.item(~isFocus, ~isActive, ~theme)}>
     <icon />
-    <Text
-      text={node.displayName}
-      style={Styles.text(~theme, ~isActive, ~font)}
-    />
+    <Text text style={Styles.text(~isFocus, ~isActive, ~theme, ~font)} />
   </View>;
 };
 


### PR DESCRIPTION
![2020-02-01-124912_177x135_scrot](https://user-images.githubusercontent.com/5207036/73591661-a8eaf900-44f1-11ea-9ee0-6562325ec9e6.png)

This adds Source Control decorations to the file explorer, ie. embellishments showing the source control resource state of files. It also adds some list theme colors and uses those properly.

There are some uncertainties here though:

I'm not sure how vscode updates the SCM. Currently we execute `git.refresh` on `BufferUpdate`, which isn't great because it happens too frequently and of course only works for git. There is unfortunately no save action/event though, so `BufferUpdate` seems like the best approximation for now.

I'm also not sure what some of the values we get actually are. The type of the payload as defined in the protocol, of which I have yet to figure out the first two, is:

```
export type DecorationData = [number, boolean, string, string, ThemeColor, string];
```

I don't know how to handle multiple decorations for the same file. Currently we just pick the last one, and I think it would be rare to have multiple as this mechanism seems to just be used for SCM. But the git extension itself registers two decoration providers, so who knows...

TODO:
- [ ] Add "letter" indicator, as in vscode (should we spend real estate on this?)
- [ ] Add tooltip
- [ ] Batch decoration requests?
- [ ] Add proper support for custom theme colors instead of hard-coding them (probably a separate PR as part of a Theme revamp)

I don't think any of the above are blockers, so this can be merged as-is.