### PR TITLE
SCM: Initial Pane Experience

### DIFF
--- a/src/Components/FontIcon.re
+++ b/src/Components/FontIcon.re
@@ -8,6 +8,19 @@ open Revery.UI;
 open Oni_Core.CamomileBundled.Camomile;
 module ZedBundled = Oni_Core.ZedBundled;
 
+module Styles = {
+  open Style;
+
+  let text = (~fontFamily, ~fontSize, ~color, ~backgroundColor, ~margin) => [
+    Style.fontFamily(fontFamily),
+    Style.fontSize(fontSize),
+    Style.color(color),
+    Style.backgroundColor(backgroundColor),
+    Style.margin(margin),
+    textWrap(Revery.TextWrapping.NoWrap),
+  ];
+};
+
 let codeToIcon = icon => ZedBundled.singleton(UChar.of_int(icon));
 
 let make =
@@ -22,14 +35,11 @@ let make =
     ) =>
   <Text
     text={codeToIcon(icon)}
-    style=[
-      Style.fontFamily(fontFamily),
-      Style.fontSize(fontSize),
-      Style.color(color),
-      Style.backgroundColor(backgroundColor),
-      Style.margin(margin),
-      Style.height(fontSize |> int_of_float),
-      Style.width(fontSize |> int_of_float),
-      Style.textWrap(Revery.TextWrapping.NoWrap),
-    ]
+    style={Styles.text(
+      ~fontFamily,
+      ~fontSize,
+      ~color,
+      ~backgroundColor,
+      ~margin,
+    )}
   />;

--- a/src/Components/FontIcon.re
+++ b/src/Components/FontIcon.re
@@ -11,12 +11,10 @@ module ZedBundled = Oni_Core.ZedBundled;
 module Styles = {
   open Style;
 
-  let text = (~fontFamily, ~fontSize, ~color, ~backgroundColor, ~margin) => [
+  let text = (~fontFamily, ~fontSize, ~color) => [
     Style.fontFamily(fontFamily),
     Style.fontSize(fontSize),
     Style.color(color),
-    Style.backgroundColor(backgroundColor),
-    Style.margin(margin),
     textWrap(Revery.TextWrapping.NoWrap),
   ];
 };
@@ -24,22 +22,8 @@ module Styles = {
 let codeToIcon = icon => ZedBundled.singleton(UChar.of_int(icon));
 
 let make =
-    (
-      ~icon,
-      ~fontFamily=FontAwesome.fontFamily,
-      ~fontSize=15.,
-      ~backgroundColor,
-      ~color,
-      ~margin=0,
-      (),
-    ) =>
+    (~icon, ~fontFamily=FontAwesome.fontFamily, ~fontSize=15., ~color, ()) =>
   <Text
     text={codeToIcon(icon)}
-    style={Styles.text(
-      ~fontFamily,
-      ~fontSize,
-      ~color,
-      ~backgroundColor,
-      ~margin,
-    )}
+    style={Styles.text(~fontFamily, ~fontSize, ~color)}
   />;

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -37,6 +37,7 @@ module Log = Kernel.Log;
 module Ripgrep = Ripgrep;
 module Scheduler = Scheduler;
 module SCMDecoration = SCMDecoration;
+module SCMResource = SCMResource;
 module Setup = Setup;
 module ShellUtility = ShellUtility;
 module StringMap = Kernel.StringMap;

--- a/src/Core/SCMResource.re
+++ b/src/Core/SCMResource.re
@@ -1,0 +1,12 @@
+[@deriving show({with_path: false})]
+type t = {
+  handle: int,
+  uri: Uri.t,
+  icons: list(string),
+  tooltip: string,
+  strikeThrough: bool,
+  faded: bool,
+  source: option(string),
+  letter: option(string),
+  color: option(string),
+};

--- a/src/Core/Utility/ListEx.re
+++ b/src/Core/Utility/ListEx.re
@@ -50,3 +50,21 @@ let rec sublist = (beginning, terminus, l) =>
       [h, ...tail];
     };
   };
+
+// Like Array.prototype.splice in JavaScript, but for lists
+let splice = (~start, ~deleteCount, ~additions, source) => {
+  let rec loop = (i, source, deleteCount, additions, acc) =>
+    switch (source) {
+    | [item, ...rest] when i < start =>
+      loop(i + 1, rest, deleteCount, additions, [item, ...acc])
+    | [_, ...rest] when deleteCount > 0 =>
+      loop(i + 1, rest, deleteCount - 1, additions, acc)
+    | _ =>
+      acc
+      |> List.rev_append(additions)
+      |> List.rev_append(source)
+      |> List.rev
+    };
+
+  loop(0, source, deleteCount, additions, []);
+};

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -34,6 +34,16 @@ type msg =
     })
   // acceptInputCommand: option(_),
   // statusBarCommands: option(_),
+  | RegisterSCMResourceGroup({
+      provider: int,
+      handle: int,
+      id: string,
+      label: string,
+    })
+  | UnregisterSCMResourceGroup({
+      provider: int,
+      handle: int,
+    })
   | RegisterTextContentProvider({
       handle: int,
       scheme: string,
@@ -213,6 +223,18 @@ let start =
             features |> member("commitTemplate") |> to_string_option,
         }),
       );
+      Ok(None);
+
+    | (
+        "MainThreadSCM",
+        "$registerGroup",
+        [`Int(provider), `Int(handle), `String(id), `String(label)],
+      ) =>
+      dispatch(RegisterSCMResourceGroup({provider, handle, id, label}));
+      Ok(None);
+
+    | ("MainThreadSCM", "$unregisterGroup", [`Int(handle), `Int(provider)]) =>
+      dispatch(UnregisterSCMResourceGroup({provider, handle}));
       Ok(None);
 
     | (

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -20,6 +20,16 @@ type msg =
     })
   // acceptInputCommand: option(_),
   // statusBarCommands: option(_),
+  | RegisterSCMResourceGroup({
+      provider: int,
+      handle: int,
+      id: string,
+      label: string,
+    })
+  | UnregisterSCMResourceGroup({
+      provider: int,
+      handle: int,
+    })
   | RegisterTextContentProvider({
       handle: int,
       scheme: string,

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -30,6 +30,13 @@ type msg =
       provider: int,
       handle: int,
     })
+  | SpliceSCMResourceStates({
+      provider: int,
+      group: int,
+      start: int,
+      deleteCount: int,
+      additions: list(Core.SCMResource.t),
+    })
   | RegisterTextContentProvider({
       handle: int,
       scheme: string,

--- a/src/Extensions/ExtHostProtocol.re
+++ b/src/Extensions/ExtHostProtocol.re
@@ -520,6 +520,41 @@ module IncomingNotifications = {
       };
     };
   };
