### PR TITLE
Developer: Add command to show the list of workspaceFolders

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -80,7 +80,7 @@ function activate(context) {
            latestText = e.document.getText().split(os.EOL).join("|");
         }
 
-		//vscode.window.showInformationMessage('Changed!');
+        //vscode.window.showInformationMessage('Changed!');
         const document = e.document;
         if (document && path.basename(document.uri.fsPath) == "test.oni-dev") {
            collection.set(document.uri, [{
@@ -94,29 +94,29 @@ function activate(context) {
         }
     }));
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	cleanup(vscode.commands.registerCommand('developer.oni.showNotification', () => {
-		// The code you place here will be executed every time your command is executed
+    // The command has been defined in the package.json file
+    // Now provide the implementation of the command with  registerCommand
+    // The commandId parameter must match the command field in package.json
+    cleanup(vscode.commands.registerCommand('developer.oni.showNotification', () => {
+        // The code you place here will be executed every time your command is executed
 
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello from extension!');
-	}));
+        // Display a message box to the user
+        vscode.window.showInformationMessage('Hello from extension!');
+    }));
     
-	cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceRootPath', () => {
-		vscode.window.showInformationMessage("Workspace rootPath: " + vscode.workspace.rootPath);
-	}));
+    cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceRootPath', () => {
+        vscode.window.showInformationMessage("Workspace rootPath: " + vscode.workspace.rootPath);
+    }));
     
-	cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceFolders', () => {
-		vscode.window.showInformationMessage("Workspace folders: " +
+    cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceFolders', () => {
+        vscode.window.showInformationMessage("Workspace folders: " +
             JSON.stringify(vscode.workspace.workspaceFolders));
-	}));
+    }));
 
     // Helper command to show buffer text
     // This helps us create a test case to validate buffer manipulations
-	cleanup(vscode.commands.registerCommand('developer.oni.getBufferText', () => {
-		vscode.window.showInformationMessage("fulltext:" + latestText);
+    cleanup(vscode.commands.registerCommand('developer.oni.getBufferText', () => {
+        vscode.window.showInformationMessage("fulltext:" + latestText);
     }));
     
     function createResourceUri(relativePath) {
@@ -162,6 +162,6 @@ function activate(context) {
 function deactivate() {}
 
 module.exports = {
-	activate,
-	deactivate
+    activate,
+    deactivate
 }

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -105,8 +105,12 @@ function activate(context) {
 	}));
     
 	cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceRootPath', () => {
-		// Display a message box to the user
-		vscode.window.showInformationMessage("rootPath: " + vscode.workspace.rootPath);
+		vscode.window.showInformationMessage("Workspace rootPath: " + vscode.workspace.rootPath);
+	}));
+    
+	cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceFolders', () => {
+		vscode.window.showInformationMessage("Workspace folders: " +
+            JSON.stringify(vscode.workspace.workspaceFolders));
 	}));
 
     // Helper command to show buffer text

--- a/development_extensions/oni-dev-extension/package.json
+++ b/development_extensions/oni-dev-extension/package.json
@@ -23,7 +23,11 @@
 			},
 			{
 				"command": "developer.oni.showWorkspaceRootPath",
-				"title": "Onivim - Developer: Show Root Path"
+				"title": "Onivim - Developer: Show Workspace Root Path"
+			},
+			{
+				"command": "developer.oni.showWorkspaceFolders",
+				"title": "Onivim - Developer: Show Workspace Folders"
 			}
 		],
 		"languages": [{


### PR DESCRIPTION
This adds a command to show the list of `vscode.workspace.workspaceFolders`, for debugging (to show the workspace info from the perspective of a plugin):
![workspaces](https://user-images.githubusercontent.com/13532591/74174090-36140900-4be8-11ea-966d-51c8785e5571.gif)

FYI @glennsl - added this based on our convo today.

I took a look at the git extensions, and I think this is an interesting spot:
https://github.com/onivim/vscode-exthost/blob/8ebec0403c19a038932368df8c89e4676e923dd2/extensions/git/src/model.ts#L69

It uses the following APIs:
- `vscode.workspace.onDidChangeWorksapceFolders`, which we should support today
- `vscode.window.onDidChangeVisibleTextEditors`, which isn't currently supported (this might be how it decides to refresh?)
- `vscode.workspace.onDidChangeConfiguration` - not yet supported (planning on implementing this with #1157 )
- `vscode.workspace.createFilesystemWatcher` - not implemented yet (another case where we need `esy-fswatch`/`reason-fswatch`)