### PR TITLE
Fix #1286: Invalid font size causes text to be invisible

### DIFF
--- a/integration_test/EditorFontFromPathTest.re
+++ b/integration_test/EditorFontFromPathTest.re
@@ -1,8 +1,10 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-let font = 
-  Sys.getcwd() ++ "/" ++ getAssetPath("Inconsolata-Regular.ttf")
+let font =
+  Sys.getcwd()
+  ++ "/"
+  ++ getAssetPath("Inconsolata-Regular.ttf")
   |> String.split_on_char('\\')
   |> String.concat("/");
 
@@ -19,10 +21,14 @@ runTest(
 
     print_endline("Using font: " ++ font);
 
-    wait(~name="The new font should be set", ~timeout=10., (state: State.t) => {
-      print_endline ("Current font is: " ++ state.editorFont.fontFile);
-      print_endline ("Expected font is: " ++ font);
-      String.equal(state.editorFont.fontFile, font)
-    });
+    wait(
+      ~name="The new font should be set",
+      ~timeout=10.,
+      (state: State.t) => {
+        print_endline("Current font is: " ++ state.editorFont.fontFile);
+        print_endline("Expected font is: " ++ font);
+        String.equal(state.editorFont.fontFile, font);
+      },
+    );
   },
 );

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -65,7 +65,7 @@ type t = {
 let default = {
   editorDetectIndentation: true,
   editorFontFamily: Some("FiraCode-Regular.ttf"),
-  editorFontSize: 14,
+  editorFontSize: Constants.defaultFontSize,
   editorHoverDelay: 1000,
   editorHoverEnabled: true,
   editorLargeFileOptimizations: true,
@@ -73,7 +73,7 @@ let default = {
   editorAcceptSuggestionOnEnter: `on,
   editorMinimapEnabled: true,
   editorMinimapShowSlider: true,
-  editorMinimapMaxColumn: Constants.default.minimapMaxColumn,
+  editorMinimapMaxColumn: Constants.minimapMaxColumn,
   editorLineNumbers: On,
   editorInsertSpaces: false,
   editorIndentSize: 4,

--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -5,50 +5,37 @@
  * to pull out to configuration values
  */
 
-type t = {
-  fontAwesomeRegularPath: string,
-  fontAwesomeSolidPath: string,
-  /* Horizontal padding on each side of the minimap */
-  minimapPadding: int,
-  /*
-   * Width of characters in minimap, in pixels
-   */
-  minimapCharacterWidth: int,
-  /*
-   * Height of characters in minimap, in pixels
-   */
-  minimapCharacterHeight: int,
-  /*
-   * Number of pixels between each line in the minimap
-   */
-  minimapLineSpacing: int,
-  scrollBarThickness: int,
-  minimapMaxColumn: int,
-  tabHeight: int,
-  /*
-   * The line count considered a 'large file' - if a file exceeds this limit,
-   * some features like syntax highlighting will be disabled.
-   */
-  largeFileLineCountThreshold: int,
-  notificationWidth: int,
-};
+let minimumFontSize = 6;
+let defaultFontSize = 14;
 
-let default: t = {
-  fontAwesomeRegularPath: "FontAwesome5FreeRegular.otf",
-  fontAwesomeSolidPath: "FontAwesome5FreeSolid.otf",
-  minimapPadding: 0,
-  minimapCharacterWidth: 1,
-  minimapCharacterHeight: 2,
-  minimapLineSpacing: 1,
-  scrollBarThickness: 15,
-  minimapMaxColumn: 120,
-  tabHeight: 35,
-  notificationWidth: 300,
+let fontAwesomeRegularPath = "FontAwesome5FreeRegular.otf";
+let fontAwesomeSolidPath = "FontAwesome5FreeSolid.otf";
 
-  /*
-   * The threshold we set right now is artificially low,
-   * because our current textmate highlighting strategy is very slow.
-   * We'll switch to a native strategy, and bump this up.
-   */
-  largeFileLineCountThreshold: 1000,
-};
+/* Horizontal padding on each side of the minimap */
+let minimapPadding = 0;
+
+/*
+ * Width of characters in minimap, in pixels
+ */
+let minimapCharacterWidth = 1;
+/*
+ * Height of characters in minimap, in pixels
+ */
+let minimapCharacterHeight = 2;
+/*
+ * Number of pixels between each line in the minimap
+ */
+let minimapLineSpacing = 1;
+let scrollBarThickness = 15;
+let minimapMaxColumn = 120;
+let tabHeight = 35;
+let notificationWidth = 300;
+
+/*
+ * The line count considered a 'large file' - if a file exceeds this limit,
+ * some features like syntax highlighting will be disabled.
+ * The threshold we set right now is artificially low,
+ * because our current textmate highlighting strategy is very slow.
+ * We'll switch to a native strategy, and bump this up.
+ */
+let largeFileLineCountThreshold = 1000;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -30,7 +30,7 @@ let create = (~bufferId=0, ()) => {
     bufferId,
     scrollX: 0.,
     scrollY: 0.,
-    minimapMaxColumnWidth: Constants.default.minimapMaxColumn,
+    minimapMaxColumnWidth: Constants.minimapMaxColumn,
     minimapScrollY: 0.,
     maxLineLength: 0,
     viewLines: 0,

--- a/src/Feature/Editor/EditorLayout.re
+++ b/src/Feature/Editor/EditorLayout.re
@@ -38,12 +38,12 @@ let getLayout =
       : 0.0;
 
   let minimapPadding =
-    isMinimapShown ? float_of_int(Constants.default.minimapPadding) : 0.0;
+    isMinimapShown ? float_of_int(Constants.minimapPadding) : 0.0;
 
   let availableWidthInPixels =
     pixelWidth
     -. lineNumberWidthInPixels
-    -. float_of_int(Constants.default.scrollBarThickness)
+    -. float_of_int(Constants.scrollBarThickness)
     -. minimapPadding
     *. 2.;
 
@@ -58,10 +58,7 @@ let getLayout =
        */
       int_of_float(
         availableWidthInPixels
-        /. (
-          characterWidth
-          +. float_of_int(Constants.default.minimapCharacterWidth)
-        ),
+        /. (characterWidth +. float_of_int(Constants.minimapCharacterWidth)),
       );
     } else {
       int_of_float(availableWidthInPixels /. characterWidth);
@@ -76,7 +73,7 @@ let getLayout =
     };
 
   let minimapWidthInPixels =
-    Constants.default.minimapCharacterWidth * minimapWidthInCharacters;
+    Constants.minimapCharacterWidth * minimapWidthInCharacters;
 
   /* Recalculate available buffer width - might be extra room if minimap is truncated! */
   let availableBufferWidth =
@@ -94,8 +91,7 @@ let getLayout =
       ? int_of_float(
           pixelHeight
           /. float_of_int(
-               Constants.default.minimapCharacterHeight
-               + Constants.default.minimapLineSpacing,
+               Constants.minimapCharacterHeight + Constants.minimapLineSpacing,
              ),
         )
       : 0;
@@ -105,7 +101,7 @@ let getLayout =
     -. bufferWidthInPixels
     -. float_of_int(minimapWidthInPixels)
     -. lineNumberWidthInPixels
-    -. float_of_int(Constants.default.scrollBarThickness)
+    -. float_of_int(Constants.scrollBarThickness)
     -. minimapPadding
     *. 2.;
 

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -447,7 +447,7 @@ let%component make =
     layout.lineNumberWidthInPixels +. layout.bufferWidthInPixels;
 
   let minimapPixelWidth =
-    layout.minimapWidthInPixels + Constants.default.minimapPadding * 2;
+    layout.minimapWidthInPixels + Constants.minimapPadding * 2;
   let minimapViewStyle =
     Style.[
       position(`Absolute),
@@ -463,7 +463,7 @@ let%component make =
       position(`Absolute),
       top(0),
       left(int_of_float(bufferPixelWidth +. float(minimapPixelWidth))),
-      width(Constants.default.scrollBarThickness),
+      width(Constants.scrollBarThickness),
       backgroundColor(theme.scrollbarSliderBackground),
       bottom(0),
     ];
@@ -473,7 +473,7 @@ let%component make =
       position(`Absolute),
       bottom(0),
       left(int_of_float(layout.lineNumberWidthInPixels)),
-      height(Constants.default.scrollBarThickness),
+      height(Constants.scrollBarThickness),
       width(int_of_float(layout.bufferWidthInPixels)),
     ];
 
@@ -939,7 +939,7 @@ let%component make =
       <EditorVerticalScrollbar
         editor
         metrics
-        width={Constants.default.scrollBarThickness}
+        width=Constants.scrollBarThickness
         height={metrics.pixelHeight}
         diagnostics=diagnosticsMap
         theme

--- a/src/Feature/Editor/EditorVerticalScrollbar.re
+++ b/src/Feature/Editor/EditorVerticalScrollbar.re
@@ -81,7 +81,7 @@ let make =
              position(`Absolute),
              top(diagTop),
              right(0),
-             width(Constants.default.scrollBarThickness / 3),
+             width(Constants.scrollBarThickness / 3),
              height(cursorSize),
              backgroundColor(Colors.red),
            ];

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -39,9 +39,9 @@ let renderLine =
       let endPosition = Index.toZeroBased(token.endPosition);
       let tokenWidth = endPosition - startPosition;
 
-      let x = float(Constants.default.minimapCharacterWidth * startPosition);
-      let height = float(Constants.default.minimapCharacterHeight);
-      let width = float(tokenWidth * Constants.default.minimapCharacterWidth);
+      let x = float(Constants.minimapCharacterWidth * startPosition);
+      let height = float(Constants.minimapCharacterHeight);
+      let width = float(tokenWidth * Constants.minimapCharacterWidth);
 
       let emphasis = shouldHighlight(startPosition);
       let color =
@@ -111,10 +111,7 @@ let%component make =
                 (),
               ) => {
   let rowHeight =
-    float(
-      Constants.default.minimapCharacterHeight
-      + Constants.default.minimapLineSpacing,
-    );
+    float(Constants.minimapCharacterHeight + Constants.minimapLineSpacing);
 
   let%hook (mouseState, dispatch) =
     React.Hooks.reducer(~initialState, reducer);
@@ -122,8 +119,7 @@ let%component make =
   let getScrollTo = (mouseY: float) => {
     let totalHeight: int = Editor.getTotalSizeInPixels(editor, metrics);
     let visibleHeight: int = metrics.pixelHeight;
-    let offsetMouseY: int =
-      int_of_float(mouseY) - Constants.default.tabHeight;
+    let offsetMouseY: int = int_of_float(mouseY) - Constants.tabHeight;
     float(offsetMouseY) /. float(visibleHeight) *. float(totalHeight);
   };
 
@@ -147,8 +143,7 @@ let%component make =
   let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
     let scrollTo = getScrollTo(evt.mouseY);
     let minimapLineSize =
-      Constants.default.minimapLineSpacing
-      + Constants.default.minimapCharacterHeight;
+      Constants.minimapLineSpacing + Constants.minimapCharacterHeight;
     let linesInMinimap = metrics.pixelHeight / minimapLineSize;
     if (evt.button == Revery_Core.MouseButton.BUTTON_LEFT) {
       onScroll(scrollTo -. editor.scrollY -. float(linesInMinimap));
@@ -158,8 +153,7 @@ let%component make =
           evt => {
             let scrollTo = getScrollTo(evt.mouseY);
             let minimapLineSize =
-              Constants.default.minimapLineSpacing
-              + Constants.default.minimapCharacterHeight;
+              Constants.minimapLineSpacing + Constants.minimapCharacterHeight;
             let linesInMinimap = metrics.pixelHeight / minimapLineSize;
             onScroll(scrollTo -. float(linesInMinimap));
           },
@@ -199,7 +193,7 @@ let%component make =
             rowHeight
             *. float(Index.toZeroBased(cursorPosition.line))
             -. scrollY,
-          ~height=float(Constants.default.minimapCharacterHeight),
+          ~height=float(Constants.minimapCharacterHeight),
           ~width=float(width),
           ~color=theme.editorLineHighlightBackground,
           (),
@@ -208,18 +202,18 @@ let%component make =
         let renderRange = (~color, ~offset, range: Range.t) =>
           {let startX =
              float(Index.toZeroBased(range.start.column))
-             *. float(Constants.default.minimapCharacterWidth)
+             *. float(Constants.minimapCharacterWidth)
              +. Constants.leftMargin
              +. Constants.gutterWidth;
            let endX =
              float(Index.toZeroBased(range.stop.column))
-             *. float(Constants.default.minimapCharacterWidth);
+             *. float(Constants.minimapCharacterWidth);
 
            Shapes.drawRect(
              ~transform,
              ~x=startX -. 1.0,
              ~y=offset -. 1.0,
-             ~height=float(Constants.default.minimapCharacterHeight) +. 2.0,
+             ~height=float(Constants.minimapCharacterHeight) +. 2.0,
              ~width=endX -. startX +. 2.,
              ~color,
              (),
@@ -228,17 +222,17 @@ let%component make =
         let renderUnderline = (~color, ~offset, range: Range.t) =>
           {let startX =
              float(Index.toZeroBased(range.start.column))
-             *. float(Constants.default.minimapCharacterWidth)
+             *. float(Constants.minimapCharacterWidth)
              +. Constants.leftMargin
              +. Constants.gutterWidth;
            let endX =
              float(Index.toZeroBased(range.stop.column))
-             *. float(Constants.default.minimapCharacterWidth);
+             *. float(Constants.minimapCharacterWidth);
 
            Shapes.drawRect(
              ~transform,
              ~x=startX -. 1.0,
-             ~y=offset +. float(Constants.default.minimapCharacterHeight),
+             ~y=offset +. float(Constants.minimapCharacterHeight),
              ~height=1.0,
              ~width=endX -. startX +. 2.,
              ~color,
@@ -286,8 +280,7 @@ let%component make =
                   ~transform,
                   ~x=0.,
                   ~y=rowHeight *. float(item) -. scrollY -. 1.0,
-                  ~height=
-                    float(Constants.default.minimapCharacterHeight) +. 2.0,
+                  ~height=float(Constants.minimapCharacterHeight) +. 2.0,
                   ~width=float(width),
                   ~color=Color.rgba(1.0, 0.0, 0.0, 0.3),
                   (),

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -35,8 +35,7 @@ let scrollTo = (view, newScrollY, metrics: EditorMetrics.t) => {
   let scrollPercentage =
     newScrollY /. (availableScroll -. float_of_int(metrics.pixelHeight));
   let minimapLineSize =
-    Constants.default.minimapCharacterWidth
-    + Constants.default.minimapCharacterHeight;
+    Constants.minimapCharacterWidth + Constants.minimapCharacterHeight;
   let linesInMinimap = metrics.pixelHeight / minimapLineSize;
   let availableMinimapScroll =
     max(view.viewLines - linesInMinimap, 0) * minimapLineSize;

--- a/src/Model/EditorVisibleRanges.re
+++ b/src/Model/EditorVisibleRanges.re
@@ -49,8 +49,7 @@ let getVisibleRangesForEditor = (editor: Editor.t, metrics: EditorMetrics.t) => 
   };
 
   let minimapLineHeight =
-    Constants.default.minimapCharacterHeight
-    + Constants.default.minimapLineSpacing;
+    Constants.minimapCharacterHeight + Constants.minimapLineSpacing;
 
   let minimapTopLine =
     int_of_float(editor.minimapScrollY /. float_of_int(minimapLineHeight));

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -25,7 +25,7 @@ module Styles = {
     justifyContent(`Center),
     alignItems(`Center),
     backgroundColor(theme.sideBarBackground),
-    height(Constants.default.tabHeight),
+    height(Constants.tabHeight),
   ];
 
   let item = (~isFocus, ~isActive, ~theme: Theme.t) => [

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -26,7 +26,7 @@ module Styles = {
     justifyContent(`Center),
     alignItems(`Center),
     backgroundColor(theme.sideBarBackground),
-    height(Core.Constants.default.tabHeight),
+    height(Core.Constants.tabHeight),
   ];
 };
 

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -58,7 +58,7 @@ let make =
       backgroundColor(theme.editorBackground),
       borderTop(~color=borderColor, ~width=2),
       borderBottom(~color=theme.editorBackground, ~width=2),
-      height(Constants.default.tabHeight),
+      height(Constants.tabHeight),
       minWidth(minWidth_),
       flexDirection(`Row),
       justifyContent(`Center),
@@ -83,7 +83,7 @@ let make =
   let iconContainerStyle =
     Style.[
       width(32),
-      height(Constants.default.tabHeight),
+      height(Constants.tabHeight),
       alignItems(`Center),
       justifyContent(`Center),
     ];

--- a/test/Core/ConfigurationParserTests.re
+++ b/test/Core/ConfigurationParserTests.re
@@ -4,6 +4,7 @@ open Oni_Core.ConfigurationValues;
 
 module Configuration = Oni_Core.Configuration;
 module ConfigurationParser = Oni_Core.ConfigurationParser;
+module Constants = Oni_Core.Constants;
 
 describe("ConfigurationParser", ({test, describe, _}) => {
   describe("per-filetype handling", ({test, _}) => {
@@ -112,6 +113,41 @@ describe("ConfigurationParser", ({test, describe, _}) => {
       )
     | Error(_) => expect.bool(false).toBe(true)
     };
+  });
+
+  let getExpectedValue = (valueGetter, configuration) => {
+    switch (ConfigurationParser.ofString(configuration)) {
+    | Ok(parsedConfig) => Configuration.getValue(valueGetter, parsedConfig)
+    | Error(_) => failwith("Unable to parse configuration: " ++ configuration)
+    };
+  };
+
+  let getFontSize = getExpectedValue(c => c.editorFontSize);
+
+  describe("editor.fontSize", ({test, _}) => {
+    test("parses string if possible", ({expect}) => {
+      let fontSize =
+        getFontSize({|
+        { "editor.fontSize": "12" }
+      |});
+      expect.int(fontSize).toBe(12);
+    });
+
+    test("uses default size if unable to parse", ({expect}) => {
+      let fontSize =
+        getFontSize({|
+        { "editor.fontSize": "true" }
+      |});
+      expect.int(fontSize).toBe(Constants.defaultFontSize);
+    });
+
+    test("does not allow value lower than minimum size", ({expect}) => {
+      let fontSize =
+        getFontSize({|
+        { "editor.fontSize": 1 }
+      |});
+      expect.int(fontSize).toBe(Constants.minimumFontSize);
+    });
   });
 
   test("vimUseSystemClipboard value", ({expect}) => {


### PR DESCRIPTION
__Issue:__ If there is an error parsing `editor.fontSize` today - the editor defaults to the font size to _`0`_, which is a horrible default. It's a really poor user experience to hit this when experimenting with configuration, and becomes difficult to recover from if you can't see the text.

__Fix:__ Add more resilient parsing for `editor.fontSize`:
- Handle floats
- Handle strings
- In the case where there is an error parsing, revert to default
- In the case where a value is too small, use the minimum size

Fixes #1286 - thanks for logging the issue, @johnridesabike!