### PR TITLE
Fix #1216: Sidebar visibility toggling + workbench.sideBar.visible se…

### DIFF
--- a/src/Model/SideBar.re
+++ b/src/Model/SideBar.re
@@ -4,17 +4,27 @@ type pane =
   | Extensions;
 
 type t = {
+  // Track the last value of 'workbench.sideBar.visible'
+  // If it changes, we should update
+  openByDefault: bool,
   isOpen: bool,
   selected: pane,
 };
 
-let initial = {isOpen: true, selected: FileExplorer};
+let initial = {openByDefault: false, isOpen: false, selected: FileExplorer};
 
 let isVisible = (pane, model) => model.isOpen && model.selected == pane;
+
+let setDefaultVisibility = (pane, defaultVisibility) =>
+  if (pane.openByDefault == defaultVisibility) {
+    pane;
+  } else {
+    {...pane, openByDefault: defaultVisibility, isOpen: defaultVisibility};
+  };
 
 let toggle = (pane, state: t) =>
   if (pane == state.selected) {
     {...state, isOpen: !state.isOpen};
   } else {
-    {isOpen: true, selected: pane};
+    {...state, isOpen: true, selected: pane};
   };

--- a/src/Model/SideBar.rei
+++ b/src/Model/SideBar.rei
@@ -4,6 +4,7 @@ type pane =
   | Extensions;
 
 type t = {
+  openByDefault: bool,
   isOpen: bool,
   selected: pane,
 };
@@ -12,3 +13,4 @@ let initial: t;
 
 let isVisible: (pane, t) => bool;
 let toggle: (pane, t) => t;
+let setDefaultVisibility: (t, bool) => t;

--- a/src/Store/SideBarReducer.re
+++ b/src/Store/SideBarReducer.re
@@ -2,6 +2,7 @@
  * SideBarReducer.re
  */
 
+open Oni_Core;
 open Oni_Model;
 open Actions;
 
@@ -12,6 +13,10 @@ let reduce = (state: SideBar.t, action: Actions.t) => {
   | ActivityBar(ActivityBar.SCMClick) => SideBar.toggle(SideBar.SCM, state)
   | ActivityBar(ActivityBar.ExtensionsClick) =>
     SideBar.toggle(SideBar.Extensions, state)
+  | ConfigurationSet(newConfig) =>
+    let sideBarSetting =
+      Configuration.getValue(c => c.workbenchSideBarVisible, newConfig);
+    SideBar.setDefaultVisibility(state, sideBarSetting);
   | _ => state
   };
 };

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -69,12 +69,7 @@ let make = (~state: State.t, ()) => {
     )
     && !zenMode;
 
-  let sideBarVisible =
-    Selectors.getActiveConfigurationValue(state, c =>
-      c.workbenchSideBarVisible
-    )
-    && !zenMode
-    && sideBar.isOpen;
+  let sideBarVisible = !zenMode && sideBar.isOpen;
 
   let statusBarHeight = statusBarVisible ? 25 : 0;
 


### PR DESCRIPTION
Fix #1216 (and #1319 )

__Issue:__ When `workbench.sideBar.visible` is `true`, the sidebar could never be opened - even when explicitly clicking.

__Defect:__ We were gating the UI rendering of the sidebar based on the configuration setting, but this isn't really the correct behavior - it might be that the `workbench.sideBar.visible` setting is `false`, but a sidebar could be opened via some other mechanism, and we shouldn't block that.

__Fix:__ Use the `workbench.sideBar.visible` as the _default_ setting, and update the side bar visibility if it changes - but don't gate the rendering on it.

