### PR TITLE
Bugfix: Crash when clicking on line number

### DIFF
--- a/integration_test/EditorFontFromPathTest.re
+++ b/integration_test/EditorFontFromPathTest.re
@@ -1,8 +1,10 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-let font = 
-  Sys.getcwd() ++ "/" ++ getAssetPath("Inconsolata-Regular.ttf")
+let font =
+  Sys.getcwd()
+  ++ "/"
+  ++ getAssetPath("Inconsolata-Regular.ttf")
   |> String.split_on_char('\\')
   |> String.concat("/");
 
@@ -19,10 +21,14 @@ runTest(
 
     print_endline("Using font: " ++ font);
 
-    wait(~name="The new font should be set", ~timeout=10., (state: State.t) => {
-      print_endline ("Current font is: " ++ state.editorFont.fontFile);
-      print_endline ("Expected font is: " ++ font);
-      String.equal(state.editorFont.fontFile, font)
-    });
+    wait(
+      ~name="The new font should be set",
+      ~timeout=10.,
+      (state: State.t) => {
+        print_endline("Current font is: " ++ state.editorFont.fontFile);
+        print_endline("Expected font is: " ++ font);
+        String.equal(state.editorFont.fontFile, font);
+      },
+    );
   },
 );

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -575,6 +575,9 @@ let%component make =
           relY,
         );
 
+      let col = col < 0 ? 0 : col;
+      let line = line < 0 ? 0: line;
+
       if (line < numberOfLines) {
         Log.tracef(m => m("  topVisibleLine is %i", topVisibleLine));
         Log.tracef(m => m("  setPosition (%i, %i)", line + 1, col));

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -576,7 +576,7 @@ let%component make =
         );
 
       let col = col < 0 ? 0 : col;
-      let line = line < 0 ? 0: line;
+      let line = line < 0 ? 0 : line;
 
       if (line < numberOfLines) {
         Log.tracef(m => m("  topVisibleLine is %i", topVisibleLine));


### PR DESCRIPTION
Reported as a comment on the Patreon post - thank you Eric! https://www.patreon.com/posts/onivim-2-v0-3-0-32839297

Clicking on a line number, or the diff line on the editor surface, causes an ` Invalid_argument("index out of bounds"): ` error. This is because it calculates the position as if it were part of the line - but it is before the line - so we end up with a negative column - which crashes when we try to look up the text at the position.

@glennsl has a more thorough fix coming as part of revamping / refactoring the EditorSurface - but this is a quick fix in the meantime to keep it from crashing.