### PR TITLE
Bugfix: Memory leak in TreeView

### DIFF
--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -233,15 +233,8 @@ module Make = (Model: TreeModel) => {
                   ~tree,
                   (),
                 ) => {
-    let%hook (outerRef, setOuterRef) = Hooks.ref(None);
-
-    let menuHeight =
-      switch (outerRef) {
-      | Some(node) =>
-        let dimensions: Dimensions.t = node#measurements();
-        dimensions.height;
-      | None => itemHeight * initialRowsToRender
-      };
+    let%hook (menuHeight, setMenuHeight) =
+      Hooks.state(itemHeight * initialRowsToRender);
 
     let count = Model.expandedSubtreeSize(tree);
 
@@ -299,7 +292,7 @@ module Make = (Model: TreeModel) => {
 
     <View
       style=Styles.container
-      ref={ref => setOuterRef(Some(ref))}
+      onDimensionsChanged={({height}) => setMenuHeight(_ => height)}
       onMouseWheel>
       <View style={Styles.viewport(~showScrollbar)}>
         <View style={Styles.content(~scrollTop)}>

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -292,7 +292,7 @@ module Make = (Model: TreeModel) => {
 
     <View
       style=Styles.container
-      onDimensionsChanged={({height}) => setMenuHeight(_ => height)}
+      onDimensionsChanged={({height, _}) => setMenuHeight(_ => height)}
       onMouseWheel>
       <View style={Styles.viewport(~showScrollbar)}>
         <View style={Styles.content(~scrollTop)}>


### PR DESCRIPTION
This fixes a memory leak in the TreeView - it seems that the `node` was being captured in a closure and not being cleaned up. Opening / closing the explorer would lead to the memory growing relatively quickly.

I believe this was a pre-existing memory leak, but because we now allocate [additional Skia objects per-node](https://github.com/revery-ui/revery/blob/2327429ff895c780f97c2f695ac42106e21759a2/src/UI/Node.re#L72), it is now exacerbated.

I could consistently repro this leak on all platforms by opening and closing the treeview, but I suspect there were other manifestations as well. It'll be worth taking a pass over other places we use `ref` and seeing if we can have a lighter dependency - we can add additional eventso the revery event model if it makes sense.

This also seems to fix a size issue with the treeview - when switching between the file explorer / extensions pane, the tree view would stick at the initial height. However, with this change, it stay s the correct size moving between them.