### PR TITLE
Fix build failure caused by merges overlapping without conflict

### DIFF
--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -126,7 +126,7 @@ let nodeView =
 
   let tooltipText =
     switch (decoration) {
-    | Some((decoration: SCMDecoration.t)) =>
+    | Some((decoration: Decoration.t)) =>
       node.path ++ " • " ++ decoration.tooltip
     | None => node.path
     };


### PR DESCRIPTION
#1330 added a new use of `SCMDecoration` while #1327 renamed it to `Decoration`, causing a build failure but not a merge conflict. This renames the new use as well.