### PR TITLE
Feature - Terminal - Part 1: Initial extension host integration

### DIFF
--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -223,9 +223,13 @@ let start =
     | ("MainThreadSCM", method, args) =>
       SCM.handleMessage(~dispatch=msg => dispatch(SCM(msg)), method, args);
       Ok(None);
-    
+
     | ("MainThreadTerminalService", method, args) =>
-      Terminal.handleMessage(~dispatch=msg => dispatch(Terminal(msg)), method, args);
+      Terminal.handleMessage(
+        ~dispatch=msg => dispatch(Terminal(msg)),
+        method,
+        args,
+      );
       Ok(None);
 
     | (scope, method, argsAsJson) =>

--- a/src/Extensions/ExtHostClient.re
+++ b/src/Extensions/ExtHostClient.re
@@ -19,9 +19,11 @@ module Log = (val Log.withNamespace("Oni2.Extensions.ExtHostClient"));
 type t = ExtHostTransport.t;
 
 module SCM = ExtHostClient_SCM;
+module Terminal = ExtHostClient_Terminal;
 
 type msg =
   | SCM(SCM.msg)
+  | Terminal(Terminal.msg)
   | RegisterTextContentProvider({
       handle: int,
       scheme: string,
@@ -220,6 +222,10 @@ let start =
 
     | ("MainThreadSCM", method, args) =>
       SCM.handleMessage(~dispatch=msg => dispatch(SCM(msg)), method, args);
+      Ok(None);
+    
+    | ("MainThreadTerminalService", method, args) =>
+      Terminal.handleMessage(~dispatch=msg => dispatch(Terminal(msg)), method, args);
       Ok(None);
 
     | (scope, method, argsAsJson) =>

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -1,6 +1,7 @@
 module Core = Oni_Core;
 module Protocol = ExtHostProtocol;
 module Workspace = Protocol.Workspace;
+module Terminal = ExtHostClient_Terminal;
 
 type t;
 
@@ -110,6 +111,7 @@ module SCM: {
 
 type msg =
   | SCM(SCM.msg)
+  | Terminal(Terminal.msg)
   | RegisterTextContentProvider({
       handle: int,
       scheme: string,

--- a/src/Extensions/ExtHostClient_Terminal.re
+++ b/src/Extensions/ExtHostClient_Terminal.re
@@ -1,0 +1,96 @@
+open Oni_Core;
+
+module Log = (val Log.withNamespace("Oni2.Extensions.Terminal"));
+
+// MODEL
+module ShellLaunchConfig  = {
+  [@deriving show({with_path: false})]
+  type t = {
+    name: string,
+    executable: string,
+    arguments: list(string),
+  };
+}
+
+// UPDATE
+
+type msg =
+  | SendProcessTitle({
+      terminalId: int,
+      title: string,
+    })
+  | SendProcessData({
+    terminalId: int,
+    data: string,
+  })
+  | SendProcessPid({
+    terminalId: int,
+    pid: int,
+  })
+  | SendProcessExit({
+    terminalId: int,
+    exitCode: int,
+  });
+
+let handleMessage = (~dispatch, method, args) =>
+  switch (method) {
+  | "$sendProcessTitle" =>
+    switch (args) {
+    | [`Int(terminalId), `String(title)] =>
+      dispatch(SendProcessTitle({terminalId, title}));
+    | _ => Log.error("Unexpected arguments for $sendProcessTitle")
+    }
+
+  | "$sendProcessData" =>
+    switch (args) {
+  | [`Int(terminalId), `String(data)] =>
+      dispatch(SendProcessData({terminalId, data}));
+    | _ => Log.error("Unexpected arguments for $sendProcessData")
+    }
+
+  | "$sendProcessPid" =>
+    switch (args) {
+    | [`Int(terminalId), `Int(pid)] => 
+      dispatch(SendProcessPid({terminalId, pid}));
+
+    | _ => Log.error("Unexpected arguments for $sendProcessPid")
+    }
+  
+  | "$sendProcessExit" =>
+    switch (args) {
+    | [`Int(terminalId), `Int(exitCode)] => 
+      dispatch(SendProcessExit({terminalId, exitCode}));
+
+    | _ => Log.error("Unexpected arguments for $sendProcessExit")
+    }
+
+  | _ =>
+    Log.warnf(m =>
+      m(
+        "Unhandled Terminal message - %s: %s",
+        method,
+        Yojson.Safe.to_string(`List(args)),
+      )
+    )
+  };
+
+// REQUESTS
+
+module Requests = {
+  let createProcess = (id, launchConfig, workspaceUri, columns, rows, client) => 
+    ExtHostTransport.send(
+      client,
+      ExtHostProtocol.OutgoingNotifications._buildNotification(
+        "ExtHostTerminalService",
+        "$createProcess",
+        `List([
+          `Int(id),
+          // TODO: launchConfig
+          `Assoc([]),
+          Uri.to_yojson(workspaceUri),
+          columns,
+          rows,
+          ]),
+      )
+    );
+};

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -303,7 +303,7 @@ let create = (~extensions, ~setup: Setup.t) => {
     | DecorationsDidChange({handle, uris}) =>
       dispatch(DecorationsChanged({handle, uris}))
     // TODO:
-    | Terminal(_) => ();
+    | Terminal(_) => ()
     };
 
   let onOutput = Log.info;

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -302,6 +302,8 @@ let create = (~extensions, ~setup: Setup.t) => {
 
     | DecorationsDidChange({handle, uris}) =>
       dispatch(DecorationsChanged({handle, uris}))
+    // TODO:
+    | Terminal(_) => ();
     };
 
   let onOutput = Log.info;


### PR DESCRIPTION
This change adds an `ExtHostClient_Terminal` module, in a similar vein to the `ExtHostClient_SCM` module.

It exposes a set of messages and a parser for unpacking `MainThreadTerminalService` messages from the extension host to the editor, as well as a `Request` module to help with making requests to the `ExtHostTerminalService` module.

Part 2 will create a `Service_Terminal` module - a service that exposes this as a subscription and effects on top of this (with the `ExtHostClient` as a dependency).