### PR TITLE
Fix #1387: Tab characters rendered in place when scrolling

### DIFF
--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -213,8 +213,8 @@ let token =
 
   | Tab =>
     CanvasContext.Deprecated.drawString(
-      ~x=x +. context.charWidth /. 4.,
-      ~y,
+      ~x=x +. context.charWidth /. 4. -. context.scrollX,
+      ~y=y -. context.scrollY,
       ~color=theme.editorWhitespaceForeground,
       ~fontFamily="FontAwesome5FreeSolid.otf",
       ~fontSize=10.,


### PR DESCRIPTION
__Issue:__ When tabs are present in the editor surface, and the editor is scrolled, the tab characters stay stuck in place.

__Defect:__ We use a slightly different codepath for rendering tabs (it uses a different font) - in this code path, we were not taking into account the scroll offsets. It looks like this regressed in https://github.com/onivim/oni2/pull/1324

__Fix:__ Include scroll offsets in x/y position calculation.

Fixes #1387 