### PR TITLE
Fix bad theme fallback colors, especially for light themes

### DIFF
--- a/src/Components/MessageBox.re
+++ b/src/Components/MessageBox.re
@@ -81,7 +81,9 @@ open Revery.UI.Components;
 module Styles = {
   open Style;
 
-  let container = (~theme: Theme.t) => [backgroundColor(theme.background)];
+  let container = (~theme: Theme.t) => [
+    backgroundColor(theme.editorBackground),
+  ];
 
   let message = [padding(20), paddingBottom(10)];
 

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -446,24 +446,20 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let scrollbarSliderActiveBackground =
     getColor(
-      defaults.editorBackground,
-      [
-        "scrollbarSlider.activeBackground",
-        "menu.selectionBackground",
-        "list.activeSelectionBackground",
-      ],
+      defaults === light ? Color.hex("#00000094") : Color.hex("#bfbfbf64"),
+      ["scrollbarSlider.activeBackground"],
     );
 
   let scrollbarSliderBackground =
     getColor(
-      defaults.editorBackground,
-      ["scrollbarSlider.background", "menu.background", "list.background"],
+      defaults === light ? Color.hex("#64646464") : Color.hex("#79797964"),
+      ["scrollbarSlider.background"],
     );
 
   let scrollbarSliderHoverBackground =
     getColor(
-      defaults.editorBackground,
-      ["scrollbarSlider.hoverBackground", "scrollbarSlider.background"],
+      defaults === light ? Color.hex("#646464B4") : Color.hex("#646464B4"),
+      ["scrollbarSlider.hoverBackground"],
     );
 
   let sneakBackground = menuSelectionBackground;

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -406,14 +406,14 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let menuBackground =
     getColor(
-      defaults.editorBackground,
-      ["menu.background", "editor.background"],
+      defaults === light ? Colors.white : Color.hex("#3c3c3c"),
+      ["menu.background", "dropdown.background"],
     );
 
   let menuForeground =
     getColor(
-      defaults.foreground,
-      ["menu.foreground", "foreground", "editor.foreground"],
+      defaults === light ? defaults.foreground : Color.hex("#f0f0f0"),
+      ["menu.foreground", "dropdown.foreground"],
     );
 
   let menuSelectionBackground =

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -89,7 +89,11 @@ type t = {
   menuSelectionBackground: Color.t,
   editorOverviewRulerBracketMatchForeground: Color.t,
   editorWhitespaceForeground: Color.t,
+  editorGroupsHeaderTabsBackground: Color.t,
+  tabActiveBackground: Color.t,
   tabActiveForeground: Color.t,
+  tabInactiveBackground: Color.t,
+  tabInactiveForeground: Color.t,
   oniVisualModeBackground: Color.t,
   oniInsertModeBackground: Color.t,
   oniReplaceModeBackground: Color.t,
@@ -187,7 +191,11 @@ let default: t = {
   menuForeground: Color.hex("#FFFFFF"),
   menuSelectionBackground: Color.hex("#495162"),
   editorWhitespaceForeground: Color.hex("#3b4048"),
+  editorGroupsHeaderTabsBackground: Color.hex("#2F3440"),
+  tabActiveBackground: Color.hex("#2F3440"),
   tabActiveForeground: Color.hex("#DCDCDC"),
+  tabInactiveBackground: Color.hex("#2F3440"),
+  tabInactiveForeground: Color.hex("#DCDCDC"),
   oniVisualModeBackground: Color.hex("#56b6c2"),
   oniInsertModeBackground: Color.hex("#98c379"),
   oniReplaceModeBackground: Color.hex("#d19a66"),
@@ -452,12 +460,6 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let sneakForeground = menuForeground;
   let sneakHighlight = default.oniNormalModeBackground;
 
-  let tabActiveForeground =
-    getColor(
-      defaultForeground,
-      ["tab.activeForeground", "editor.foreground", "foreground"],
-    );
-
   let titleBarActiveBackground =
     getColor(
       defaultBackground,
@@ -625,7 +627,38 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     sneakBackground,
     sneakForeground,
     sneakHighlight,
-    tabActiveForeground,
+    editorGroupsHeaderTabsBackground:
+      getColor(
+        defaultBackground,
+        [
+          "editorGroupHeader.tabsBackground",
+          "editor.background",
+          "background",
+        ],
+      ),
+    tabActiveBackground:
+      getColor(
+        defaultBackground,
+        ["tab.activebackground", "editor.background", "background"],
+      ),
+
+    tabActiveForeground:
+      getColor(
+        defaultForeground,
+        ["tab.activeForeground", "editor.foreground", "foreground"],
+      ),
+
+    tabInactiveBackground:
+      getColor(
+        defaultBackground,
+        ["tab.inactiveBackground", "editor.background", "background"],
+      ),
+
+    tabInactiveForeground:
+      getColor(
+        defaultForeground,
+        ["tab.inactiveForeground", "editor.foreground", "foreground"],
+      ),
     terminalBackground,
     terminalForeground,
     terminalAnsiBlack,

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -62,7 +62,6 @@ type editorGutter = {
 };
 
 type t = {
-  background: Color.t,
   foreground: Color.t,
   activityBarBackground: Color.t,
   activityBarForeground: Color.t,
@@ -162,7 +161,6 @@ type t = {
 };
 
 let default: t = {
-  background: Color.hex("#282C35"),
   foreground: Color.hex("#ECEFF4"),
   sideBarBackground: Color.hex("#21252b"),
   sideBarForeground: Color.hex("#ECEFF4"),
@@ -276,18 +274,17 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     };
   };
 
-  let background = getColor(defaults.editorBackground, ["background"]);
   let foreground = getColor(defaults.foreground, ["foreground"]);
 
   let editorBackground =
-    getColor(defaults.editorBackground, ["editor.background", "background"]);
+    getColor(defaults.editorBackground, ["editor.background"]);
   let editorForeground =
     getColor(defaults.foreground, ["editor.foreground", "foreground"]);
 
   let editorCursorBackground =
     getColor(
       defaults.editorBackground,
-      ["editorCursor.background", "editor.background", "background"],
+      ["editorCursor.background", "editor.background"],
     );
   let editorCursorForeground =
     getColor(
@@ -298,13 +295,13 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let editorHoverWidgetBackground =
     getColor(
       defaults.editorBackground,
-      ["editorHoverWidget.background", "editor.background", "background"],
+      ["editorHoverWidget.background", "editor.background"],
     );
 
   let activityBarBackground =
     getColor(
       defaults.editorBackground,
-      ["activityBar.background", "editor.background", "background"],
+      ["activityBar.background", "editor.background"],
     );
 
   let activityBarForeground =
@@ -322,7 +319,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let editorLineNumberBackground =
     getColor(
       defaults.editorBackground,
-      ["editorLineNumber.background", "editor.background", "background"],
+      ["editorLineNumber.background", "editor.background"],
     );
   let editorLineNumberForeground =
     getColor(
@@ -339,23 +336,19 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let editorLineHighlightBackground =
     getColor(
       defaults.editorBackground,
-      ["editor.lineHighlightBackground", "editor.background", "background"],
+      ["editor.lineHighlightBackground", "editor.background"],
     );
 
   let editorSuggestWidgetBackground =
     getColor(
       defaults.editorBackground,
-      ["editorSuggestWidget.background", "editor.background", "background"],
+      ["editorSuggestWidget.background", "editor.background"],
     );
 
   let editorSuggestWidgetSelectedBackground =
     getColor(
       defaults.editorBackground,
-      [
-        "editorSuggestWidget.selectedBackground",
-        "editor.background",
-        "background",
-      ],
+      ["editorSuggestWidget.selectedBackground", "editor.background"],
     );
 
   let editorSuggestWidgetBorder =
@@ -366,7 +359,6 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
         "editorHoverWidget.border",
         "editorSuggestWidget.background",
         "editor.background",
-        "background",
       ],
     );
   let editorSuggestWidgetHighlightForeground =
@@ -394,7 +386,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let menuBackground =
     getColor(
       defaults.editorBackground,
-      ["menu.background", "background", "editor.background"],
+      ["menu.background", "editor.background"],
     );
 
   let menuForeground =
@@ -412,7 +404,6 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
         "editor.selectionHighlightBackground",
         "list.focusBackground",
         "list.hoverBackground",
-        "background",
         "editor.background",
       ],
     );
@@ -461,7 +452,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let titleBarActiveBackground =
     getColor(
       defaults.editorBackground,
-      ["titleBar.activeBackground", "background", "editor.background"],
+      ["titleBar.activeBackground", "editor.background"],
     );
 
   let titleBarInactiveBackground =
@@ -470,7 +461,6 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
       [
         "titleBar.inactiveBackground",
         "titleBar.activeBackground",
-        "background",
         "editor.background",
       ],
     );
@@ -478,7 +468,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let titleBarActiveForeground =
     getColor(
       defaults.foreground,
-      ["titleBar.activeForeground", "background", "editor.foreground"],
+      ["titleBar.activeForeground", "editor.foreground"],
     );
 
   let titleBarInactiveForeground =
@@ -562,7 +552,6 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   {
     ...default,
-    background,
     foreground,
     activityBarBackground,
     activityBarForeground,
@@ -634,7 +623,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     tabActiveBackground:
       getColor(
         defaults.editorBackground,
-        ["tab.activebackground", "editor.background", "background"],
+        ["tab.activebackground", "editor.background"],
       ),
 
     tabActiveForeground:

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -425,13 +425,13 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let sideBarBackground =
     getColor(
       defaultBackground,
-      ["sideBar.background", "editor.background", "background"],
+      ["sideBar.background"],
     );
 
   let sideBarForeground =
     getColor(
-      defaultForeground,
-      ["sideBar.foreground", "editor.foreground", "foreground"],
+      defaultForeground, // Actually `null`
+      ["sideBar.foreground"],
     );
 
   let scrollbarSliderActiveBackground =

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -412,13 +412,13 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let statusBarBackground =
     getColor(
-      defaultBackground,
+      Color.hex("#007acc"),
       ["statusBar.background", "editor.background", "background"],
     );
 
   let statusBarForeground =
     getColor(
-      defaultForeground,
+      Color.hex("#fff"),
       ["statusBar.foreground", "editor.foreground", "foreground"],
     );
 

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -4,6 +4,8 @@
  * Theming color / info
  */
 
+// VSCode theme defaults and fallbacks defined in https://github.com/microsoft/vscode/blob/abb01b183d450a590cbb78acb4e787eec5445830/src/vs/workbench/common/theme.ts
+
 open Revery;
 
 type defaults = {
@@ -411,16 +413,10 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     );
 
   let statusBarBackground =
-    getColor(
-      Color.hex("#007acc"),
-      ["statusBar.background", "editor.background", "background"],
-    );
+    getColor(Color.hex("#007acc"), ["statusBar.background"]);
 
   let statusBarForeground =
-    getColor(
-      Color.hex("#fff"),
-      ["statusBar.foreground", "editor.foreground", "foreground"],
-    );
+    getColor(Color.hex("#fff"), ["statusBar.foreground"]);
 
   let sideBarBackground =
     getColor(
@@ -644,20 +640,22 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
     tabActiveForeground:
       getColor(
-        defaultForeground,
-        ["tab.activeForeground", "editor.foreground", "foreground"],
+        defaults === light ? Color.hex("#333") : Colors.white,
+        ["tab.activeForeground"],
       ),
 
     tabInactiveBackground:
       getColor(
-        defaultBackground,
-        ["tab.inactiveBackground", "editor.background", "background"],
+        defaults === light ? Color.hex("#ececec") : Color.hex("#2d2d2d"),
+        ["tab.inactiveBackground"],
       ),
 
     tabInactiveForeground:
       getColor(
-        defaultForeground,
-        ["tab.inactiveForeground", "editor.foreground", "foreground"],
+        defaults === light
+          ? Color.multiplyAlpha(0.7, Color.hex("#333"))
+          : Color.multiplyAlpha(0.5, Colors.white), // should be lower opacity variant of _actual_ active foreground color, not the _default_ active foreground color
+        ["tab.inactiveForeground"],
       ),
     terminalBackground,
     terminalForeground,

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -274,9 +274,9 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   };
 
   let background =
-    getColor(defaultBackground, ["background", "editor.background"]);
+    getColor(defaultBackground, ["background"]);
   let foreground =
-    getColor(defaultForeground, ["foreground", "editor.foreground"]);
+    getColor(defaultForeground, ["foreground"]);
 
   let editorBackground =
     getColor(defaultBackground, ["editor.background", "background"]);

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -4,7 +4,11 @@
  * Theming color / info
  */
 
-// VSCode theme defaults and fallbacks defined in https://github.com/microsoft/vscode/blob/abb01b183d450a590cbb78acb4e787eec5445830/src/vs/workbench/common/theme.ts
+// VSCode theme defaults and fallbacks defined in
+// https://github.com/microsoft/vscode/blob/634068a42471d610453d97fa0c81ec7e713c4e17/src/vs/platform/theme/common/colorRegistry.ts
+// https://github.com/microsoft/vscode/blob/abb01b183d450a590cbb78acb4e787eec5445830/src/vs/workbench/common/theme.ts
+// https://github.com/microsoft/vscode/blob/d49c5f3bc73ca4b41fe1306b2bf1d5b4bff96291/src/vs/editor/common/view/editorColorRegistry.ts
+// https://github.com/microsoft/vscode/blob/0991720b7b44ffc15760b578b284caff78ccf398/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
 
 open Revery;
 
@@ -582,33 +586,33 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     editorSuggestWidgetSelectedBackground,
     listActiveSelectionBackground:
       getColor(
-        defaultBackground,
-        ["list.activeSelectionBackground", "menu.selectionBackground"],
+        defaults === light ? Color.hex("#0074E8") : Color.hex("#094771"),
+        ["list.activeSelectionBackground"],
       ),
     listActiveSelectionForeground:
       getColor(
-        defaultForeground,
-        ["list.activeSelectionForeground", "menu.foreground"],
+        Colors.white,
+        ["list.activeSelectionForeground"],
       ),
     listFocusBackground:
       getColor(
-        defaultBackground,
-        ["list.focusBackground", "menu.selectionBackground"],
+        defaults === light ? Color.hex("#D6EBFF") : Color.hex("#062F4A"),
+        ["list.focusBackground"],
       ),
     listFocusForeground:
       getColor(
-        defaultForeground,
-        ["list.focusForeground", "menu.foreground"],
+        defaultForeground, // Actually `null`, but not sure what that means
+        ["list.focusForeground"],
       ),
     listHoverBackground:
       getColor(
-        defaultBackground,
-        ["list.hoverBackground", "menu.selectionBackground"],
+        defaults === light ? Color.hex("#F0F0F0") : Color.hex("#2A2D2E"),
+        ["list.hoverBackground"],
       ),
     listHoverForeground:
       getColor(
-        defaultForeground,
-        ["list.hoverForeground", "menu.foreground"],
+        defaultForeground, // Actually `null`, but not sure what that means
+        ["list.hoverForeground"],
       ),
     menuBackground,
     menuForeground,

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -613,12 +613,8 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     sneakHighlight,
     editorGroupsHeaderTabsBackground:
       getColor(
-        defaults.editorBackground,
-        [
-          "editorGroupHeader.tabsBackground",
-          "editor.background",
-          "background",
-        ],
+        defaults === light ? Color.hex("#f3f3f3") : Color.hex("#252526"),
+        ["editorGroupHeader.tabsBackground"],
       ),
     tabActiveBackground:
       getColor(

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -65,6 +65,9 @@ type t = {
   foreground: Color.t,
   activityBarBackground: Color.t,
   activityBarForeground: Color.t,
+  activityBarInactiveForeground: Color.t,
+  activityBarActiveBackground: Color.t,
+  activityBarActiveBorder: Color.t,
   editorBackground: Color.t,
   editorForeground: Color.t,
   editorCursorBackground: Color.t,
@@ -165,7 +168,10 @@ let default: t = {
   sideBarBackground: Color.hex("#21252b"),
   sideBarForeground: Color.hex("#ECEFF4"),
   activityBarBackground: Color.hex("#2F3440"),
-  activityBarForeground: Color.hex("#DCDCDC"),
+  activityBarForeground: Colors.white,
+  activityBarInactiveForeground: Color.hex("#DCDCDC"),
+  activityBarActiveBackground: Colors.transparentWhite,
+  activityBarActiveBorder: Colors.white,
   editorBackground: Color.hex("#2F3440"),
   editorForeground: Color.hex("#DCDCDC"),
   editorCursorBackground: Color.hex("#2F3440"),
@@ -306,6 +312,24 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let activityBarForeground =
     getColor(Colors.white, ["activityBar.foreground"]);
+
+  let activityBarInactiveForeground =
+    getColor(
+      Color.multiplyAlpha(0.4, Colors.white),
+      ["activityBar.inactiveForeground"],
+    );
+
+  let activityBarActiveBackground =
+    getColor(
+      Colors.transparentWhite, // Actually `null`
+      ["activityBar.activeBackground"],
+    );
+
+  let activityBarActiveBorder =
+    getColor(
+      Colors.white,
+      ["activityBar.activeBackground", "acitivityBar.foreground"],
+    );
 
   let editorHoverWidgetBorder =
     getColor(
@@ -552,6 +576,9 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     foreground,
     activityBarBackground,
     activityBarForeground,
+    activityBarInactiveForeground,
+    activityBarActiveBackground,
+    activityBarActiveBorder,
     editorBackground,
     editorForeground,
     editorCursorBackground,

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -300,15 +300,12 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let activityBarBackground =
     getColor(
-      defaults.editorBackground,
-      ["activityBar.background", "editor.background"],
+      defaults === light ? Color.hex("#2c2c2c") : Color.hex("#333"),
+      ["activityBar.background"],
     );
 
   let activityBarForeground =
-    getColor(
-      defaults.foreground,
-      ["activityBar.foreground", "editor.foreground", "foreground"],
-    );
+    getColor(Colors.white, ["activityBar.foreground"]);
 
   let editorHoverWidgetBorder =
     getColor(

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -13,30 +13,35 @@
 open Revery;
 
 type defaults = {
-  editorBackground: string,
-  editorForeground: string,
-  editorIndentGuideBackground: string,
-  editorIndentGuideActiveBackground: string,
+  foreground: Color.t,
+  editorBackground: Color.t,
+  editorForeground: Color.t,
+  editorIndentGuideBackground: Color.t,
+  editorIndentGuideActiveBackground: Color.t,
 };
 
 let light: defaults = {
-  editorBackground: "#FFF",
-  editorForeground: "#000",
-  editorIndentGuideBackground: "#D3D3D3",
-  editorIndentGuideActiveBackground: "#939393",
+  foreground: Color.hex("#616161"),
+  editorBackground: Color.hex("#fffffe"),
+  editorForeground: Color.hex("#333"),
+  editorIndentGuideBackground: Color.hex("#D3D3D3"),
+  editorIndentGuideActiveBackground: Color.hex("#939393"),
 };
 
 let dark: defaults = {
-  editorBackground: "#1E1E1E",
-  editorForeground: "#D4D4D4",
-  editorIndentGuideBackground: "#404040",
-  editorIndentGuideActiveBackground: "#707070",
+  foreground: Color.hex("#ccc"),
+  editorBackground: Color.hex("#1E1E1E"),
+  editorForeground: Color.hex("#bbb"),
+  editorIndentGuideBackground: Color.hex("#404040"),
+  editorIndentGuideActiveBackground: Color.hex("#707070"),
 };
+
 let hcDark: defaults = {
-  editorBackground: "#000",
-  editorForeground: "#FFF",
-  editorIndentGuideBackground: "#FFF",
-  editorIndentGuideActiveBackground: "#FFF",
+  foreground: Color.hex("#fff"),
+  editorBackground: Color.hex("#000"),
+  editorForeground: Color.hex("#FFF"),
+  editorIndentGuideBackground: Color.hex("#FFF"),
+  editorIndentGuideActiveBackground: Color.hex("#FFF"),
 };
 
 let getDefaults = uiTheme =>
@@ -259,8 +264,6 @@ let default: t = {
 let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   open Textmate.ColorTheme;
   let defaults = getDefaults(uiTheme);
-  let defaultBackground = defaults.editorBackground |> Color.hex;
-  let defaultForeground = defaults.editorForeground |> Color.hex;
 
   let emptyString = "";
   let getColor = (default, items) => {
@@ -273,83 +276,81 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     };
   };
 
-  let background =
-    getColor(defaultBackground, ["background"]);
-  let foreground =
-    getColor(defaultForeground, ["foreground"]);
+  let background = getColor(defaults.editorBackground, ["background"]);
+  let foreground = getColor(defaults.foreground, ["foreground"]);
 
   let editorBackground =
-    getColor(defaultBackground, ["editor.background", "background"]);
+    getColor(defaults.editorBackground, ["editor.background", "background"]);
   let editorForeground =
-    getColor(defaultForeground, ["editor.foreground", "foreground"]);
+    getColor(defaults.foreground, ["editor.foreground", "foreground"]);
 
   let editorCursorBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["editorCursor.background", "editor.background", "background"],
     );
   let editorCursorForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["editorCursor.foreground", "editor.foreground", "foreground"],
     );
 
   let editorHoverWidgetBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["editorHoverWidget.background", "editor.background", "background"],
     );
 
   let activityBarBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["activityBar.background", "editor.background", "background"],
     );
 
   let activityBarForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["activityBar.foreground", "editor.foreground", "foreground"],
     );
 
   let editorHoverWidgetBorder =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["editorHoverWidget.border", "editor.foreground", "foreground"],
     );
 
   let editorLineNumberBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["editorLineNumber.background", "editor.background", "background"],
     );
   let editorLineNumberForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["editorLineNumber.foreground", "editor.foreground", "foreground"],
     );
 
   let editorRulerForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["editorRuler.foreground", "editor.foreground", "foreground"],
     );
 
   let editorLineHighlightBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["editor.lineHighlightBackground", "editor.background", "background"],
     );
 
   let editorSuggestWidgetBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["editorSuggestWidget.background", "editor.background", "background"],
     );
 
   let editorSuggestWidgetSelectedBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       [
         "editorSuggestWidget.selectedBackground",
         "editor.background",
@@ -359,7 +360,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let editorSuggestWidgetBorder =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       [
         "editorSuggestWidget.border",
         "editorHoverWidget.border",
@@ -370,7 +371,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     );
   let editorSuggestWidgetHighlightForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       [
         "editorSuggestWidget.highlightForeground",
         "editor.foreground",
@@ -380,31 +381,31 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let editorIndentGuideBackground =
     getColor(
-      defaults.editorIndentGuideBackground |> Color.hex,
+      defaults.editorIndentGuideBackground,
       ["editorIndentGuide.background"],
     );
 
   let editorIndentGuideActiveBackground =
     getColor(
-      defaults.editorIndentGuideActiveBackground |> Color.hex,
+      defaults.editorIndentGuideActiveBackground,
       ["editorIndentGuide.activeBackground"],
     );
 
   let menuBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["menu.background", "background", "editor.background"],
     );
 
   let menuForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["menu.foreground", "foreground", "editor.foreground"],
     );
 
   let menuSelectionBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       [
         "menu.selectionBackground",
         "list.activeSelectionBackground",
@@ -423,20 +424,17 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     getColor(Color.hex("#fff"), ["statusBar.foreground"]);
 
   let sideBarBackground =
-    getColor(
-      defaultBackground,
-      ["sideBar.background"],
-    );
+    getColor(defaults.editorBackground, ["sideBar.background"]);
 
   let sideBarForeground =
     getColor(
-      defaultForeground, // Actually `null`
+      defaults.foreground, // Actually `null`
       ["sideBar.foreground"],
     );
 
   let scrollbarSliderActiveBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       [
         "scrollbarSlider.activeBackground",
         "menu.selectionBackground",
@@ -446,13 +444,13 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let scrollbarSliderBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["scrollbarSlider.background", "menu.background", "list.background"],
     );
 
   let scrollbarSliderHoverBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["scrollbarSlider.hoverBackground", "scrollbarSlider.background"],
     );
 
