### PR TITLE
Use hook setter for inter-component comunication in ContextMenu

### DIFF
--- a/src/Components/ContextMenu.re
+++ b/src/Components/ContextMenu.re
@@ -9,38 +9,13 @@ module Constants = {
   // let maxMenuHeight = 600;
 };
 
-// TYPES
-
-module Id: {
-  type t;
-  let create: unit => t;
-} = {
-  type t = int;
-
-  let lastId = ref(0);
-  let create = () => {
-    incr(lastId);
-    lastId^;
-  };
-};
+// MODEL
 
 [@deriving show({with_path: false})]
 type item('data) = {
   label: string,
   // icon: option(IconTheme.IconDefinition.t),
   data: [@opaque] 'data,
-};
-
-type placement = {
-  x: int,
-  y: int,
-  orientation: ([ | `Top | `Middle | `Bottom], [ | `Left | `Middle | `Right]),
-};
-
-type t('data) = {
-  id: Id.t,
-  placement: option(placement),
-  items: list(item('data)),
 };
 
 // MENUITEM
@@ -150,10 +125,10 @@ module Menu = {
   };
 
   let component = React.Expert.component("Menu");
-  let make = (~items, ~placement, ~theme, ~font, ~onItemSelect, ()) =>
+  let make = (~items, ~x, ~y, ~orientation, ~theme, ~font, ~onItemSelect, ()) =>
     component(hooks => {
       let ((maybeRef, setRef), hooks) = Hooks.state(None, hooks);
-      let {x, y, orientation: (orientY, orientX)} = placement;
+      let (orientY, orientX) = orientation;
 
       let height =
         switch (maybeRef) {
@@ -195,6 +170,11 @@ module Menu = {
 // OVERLAY
 
 module Overlay = {
+  let internalSetMenus = ref(_ => ());
+
+  let setMenu = (id, menu) => internalSetMenus^(IntMap.add(id, menu));
+  let clearMenu = id => internalSetMenus^(IntMap.remove(id));
+
   module Styles = {
     open Style;
 
@@ -209,68 +189,79 @@ module Overlay = {
     ];
   };
 
-  let make = (~model, ~theme, ~font, ~onOverlayClick, ~onItemSelect, ()) =>
-    switch (model) {
-    | {items, placement: Some(placement), _} =>
-      <Clickable onClick=onOverlayClick style=Styles.overlay>
-        <Menu items placement theme font onItemSelect />
-      </Clickable>
-    | _ => React.empty
+  let%component make = (~onClick, ()) => {
+    let%hook (menus, setMenus) = Hooks.state(IntMap.empty);
+    internalSetMenus := setMenus;
+
+    if (IntMap.is_empty(menus)) {
+      React.empty;
+    } else {
+      <Clickable onClick style=Styles.overlay>
+        {IntMap.bindings(menus) |> List.map(snd) |> React.listToElement}
+      </Clickable>;
     };
-};
-
-// INSTANCE
-
-module Make = (()) => {
-  let id = Id.create();
-
-  let init = items => {id, placement: None, items};
-
-  // ANCHOR
-
-  module Anchor = {
-    let component = React.Expert.component("Anchor");
-    let make =
-        (
-          ~model as maybeModel,
-          ~orientation=(`Bottom, `Left),
-          ~offsetX=0,
-          ~offsetY=0,
-          ~onUpdate,
-          (),
-        ) =>
-      component(hooks => {
-        let (maybeRef, hooks) = Hooks.ref(None, hooks);
-
-        switch (maybeModel, maybeRef^) {
-        | (Some(model), Some(node)) =>
-          if (model.id == id) {
-            let (x, y, width, _) =
-              Math.BoundingBox2d.getBounds(node#getBoundingBox());
-
-            let x =
-              switch (orientation) {
-              | (_, `Left) => x
-              | (_, `Middle) => x -. width /. 2.
-              | (_, `Right) => x -. width
-              };
-
-            let placement =
-              Some({
-                x: int_of_float(x) + offsetX,
-                y: int_of_float(y) + offsetY,
-                orientation,
-              });
-
-            if (model.placement != placement) {
-              onUpdate({...model, placement});
-            };
-          }
-
-        | _ => ()
-        };
-
-        (<View ref={node => maybeRef := Some(node)} />, hooks);
-      });
   };
 };
+
+// ANCHOR
+
+module Anchor = {
+  let generateId = {
+    let lastId = ref(0);
+
+    () => {
+      incr(lastId);
+      lastId^;
+    };
+  };
+
+  let component = React.Expert.component("Anchor");
+  let make =
+      (
+        ~items,
+        ~orientation=(`Bottom, `Left),
+        ~offsetX=0,
+        ~offsetY=0,
+        ~onItemSelect,
+        ~theme,
+        ~font,
+        (),
+      ) =>
+    component(hooks => {
+      let ((id, _), hooks) = Hooks.state(generateId(), hooks);
+      let ((maybeRef, setRef), hooks) = Hooks.state(None, hooks);
+      let ((), hooks) =
+        Hooks.effect(
+          OnMount,
+          () => Some(() => Overlay.clearMenu(id)),
+          hooks,
+        );
+
+      switch (maybeRef) {
+      | Some(node) =>
+        let (x, y, width, _) =
+          Math.BoundingBox2d.getBounds(node#getBoundingBox());
+
+        let x =
+          switch (orientation) {
+          | (_, `Left) => x
+          | (_, `Middle) => x -. width /. 2.
+          | (_, `Right) => x -. width
+          };
+
+        let x = int_of_float(x) + offsetX;
+        let y = int_of_float(y) + offsetY;
+
+        Overlay.setMenu(
+          id,
+          <Menu items x y orientation theme font onItemSelect />,
+        );
+
+      | None => ()
+      };
+
+      (<View ref={node => setRef(_ => Some(node))} />, hooks);
+    });
+};
+
+include Anchor;

--- a/src/Components/ContextMenu.rei
+++ b/src/Components/ContextMenu.rei
@@ -4,44 +4,27 @@ open Revery.UI;
 [@deriving show]
 type item('data) = {
   label: string,
-  // icon: option(IconTheme.IconDefinition.t),
+  // TODO: icon: option(IconTheme.IconDefinition.t),
   data: [@opaque] 'data,
 };
 
-type t('data);
-
 module Overlay: {
-  let make:
-    (
-      ~model: t('data),
-      ~theme: Theme.t,
-      ~font: UiFont.t,
-      ~onOverlayClick: unit => unit,
-      ~onItemSelect: item('data) => unit,
-      unit
-    ) =>
-    element;
+  let make: (~key: React.Key.t=?, ~onClick: unit => unit, unit) => element;
 };
 
-module Make:
-  () =>
-   {
-    let init: list(item('data)) => t('data);
-
-    module Anchor: {
-      let make:
-        (
-          ~model: option(t('data)),
-          ~orientation: (
-                          [ | `Top | `Middle | `Bottom],
-                          [ | `Left | `Middle | `Right],
-                        )
-                          =?,
-          ~offsetX: int=?,
-          ~offsetY: int=?,
-          ~onUpdate: t('data) => unit,
-          unit
-        ) =>
-        element;
-    };
-  };
+let make:
+  (
+    ~items: list(item('data)),
+    ~orientation: (
+                    [ | `Top | `Middle | `Bottom],
+                    [ | `Left | `Middle | `Right],
+                  )
+                    =?,
+    ~offsetX: int=?,
+    ~offsetY: int=?,
+    ~onItemSelect: item('data) => unit,
+    ~theme: Theme.t,
+    ~font: UiFont.t,
+    unit
+  ) =>
+  element;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -62,7 +62,6 @@ type t =
   | TextInput([@opaque] Revery.Events.textInputEvent)
   | HoverShow
   | ChangeMode([@opaque] Vim.Mode.t)
-  | ContextMenuUpdated([@opaque] ContextMenu.t(t))
   | ContextMenuOverlayClicked
   | ContextMenuItemSelected(ContextMenu.item(t))
   | DiagnosticsHotKey

--- a/src/Model/Notifications.re
+++ b/src/Model/Notifications.re
@@ -3,9 +3,6 @@ open Notification;
 
 type t = list(Notification.t);
 
-module ContextMenu =
-  Oni_Components.ContextMenu.Make({});
-
 let initial: t = [];
 
 let reduce = (state, action: Actions.t) => {

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -9,7 +9,6 @@ open Oni_Input;
 open Oni_Syntax;
 
 module Ext = Oni_Extensions;
-module ContextMenu = Oni_Components.ContextMenu;
 module KeyDisplayer = Oni_Components.KeyDisplayer;
 module Completions = Feature_LanguageSupport.Completions;
 module Diagnostics = Feature_LanguageSupport.Diagnostics;
@@ -17,13 +16,19 @@ module Definition = Feature_LanguageSupport.Definition;
 module LanguageFeatures = Feature_LanguageSupport.LanguageFeatures;
 module BufferSyntaxHighlights = Feature_Editor.BufferSyntaxHighlights;
 
+module ContextMenu = {
+  type t =
+    | NotificationStatusBarItem
+    | Nothing;
+};
+
 type t = {
   buffers: Buffers.t,
   bufferRenderers: BufferRenderers.t,
   bufferHighlights: BufferHighlights.t,
   bufferSyntaxHighlights: BufferSyntaxHighlights.t,
   commands: Commands.t,
-  contextMenu: option(ContextMenu.t(Actions.t)),
+  contextMenu: ContextMenu.t,
   mode: Vim.Mode.t,
   completions: Completions.t,
   configuration: Configuration.t,
@@ -80,7 +85,7 @@ let create: unit => t =
     bufferRenderers: BufferRenderers.initial,
     bufferSyntaxHighlights: BufferSyntaxHighlights.empty,
     commands: Commands.empty,
-    contextMenu: None,
+    contextMenu: ContextMenu.Nothing,
     completions: Completions.initial,
     configuration: Configuration.default,
     decorationProviders: [],

--- a/src/Store/ContextMenuStore.re
+++ b/src/Store/ContextMenuStore.re
@@ -1,24 +1,6 @@
 open Oni_Model;
 open Actions;
 
-module ContextMenu = Oni_Components.ContextMenu;
-
-let contextMenu =
-  Notifications.ContextMenu.init(
-    ContextMenu.[
-      {
-        label: "Clear All",
-        // icon: None,
-        data: ClearNotifications,
-      },
-      {
-        label: "Open",
-        // icon: None,
-        data: StatusBar(NotificationCountClicked),
-      },
-    ],
-  );
-
 let start = () => {
   let selectItemEffect = (item: ContextMenu.item(_)) =>
     Isolinear.Effect.createWithDispatch(
@@ -30,23 +12,18 @@ let start = () => {
     let default = (state, Isolinear.Effect.none);
 
     switch (action) {
-    | ContextMenuUpdated(model) => (
-        {...state, contextMenu: Some(model)},
-        Isolinear.Effect.none,
-      )
-
     | ContextMenuOverlayClicked => (
-        {...state, contextMenu: None},
+        {...state, contextMenu: State.ContextMenu.Nothing},
         Isolinear.Effect.none,
       )
 
     | ContextMenuItemSelected(item) => (
-        {...state, contextMenu: None},
+        {...state, contextMenu: State.ContextMenu.Nothing},
         selectItemEffect(item),
       )
 
     | StatusBar(NotificationsContextMenu) => (
-        {...state, contextMenu: Some(contextMenu)},
+        {...state, contextMenu: State.ContextMenu.NotificationStatusBarItem},
         Isolinear.Effect.none,
       )
 

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -55,8 +55,8 @@ let make = (~state: State.t, ()) => {
         _,
       } = state;
 
-  let onContextMenuUpdate = model =>
-    GlobalContext.current().dispatch(ContextMenuUpdated(model));
+  let onContextMenuItemSelect = item =>
+    GlobalContext.current().dispatch(ContextMenuItemSelected(item));
 
   let statusBarVisible =
     Selectors.getActiveConfigurationValue(state, c =>
@@ -77,7 +77,7 @@ let make = (~state: State.t, ()) => {
   let statusBar =
     statusBarVisible
       ? <View style={Styles.statusBar(statusBarHeight)}>
-          <StatusBar state contextMenu onContextMenuUpdate />
+          <StatusBar state contextMenu onContextMenuItemSelect />
         </View>
       : React.empty;
 
@@ -129,22 +129,10 @@ let make = (~state: State.t, ()) => {
        }}
     </Overlay>
     statusBar
-    {switch (contextMenu) {
-     | Some(model) =>
-       let onOverlayClick = () =>
-         GlobalContext.current().dispatch(ContextMenuOverlayClicked);
-       let onItemSelect = item =>
-         GlobalContext.current().dispatch(ContextMenuItemSelected(item));
+    {let onClick = () =>
+       GlobalContext.current().dispatch(ContextMenuOverlayClicked);
 
-       <ContextMenu.Overlay
-         theme
-         font=uiFont
-         model
-         onOverlayClick
-         onItemSelect
-       />;
-     | None => React.empty
-     }}
+     <ContextMenu.Overlay onClick />}
     <Tooltip.Overlay theme font=uiFont />
     <Modals state />
     <Overlay> <SneakView state /> </Overlay>


### PR DESCRIPTION
Uses the same hook setter trick used in Tooltip, which simplifies the API quite a bit. Also added support for multiple open menus at once in the component itself. Making sure there's only a single menu open is therefore an application-concern now, which is much cleaner.