### PR TITLE
Feature - Terminal: Handle resize

### DIFF
--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -36,6 +36,7 @@ type splitDirection =
 [@deriving show({with_path: false})]
 type msg =
   | NewTerminal({splitDirection})
+  | Resized({id: int, rows: int, columns: int})
   | Service(Service_Terminal.msg);
 
 type outmsg =
@@ -76,6 +77,9 @@ let update = (_extHostClient, model: t, msg) => {
       {idToTerminal, nextId: id + 1},
       TerminalCreated({name: getBufferName(id), splitDirection}),
     );
+  | Resized({id, rows, columns}) => 
+    let newModel = updateById(id, term => { ...term, rows, columns}, model);
+    (newModel, Nothing)
   | Service(ProcessStarted({id, pid})) =>
     let newModel = updateById(id, term => {...term, pid: Some(pid)}, model);
     (newModel, Nothing);

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -36,7 +36,11 @@ type splitDirection =
 [@deriving show({with_path: false})]
 type msg =
   | NewTerminal({splitDirection})
-  | Resized({id: int, rows: int, columns: int})
+  | Resized({
+      id: int,
+      rows: int,
+      columns: int,
+    })
   | Service(Service_Terminal.msg);
 
 type outmsg =
@@ -77,9 +81,9 @@ let update = (_extHostClient, model: t, msg) => {
       {idToTerminal, nextId: id + 1},
       TerminalCreated({name: getBufferName(id), splitDirection}),
     );
-  | Resized({id, rows, columns}) => 
-    let newModel = updateById(id, term => { ...term, rows, columns}, model);
-    (newModel, Nothing)
+  | Resized({id, rows, columns}) =>
+    let newModel = updateById(id, term => {...term, rows, columns}, model);
+    (newModel, Nothing);
   | Service(ProcessStarted({id, pid})) =>
     let newModel = updateById(id, term => {...term, pid: Some(pid)}, model);
     (newModel, Nothing);

--- a/src/Feature/Terminal/Feature_Terminal.rei
+++ b/src/Feature/Terminal/Feature_Terminal.rei
@@ -28,7 +28,11 @@ type splitDirection =
 [@deriving show({with_path: false})]
 type msg =
   | NewTerminal({splitDirection})
-  | Resized({id: int, rows: int, columns: int})
+  | Resized({
+      id: int,
+      rows: int,
+      columns: int,
+    })
   | Service(Service_Terminal.msg);
 
 type outmsg =

--- a/src/Feature/Terminal/Feature_Terminal.rei
+++ b/src/Feature/Terminal/Feature_Terminal.rei
@@ -28,6 +28,7 @@ type splitDirection =
 [@deriving show({with_path: false})]
 type msg =
   | NewTerminal({splitDirection})
+  | Resized({id: int, rows: int, columns: int})
   | Service(Service_Terminal.msg);
 
 type outmsg =

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -120,8 +120,8 @@ module Sub = {
         if (params.rows != state.rows || params.columns != state.columns) {
           ExtHostClient.Terminal.Requests.acceptProcessResize(
             params.id,
-            params.rows,
             params.columns,
+            params.rows,
             params.extHostClient,
           );
         };

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -106,6 +106,16 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
         state.configuration,
       );
     };
+    
+  let onDimensionsChanged =
+      ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
+    GlobalContext.current().notifyEditorSizeChanged(
+      ~editorGroupId=editorGroup.editorGroupId,
+      ~width,
+      ~height,
+      (),
+    );
+  };
 
   let children = {
     let maybeEditor = EditorGroup.getActiveEditor(editorGroup);
@@ -116,15 +126,6 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
     let editorView =
       switch (maybeEditor) {
       | Some(editor) =>
-        let onDimensionsChanged =
-            ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
-          GlobalContext.current().notifyEditorSizeChanged(
-            ~editorGroupId=editorGroup.editorGroupId,
-            ~width,
-            ~height,
-            (),
-          );
-        };
         let onScroll = deltaY => {
           let () =
             GlobalContext.current().editorScrollDelta(
@@ -203,8 +204,8 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             metrics
             editor
             buffer
-            onDimensionsChanged
             onCursorChange
+            onDimensionsChanged={(_) => ()}
             onScroll
             theme
             rulers
@@ -263,7 +264,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
     );
   };
 
-  <View onMouseDown style>
+  <View onMouseDown style onDimensionsChanged>
     <View style=absoluteStyle> children </View>
     <View style=overlayStyle />
   </View>;

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -106,7 +106,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
         state.configuration,
       );
     };
-    
+
   let onDimensionsChanged =
       ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
     // TODO: Handle show tabs
@@ -206,7 +206,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             editor
             buffer
             onCursorChange
-            onDimensionsChanged={(_) => ()}
+            onDimensionsChanged={_ => ()}
             onScroll
             theme
             rulers

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -109,6 +109,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
     
   let onDimensionsChanged =
       ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