@@ -462,13 +460,13 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let titleBarActiveBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       ["titleBar.activeBackground", "background", "editor.background"],
     );
 
   let titleBarInactiveBackground =
     getColor(
-      defaultBackground,
+      defaults.editorBackground,
       [
         "titleBar.inactiveBackground",
         "titleBar.activeBackground",
@@ -479,13 +477,13 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
 
   let titleBarActiveForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       ["titleBar.activeForeground", "background", "editor.foreground"],
     );
 
   let titleBarInactiveForeground =
     getColor(
-      defaultForeground,
+      defaults.foreground,
       [
         "titleBar.inactiveForeground",
         "titlebar.activeForeground",
@@ -590,10 +588,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
         ["list.activeSelectionBackground"],
       ),
     listActiveSelectionForeground:
-      getColor(
-        Colors.white,
-        ["list.activeSelectionForeground"],
-      ),
+      getColor(Colors.white, ["list.activeSelectionForeground"]),
     listFocusBackground:
       getColor(
         defaults === light ? Color.hex("#D6EBFF") : Color.hex("#062F4A"),
@@ -601,7 +596,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
       ),
     listFocusForeground:
       getColor(
-        defaultForeground, // Actually `null`, but not sure what that means
+        defaults.foreground, // Actually `null`, but not sure what that means
         ["list.focusForeground"],
       ),
     listHoverBackground:
@@ -611,7 +606,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
       ),
     listHoverForeground:
       getColor(
-        defaultForeground, // Actually `null`, but not sure what that means
+        defaults.foreground, // Actually `null`, but not sure what that means
         ["list.hoverForeground"],
       ),
     menuBackground,
@@ -629,7 +624,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     sneakHighlight,
     editorGroupsHeaderTabsBackground:
       getColor(
-        defaultBackground,
+        defaults.editorBackground,
         [
           "editorGroupHeader.tabsBackground",
           "editor.background",
@@ -638,7 +633,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
       ),
     tabActiveBackground:
       getColor(
-        defaultBackground,
+        defaults.editorBackground,
         ["tab.activebackground", "editor.background", "background"],
       ),
 

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -452,6 +452,12 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let sneakForeground = menuForeground;
   let sneakHighlight = default.oniNormalModeBackground;
 
+  let tabActiveForeground =
+    getColor(
+      defaultForeground,
+      ["tab.activeForeground", "editor.foreground", "foreground"],
+    );
+
   let titleBarActiveBackground =
     getColor(
       defaultBackground,
@@ -619,6 +625,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     sneakBackground,
     sneakForeground,
     sneakHighlight,
+    tabActiveForeground,
     terminalBackground,
     terminalForeground,
     terminalAnsiBlack,

--- a/src/Feature/Editor/EditorHorizontalScrollbar.re
+++ b/src/Feature/Editor/EditorHorizontalScrollbar.re
@@ -21,7 +21,7 @@ let make =
       left(scrollMetrics.thumbOffset),
       width(scrollMetrics.thumbSize),
       top(0),
-      backgroundColor(theme.scrollbarSliderActiveBackground),
+      backgroundColor(theme.scrollbarSliderBackground),
     ];
 
   switch (scrollMetrics.visible) {

--- a/src/Feature/Editor/EditorVerticalScrollbar.re
+++ b/src/Feature/Editor/EditorVerticalScrollbar.re
@@ -36,7 +36,7 @@ let make =
       left(0),
       width(totalWidth),
       height(scrollMetrics.thumbSize),
-      backgroundColor(theme.scrollbarSliderActiveBackground),
+      backgroundColor(theme.scrollbarSliderBackground),
     ];
 
   let totalPixel =

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -111,10 +111,10 @@ module Styles = {
     marginHorizontal(8),
   ];
 
-  let title = (~font: UiFont.t) => [
+  let title = (~font: UiFont.t, ~theme: Theme.t) => [
     fontFamily(font.fontFile),
     fontSize(font.fontSize),
-    color(Colors.white),
+    color(theme.sideBarForeground),
     marginVertical(8),
     marginHorizontal(8),
   ];
@@ -165,7 +165,10 @@ let make =
   <View style=Styles.pane>
     <View style={Styles.queryPane(~theme)}>
       <View style=Styles.row>
-        <Text style={Styles.title(~font=uiFont)} text="Find in Files" />
+        <Text
+          style={Styles.title(~font=uiFont, ~theme)}
+          text="Find in Files"
+        />
       </View>
       <View style=Styles.row>
         <Input
@@ -181,7 +184,7 @@ let make =
     </View>
     <View style=Styles.resultsPane>
       <Text
-        style={Styles.title(~font=uiFont)}
+        style={Styles.title(~font=uiFont, ~theme)}
         text={Printf.sprintf("%n results", List.length(model.hits))}
       />
       <LocationList theme uiFont editorFont items onSelectItem />

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -26,10 +26,10 @@ module Styles = {
     borderLeft(
       ~width=2,
       ~color=
-        isActive ? theme.oniNormalModeBackground : Colors.transparentWhite,
+        isActive ? theme.activityBarActiveBorder : Colors.transparentWhite,
     ),
     backgroundColor(
-      isHovered ? theme.menuSelectionBackground : Colors.transparentWhite,
+      isHovered ? theme.activityBarActiveBackground : Colors.transparentWhite,
     ),
   ];
 };
@@ -41,7 +41,14 @@ let%component item = (~onClick, ~theme: Theme.t, ~isActive, ~icon, ()) => {
 
   <View onMouseOver onMouseOut>
     <Sneakable onClick style={Styles.item(~isHovered, ~isActive, ~theme)}>
-      <FontIcon color={theme.activityBarForeground} fontSize=22. icon />
+      <FontIcon
+        color={
+          isActive
+            ? theme.activityBarForeground : theme.activityBarInactiveForeground
+        }
+        fontSize=22.
+        icon
+      />
     </Sneakable>
   </View>;
 };

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -79,7 +79,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
   let theme = state.theme;
   let mode = state.mode;
 
-  let style = editorViewStyle(theme.background, theme.foreground);
+  let style = editorViewStyle(theme.editorBackground, theme.foreground);
 
   let isActive = EditorGroups.isActive(state.editorGroups, editorGroup);
 

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -20,7 +20,7 @@ let editorViewStyle = (background, foreground) =>
 
 let make = (~state: State.t, ()) => {
   let theme = state.theme;
-  let style = editorViewStyle(theme.background, theme.foreground);
+  let style = editorViewStyle(theme.editorBackground, theme.foreground);
 
   if (state.zenMode) {
     <View style>

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -33,10 +33,10 @@ module Styles = {
     flexGrow(1),
     alignItems(`Center),
     backgroundColor(
-      if (isFocus) {
-        theme.listFocusBackground;
-      } else if (isActive) {
+      if (isActive) {
         theme.listActiveSelectionBackground;
+      } else if (isFocus) {
+        theme.listFocusBackground;
       } else {
         Colors.transparentWhite;
       },
@@ -55,10 +55,10 @@ module Styles = {
       ) {
       | Some(color) => color
       | None =>
-        if (isFocus) {
-          theme.listFocusForeground;
-        } else if (isActive) {
+        if (isActive) {
           theme.listActiveSelectionForeground;
+        } else if (isFocus) {
+          theme.listFocusForeground;
         } else {
           theme.foreground;
         }

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -162,8 +162,12 @@ let make =
 
   <View style=Styles.container>
     <TreeView
-      scrollOffset onScrollOffsetChange tree itemHeight=22 onClick=onNodeClick
-      arrowColor=theme.foreground>
+      scrollOffset
+      onScrollOffsetChange
+      tree
+      itemHeight=22
+      onClick=onNodeClick
+      arrowColor={theme.foreground}>
       ...{node => {
         let decorations =
           StringMap.find_opt(node.path, state.fileExplorer.decorations);

--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -162,7 +162,8 @@ let make =
 
   <View style=Styles.container>
     <TreeView
-      scrollOffset onScrollOffsetChange tree itemHeight=22 onClick=onNodeClick>
+      scrollOffset onScrollOffsetChange tree itemHeight=22 onClick=onNodeClick
+      arrowColor=theme.foreground>
       ...{node => {
         let decorations =
           StringMap.find_opt(node.path, state.fileExplorer.decorations);

--- a/src/UI/MenuItem.re
+++ b/src/UI/MenuItem.re
@@ -12,7 +12,7 @@ module Constants = {
 
 module Styles = {
   let bg = (~theme: Theme.t, ~isFocused) =>
-    isFocused ? theme.menuSelectionBackground : theme.menuBackground;
+    isFocused ? theme.listFocusBackground : theme.menuBackground;
 
   let text = (~theme: Theme.t, ~font: UiFont.t, ~isFocused) =>
     Style.[

--- a/src/UI/NotificationsPane.re
+++ b/src/UI/NotificationsPane.re
@@ -21,18 +21,14 @@ module Notification = {
       paddingVertical(5),
     ];
 
-    let text = (~background, ~font: UiFont.t) => [
+    let text = (~font: UiFont.t) => [
       fontFamily(font.fontFile),
       fontSize(11.),
       textWrap(TextWrapping.NoWrap),
       marginLeft(6),
-      backgroundColor(background),
     ];
 
-    let message = (~background, ~font) => [
-      flexGrow(1),
-      ...text(~background, ~font),
-    ];
+    let message = (~font) => [flexGrow(1), ...text(~font)];
 
     let closeButton = [alignSelf(`Stretch), paddingHorizontal(5)];
   };
@@ -75,10 +71,7 @@ module Notification = {
 
     <View style=Styles.container>
       <icon />
-      <Text
-        style={Styles.message(~background=theme.background, ~font)}
-        text={item.message}
-      />
+      <Text style={Styles.message(~font)} text={item.message} />
       <closeButton />
     </View>;
   };
@@ -107,7 +100,6 @@ module Styles = {
     fontFamily(font.fontFile),
     fontSize(font.fontSize),
     color(theme.editorForeground),
-    backgroundColor(theme.editorBackground),
     margin(8),
   ];
 };

--- a/src/UI/NotificationsPane.re
+++ b/src/UI/NotificationsPane.re
@@ -21,14 +21,15 @@ module Notification = {
       paddingVertical(5),
     ];
 
-    let text = (~font: UiFont.t) => [
+    let text = (~font: UiFont.t, ~theme: Theme.t) => [
       fontFamily(font.fontFile),
       fontSize(11.),
       textWrap(TextWrapping.NoWrap),
       marginLeft(6),
+      color(theme.foreground),
     ];
 
-    let message = (~font) => [flexGrow(1), ...text(~font)];
+    let message = (~font, ~theme) => [flexGrow(1), ...text(~font, ~theme)];
 
     let closeButton = [alignSelf(`Stretch), paddingHorizontal(5)];
   };
@@ -71,7 +72,7 @@ module Notification = {
 
     <View style=Styles.container>
       <icon />
-      <Text style={Styles.message(~font)} text={item.message} />
+      <Text style={Styles.message(~font, ~theme)} text={item.message} />
       <closeButton />
     </View>;
   };
@@ -99,7 +100,7 @@ module Styles = {
   let title = (~theme: Theme.t, ~font: UiFont.t) => [
     fontFamily(font.fontFile),
     fontSize(font.fontSize),
-    color(theme.editorForeground),
+    color(theme.foreground),
     margin(8),
   ];
 };

--- a/src/UI/OniBoxShadow.re
+++ b/src/UI/OniBoxShadow.re
@@ -21,7 +21,7 @@ let make = (~children, ~theme: Theme.t, ~configuration: Configuration.t, ()) => 
       ...children
     </View>;
   } else {
-    <View style=Style.[border(~color=theme.background, ~width=1)]>
+    <View style=Style.[border(~color=theme.editorBackground, ~width=1)]>
       ...children
     </View>;
   };

--- a/src/UI/QuickmenuView.re
+++ b/src/UI/QuickmenuView.re
@@ -36,9 +36,6 @@ module Styles = {
     fontFamily(highlighted ? font.fontFileSemiBold : font.fontFile),
     textOverflow(`Ellipsis),
     fontSize(12.),
-    backgroundColor(
-      isFocused ? theme.menuSelectionBackground : theme.menuBackground,
-    ),
     color(highlighted ? theme.oniNormalModeBackground : theme.menuForeground),
     textWrap(TextWrapping.NoWrap),
   ];

--- a/src/UI/QuickmenuView.re
+++ b/src/UI/QuickmenuView.re
@@ -32,7 +32,7 @@ module Styles = {
 
   let menuItem = [fontSize(14.), cursor(Revery.MouseCursors.pointer)];
 
-  let label = (~font: UiFont.t, ~theme: Theme.t, ~highlighted, ~isFocused) => [
+  let label = (~font: UiFont.t, ~theme: Theme.t, ~highlighted) => [
     fontFamily(highlighted ? font.fontFileSemiBold : font.fontFile),
     textOverflow(`Ellipsis),
     fontSize(12.),
@@ -132,7 +132,7 @@ let make =
     let item = items[index];
     let isFocused = Some(index) == focused;
 
-    let style = Styles.label(~font, ~theme, ~isFocused);
+    let style = Styles.label(~font, ~theme);
     let text = Quickmenu.getLabel(item);
     let highlights = item.highlight;
     let normalStyle = style(~highlighted=false);

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -97,7 +97,7 @@ let make = (~state: State.t, ()) => {
         ])
       : React.empty;
 
-  <View style={Styles.root(theme.background, theme.foreground)}>
+  <View style={Styles.root(theme.editorBackground, theme.foreground)}>
     <Titlebar
       focused={state.windowIsFocused}
       maximized={state.windowIsMaximized}

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -126,7 +126,9 @@ let make =
     <Sneakable onClick=onClose style=Styles.icon>
       <FontIcon
         icon={modified ? FontAwesome.circle : FontAwesome.times}
-        color={theme.tabActiveForeground}
+        color={
+          isActive ? theme.tabActiveForeground : theme.tabInactiveForeground
+        }
         fontSize={modified ? 10. : 12.}
       />
     </Sneakable>

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -25,29 +25,7 @@ let proportion = p => float(Constants.minWidth) *. p |> int_of_float;
 module Styles = {
   open Style;
 
-  let horizontalBorder = (tabPosition, numberOfTabs) =>
-    Style.(
-      switch (tabPosition, numberOfTabs) {
-      /* A single tab should have no borders */
-      | (1, 1) => []
-      /* The last tab should also have no borders */
-      | (i, l) when i == l => []
-      /* Every other tab should have a right border */
-      | (_, _) => [
-          borderRight(~width=1, ~color=Color.rgba(0., 0., 0., 0.1)),
-        ]
-      }
-    );
-
-  let container =
-      (
-        ~mode,
-        ~isActive,
-        ~showHighlight,
-        ~tabPosition,
-        ~numberOfTabs,
-        ~theme: Theme.t,
-      ) => {
+  let container = (~mode, ~isActive, ~showHighlight, ~theme: Theme.t) => {
     let (modeColor, _) = Theme.getColorsForMode(theme, mode);
 
     let borderColor =
@@ -60,13 +38,11 @@ module Styles = {
         isActive ? theme.tabActiveBackground : theme.tabInactiveBackground,
       ),
       borderTop(~color=borderColor, ~width=2),
-      borderBottom(~color=theme.editorBackground, ~width=2),
       height(Constants.tabHeight),
       minWidth(Constants.minWidth),
       flexDirection(`Row),
       justifyContent(`Center),
       alignItems(`Center),
-      ...horizontalBorder(tabPosition, numberOfTabs),
     ];
   };
 
@@ -93,8 +69,6 @@ module Styles = {
 let make =
     (
       ~title,
-      ~tabPosition,
-      ~numberOfTabs,
       ~isActive,
       ~modified,
       ~onClick,
@@ -132,15 +106,7 @@ let make =
     };
   };
 
-  <View
-    style={Styles.container(
-      ~mode,
-      ~isActive,
-      ~showHighlight,
-      ~tabPosition,
-      ~numberOfTabs,
-      ~theme,
-    )}>
+  <View style={Styles.container(~mode, ~isActive, ~showHighlight, ~theme)}>
     <Sneakable
       onSneak=onClick
       onAnyClick

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -76,7 +76,6 @@ module Styles = {
     ),
     fontSize(uiFont.fontSize),
     color(theme.tabActiveForeground),
-    backgroundColor(theme.editorBackground),
     justifyContent(`Center),
     alignItems(`Center),
   ];

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -26,17 +26,16 @@ module Styles = {
   open Style;
 
   let container = (~mode, ~isActive, ~showHighlight, ~theme: Theme.t) => {
+    let background =
+      isActive ? theme.tabActiveBackground : theme.tabInactiveBackground;
     let (modeColor, _) = Theme.getColorsForMode(theme, mode);
 
-    let borderColor =
-      isActive && showHighlight ? modeColor : Colors.transparentBlack;
+    let borderColor = isActive && showHighlight ? modeColor : background;
 
     [
       overflow(`Hidden),
       paddingHorizontal(5),
-      backgroundColor(
-        isActive ? theme.tabActiveBackground : theme.tabInactiveBackground,
-      ),
+      backgroundColor(background),
       borderTop(~color=borderColor, ~width=2),
       height(Constants.tabHeight),
       minWidth(Constants.minWidth),

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -56,7 +56,9 @@ module Styles = {
     [
       overflow(`Hidden),
       paddingHorizontal(5),
-      backgroundColor(theme.editorBackground),
+      backgroundColor(
+        isActive ? theme.tabActiveBackground : theme.tabInactiveBackground,
+      ),
       borderTop(~color=borderColor, ~width=2),
       borderBottom(~color=theme.editorBackground, ~width=2),
       height(Constants.tabHeight),
@@ -75,7 +77,7 @@ module Styles = {
       isActive && showHighlight ? uiFont.fontFileItalic : uiFont.fontFile,
     ),
     fontSize(uiFont.fontSize),
-    color(theme.tabActiveForeground),
+    color(isActive ? theme.tabActiveForeground : theme.tabInactiveForeground),
     justifyContent(`Center),
     alignItems(`Center),
   ];

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -3,7 +3,6 @@
  *
  */
 
-open Revery;
 open Revery.UI;
 
 open Oni_Core;

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -14,82 +14,96 @@ module Ext = Oni_Extensions;
 module FontAwesome = Oni_Components.FontAwesome;
 module FontIcon = Oni_Components.FontIcon;
 
-type tabAction = unit => unit;
+module Constants = {
+  include Constants;
 
-let minWidth_ = 125;
-let proportion = p => float_of_int(minWidth_) *. p |> int_of_float;
+  let minWidth = 125;
+};
 
-let horizontalBorderStyles = (tabPosition, numberOfTabs) =>
-  Style.(
-    switch (tabPosition, numberOfTabs) {
-    /* A single tab should have no borders */
-    | (1, 1) => []
-    /* The last tab should also have no borders */
-    | (i, l) when i == l => []
-    /* Every other tab should have a right border */
-    | (_, _) => [borderRight(~width=1, ~color=Color.rgba(0., 0., 0., 0.1))]
-    }
-  );
+let proportion = p => float(Constants.minWidth) *. p |> int_of_float;
 
-let make =
-    (
-      ~title,
-      ~tabPosition,
-      ~numberOfTabs,
-      ~active,
-      ~modified,
-      ~onClick,
-      ~onClose,
-      ~theme: Theme.t,
-      ~uiFont: UiFont.t,
-      ~mode: Vim.Mode.t,
-      ~showHighlight: bool,
-      (),
-    ) => {
-  let (modeColor, _) = Theme.getColorsForMode(theme, mode);
+module Styles = {
+  open Style;
 
-  let borderColor =
-    active && showHighlight ? modeColor : Colors.transparentBlack;
+  let horizontalBorder = (tabPosition, numberOfTabs) =>
+    Style.(
+      switch (tabPosition, numberOfTabs) {
+      /* A single tab should have no borders */
+      | (1, 1) => []
+      /* The last tab should also have no borders */
+      | (i, l) when i == l => []
+      /* Every other tab should have a right border */
+      | (_, _) => [
+          borderRight(~width=1, ~color=Color.rgba(0., 0., 0., 0.1)),
+        ]
+      }
+    );
 
-  let containerStyle =
-    Style.[
+  let container =
+      (
+        ~mode,
+        ~isActive,
+        ~showHighlight,
+        ~tabPosition,
+        ~numberOfTabs,
+        ~theme: Theme.t,
+      ) => {
+    let (modeColor, _) = Theme.getColorsForMode(theme, mode);
+
+    let borderColor =
+      isActive && showHighlight ? modeColor : Colors.transparentBlack;
+
+    [
       overflow(`Hidden),
       paddingHorizontal(5),
       backgroundColor(theme.editorBackground),
       borderTop(~color=borderColor, ~width=2),
       borderBottom(~color=theme.editorBackground, ~width=2),
       height(Constants.tabHeight),
-      minWidth(minWidth_),
+      minWidth(Constants.minWidth),
       flexDirection(`Row),
       justifyContent(`Center),
       alignItems(`Center),
-      ...horizontalBorderStyles(tabPosition, numberOfTabs),
+      ...horizontalBorder(tabPosition, numberOfTabs),
     ];
+  };
 
-  let isBold = active && showHighlight;
+  let text = (~isActive, ~showHighlight, ~uiFont: UiFont.t, ~theme: Theme.t) => [
+    width(proportion(0.80) - 10),
+    textOverflow(`Ellipsis),
+    fontFamily(
+      isActive && showHighlight ? uiFont.fontFileItalic : uiFont.fontFile,
+    ),
+    fontSize(uiFont.fontSize),
+    color(theme.tabActiveForeground),
+    backgroundColor(theme.editorBackground),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
 
-  let textStyle =
-    Style.[
-      width(proportion(0.80) - 10),
-      textOverflow(`Ellipsis),
-      fontFamily(isBold ? uiFont.fontFileItalic : uiFont.fontFile),
-      fontSize(uiFont.fontSize),
-      color(theme.tabActiveForeground),
-      backgroundColor(theme.editorBackground),
-      justifyContent(`Center),
-      alignItems(`Center),
-    ];
+  let icon = [
+    width(32),
+    height(Constants.tabHeight),
+    alignItems(`Center),
+    justifyContent(`Center),
+  ];
+};
 
-  let iconContainerStyle =
-    Style.[
-      width(32),
-      height(Constants.tabHeight),
-      alignItems(`Center),
-      justifyContent(`Center),
-    ];
-
-  let icon = modified ? FontAwesome.circle : FontAwesome.times;
-
+let make =
+    (
+      ~title,
+      ~tabPosition,
+      ~numberOfTabs,
+      ~isActive,
+      ~modified,
+      ~onClick,
+      ~onClose,
+      ~theme,
+      ~uiFont: UiFont.t,
+      ~mode,
+      ~showHighlight: bool,
+      (),
+    ) => {
   let state = GlobalContext.current().state;
   let language =
     Ext.LanguageInfo.getLanguageFromFilePath(state.languageInfo, title);
@@ -98,11 +112,11 @@ let make =
 
   let fileIconView =
     switch (fileIcon) {
-    | Some(v) =>
+    | Some(icon) =>
       <FontIcon
         fontFamily="seti.ttf"
-        icon={v.fontCharacter}
-        color={v.fontColor}
+        icon={icon.fontCharacter}
+        color={icon.fontColor}
         /* TODO: Use 'weight' value from IconTheme font */
         fontSize={uiFont.fontSize *. 1.5}
       />
@@ -117,7 +131,15 @@ let make =
     };
   };
 
-  <View style=containerStyle>
+  <View
+    style={Styles.container(
+      ~mode,
+      ~isActive,
+      ~showHighlight,
+      ~tabPosition,
+      ~numberOfTabs,
+      ~theme,
+    )}>
     <Sneakable
       onSneak=onClick
       onAnyClick
@@ -128,12 +150,15 @@ let make =
         alignItems(`Center),
         justifyContent(`Center),
       ]>
-      <View style=iconContainerStyle> fileIconView </View>
-      <Text style=textStyle text=title />
+      <View style=Styles.icon> fileIconView </View>
+      <Text
+        style={Styles.text(~isActive, ~showHighlight, ~uiFont, ~theme)}
+        text=title
+      />
     </Sneakable>
-    <Sneakable onClick=onClose style=iconContainerStyle>
+    <Sneakable onClick=onClose style=Styles.icon>
       <FontIcon
-        icon
+        icon={modified ? FontAwesome.circle : FontAwesome.times}
         color={theme.tabActiveForeground}
         fontSize={modified ? 10. : 12.}
       />

--- a/src/UI/Tabs.re
+++ b/src/UI/Tabs.re
@@ -16,17 +16,7 @@ type tabInfo = {
   renderer: Oni_Model.BufferRenderer.t,
 };
 
-let toTab =
-    (
-      theme,
-      mode,
-      uiFont,
-      numberOfTabs,
-      active,
-      activeEditorId,
-      index,
-      t: tabInfo,
-    ) => {
+let toTab = (theme, mode, uiFont, active, activeEditorId, t: tabInfo) => {
   let title =
     switch (t.renderer) {
     | Welcome => "Welcome"
@@ -35,8 +25,6 @@ let toTab =
 
   <Tab
     theme
-    tabPosition={index + 1}
-    numberOfTabs
     title
     isActive={Some(t.editorId) == activeEditorId}
     showHighlight=active
@@ -157,12 +145,9 @@ let%component make =
     });
   };
 
-  let tabCount = List.length(tabs);
   let tabComponents =
     tabs
-    |> List.mapi(
-         toTab(theme, mode, uiFont, tabCount, active, activeEditorId),
-       )
+    |> List.map(toTab(theme, mode, uiFont, active, activeEditorId))
     |> React.listToElement;
 
   let outerStyle =

--- a/src/UI/Tabs.re
+++ b/src/UI/Tabs.re
@@ -38,7 +38,7 @@ let toTab =
     tabPosition={index + 1}
     numberOfTabs
     title
-    active={Some(t.editorId) == activeEditorId}
+    isActive={Some(t.editorId) == activeEditorId}
     showHighlight=active
     modified={t.modified}
     uiFont

--- a/src/UI/Tabs.re
+++ b/src/UI/Tabs.re
@@ -165,10 +165,15 @@ let%component make =
        )
     |> React.listToElement;
 
-  let outerStyle = Style.[flexDirection(`Row), overflow(`Scroll)];
+  let outerStyle =
+    Style.[
+      flexDirection(`Row),
+      overflow(`Scroll),
+      backgroundColor(theme.editorGroupsHeaderTabsBackground),
+    ];
 
   let innerViewTransform =
-    Transform.[TranslateX((-1.) *. float_of_int(actualScrollLeft))];
+    Transform.[TranslateX((-1.) *. float(actualScrollLeft))];
 
   let innerStyle =
     Style.[flexDirection(`Row), transform(innerViewTransform)];

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -77,11 +77,11 @@ module Styles = {
 };
 
 module Make = (Model: TreeModel) => {
-  let arrow = (~isOpen, ()) =>
+  let arrow = (~isOpen, ~color, ()) =>
     <View style={Styles.arrow(int_of_float(Constants.arrowSize))}>
       <FontIcon
         fontSize=Constants.arrowSize
-        color=Colors.white
+        color
         icon={isOpen ? FontAwesome.caretDown : FontAwesome.caretRight}
       />
     </View>;
@@ -97,6 +97,7 @@ module Make = (Model: TreeModel) => {
   let rec nodeView =
           (
             ~renderContent,
+            ~arrowColor,
             ~itemHeight,
             ~clipRange as (clipStart, clipEnd),
             ~onClick,
@@ -122,6 +123,7 @@ module Make = (Model: TreeModel) => {
           let element =
             <nodeView
               renderContent
+              arrowColor
               itemHeight
               clipRange=(clipStart - count, clipEnd - count)
               onClick
@@ -149,7 +151,7 @@ module Make = (Model: TreeModel) => {
       switch (Model.kind(node)) {
       | `Node(state) =>
         <View>
-          <item arrow={arrow(~isOpen=state == `Open)} />
+          <item arrow={arrow(~isOpen=state == `Open, ~color=arrowColor)} />
           <View style=Styles.children>
             {switch (state) {
              | `Open => node |> Model.children |> renderChildren
@@ -220,6 +222,7 @@ module Make = (Model: TreeModel) => {
   let%component make =
                 (
                   ~children as renderContent,
+                  ~arrowColor=Colors.white,
                   ~itemHeight,
                   ~initialRowsToRender=10,
                   ~onClick,
@@ -296,7 +299,14 @@ module Make = (Model: TreeModel) => {
       onMouseWheel>
       <View style={Styles.viewport(~showScrollbar)}>
         <View style={Styles.content(~scrollTop)}>
-          <nodeView renderContent itemHeight clipRange onClick node=tree />
+          <nodeView
+            renderContent
+            arrowColor
+            itemHeight
+            clipRange
+            onClick
+            node=tree
+          />
         </View>
       </View>
       {showScrollbar ? <scrollbar /> : React.empty}

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -13,7 +13,7 @@ module Model = Oni_Model;
 module Styles = {
   let container = (~theme: Theme.t) =>
     Style.[
-      backgroundColor(theme.background),
+      backgroundColor(theme.editorBackground),
       color(theme.foreground),
       flexGrow(1),
       flexDirection(`Column),
@@ -26,7 +26,6 @@ module Styles = {
     Style.[
       fontFamily(font.fontFile),
       fontSize(20.),
-      backgroundColor(theme.background),
       color(theme.foreground),
       marginTop(-40),
     ];
@@ -35,7 +34,6 @@ module Styles = {
     Style.[
       fontFamily(font.fontFile),
       fontSize(12.),
-      backgroundColor(theme.background),
       color(theme.editorForeground),
     ];
 
@@ -75,7 +73,6 @@ module KeyBindingView = {
     let commandText = (~theme: Theme.t, ~fontFile, ~fontSize) => [
       fontFamily(fontFile),
       Style.fontSize(fontSize),
-      backgroundColor(theme.background),
       color(theme.editorForeground),
     ];
 

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -73,7 +73,7 @@ module KeyBindingView = {
     let commandText = (~theme: Theme.t, ~fontFile, ~fontSize) => [
       fontFamily(fontFile),
       Style.fontSize(fontSize),
-      color(theme.editorForeground),
+      color(theme.foreground),
     ];
 
     let spacer = Style.[flexGrow(1)];


### PR DESCRIPTION
Fixes #1073 

- The tab colors weren't picked up from the theme, now they are
- The treeview arrow color was hard-coded, now uses theme foreground color
- The theme used in #1370 depends a lot on fallback colors, which were mostly wrong in out theme settings. I've fixed up quite a few of them, but the theme architecture really needs an overhaul to be able handle this correctly.
- The dropshadow from the minimap seems like a custom style. It doesn't show up in any vscode theme I have, including the theme used in #1370.

I also brought in a few more theme colors for the tabs and activity bar, and cleaned up the tabs component a bit.

![2020-02-28-132124_800x600_scrot](https://user-images.githubusercontent.com/5207036/75548348-58ea4e00-5a2d-11ea-8c5b-8dc569c929aa.png)

Edit: For comparison, a screenshot of vscode and oni2 before, from #1370:

![themes_not_applied_consistently](https://user-images.githubusercontent.com/7700482/75327435-ab383d00-587c-11ea-961b-ea93912a7b66.png)