### PR TITLE
Revery: Pick up additional perf improvements from Revery & Reason-Skia

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "aacafe5151320a5bccbc2613785ac8e1",
+  "checksum": "96d4da57ee9383574bb29240481f4b52",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#ed59d02@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+    "revery@github:revery-ui/revery#63fff7c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#ed59d02",
+      "version": "github:revery-ui/revery#63fff7c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#ed59d02" ]
+        "source": [ "github:revery-ui/revery#63fff7c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -133,7 +133,7 @@
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -150,14 +150,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.15.0@d41d8cd9": {
-      "id": "resolve@1.15.0@d41d8cd9",
+    "resolve@1.15.1@d41d8cd9": {
+      "id": "resolve@1.15.1@d41d8cd9",
       "name": "resolve",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz#sha1:1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz#sha1:27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
         ]
       },
       "overrides": [],
@@ -234,7 +234,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.15.0@d41d8cd9" ],
+      "dependencies": [ "resolve@1.15.1@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -312,13 +312,13 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#b588454",
+      "version": "github:revery-ui/reason-skia#7a753c6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#b588454" ]
+        "source": [ "github:revery-ui/reason-skia#7a753c6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1070,7 +1070,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+        "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "aacafe5151320a5bccbc2613785ac8e1",
+  "checksum": "96d4da57ee9383574bb29240481f4b52",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#ed59d02@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+    "revery@github:revery-ui/revery#63fff7c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#ed59d02",
+      "version": "github:revery-ui/revery#63fff7c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#ed59d02" ]
+        "source": [ "github:revery-ui/revery#63fff7c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -133,7 +133,7 @@
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -150,14 +150,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.15.0@d41d8cd9": {
-      "id": "resolve@1.15.0@d41d8cd9",
+    "resolve@1.15.1@d41d8cd9": {
+      "id": "resolve@1.15.1@d41d8cd9",
       "name": "resolve",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz#sha1:1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz#sha1:27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
         ]
       },
       "overrides": [],
@@ -234,7 +234,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.15.0@d41d8cd9" ],
+      "dependencies": [ "resolve@1.15.1@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -312,13 +312,13 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#b588454",
+      "version": "github:revery-ui/reason-skia#7a753c6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#b588454" ]
+        "source": [ "github:revery-ui/reason-skia#7a753c6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1070,7 +1070,7 @@
       "overrides": [],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+        "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "aacafe5151320a5bccbc2613785ac8e1",
+  "checksum": "96d4da57ee9383574bb29240481f4b52",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#ed59d02@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+    "revery@github:revery-ui/revery#63fff7c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#ed59d02",
+      "version": "github:revery-ui/revery#63fff7c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#ed59d02" ]
+        "source": [ "github:revery-ui/revery#63fff7c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -133,7 +133,7 @@
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -150,14 +150,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.15.0@d41d8cd9": {
-      "id": "resolve@1.15.0@d41d8cd9",
+    "resolve@1.15.1@d41d8cd9": {
+      "id": "resolve@1.15.1@d41d8cd9",
       "name": "resolve",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz#sha1:1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz#sha1:27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
         ]
       },
       "overrides": [],
@@ -234,7 +234,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.15.0@d41d8cd9" ],
+      "dependencies": [ "resolve@1.15.1@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -312,13 +312,13 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#b588454",
+      "version": "github:revery-ui/reason-skia#7a753c6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#b588454" ]
+        "source": [ "github:revery-ui/reason-skia#7a753c6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1070,7 +1070,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+        "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -234,7 +234,6 @@
     "reasonFuzz": "github:CrossR/reasonFuzz#d36e084",
     "pesy": "0.4.1",
     "@opam/ppx_tools_versioned": "5.2.3",
-    "reason-fontkit": "2.7.0",
     "@opam/camomile": "1.0.1",
     "@opam/ocamlfind": "1.8.1",
     "@opam/biniou": "1.2.0",
@@ -242,7 +241,7 @@
     "@opam/lwt_ppx": "1.2.2",
     "@opam/merlin-extend": "0.4",
     "reason-tree-sitter": "github:onivim/reason-tree-sitter#e2c571e",
-    "revery": "revery-ui/revery#ed59d02",
+    "revery": "revery-ui/revery#63fff7c",
     "reason-libvim": "onivim/reason-libvim#3782892",
     "editor-core-types": "onivim/editor-core-types#16dd98e",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
@@ -253,8 +252,7 @@
     "rench": "bryphe/rench#a976fe5",
     "@esy-ocaml/reason": "facebook/reason#8f71db0",
     "reason-textmate": "onivim/reason-textmate#5f0dc38",
-    "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
-    "reason-skia": "revery-ui/reason-skia#b588454"
+    "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d"
   },
   "devDependencies": {
     "ocaml": "~4.8.1",

--- a/src/Feature/Editor/BufferViewTokenizer.re
+++ b/src/Feature/Editor/BufferViewTokenizer.re
@@ -92,10 +92,7 @@ let getCharacterPositionAndWidth = (~viewOffset: int=0, line: BufferLine.t, i) =
 };
 
 let colorEqual = (c1: Color.t, c2: Color.t) => {
-  Float.equal(c1.r, c2.r)
-  && Float.equal(c1.g, c2.g)
-  && Float.equal(c1.b, c2.b)
-  && Float.equal(c1.a, c2.a);
+  Color.equals(c1, c2);
 };
 
 let tokenize = (~startIndex=0, ~endIndex, line, colorizer) => {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "46e2387b6da84d42bdc219a6af34ec1a",
+  "checksum": "92886f2877a316af93970c975199fb23",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -118,13 +118,13 @@
       "dependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#ed59d02@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+    "revery@github:revery-ui/revery#63fff7c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#ed59d02",
+      "version": "github:revery-ui/revery#63fff7c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#ed59d02" ]
+        "source": [ "github:revery-ui/revery#63fff7c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -133,7 +133,7 @@
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -150,14 +150,14 @@
       ],
       "devDependencies": []
     },
-    "resolve@1.15.0@d41d8cd9": {
-      "id": "resolve@1.15.0@d41d8cd9",
+    "resolve@1.15.1@d41d8cd9": {
+      "id": "resolve@1.15.1@d41d8cd9",
       "name": "resolve",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz#sha1:1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz#sha1:27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
         ]
       },
       "overrides": [],
@@ -234,7 +234,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "resolve@1.15.0@d41d8cd9" ],
+      "dependencies": [ "resolve@1.15.1@d41d8cd9" ],
       "devDependencies": []
     },
     "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9": {
@@ -312,13 +312,13 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#b588454@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#7a753c6@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#b588454",
+      "version": "github:revery-ui/reason-skia#7a753c6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#b588454" ]
+        "source": [ "github:revery-ui/reason-skia#7a753c6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1070,7 +1070,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-        "revery@github:revery-ui/revery#ed59d02@d41d8cd9",
+        "revery@github:revery-ui/revery#63fff7c@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#d36e084@d41d8cd9",


### PR DESCRIPTION
Pick up several performance improvements in the Skia layer:
- `recalculate` phase improvements: https://github.com/revery-ui/revery/pull/754
- Caching of paint objects for nodes: https://github.com/revery-ui/revery/pull/756
- Speed up performance of setting Paint color: https://github.com/revery-ui/revery/pull/755

__TODO:__
- [x] Pick up commit from Revery master once all fixes are in