### PR TITLE
Fix box shadows

### DIFF
--- a/src/Components/ContextMenu.re
+++ b/src/Components/ContextMenu.re
@@ -140,11 +140,11 @@ module Menu = {
       color(theme.menuForeground),
       width(Constants.menuWidth),
       boxShadow(
-        ~xOffset=-5.,
-        ~yOffset=-5.,
-        ~blurRadius=25.,
-        ~spreadRadius=-10.,
-        ~color=Color.rgba(0., 0., 0., 0.0001),
+        ~xOffset=3.,
+        ~yOffset=3.,
+        ~blurRadius=5.,
+        ~spreadRadius=0.,
+        ~color=Color.rgba(0., 0., 0., 0.2),
       ),
     ];
   };

--- a/src/UI/OniBoxShadow.re
+++ b/src/UI/OniBoxShadow.re
@@ -6,17 +6,20 @@ let make = (~children, ~theme: Theme.t, ~configuration: Configuration.t, ()) => 
   let useBoxShadow = Configuration.getValue(c => c.uiShadows, configuration);
 
   if (useBoxShadow) {
-    <BoxShadow
-      boxShadow={Style.BoxShadow.make(
-        ~xOffset=-11.,
-        ~yOffset=-11.,
-        ~blurRadius=25.,
-        ~spreadRadius=0.,
-        ~color=Color.rgba(0., 0., 0., 0.2),
-        (),
-      )}>
+    let color = Color.rgba(0., 0., 0., 0.75);
+    <View
+      style=[
+        Style.backgroundColor(color),
+        Style.boxShadow(
+          ~xOffset=4.,
+          ~yOffset=4.,
+          ~blurRadius=12.,
+          ~spreadRadius=0.,
+          ~color,
+        ),
+      ]>
       ...children
-    </BoxShadow>;
+    </View>;
   } else {
     <View style=Style.[border(~color=theme.background, ~width=1)]>
       ...children


### PR DESCRIPTION

![2020-02-08-190049_226x113_scrot](https://user-images.githubusercontent.com/5207036/74089848-ce55a500-4aa5-11ea-8ac7-42a538039e74.png)
![2020-02-08-190032_470x430_scrot](https://user-images.githubusercontent.com/5207036/74089849-d01f6880-4aa5-11ea-9627-eea87950dea2.png)

Both the quick menu and context menu drop shadows had disappeared, but for different reasons. The context menu shadow disappeared because the color alpha channel started working and ti was set to a tiny amount, and the quick menu shadow disappeared because it's not rendered unless there's also a background color.