+
+  module SCM = {
+    let parseResource =
+      fun
+      | `List([
+          `Int(handle),
+          uri,
+          `List(icons),
+          `String(tooltip),
+          `Bool(strikeThrough),
+          `Bool(faded),
+          source,
+          letter,
+          color,
+        ]) =>
+        SCMResource.{
+          handle,
+          uri: Uri.of_yojson(uri) |> Stdlib.Result.get_ok,
+          icons:
+            List.filter_map(
+              fun
+              | `String(icon) => Some(icon)
+              | _ => None,
+              icons,
+            ),
+          tooltip,
+          strikeThrough,
+          faded,
+          source: source |> Yojson.Safe.Util.to_string_option,
+          letter: letter |> Yojson.Safe.Util.to_string_option,
+          color: Yojson.Safe.Util.(color |> member("id") |> to_string_option),
+        }
+
+      | _ => failwith("Unexpected json for scm resource");
+  };
 };
 
 module OutgoingNotifications = {

--- a/src/Feature/Editor/CompletionsView.re
+++ b/src/Feature/Editor/CompletionsView.re
@@ -98,6 +98,7 @@ module Styles = {
     flexGrow(0),
     backgroundColor(color),
     width(25),
+    padding(4),
   ];
 
   let label = [flexGrow(1), margin(4)];
@@ -165,9 +166,7 @@ let itemView =
     <View style={Styles.icon(~color=iconColor)}>
       <FontIcon
         icon
-        backgroundColor=iconColor
         color={theme.editorSuggestWidgetBackground}
-        margin=4
         // Not sure why, but specifying a font size fails to render the icon!
         // Might be a bug with Revery font loading / re - rendering in this case?
       />

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -133,7 +133,7 @@ type t =
   | SearchHotkey
   | Search(Feature_Search.msg)
   | Sneak(Sneak.action)
-  | PaneTabClicked(Pane.paneType)
+  | PaneTabClicked(Pane.pane)
   | VimDirectoryChanged(string)
   | WindowCloseBlocked
   | WindowCloseDiscardConfirmed

--- a/src/Model/ActivityBar.re
+++ b/src/Model/ActivityBar.re
@@ -2,4 +2,5 @@
 type action =
   | FileExplorerClick
   | SearchClick
+  | SCMClick
   | ExtensionsClick;

--- a/src/Model/Pane.re
+++ b/src/Model/Pane.re
@@ -5,25 +5,16 @@
  */
 
 [@deriving show({with_path: false})]
-type paneType =
+type pane =
   | Search
   | Diagnostics
   | Notifications;
 
 type t = {
-  activePane: paneType,
+  selected: pane,
   isOpen: bool,
 };
 
-let initial = {activePane: Search, isOpen: false};
+let initial = {selected: Search, isOpen: false};
 
-let getType = pane => !pane.isOpen ? None : Some(pane.activePane);
-
-let isOpen = pane => pane.isOpen;
-
-let isTypeOpen = (paneType, pane) =>
-  pane.isOpen && pane.activePane == paneType;
-
-let setClosed = pane => {...pane, isOpen: false};
-
-let setOpen = paneType => {activePane: paneType, isOpen: true};
+let isVisible = (pane, model) => model.isOpen && model.selected == pane;

--- a/src/Model/Pane.rei
+++ b/src/Model/Pane.rei
@@ -5,18 +5,16 @@
  */
 
 [@deriving show({with_path: false})]
-type paneType =
+type pane =
   | Search
   | Diagnostics
   | Notifications;
 
-type t;
+type t = {
+  selected: pane,
+  isOpen: bool,
+};
 
 let initial: t;
 
-let getType: t => option(paneType);
-let isOpen: t => bool;
-let isTypeOpen: (paneType, t) => bool;
-
-let setClosed: t => t;
-let setOpen: paneType => t;
+let isVisible: (pane, t) => bool;

--- a/src/Model/SCM.re
+++ b/src/Model/SCM.re
@@ -1,6 +1,6 @@
 open Oni_Core;
 
-module Group = {
+module ResourceGroup = {
   [@deriving show({with_path: false})]
   type t = {
     handle: int,
@@ -17,7 +17,7 @@ module Provider = {
     id: string,
     label: string,
     rootUri: option(Uri.t),
-    groups: list(Group.t),
+    resourceGroups: list(ResourceGroup.t),
     hasQuickDiffProvider: bool,
     count: int,
     commitTemplate: string,
@@ -49,6 +49,16 @@ type msg =
       rootUri: option(Uri.t),
     })
   | LostProvider({handle: int})
+  | NewResourceGroup({
+      provider: int,
+      handle: int,
+      id: string,
+      label: string,
+    })
+  | LostResourceGroup({
+      provider: int,
+      handle: int,
+    })
   | CountChanged({
       handle: int,
       count: int,

--- a/src/Model/SCM.re
+++ b/src/Model/SCM.re
@@ -7,6 +7,7 @@ module ResourceGroup = {
     id: string,
     label: string,
     hideWhenEmpty: bool,
+    resources: list(SCMResource.t),
   };
 };
 
@@ -58,6 +59,13 @@ type msg =
   | LostResourceGroup({
       provider: int,
       handle: int,
+    })
+  | ResourceStatesChanged({
+      provider: int,
+      group: int,
+      spliceStart: int,
+      deleteCount: int,
+      additions: list(SCMResource.t),
     })
   | CountChanged({
       handle: int,

--- a/src/Model/SideBar.re
+++ b/src/Model/SideBar.re
@@ -1,5 +1,6 @@
 type sideBarType =
   | FileExplorer
+  | SCM
   | Extensions;
 
 type t = {
@@ -7,7 +8,7 @@ type t = {
   activeType: sideBarType,
 };
 
-let initial = {isOpen: true, activeType: FileExplorer};
+let initial = {isOpen: true, activeType: SCM};
 
 let setOpen = sideBarType => {isOpen: true, activeType: sideBarType};
 

--- a/src/Model/SideBar.re
+++ b/src/Model/SideBar.re
@@ -1,26 +1,20 @@
-type sideBarType =
+type pane =
   | FileExplorer
   | SCM
   | Extensions;
 
 type t = {
   isOpen: bool,
-  activeType: sideBarType,
+  selected: pane,
 };
 
-let initial = {isOpen: true, activeType: SCM};
+let initial = {isOpen: true, selected: FileExplorer};
 
-let setOpen = sideBarType => {isOpen: true, activeType: sideBarType};
+let isVisible = (pane, model) => model.isOpen && model.selected == pane;
 
-let setClosed = (sideBar: t) => {...sideBar, isOpen: false};
-
-let getType = sideBar => sideBar.activeType;
-
-let isOpen = sideBar => sideBar.isOpen;
-
-let toggle = (sideBarType, state: t) =>
-  if (sideBarType == state.activeType) {
+let toggle = (pane, state: t) =>
+  if (pane == state.selected) {
     {...state, isOpen: !state.isOpen};
   } else {
-    {isOpen: true, activeType: sideBarType};
+    {isOpen: true, selected: pane};
   };

--- a/src/Model/SideBar.rei
+++ b/src/Model/SideBar.rei
@@ -1,13 +1,14 @@
-type sideBarType =
+type pane =
   | FileExplorer
   | SCM
   | Extensions;
 
-type t;
+type t = {
+  isOpen: bool,
+  selected: pane,
+};
 
 let initial: t;
-let setOpen: sideBarType => t;
-let setClosed: t => t;
-let getType: t => sideBarType;
-let isOpen: t => bool;
-let toggle: (sideBarType, t) => t;
+
+let isVisible: (pane, t) => bool;
+let toggle: (pane, t) => t;

--- a/src/Model/SideBar.rei
+++ b/src/Model/SideBar.rei
@@ -1,5 +1,6 @@
 type sideBarType =
   | FileExplorer
+  | SCM
   | Extensions;
 
 type t;

--- a/src/Store/PaneReducer.re
+++ b/src/Store/PaneReducer.re
@@ -4,8 +4,15 @@
 
 open Oni_Model;
 open Actions;
+
 let showSearchPane = (state: State.t, isSearchFocused) => {
-  let newState = {...state, pane: Pane.setOpen(Pane.Search)};
+  let newState = {
+    ...state,
+    pane: {
+      isOpen: true,
+      selected: Search,
+    },
+  };
 
   if (isSearchFocused) {
     newState;
@@ -15,7 +22,13 @@ let showSearchPane = (state: State.t, isSearchFocused) => {
 };
 
 let hideSearchPane = (state: State.t, isSearchFocused) => {
-  let newState = {...state, pane: Pane.setClosed(state.pane)};
+  let newState = {
+    ...state,
+    pane: {
+      ...state.pane,
+      isOpen: false,
+    },
+  };
 
   if (isSearchFocused) {
     newState |> FocusManager.pop(Search);
@@ -24,51 +37,57 @@ let hideSearchPane = (state: State.t, isSearchFocused) => {
   };
 };
 
-let closePane = (state: State.t) => {
-  ...state,
-  pane: Pane.setClosed(state.pane),
-};
-
 let openDiagnosticsPane = (state: State.t) => {
   ...state,
-  pane: Pane.setOpen(Pane.Diagnostics),
+  pane: {
+    isOpen: true,
+    selected: Diagnostics,
+  },
 };
 
 let openNotificationsPane = (state: State.t) => {
   ...state,
-  pane: Pane.setOpen(Pane.Notifications),
+  pane: {
+    isOpen: true,
+    selected: Notifications,
+  },
+};
+
+let closePane = (state: State.t) => {
+  ...state,
+  pane: {
+    ...state.pane,
+    isOpen: false,
+  },
 };
 
 let reduce = (action: Actions.t, state: State.t) =>
-  switch (action, Pane.getType(state.pane)) {
-  | (SearchHotkey, Some(Pane.Search))
-  | (ActivityBar(ActivityBar.SearchClick), Some(Pane.Search)) =>
+  switch (action) {
+  | SearchHotkey
+  | ActivityBar(SearchClick) when Pane.isVisible(Search, state.pane) =>
     FocusManager.current(state) == Search
       ? hideSearchPane(state, true) : showSearchPane(state, false)
 
-  | (SearchHotkey, _)
-  | (PaneTabClicked(Pane.Search), _)
-  | (ActivityBar(ActivityBar.SearchClick), _) =>
+  | SearchHotkey
+  | PaneTabClicked(Search)
+  | ActivityBar(SearchClick) =>
     showSearchPane(state, FocusManager.current(state) == Search)
 
-  | (DiagnosticsHotKey, Some(Pane.Diagnostics))
-  | (StatusBar(StatusBarModel.DiagnosticsClicked), Some(Pane.Diagnostics)) =>
+  | DiagnosticsHotKey
+  | StatusBar(DiagnosticsClicked)
+      when Pane.isVisible(Diagnostics, state.pane) =>
     closePane(state)
 
-  | (DiagnosticsHotKey, _)
-  | (PaneTabClicked(Pane.Diagnostics), _)
-  | (StatusBar(StatusBarModel.DiagnosticsClicked), _) =>
-    openDiagnosticsPane(state)
+  | DiagnosticsHotKey
+  | PaneTabClicked(Diagnostics)
+  | StatusBar(DiagnosticsClicked) => openDiagnosticsPane(state)
 
-  | (
-      StatusBar(StatusBarModel.NotificationCountClicked),
-      Some(Pane.Notifications),
-    ) =>
+  | StatusBar(NotificationCountClicked)
+      when Pane.isVisible(Notifications, state.pane) =>
     closePane(state)
 
-  | (PaneTabClicked(Pane.Notifications), _)
-  | (StatusBar(StatusBarModel.NotificationCountClicked), _) =>
-    openNotificationsPane(state)
+  | PaneTabClicked(Notifications)
+  | StatusBar(NotificationCountClicked) => openNotificationsPane(state)
 
   | _ => state
   };

--- a/src/Store/SideBarReducer.re
+++ b/src/Store/SideBarReducer.re
@@ -9,6 +9,7 @@ let reduce = (state: SideBar.t, action: Actions.t) => {
   switch (action) {
   | ActivityBar(ActivityBar.FileExplorerClick) =>
     SideBar.toggle(SideBar.FileExplorer, state)
+  | ActivityBar(ActivityBar.SCMClick) => SideBar.toggle(SideBar.SCM, state)
   | ActivityBar(ActivityBar.ExtensionsClick) =>
     SideBar.toggle(SideBar.Extensions, state)
   | _ => state

--- a/src/UI/Accordion.re
+++ b/src/UI/Accordion.re
@@ -61,7 +61,6 @@ let make =
         fontSize=Constants.arrowSize
         color=Colors.white
         icon={expanded ? FontAwesome.caretDown : FontAwesome.caretRight}
-        backgroundColor=Colors.transparentWhite
       />
       <Text style={Styles.titleText(~theme, ~font=uiFont)} text=title />
     </View>

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -30,7 +30,7 @@ let item = (~onClick, ~theme: Theme.t, ~icon, ()) => {
   let color = theme.activityBarForeground;
 
   <Sneakable onClick style=Styles.item>
-    <FontIcon backgroundColor color icon />
+    <FontIcon backgroundColor color fontSize=22. icon />
   </Sneakable>;
 };
 

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -1,11 +1,34 @@
 open Revery.UI;
 
+open Oni_Core;
 open Oni_Model;
 
 module FontAwesome = Oni_Components.FontAwesome;
 module FontIcon = Oni_Components.FontIcon;
 
-let button = Style.[marginVertical(24)];
+module Styles = {
+  open Style;
+
+  let container = (~theme: Theme.t, ~offsetX) => [
+    top(0),
+    bottom(0),
+    backgroundColor(theme.activityBarBackground),
+    alignItems(`Center),
+    width(50),
+    transform(Transform.[TranslateX(offsetX)]),
+  ];
+
+  let button = [marginVertical(24)];
+};
+
+let item = (~onClick, ~theme: Theme.t, ~icon, ()) => {
+  let backgroundColor = theme.activityBarBackground;
+  let color = theme.activityBarForeground;
+
+  <Sneakable onClick style=Styles.button>
+    <FontIcon backgroundColor color icon />
+  </Sneakable>;
+};
 
 let onExplorerClick = _ => {
   GlobalContext.current().dispatch(Actions.ActivityBar(FileExplorerClick));
@@ -31,33 +54,13 @@ let animation =
     |> delay(Revery.Time.milliseconds(75))
   );
 
