### PR TITLE
Bugfix: Don't clear notifications with <ESC>

### DIFF
--- a/integration_test/EchoNotificationTest.re
+++ b/integration_test/EchoNotificationTest.re
@@ -2,7 +2,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 
 // This test validates that certain keystrokes are ignored by our Vim layer
-runTest(~name="InputIgnore test", (dispatch, wait, runEffects) => {
+runTest(~name="InputIgnore test", (_dispatch, wait, runEffects) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     state.mode == Vim.Types.Normal
   );
@@ -18,13 +18,5 @@ runTest(~name="InputIgnore test", (dispatch, wait, runEffects) => {
     } else {
       true;
     }
-  );
-
-  // Escape clears notification
-  dispatch(KeyboardInput("<esc>"));
-  runEffects();
-
-  wait(~name="Notification is cleared", (state: State.t) =>
-    List.length(state.notifications) == 0
   );
 });

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -131,17 +131,6 @@ let start =
     });
 
   let _: unit => unit =
-    // Unhandled escape is called when there is an `<esc>` sent to Vim,
-    // but nothing to escape from (ie, in normal mode with no pending operator)
-    Vim.onUnhandledEscape(() => {
-      let state = getState();
-      if (Notifications.any(state.notifications)) {
-        let oldestNotification = Notifications.getOldest(state.notifications);
-        dispatch(Actions.HideNotification(oldestNotification));
-      };
-    });
-
-  let _: unit => unit =
     Vim.Mode.onChanged(newMode => dispatch(Actions.ChangeMode(newMode)));
 
   let _: unit => unit =


### PR DESCRIPTION
As part of our older notification experience (before @glennsl did the awesome UX revamp in #1184 ), we had set it up so that pressing `<ESC>` when a notification was open would clear it out.

This is still wired up, but I think it makes less sense in the current experience, since the notifications are much less obtrusive - it's not obvious that pressing 'esc' is removing them unless you watch the notification counter carefully.