### PR TITLE
Bugfix: Crash when deleting all lines of a file

### DIFF
--- a/integration_test/RegressionDeleteAllLinesTest.re
+++ b/integration_test/RegressionDeleteAllLinesTest.re
@@ -1,0 +1,54 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+module BufferSyntaxHighlights = Feature_Editor.BufferSyntaxHighlights;
+
+// Validate that textmate highlight runs
+runTest(~name="RegressionDeleteAllLinesTest", (dispatch, wait, runEffects) => {
+  wait(~name="Capture initial state", (state: State.t) =>
+    state.mode == Vim.Types.Normal
+  );
+
+  let testFile = getAssetPath("some-test-file.txt");
+
+  // Create a buffer
+  dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+  // Wait for lines to be available in buffer
+  wait(~name="Buffer is loaded", (state: State.t) =>
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => false
+    | Some(buf) => Buffer.getNumberOfLines(buf) > 1
+    }
+  );
+
+  wait(
+    ~name="Dispatch gotOriginalContent to simulate a diff", (state: State.t) => {
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => failwith("Should have an active buffer now!")
+    | Some(buf) =>
+      let bufferId = Buffer.getId(buf);
+      let lines = Buffer.getLines(buf);
+      dispatch(Actions.GotOriginalContent({bufferId, lines}));
+      true;
+    }
+  });
+
+  // Delete all contents of the buffer
+  dispatch(KeyboardInput("g"));
+  dispatch(KeyboardInput("g"));
+
+  dispatch(KeyboardInput("d"));
+
+  dispatch(KeyboardInput("G"));
+  runEffects();
+
+  // Wait for highlights to show up
+  wait(~name="Verify all lines are deleted", ~timeout=10.0, (state: State.t) => {
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => false
+    | Some(buf) => Buffer.getNumberOfLines(buf) == 0
+    }
+  });
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -20,6 +20,7 @@
            QuickOpenEventuallyCompletesTest
            SearchShowClearHighlightsTest
            RegressionCommandLineNoCompletionTest
+           RegressionDeleteAllLinesTest
            RegressionFileModifiedIndicationTest
            RegressionVspEmptyInitialBufferTest
            RegressionVspEmptyExistingBufferTest
@@ -67,6 +68,7 @@
         QuickOpenEventuallyCompletesTest.exe
         Regression1097Test.exe
         RegressionCommandLineNoCompletionTest.exe
+        RegressionDeleteAllLinesTest.exe
         RegressionFileModifiedIndicationTest.exe
         RegressionVspEmptyInitialBufferTest.exe
         RegressionVspEmptyExistingBufferTest.exe

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -55,13 +55,11 @@ let generate = buffer =>
          );
 
        // if there are deleted lines past the end of the current document, mark the last lines as having deletes afterwards, or being modified
-       let markerLen = Array.length(markers);
-       if (markerLen > 0
-           && Array.length(deletes)
-           - shift^
-           - 1 > Array.length(adds)) {
-         markers[markerLen - 1] = (
-           switch (markers[markerLen - 1]) {
+       if (markers == [||]) {
+         [|DeletedBefore|];
+       } else if (Array.length(deletes) - shift^ - 1 > Array.length(adds)) {
+         markers[Array.length(markers) - 1] = (
+           switch (markers[Array.length(markers) - 1]) {
            | Modified
            | Added => Modified
 
@@ -70,9 +68,10 @@ let generate = buffer =>
            | Unmodified => DeletedAfter
            }
          );
+         markers;
+       } else {
+         markers;
        };
-
-       markers;
      });
 
 let markerPaint = Skia.Paint.make();

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -55,9 +55,13 @@ let generate = buffer =>
          );
 
        // if there are deleted lines past the end of the current document, mark the last lines as having deletes afterwards, or being modified
-       if (Array.length(deletes) - shift^ - 1 > Array.length(adds)) {
-         markers[Array.length(markers) - 1] = (
-           switch (markers[Array.length(markers) - 1]) {
+       let markerLen = Array.length(markers);
+       if (markerLen > 0
+           && Array.length(deletes)
+           - shift^
+           - 1 > Array.length(adds)) {
+         markers[markerLen - 1] = (
+           switch (markers[markerLen - 1]) {
            | Modified
            | Added => Modified
 

--- a/test/UI/EditorDiffMarkersTest.re
+++ b/test/UI/EditorDiffMarkersTest.re
@@ -96,6 +96,21 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       };
     });
 
+    test("block deleted entirely", ({expect}) => {
+      let was = [|"a", "b", "c", "d"|];
+      let now = [||];
+
+      let buffer = Buffer.ofLines(now) |> Buffer.setOriginalLines(was);
+
+      let actual = EditorDiffMarkers.generate(buffer);
+      let expected = EditorDiffMarkers.([|DeletedBefore|]);
+
+      switch (actual) {
+      | Some(actual) => expect.array(actual).toEqual(expected)
+      | None => failwith("unreachable")
+      };
+    });
+
     test("single modified", ({expect}) => {
       let was = [|"a", "b", "c", "d"|];
       let now = [|"a", "b", "C", "d"|];


### PR DESCRIPTION
__Issue:__ While working on #1383 and tested the fix, I saw a crash when opening a file, and then deleting all lines (`ggdG`).

I obtained a crash log which made it pretty easy to troubleshoot: 
```
(Invalid_argument "index out of bounds"):
Raised by primitive operation at file "src/Feature/Editor/EditorDiffMarkers.re", line 60, characters 18-54
Called from file "option.ml", line 24, characters 57-62
Called from file "src/Feature/Editor/EditorSurface.re", line 181, characters 8-42
Called from file "src/UI/EditorGroupView.re", line 204, characters 10-925
Called from file "src/UI/EditorLayoutView.re", line 54, characters 12-74
Called from file "list.ml", line 92, characters 20-23
Called from file "src/UI/EditorLayoutView.re", line 37, characters 2-583
Called from file "src/UI/EditorLayoutView.re", line 66, characters 17-46
...
```

It seems in the case where `markers` is a 0-length array, we'd crash with an out-of-bounds exception. This just checks for the length==0 case and skips the check.

In addition, added an integration test that exercises this.