-let%component make = (~state: State.t, ()) => {
-  let bg = state.theme.activityBarBackground;
-  let fg = state.theme.activityBarForeground;
+let%component make = (~theme, ()) => {
+  let%hook (offsetX, _animationState, _reset) = Hooks.animation(animation);
 
-  let%hook (transition, _animationState, _reset) =
-    Hooks.animation(animation, ~active=true);
-
-  <View
-    style=Style.[
-      top(0),
-      bottom(0),
-      backgroundColor(bg),
-      alignItems(`Center),
-      width(50),
-      transform(Transform.[TranslateX(transition)]),
-    ]>
-    <Sneakable onClick=onExplorerClick style=button>
-      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.copy />
-    </Sneakable>
-    <Sneakable onClick=onSearchClick style=button>
-      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.search />
-    </Sneakable>
-    <Sneakable onClick=onSCMClick style=button>
-      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.codeBranch />
-    </Sneakable>
-    <Sneakable onClick=onExtensionsClick style=button>
-      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.thLarge />
-    </Sneakable>
+  <View style={Styles.container(~theme, ~offsetX)}>
+    <item onClick=onExplorerClick theme icon=FontAwesome.copy />
+    <item onClick=onSearchClick theme icon=FontAwesome.search />
+    <item onClick=onSCMClick theme icon=FontAwesome.codeBranch />
+    <item onClick=onExtensionsClick theme icon=FontAwesome.thLarge />
   </View>;
 };

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -15,6 +15,10 @@ let onSearchClick = _ => {
   GlobalContext.current().dispatch(Actions.ActivityBar(SearchClick));
 };
 
+let onSCMClick = _ => {
+  GlobalContext.current().dispatch(Actions.ActivityBar(SCMClick));
+};
+
 let onExtensionsClick = _ => {
   GlobalContext.current().dispatch(Actions.ActivityBar(ExtensionsClick));
 };
@@ -48,6 +52,9 @@ let%component make = (~state: State.t, ()) => {
     </Sneakable>
     <Sneakable onClick=onSearchClick style=button>
       <FontIcon backgroundColor=bg color=fg icon=FontAwesome.search />
+    </Sneakable>
+    <Sneakable onClick=onSCMClick style=button>
+      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.codeBranch />
     </Sneakable>
     <Sneakable onClick=onExtensionsClick style=button>
       <FontIcon backgroundColor=bg color=fg icon=FontAwesome.box />

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -18,24 +18,29 @@ module Styles = {
     transform(Transform.[TranslateX(offsetX)]),
   ];
 
-  let item = (~isHovered, ~theme: Theme.t) => [
+  let item = (~isHovered, ~isActive, ~theme: Theme.t) => [
     height(50),
     width(50),
     justifyContent(`Center),
     alignItems(`Center),
+    borderLeft(
+      ~width=2,
+      ~color=
+        isActive ? theme.oniNormalModeBackground : Colors.transparentWhite,
+    ),
     backgroundColor(
       isHovered ? theme.menuSelectionBackground : Colors.transparentWhite,
     ),
   ];
 };
 
-let%component item = (~onClick, ~theme: Theme.t, ~icon, ()) => {
+let%component item = (~onClick, ~theme: Theme.t, ~isActive, ~icon, ()) => {
   let%hook (isHovered, setHovered) = Hooks.state(false);
   let onMouseOver = _ => setHovered(_ => true);
   let onMouseOut = _ => setHovered(_ => false);
 
   <View onMouseOver onMouseOut>
-    <Sneakable onClick style={Styles.item(~isHovered, ~theme)}>
+    <Sneakable onClick style={Styles.item(~isHovered, ~isActive, ~theme)}>
       <FontIcon color={theme.activityBarForeground} fontSize=22. icon />
     </Sneakable>
   </View>;
@@ -65,13 +70,36 @@ let animation =
     |> delay(Revery.Time.milliseconds(75))
   );
 
-let%component make = (~theme, ()) => {
+let%component make = (~theme, ~sideBar: SideBar.t, ~pane: Pane.t, ()) => {
   let%hook (offsetX, _animationState, _reset) = Hooks.animation(animation);
 
+  let isSidebarVisible = it => SideBar.isVisible(it, sideBar);
+  let isPaneVisible = it => Pane.isVisible(it, pane);
+
   <View style={Styles.container(~theme, ~offsetX)}>
-    <item onClick=onExplorerClick theme icon=FontAwesome.copy />
-    <item onClick=onSearchClick theme icon=FontAwesome.search />
-    <item onClick=onSCMClick theme icon=FontAwesome.codeBranch />
-    <item onClick=onExtensionsClick theme icon=FontAwesome.thLarge />
+    <item
+      onClick=onExplorerClick
+      theme
+      isActive={isSidebarVisible(FileExplorer)}
+      icon=FontAwesome.copy
+    />
+    <item
+      onClick=onSearchClick
+      theme
+      isActive={isPaneVisible(Search)}
+      icon=FontAwesome.search
+    />
+    <item
+      onClick=onSCMClick
+      theme
+      isActive={isSidebarVisible(SCM)}
+      icon=FontAwesome.codeBranch
+    />
+    <item
+      onClick=onExtensionsClick
+      theme
+      isActive={isSidebarVisible(Extensions)}
+      icon=FontAwesome.thLarge
+    />
   </View>;
 };

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -14,18 +14,22 @@ module Styles = {
     bottom(0),
     backgroundColor(theme.activityBarBackground),
     alignItems(`Center),
-    width(50),
     transform(Transform.[TranslateX(offsetX)]),
   ];
 
-  let button = [marginVertical(24)];
+  let item = [
+    height(50),
+    width(50),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
 };
 
 let item = (~onClick, ~theme: Theme.t, ~icon, ()) => {
   let backgroundColor = theme.activityBarBackground;
   let color = theme.activityBarForeground;
 
-  <Sneakable onClick style=Styles.button>
+  <Sneakable onClick style=Styles.item>
     <FontIcon backgroundColor color icon />
   </Sneakable>;
 };

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -25,14 +25,10 @@ module Styles = {
   ];
 };
 
-let item = (~onClick, ~theme: Theme.t, ~icon, ()) => {
-  let backgroundColor = theme.activityBarBackground;
-  let color = theme.activityBarForeground;
-
+let item = (~onClick, ~theme: Theme.t, ~icon, ()) =>
   <Sneakable onClick style=Styles.item>
-    <FontIcon backgroundColor color fontSize=22. icon />
+    <FontIcon color={theme.activityBarForeground} fontSize=22. icon />
   </Sneakable>;
-};
 
 let onExplorerClick = _ => {
   GlobalContext.current().dispatch(Actions.ActivityBar(FileExplorerClick));

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -1,3 +1,4 @@
+open Revery;
 open Revery.UI;
 
 open Oni_Core;
@@ -17,18 +18,28 @@ module Styles = {
     transform(Transform.[TranslateX(offsetX)]),
   ];
 
-  let item = [
+  let item = (~isHovered, ~theme: Theme.t) => [
     height(50),
     width(50),
     justifyContent(`Center),
     alignItems(`Center),
+    backgroundColor(
+      isHovered ? theme.menuSelectionBackground : Colors.transparentWhite,
+    ),
   ];
 };
 
-let item = (~onClick, ~theme: Theme.t, ~icon, ()) =>
-  <Sneakable onClick style=Styles.item>
-    <FontIcon color={theme.activityBarForeground} fontSize=22. icon />
-  </Sneakable>;
+let%component item = (~onClick, ~theme: Theme.t, ~icon, ()) => {
+  let%hook (isHovered, setHovered) = Hooks.state(false);
+  let onMouseOver = _ => setHovered(_ => true);
+  let onMouseOut = _ => setHovered(_ => false);
+
+  <View onMouseOver onMouseOut>
+    <Sneakable onClick style={Styles.item(~isHovered, ~theme)}>
+      <FontIcon color={theme.activityBarForeground} fontSize=22. icon />
+    </Sneakable>
+  </View>;
+};
 
 let onExplorerClick = _ => {
   GlobalContext.current().dispatch(Actions.ActivityBar(FileExplorerClick));

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -48,7 +48,7 @@ let%component make = (~state: State.t, ()) => {
       transform(Transform.[TranslateX(transition)]),
     ]>
     <Sneakable onClick=onExplorerClick style=button>
-      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.file />
+      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.copy />
     </Sneakable>
     <Sneakable onClick=onSearchClick style=button>
       <FontIcon backgroundColor=bg color=fg icon=FontAwesome.search />
@@ -57,7 +57,7 @@ let%component make = (~state: State.t, ()) => {
       <FontIcon backgroundColor=bg color=fg icon=FontAwesome.codeBranch />
     </Sneakable>
     <Sneakable onClick=onExtensionsClick style=button>
-      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.box />
+      <FontIcon backgroundColor=bg color=fg icon=FontAwesome.thLarge />
     </Sneakable>
   </View>;
 };

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -113,7 +113,6 @@ let nodeView =
       <FontIcon
         color={theme.sideBarForeground}
         icon={isOpen ? FontAwesome.folderOpen : FontAwesome.folder}
-        backgroundColor=Colors.transparentWhite
       />
     | _ => <icon />
     };

--- a/src/UI/NotificationsPane.re
+++ b/src/UI/NotificationsPane.re
@@ -58,7 +58,6 @@ module Notification = {
       <FontIcon
         icon={iconFor(item)}
         fontSize=16.
-        backgroundColor={theme.background}
         color={colorFor(item, ~theme)}
       />;
 
@@ -69,7 +68,6 @@ module Notification = {
         <FontIcon
           icon=FontAwesome.times
           fontSize=13.
-          backgroundColor={theme.background}
           color={theme.foreground}
         />
       </Clickable>;

--- a/src/UI/PaneView.re
+++ b/src/UI/PaneView.re
@@ -23,65 +23,63 @@ let showNotifications = () =>
     Actions.PaneTabClicked(Pane.Notifications),
   );
 
-let make = (~theme, ~uiFont, ~editorFont, ~state: State.t, ()) => {
-  state.pane
-  |> Pane.getType
-  |> Option.map(paneType => {
-       let childPane =
-         switch (paneType) {
-         | Pane.Search =>
-           let onSelectResult = (file, location) =>
-             GlobalContext.current().dispatch(
-               Actions.OpenFileByPath(file, None, Some(location)),
-             );
-           let dispatch = msg =>
-             GlobalContext.current().dispatch(Actions.Search(msg));
+let make = (~theme, ~uiFont, ~editorFont, ~state: State.t, ()) =>
+  if (!state.pane.isOpen) {
+    <View />;
+  } else {
+    let childPane =
+      switch (state.pane.selected) {
+      | Pane.Search =>
+        let onSelectResult = (file, location) =>
+          GlobalContext.current().dispatch(
+            Actions.OpenFileByPath(file, None, Some(location)),
+          );
+        let dispatch = msg =>
+          GlobalContext.current().dispatch(Actions.Search(msg));
 
-           <Feature_Search
-             isFocused={FocusManager.current(state) == Focus.Search}
-             theme
-             uiFont
-             editorFont
-             model={state.searchPane}
-             onSelectResult
-             dispatch
-           />;
+        <Feature_Search
+          isFocused={FocusManager.current(state) == Focus.Search}
+          theme
+          uiFont
+          editorFont
+          model={state.searchPane}
+          onSelectResult
+          dispatch
+        />;
 
-         | Pane.Diagnostics => <DiagnosticsPane state />
-         | Pane.Notifications => <NotificationsPane state />
-         };
-       [
-         <WindowHandle theme direction=Horizontal />,
-         <View style={Styles.pane(~theme)}>
-           <View style=Style.[flexDirection(`Row)]>
-             <PaneTab
-               uiFont
-               theme
-               title="Search"
-               onClick=showSearch
-               active={paneType == Pane.Search}
-             />
-             <PaneTab
-               uiFont
-               theme
-               title="Problems"
-               onClick=showProblems
-               active={paneType == Pane.Diagnostics}
-             />
-             <PaneTab
-               uiFont
-               theme
-               title="Notifications"
-               onClick=showNotifications
-               active={paneType == Pane.Notifications}
-             />
-           </View>
-           <View style=Style.[flexDirection(`Column), flexGrow(1)]>
-             childPane
-           </View>
-         </View>,
-       ]
-       |> React.listToElement;
-     })
-  |> Option.value(~default=<View />);
-};
+      | Pane.Diagnostics => <DiagnosticsPane state />
+      | Pane.Notifications => <NotificationsPane state />
+      };
+    [
+      <WindowHandle theme direction=Horizontal />,
+      <View style={Styles.pane(~theme)}>
+        <View style=Style.[flexDirection(`Row)]>
+          <PaneTab
+            uiFont
+            theme
+            title="Search"
+            onClick=showSearch
+            active={state.pane.selected == Pane.Search}
+          />
+          <PaneTab
+            uiFont
+            theme
+            title="Problems"
+            onClick=showProblems
+            active={state.pane.selected == Pane.Diagnostics}
+          />
+          <PaneTab
+            uiFont
+            theme
+            title="Notifications"
+            onClick=showNotifications
+            active={state.pane.selected == Pane.Notifications}
+          />
+        </View>
+        <View style=Style.[flexDirection(`Column), flexGrow(1)]>
+          childPane
+        </View>
+      </View>,
+    ]
+    |> React.listToElement;
+  };

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -84,7 +84,7 @@ let make = (~state: State.t, ()) => {
   let activityBar =
     activityBarVisible
       ? React.listToElement([
-          <Dock state />,
+          <Dock theme />,
           <WindowHandle direction=Vertical theme />,
         ])
       : React.empty;

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -47,6 +47,7 @@ let make = (~state: State.t, ()) => {
         editorFont,
         sideBar,
         zenMode,
+        pane,
         _,
       } = state;
 
@@ -70,7 +71,7 @@ let make = (~state: State.t, ()) => {
       c.workbenchSideBarVisible
     )
     && !zenMode
-    && SideBar.isOpen(sideBar);
+    && sideBar.isOpen;
 
   let statusBarHeight = statusBarVisible ? 25 : 0;
 
@@ -84,7 +85,7 @@ let make = (~state: State.t, ()) => {
   let activityBar =
     activityBarVisible
       ? React.listToElement([
-          <Dock theme />,
+          <Dock theme sideBar pane />,
           <WindowHandle direction=Vertical theme />,
         ])
       : React.empty;

--- a/src/UI/SCMPane.re
+++ b/src/UI/SCMPane.re
@@ -94,6 +94,7 @@ let groupView =
 };
 
 let make = (~state: State.t, ()) => {
+  [@warning "-27"]
   let {theme, uiFont as font, workspace, _}: State.t = state;
 
   let groups = {

--- a/src/UI/SCMPane.re
+++ b/src/UI/SCMPane.re
@@ -61,11 +61,16 @@ let%component itemView =
     )
     |> Option.value(~default="/");
 
-  let displayName =
-    Path.toRelative(~base, Uri.toFileSystemPath(resource.uri));
+  let path = Uri.toFileSystemPath(resource.uri);
+  let displayName = Path.toRelative(~base, path);
+
+  let onClick = () =>
+    GlobalContext.current().dispatch(Actions.OpenFileByPath(path, None, None));
 
   <View style={Styles.item(~isHovered, ~theme)} onMouseOver onMouseOut>
-    <Text style={Styles.text(~font, ~theme)} text=displayName />
+    <Sneakable onClick>
+      <Text style={Styles.text(~font, ~theme)} text=displayName />
+    </Sneakable>
   </View>;
 };
 

--- a/src/UI/SCMPane.re
+++ b/src/UI/SCMPane.re
@@ -65,7 +65,9 @@ let%component itemView =
   let displayName = Path.toRelative(~base, path);
 
   let onClick = () =>
-    GlobalContext.current().dispatch(Actions.OpenFileByPath(path, None, None));
+    GlobalContext.current().dispatch(
+      Actions.OpenFileByPath(path, None, None),
+    );
 
   <View style={Styles.item(~isHovered, ~theme)} onMouseOver onMouseOut>
     <Sneakable onClick>

--- a/src/UI/SCMPane.re
+++ b/src/UI/SCMPane.re
@@ -31,11 +31,65 @@ module Styles = {
 
   let groupItems = [marginLeft(6)];
 
-  let item = [marginVertical(2)];
+  let item = (~isHovered, ~theme: Theme.t) => [
+    isHovered
+      ? backgroundColor(theme.listHoverBackground)
+      : backgroundColor(theme.sideBarBackground),
+    paddingVertical(2),
+    cursor(MouseCursors.pointer),
+  ];
+};
+
+let%component itemView =
+              (
+                ~provider: SCM.Provider.t,
+                ~resource: SCMResource.t,
+                ~theme,
+                ~font,
+                ~workspace: Workspace.t,
+                (),
+              ) => {
+  open Base;
+  let%hook (isHovered, setHovered) = Hooks.state(false);
+  let onMouseOver = _ => setHovered(_ => true);
+  let onMouseOut = _ => setHovered(_ => false);
+
+  let base =
+    Option.first_some(
+      Option.map(provider.rootUri, ~f=Uri.toFileSystemPath),
+      Option.map(workspace, ~f=w => w.workingDirectory),
+    )
+    |> Option.value(~default="/");
+
+  let displayName =
+    Path.toRelative(~base, Uri.toFileSystemPath(resource.uri));
+
+  <View style={Styles.item(~isHovered, ~theme)} onMouseOver onMouseOut>
+    <Text style={Styles.text(~font, ~theme)} text=displayName />
+  </View>;
+};
+
+let groupView =
+    (~provider, ~group: SCM.ResourceGroup.t, ~theme, ~font, ~workspace, ()) => {
+  let label = String.uppercase_ascii(group.label);
+  <View style=Styles.group>
+    <View style=Styles.groupLabel>
+      <Text style={Styles.groupLabelText(~font, ~theme)} text=label />
+    </View>
+    <View style=Styles.groupItems>
+      ...{
+           group.resources
+           |> List.map(resource =>
+                <itemView provider resource theme font workspace />
+              )
+           |> React.listToElement
+         }
+    </View>
+  </View>;
 };
 
 let make = (~state: State.t, ()) => {
-  let {theme, uiFont, _}: State.t = state;
+  let {theme, uiFont as font, workspace, _}: State.t = state;
 
   let groups = {
     open Base.List.Let_syntax;
@@ -46,47 +100,12 @@ let make = (~state: State.t, ()) => {
     return((provider, group));
   };
 
-  let itemView = (~provider: SCM.Provider.t, ~resource: SCMResource.t, ()) => {
-    open Base;
-
-    let base =
-      Option.first_some(
-        Option.map(provider.rootUri, ~f=Uri.toFileSystemPath),
-        Option.map(state.workspace, ~f=w => w.workingDirectory),
-      )
-      |> Option.value(~default="/");
-
-    let displayName =
-      Path.toRelative(~base, Uri.toFileSystemPath(resource.uri));
-
-    <View style=Styles.item>
-      <Text style={Styles.text(~font=uiFont, ~theme)} text=displayName />
-    </View>;
-  };
-
-  let groupView = (~provider, ~group: SCM.ResourceGroup.t, ()) => {
-    let label = String.uppercase_ascii(group.label);
-    <View style=Styles.group>
-      <View style=Styles.groupLabel>
-        <Text
-          style={Styles.groupLabelText(~font=uiFont, ~theme)}
-          text=label
-        />
-      </View>
-      <View style=Styles.groupItems>
-        ...{
-             group.resources
-             |> List.map(resource => <itemView provider resource />)
-             |> React.listToElement
-           }
-      </View>
-    </View>;
-  };
-
   <View style=Styles.container>
     ...{
          groups
-         |> List.map(((provider, group)) => <groupView provider group />)
+         |> List.map(((provider, group)) =>
+              <groupView provider group theme font workspace />
+            )
          |> React.listToElement
        }
   </View>;

--- a/src/UI/SCMPane.re
+++ b/src/UI/SCMPane.re
@@ -1,0 +1,93 @@
+open Oni_Core;
+open Oni_Model;
+open Revery;
+open Revery.UI;
+open Utility;
+
+module Styles = {
+  open Style;
+
+  let container = [padding(10), flexGrow(1)];
+
+  let text = (~theme: Theme.t, ~font: UiFont.t) => [
+    fontSize(font.fontSize),
+    fontFamily(font.fontFile),
+    color(theme.sideBarForeground),
+    textWrap(TextWrapping.NoWrap),
+    textOverflow(`Ellipsis),
+  ];
+
+  let group = [];
+
+  let groupLabel = [paddingVertical(3)];
+
+  let groupLabelText = (~theme: Theme.t, ~font: UiFont.t) => [
+    fontSize(font.fontSize *. 0.85),
+    fontFamily(font.fontFileBold),
+    color(theme.sideBarForeground),
+    textWrap(TextWrapping.NoWrap),
+    textOverflow(`Ellipsis),
+  ];
+
+  let groupItems = [marginLeft(6)];
+
+  let item = [marginVertical(2)];
+};
+
+let make = (~state: State.t, ()) => {
+  let {theme, uiFont, _}: State.t = state;
+
+  let groups = {
+    open Base.List.Let_syntax;
+
+    let%bind provider = state.scm.providers;
+    let%bind group = provider.resourceGroups;
+
+    return((provider, group));
+  };
+
+  let itemView = (~provider: SCM.Provider.t, ~resource: SCMResource.t, ()) => {
+    open Base;
+
+    let base =
+      Option.first_some(
+        Option.map(provider.rootUri, ~f=Uri.toFileSystemPath),
+        Option.map(state.workspace, ~f=w => w.workingDirectory),
+      )
+      |> Option.value(~default="/");
+
+    let displayName =
+      Path.toRelative(~base, Uri.toFileSystemPath(resource.uri));
+
+    <View style=Styles.item>
+      <Text style={Styles.text(~font=uiFont, ~theme)} text=displayName />
+    </View>;
+  };
+
+  let groupView = (~provider, ~group: SCM.ResourceGroup.t, ()) => {
+    let label = String.uppercase_ascii(group.label);
+    <View style=Styles.group>
+      <View style=Styles.groupLabel>
+        <Text
+          style={Styles.groupLabelText(~font=uiFont, ~theme)}
+          text=label
+        />
+      </View>
+      <View style=Styles.groupItems>
+        ...{
+             group.resources
+             |> List.map(resource => <itemView provider resource />)
+             |> React.listToElement
+           }
+      </View>
+    </View>;
+  };
+
+  <View style=Styles.container>
+    ...{
+         groups
+         |> List.map(((provider, group)) => <groupView provider group />)
+         |> React.listToElement
+       }
+  </View>;
+};

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -51,12 +51,14 @@ let%component make = (~state: State.t, ()) => {
   let title =
     switch (sideBarType) {
     | FileExplorer => "Explorer"
+    | SCM => "Source Control"
     | Extensions => "Extensions"
     };
 
   let elem =
     switch (sideBarType) {
     | FileExplorer => <FileExplorerView state />
+    | SCM => <SCMPane state />
     | Extensions => <ExtensionListView state />
     };
 

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -43,20 +43,18 @@ let%component make = (~state: State.t, ()) => {
   let bg = theme.sideBarBackground;
   let fg = theme.sideBarForeground;
 
-  let sideBarType = SideBar.getType(sideBar);
-
   let%hook (transition, _animationState, _reset) =
     Hooks.animation(animation, ~active=true);
 
   let title =
-    switch (sideBarType) {
+    switch (sideBar.selected) {
     | FileExplorer => "Explorer"
     | SCM => "Source Control"
     | Extensions => "Extensions"
     };
 
   let elem =
-    switch (sideBarType) {
+    switch (sideBar.selected) {
     | FileExplorer => <FileExplorerView state />
     | SCM => <SCMPane state />
     | Extensions => <ExtensionListView state />

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -104,12 +104,7 @@ module Notification = {
       Hooks.animation(Animations.sequence, ~active=true);
 
     let icon = () =>
-      <FontIcon
-        icon={iconFor(item)}
-        fontSize=16.
-        backgroundColor=background
-        color=foreground
-      />;
+      <FontIcon icon={iconFor(item)} fontSize=16. color=foreground />;
 
     <View style={Styles.container(~background, ~yOffset)}>
       <icon />
@@ -251,12 +246,9 @@ let notificationCount =
         justifyContent(`Center),
         alignItems(`Center),
       ]>
-      <FontIcon
-        icon=FontAwesome.bell
-        backgroundColor=background
-        color
-        margin=4
-      />
+      <View style=Style.[margin(4)]>
+        <FontIcon icon=FontAwesome.bell color />
+      </View>
       <Text style={Styles.text(~color, ~background, font)} text />
     </View>
   </item>;
@@ -276,12 +268,9 @@ let diagnosticCount = (~font, ~background, ~theme: Theme.t, ~diagnostics, ()) =>
         justifyContent(`Center),
         alignItems(`Center),
       ]>
-      <FontIcon
-        icon=FontAwesome.timesCircle
-        backgroundColor=background
-        color
-        margin=4
-      />
+      <View style=Style.[margin(4)]>
+        <FontIcon icon=FontAwesome.timesCircle color />
+      </View>
       <Text style={Styles.text(~color, ~background, font)} text />
     </View>
   </item>;

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -102,7 +102,6 @@ let make =
       <FontIcon
         fontFamily="seti.ttf"
         icon={v.fontCharacter}
-        backgroundColor={theme.editorBackground}
         color={v.fontColor}
         /* TODO: Use 'weight' value from IconTheme font */
         fontSize={uiFont.fontSize *. 1.5}
@@ -135,7 +134,6 @@ let make =
     <Sneakable onClick=onClose style=iconContainerStyle>
       <FontIcon
         icon
-        backgroundColor={theme.editorBackground}
         color={theme.tabActiveForeground}
         fontSize={modified ? 10. : 12.}
       />

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -83,7 +83,6 @@ module Make = (Model: TreeModel) => {
         fontSize=Constants.arrowSize
         color=Colors.white
         icon={isOpen ? FontAwesome.caretDown : FontAwesome.caretRight}
-        backgroundColor=Colors.transparentWhite
       />
     </View>;
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -72,16 +72,20 @@ module Styles = {
     fontSize(12),
     color(Colors.white),
   ];
+
+  let arrow = size => [width(size), height(size)];
 };
 
 module Make = (Model: TreeModel) => {
   let arrow = (~isOpen, ()) =>
-    <FontIcon
-      fontSize=Constants.arrowSize
-      color=Colors.white
-      icon={isOpen ? FontAwesome.caretDown : FontAwesome.caretRight}
-      backgroundColor=Colors.transparentWhite
-    />;
+    <View style={Styles.arrow(int_of_float(Constants.arrowSize))}>
+      <FontIcon
+        fontSize=Constants.arrowSize
+        color=Colors.white
+        icon={isOpen ? FontAwesome.caretDown : FontAwesome.caretRight}
+        backgroundColor=Colors.transparentWhite
+      />
+    </View>;
 
   let noArrow = () =>
     <View

--- a/src/UI/dune
+++ b/src/UI/dune
@@ -1,7 +1,7 @@
 (library
     (name Oni_UI)
     (public_name Oni2.ui)
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show))
+    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show ppx_let))
     (libraries 
         str
         bigarray
@@ -17,4 +17,5 @@
         Revery
         editor-core-types
         ppx_deriving.runtime
+        base
     ))

--- a/test/Core/Utility/UtilityTests.re
+++ b/test/Core/Utility/UtilityTests.re
@@ -2,36 +2,93 @@ open TestFramework;
 
 open Oni_Core.Utility;
 
-describe("last", ({test, _}) => {
-  open ListEx;
+describe("ListEx", ({describe, _}) => {
+  describe("last", ({test, _}) => {
+    open ListEx;
 
-  test("empty", ({expect}) =>
-    expect.bool(last([]) == None).toBe(true)
-  );
+    test("empty", ({expect}) =>
+      expect.bool(last([]) == None).toBe(true)
+    );
 
-  test("one", ({expect}) =>
-    expect.bool(last([1]) == Some(1)).toBe(true)
-  );
+    test("one", ({expect}) =>
+      expect.bool(last([1]) == Some(1)).toBe(true)
+    );
 
-  test("many", ({expect}) =>
-    expect.bool(last([1, 2]) == Some(2)).toBe(true)
-  );
-});
+    test("many", ({expect}) =>
+      expect.bool(last([1, 2]) == Some(2)).toBe(true)
+    );
+  });
 
-describe("dropLast", ({test, _}) => {
-  open ListEx;
+  describe("dropLast", ({test, _}) => {
+    open ListEx;
 
-  test("empty", ({expect}) =>
-    expect.list(dropLast([])).toEqual([])
-  );
+    test("empty", ({expect}) =>
+      expect.list(dropLast([])).toEqual([])
+    );
 
-  test("one", ({expect}) =>
-    expect.list(dropLast([1])).toEqual([])
-  );
+    test("one", ({expect}) =>
+      expect.list(dropLast([1])).toEqual([])
+    );
 
-  test("many", ({expect}) => {
-    expect.list(dropLast([1, 2])).toEqual([1]);
-    expect.list(dropLast([1, 2, 3])).toEqual([1, 2]);
+    test("many", ({expect}) => {
+      expect.list(dropLast([1, 2])).toEqual([1]);
+      expect.list(dropLast([1, 2, 3])).toEqual([1, 2]);
+    });
+  });
+
+  describe("safeMap", ({test, _}) => {
+    test("empty", ({expect}) =>
+      expect.list(ListEx.safeMap(x => x, [])).toEqual([])
+    );
+
+    test("one", ({expect}) =>
+      expect.list(ListEx.safeMap(x => x, [1])).toEqual([1])
+    );
+
+    test("many", ({expect}) => {
+      expect.list(ListEx.safeMap(x => x, [1, 2, 3])).toEqual([1, 2, 3])
+    });
+
+    test("int_to_string", ({expect}) => {
+      expect.list(ListEx.safeMap(string_of_int, [1, 2, 3])).toEqual([
+        "1",
+        "2",
+        "3",
+      ])
+    });
+  });
+
+  describe("safeConcat", ({test, _}) => {
+    test("empty", ({expect}) =>
+      expect.list(ListEx.safeConcat([])).toEqual([])
+    );
+
+    test("one of one", ({expect}) =>
+      expect.list(ListEx.safeConcat([[1]])).toEqual([1])
+    );
+
+    test("one of many", ({expect}) => {
+      expect.list(ListEx.safeConcat([[1, 2, 3]])).toEqual([1, 2, 3])
+    });
+
+    test("many of one", ({expect}) => {
+      expect.list(ListEx.safeConcat([[1], [2], [3]])).toEqual([1, 2, 3])
+    });
+
+    test("many of many", ({expect}) => {
+      expect.list(ListEx.safeConcat([[1, 2, 3], [4, 5, 6], [7, 8, 9]])).
+        toEqual([
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+      ])
+    });
   });
 });
 
@@ -271,61 +328,6 @@ describe("StringEx", ({describe, _}) => {
       expect.int(charStart).toBe(61);
       expect.int(charEnd).toBe(68);
     });
-  });
-});
-
-describe("ListEx.safeMap", ({test, _}) => {
-  test("empty", ({expect}) =>
-    expect.list(ListEx.safeMap(x => x, [])).toEqual([])
-  );
-
-  test("one", ({expect}) =>
-    expect.list(ListEx.safeMap(x => x, [1])).toEqual([1])
-  );
-
-  test("many", ({expect}) => {
-    expect.list(ListEx.safeMap(x => x, [1, 2, 3])).toEqual([1, 2, 3])
-  });
-
-  test("int_to_string", ({expect}) => {
-    expect.list(ListEx.safeMap(string_of_int, [1, 2, 3])).toEqual([
-      "1",
-      "2",
-      "3",
-    ])
-  });
-});
-
-describe("ListEx.safeConcat", ({test, _}) => {
-  test("empty", ({expect}) =>
-    expect.list(ListEx.safeConcat([])).toEqual([])
-  );
-
-  test("one of one", ({expect}) =>
-    expect.list(ListEx.safeConcat([[1]])).toEqual([1])
-  );
-
-  test("one of many", ({expect}) => {
-    expect.list(ListEx.safeConcat([[1, 2, 3]])).toEqual([1, 2, 3])
-  });
-
-  test("many of one", ({expect}) => {
-    expect.list(ListEx.safeConcat([[1], [2], [3]])).toEqual([1, 2, 3])
-  });
-
-  test("many of many", ({expect}) => {
-    expect.list(ListEx.safeConcat([[1, 2, 3], [4, 5, 6], [7, 8, 9]])).
-      toEqual([
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-    ])
   });
 });
 

--- a/test/Core/Utility/UtilityTests.re
+++ b/test/Core/Utility/UtilityTests.re
@@ -90,6 +90,126 @@ describe("ListEx", ({describe, _}) => {
       ])
     });
   });
+
+  describe("splice", ({test, _}) => {
+    test("empty", ({expect}) =>
+      expect.list(ListEx.splice(~start=0, ~deleteCount=0, ~additions=[], [])).
+        toEqual(
+        [],
+      )
+    );
+
+    test("start > source length", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=8, ~deleteCount=2, ~additions=[3, 4], [1, 2]),
+      ).
+        toEqual([
+        1,
+        2,
+        3,
+        4,
+      ])
+    );
+
+    test("delete first", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=0, ~deleteCount=1, ~additions=[], [1, 2, 3]),
+      ).
+        toEqual([
+        2,
+        3,
+      ])
+    );
+
+    test("delete last", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=2, ~deleteCount=1, ~additions=[], [1, 2, 3]),
+      ).
+        toEqual([
+        1,
+        2,
+      ])
+    );
+
+    test("delete middle", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=1, ~deleteCount=1, ~additions=[], [1, 2, 3]),
+      ).
+        toEqual([
+        1,
+        3,
+      ])
+    );
+
+    test("add first", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=0, ~deleteCount=0, ~additions=[9], [1, 2, 3]),
+      ).
+        toEqual([
+        9,
+        1,
+        2,
+        3,
+      ])
+    );
+
+    test("add last", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=3, ~deleteCount=0, ~additions=[9], [1, 2, 3]),
+      ).
+        toEqual([
+        1,
+        2,
+        3,
+        9,
+      ])
+    );
+
+    test("add middle", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=1, ~deleteCount=0, ~additions=[9], [1, 2, 3]),
+      ).
+        toEqual([
+        1,
+        9,
+        2,
+        3,
+      ])
+    );
+
+    test("replace first", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=0, ~deleteCount=1, ~additions=[9], [1, 2, 3]),
+      ).
+        toEqual([
+        9,
+        2,
+        3,
+      ])
+    );
+
+    test("replace last", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=2, ~deleteCount=1, ~additions=[9], [1, 2, 3]),
+      ).
+        toEqual([
+        1,
+        2,
+        9,
+      ])
+    );
+
+    test("replace middle", ({expect}) =>
+      expect.list(
+        ListEx.splice(~start=1, ~deleteCount=1, ~additions=[9], [1, 2, 3]),
+      ).
+        toEqual([
+        1,
+        9,
+        3,
+      ])
+    );
+  });
 });
 
 describe("JsonEx", ({describe, _}) => {


### PR DESCRIPTION

![2020-02-07-224422_267x215_scrot](https://user-images.githubusercontent.com/5207036/74068236-6d719280-49fb-11ea-8fa5-421c8345750e.png)
Currently just lists the resource in each group. Clicking on a resource opens the file, and it updates on every `BufferUpdate`, as with the file explorer decorations. It does not properly handle multiple providers/repositories yet though.

This also adds hover styles and active indicators to the dock items.