### PR TITLE
Theming: Fix editorWhitespace.foreground defaults

### DIFF
--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -18,6 +18,7 @@ type defaults = {
   editorForeground: Color.t,
   editorIndentGuideBackground: Color.t,
   editorIndentGuideActiveBackground: Color.t,
+  editorWhitespaceForeground: Color.t,
 };
 
 let light: defaults = {
@@ -26,6 +27,7 @@ let light: defaults = {
   editorForeground: Color.hex("#333"),
   editorIndentGuideBackground: Color.hex("#D3D3D3"),
   editorIndentGuideActiveBackground: Color.hex("#939393"),
+  editorWhitespaceForeground: Color.hex("#33333333"),
 };
 
 let dark: defaults = {
@@ -34,6 +36,7 @@ let dark: defaults = {
   editorForeground: Color.hex("#bbb"),
   editorIndentGuideBackground: Color.hex("#404040"),
   editorIndentGuideActiveBackground: Color.hex("#707070"),
+  editorWhitespaceForeground: Color.hex("#e3e4e229"),
 };
 
 let hcDark: defaults = {
@@ -42,6 +45,7 @@ let hcDark: defaults = {
   editorForeground: Color.hex("#FFF"),
   editorIndentGuideBackground: Color.hex("#FFF"),
   editorIndentGuideActiveBackground: Color.hex("#FFF"),
+  editorWhitespaceForeground: Color.hex("#e3e4e229"),
 };
 
 let getDefaults = uiTheme =>
@@ -392,6 +396,14 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
       ],
     );
 
+  let editorWhitespaceForeground =
+    getColor(
+      defaults.editorWhitespaceForeground,
+      [
+        "editorWhitespace.foreground",
+      ],
+    );
+
   let editorIndentGuideBackground =
     getColor(
       defaults.editorIndentGuideBackground,
@@ -591,6 +603,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
     editorSuggestWidgetBorder,
     editorSuggestWidgetHighlightForeground,
     editorSuggestWidgetSelectedBackground,
+    editorWhitespaceForeground,
     listActiveSelectionBackground:
       getColor(
         defaults === light ? Color.hex("#0074E8") : Color.hex("#094771"),

--- a/src/Core/Theme.re
+++ b/src/Core/Theme.re
@@ -399,9 +399,7 @@ let ofColorTheme = (uiTheme, ct: Textmate.ColorTheme.t) => {
   let editorWhitespaceForeground =
     getColor(
       defaults.editorWhitespaceForeground,
-      [
-        "editorWhitespace.foreground",
-      ],
+      ["editorWhitespace.foreground"],
     );
 
   let editorIndentGuideBackground =


### PR DESCRIPTION
Following from the huge improvements @glennsl made in #1380 for light themes - I noticed there's still an issue with the whitespace rendering - the 'dots' when show whitespace are on are very dark and distracting compared to the text:

__Before:__
![image](https://user-images.githubusercontent.com/13532591/75593282-b7b5c480-5a39-11ea-98c5-d5d61ef9dfa4.png)

__After:__
![image](https://user-images.githubusercontent.com/13532591/75593343-e5027280-5a39-11ea-8072-639ed7184211.png)

The value was hardcoded and not picked up from themes, previously - this loads it from the theme and brings in the same defaults as VSCode for light/dark/hc themes.
