### PR TITLE
Fix extension list scrunching the search pane

### DIFF
--- a/src/UI/ExtensionListView.re
+++ b/src/UI/ExtensionListView.re
@@ -8,8 +8,6 @@ open Oni_Components;
 open Oni_Extensions;
 
 module Styles = {
-  let container = Style.[flexGrow(1)];
-
   let text = (~theme: Theme.t, ~font: UiFont.t) =>
     Style.[
       fontSize(font.fontSize),
@@ -94,9 +92,7 @@ let make = (~state: State.t, ()) => {
   let allExtensions = bundledExtensions @ userExtensions |> Array.of_list;
   //let developmentCount = Array.length(developmentExtensions);
 
-  <View style=Styles.container>
-    <FlatList rowHeight=50 count={Array.length(allExtensions)} focused=None>
-      ...{renderItem(allExtensions)}
-    </FlatList>
-  </View>;
+  <FlatList rowHeight=50 count={Array.length(allExtensions)} focused=None>
+    ...{renderItem(allExtensions)}
+  </FlatList>;
 };


### PR DESCRIPTION
This fixes it so that the extension list doesn't scrunch the search pane, and hopefully doesn't unfix something else using the FlatList. I think I've tested everything, even the completions view eventually.

I also tried to fix the Dock scrunching the status bar when the window is really small, but wasn't able to figure out the right incantation for that.