+    // TODO: Handle show tabs
     GlobalContext.current().notifyEditorSizeChanged(
       ~editorGroupId=editorGroup.editorGroupId,
       ~width,

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -109,7 +109,8 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
 
   let onDimensionsChanged =
       ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
-    // TODO: Handle show tabs
+    let height = showTabs ? height - Constants.tabHeight : height;
+
     GlobalContext.current().notifyEditorSizeChanged(
       ~editorGroupId=editorGroup.editorGroupId,
       ~width,

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -33,20 +33,32 @@ let make =
 
   let size = editorFont.fontSize;
 
-  let onDimensionsChanged = (({height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t)) => {
+  let onDimensionsChanged =
+      (
+        {height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t,
+      ) => {
     // If we have a loaded font, figure out how many columns and rows we can show
-    print_endline (Printf.sprintf("TERMINAL DIMENSIONS: %dx%d", width, height ));
+    print_endline(
+      Printf.sprintf("TERMINAL DIMENSIONS: %dx%d", width, height),
+    );
 
-    Option.iter((font) => {
-      let terminalFont = ReveryTerminal.Font.make(~size, font); 
-      let rows = (float_of_int(height) /. terminalFont.lineHeight) |> int_of_float;
-      let columns = (float_of_int(width) /. terminalFont.characterWidth) |> int_of_float;
-      
-    print_endline (Printf.sprintf("RESIZED: %dx%d", rows, columns ));
-      GlobalContext.current().dispatch(Actions.Terminal(
-        Feature_Terminal.Resized({id: terminal.id, rows, columns}) 
-      ));
-    }, maybeFont);
+    Option.iter(
+      font => {
+        let terminalFont = ReveryTerminal.Font.make(~size, font);
+        let rows =
+          float_of_int(height) /. terminalFont.lineHeight |> int_of_float;
+        let columns =
+          float_of_int(width) /. terminalFont.characterWidth |> int_of_float;
+
+        print_endline(Printf.sprintf("RESIZED: %dx%d", rows, columns));
+        GlobalContext.current().dispatch(
+          Actions.Terminal(
+            Feature_Terminal.Resized({id: terminal.id, rows, columns}),
+          ),
+        );
+      },
+      maybeFont,
+    );
   };
 
   let element =
@@ -59,6 +71,7 @@ let make =
       maybeFont,
     )
     |> Option.value(~default=React.empty);
-  <View onDimensionsChanged
-    style={Styles.container(metrics)}> element </View>;
+  <View onDimensionsChanged style={Styles.container(metrics)}>
+    element
+  </View>;
 };

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -4,7 +4,9 @@
  * Component for the 'terminal' buffer renderer
  */
 
+open Revery;
 open Revery.UI;
+open Revery.UI.Components;
 open Oni_Core;
 
 module EditorMetrics = Feature_Editor.EditorMetrics;
@@ -28,6 +30,10 @@ let make =
   let maybeFont =
     Revery.Font.load(editorFont.fontFile) |> Stdlib.Result.to_option;
 
+  let onDimensionsChanged = (({height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t)) => {
+    print_endline (Printf.sprintf("TERMINAL DIMENSIONS: %dx%d", width, height ));
+  };
+
   let element =
     Option.map(
       font => {
@@ -39,5 +45,6 @@ let make =
       maybeFont,
     )
     |> Option.value(~default=React.empty);
-  <View style={Styles.container(metrics)}> element </View>;
+  <View onDimensionsChanged
+    style={Styles.container(metrics)}> element </View>;
 };

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -4,9 +4,7 @@
  * Component for the 'terminal' buffer renderer
  */
 
-open Revery;
 open Revery.UI;
-open Revery.UI.Components;
 open Oni_Core;
 open Oni_Model;
 

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -38,10 +38,6 @@ let make =
         {height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t,
       ) => {
     // If we have a loaded font, figure out how many columns and rows we can show
-    print_endline(
-      Printf.sprintf("TERMINAL DIMENSIONS: %dx%d", width, height),
-    );
-
     Option.iter(
       font => {
         let terminalFont = ReveryTerminal.Font.make(~size, font);
@@ -50,7 +46,6 @@ let make =
         let columns =
           float_of_int(width) /. terminalFont.characterWidth |> int_of_float;
 
-        print_endline(Printf.sprintf("RESIZED: %dx%d", rows, columns));
         GlobalContext.current().dispatch(
           Actions.Terminal(
             Feature_Terminal.Resized({id: terminal.id, rows, columns}),


### PR DESCRIPTION
This implements resize handling, such that the terminal instance is always in sync with the visual representation.

In the UI, we hook up an `onDimensionsChanged` handler for the `<TerminalView />` - if the dimensions change, we recalculate the visible rows / columns and dispatch a msg, which updates the terminal state. 

The terminal subscription manages synchronizing this - there was a bug where the order of arguments for `rows`/`columns` was reversed, so that was fixed.

In addition, we were only caring about the size of `<EditorSurface />` buffer renderers - this changes the `<EditorGroupView />` such that it sizes any buffer renderer, as the terminal relies on this to be correctly sized.