### PR TITLE
Test - Integration: Use headless rendering APIs for more coverage

### DIFF
--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -72,23 +72,24 @@ let runTest =
   let initialState = Model.State.create();
   let currentState = ref(initialState);
 
-  let headlessWindow = Revery.Utility.HeadlessWindow.create(
+  let headlessWindow =
+    Revery.Utility.HeadlessWindow.create(
       Revery.WindowCreateOptions.create(~width=3440, ~height=1440, ()),
-  );
+    );
 
   let onStateChanged = state => {
     currentState := state;
-    
-    Oni_UI.GlobalContext.set({...Oni_UI.GlobalContext.current(),
+
+    Oni_UI.GlobalContext.set({
+      ...Oni_UI.GlobalContext.current(),
       getState: () => currentState^,
-      state});
-      
+      state,
+    });
+
     Revery.Utility.HeadlessWindow.render(
       headlessWindow,
-      <Oni_UI.Root state />
+      <Oni_UI.Root state />,
     );
-
-    Revery.Utility.HeadlessWindow.takeScreenshot(headlessWindow, "screenshot.png");
   };
 
   InitLog.info("Starting store...");

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -72,8 +72,23 @@ let runTest =
   let initialState = Model.State.create();
   let currentState = ref(initialState);
 
-  let onStateChanged = v => {
-    currentState := v;
+  let headlessWindow = Revery.Utility.HeadlessWindow.create(
+      Revery.WindowCreateOptions.create(~width=3440, ~height=1440, ()),
+  );
+
+  let onStateChanged = state => {
+    currentState := state;
+    
+    Oni_UI.GlobalContext.set({...Oni_UI.GlobalContext.current(),
+      getState: () => currentState^,
+      state});
+      
+    Revery.Utility.HeadlessWindow.render(
+      headlessWindow,
+      <Oni_UI.Root state />
+    );
+
+    Revery.Utility.HeadlessWindow.takeScreenshot(headlessWindow, "screenshot.png");
   };
 
   InitLog.info("Starting store...");

--- a/integration_test/lib/dune
+++ b/integration_test/lib/dune
@@ -1,5 +1,5 @@
 (library
     (name Oni_IntegrationTestLib)
     (modules (:standard))
-    (preprocess (pps ppx_deriving_yojson ppx_deriving.show))
+    (preprocess (pps brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show))
     (libraries Oni2.feature.terminal Oni2.store Oni2.extensions Oni2.model Oni2.core))


### PR DESCRIPTION
This hooks up the Revery `HeadlessWindow` APIs, so that we can exercise our rendering / UI during our integration tests, to get more coverage.

Previously, this wasn't doable, because we could only render when OpenGL was present - but Skia gives us a fallback to software rendering.