### PR TITLE
[WIP] Fix #463 - Part 1 - Model editor/split size in the WindowTree

### DIFF
--- a/src/Model/WindowTree.re
+++ b/src/Model/WindowTree.re
@@ -9,12 +9,13 @@ type direction =
   | Horizontal
   | Vertical;
 
+type splitSize =
+  | Percent(float);
+
 [@deriving show({with_path: false})]
 type split = {
   id: int,
   editorGroupId: int,
-  width: option(int),
-  height: option(int),
 };
 
 [@deriving show({with_path: false})]
@@ -25,11 +26,9 @@ type t =
 
 let empty = Parent(Vertical, [Empty]);
 
-let createSplit = (~width=?, ~height=?, ~editorGroupId, ()) => {
+let createSplit = (~editorGroupId, ()) => {
   id: WindowSplitId.getUniqueId(),
   editorGroupId,
-  width,
-  height,
 };
 
 let getSplits = (tree: t) => {


### PR DESCRIPTION
There isn't a way to resize windows today, which is a blocker - #463 

This is the beginning of implement sizing in the `WindowTree`.

__TODO:__
- [x] Generalize distribution of height / width across the children
- [ ] Implement actual `measure` function for the children
- [ ] Add test case for setting split size
- [ ] Add test case for setting parent size
- [ ] Add test case that parent 'inherits' split's size when adding a split that changes direction

Next steps:
- Add an id to Parent so it can be targeted by resize. Add logic that, given an id + a resize operation, we'll resize the correct entity (either a split or parent).
- Wire up the [Vim commands for resizing splits](https://vim.fandom.com/wiki/Resize_splits_more_quickly)
- Implement UX via the mouse for this as well (ie, add a mouse capture handler to `<WindowHandle />`, and dispatch appropriate resize commands in response)
- Implement sizing for the pane
- Implement hiding / showing the activity bar with the mouse

