### PR TITLE
Bugfix: Add RLS as executable in OSX release script

### DIFF
--- a/integration_test/EditorFontFromPathTest.re
+++ b/integration_test/EditorFontFromPathTest.re
@@ -1,8 +1,10 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-let font = 
-  Sys.getcwd() ++ "/" ++ getAssetPath("Inconsolata-Regular.ttf")
+let font =
+  Sys.getcwd()
+  ++ "/"
+  ++ getAssetPath("Inconsolata-Regular.ttf")
   |> String.split_on_char('\\')
   |> String.concat("/");
 
@@ -19,10 +21,14 @@ runTest(
 
     print_endline("Using font: " ++ font);
 
-    wait(~name="The new font should be set", ~timeout=10., (state: State.t) => {
-      print_endline ("Current font is: " ++ state.editorFont.fontFile);
-      print_endline ("Expected font is: " ++ font);
-      String.equal(state.editorFont.fontFile, font)
-    });
+    wait(
+      ~name="The new font should be set",
+      ~timeout=10.,
+      (state: State.t) => {
+        print_endline("Current font is: " ++ state.editorFont.fontFile);
+        print_endline("Expected font is: " ++ font);
+        String.equal(state.editorFont.fontFile, font);
+      },
+    );
   },
 );

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -98,6 +98,7 @@ if (process.platform == "linux") {
     "Oni2",
     "Oni2_editor",
     "rg",
+    "rls",
     "node"
   ];
 


### PR DESCRIPTION
Add the reason-language-server executable in the `executable` section for code-signing - it was being missed by our code-signing script because it was put in the `Resources` directory instead of the `MacOS` directory of the app bundle.