### PR TITLE
fix: Correctly handle go to definition on Windows

### DIFF
--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -117,7 +117,9 @@ let fromMemory = path => fromScheme(~scheme=Scheme.Memory, path);
 let fromPath = path => fromScheme(~scheme=Scheme.File, path);
 
 let toString = (uri: t) => {
-  Scheme.toString(uri.scheme) ++ "://" ++ uri.path;
+  Scheme.toString(uri.scheme)
+  ++ "://"
+  ++ Internal.addSlash(uri.scheme, uri.path);
 };
 
 let toFileSystemPath = (uri: t) => {

--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -65,13 +65,13 @@ module Internal = {
     switch (scheme) {
     | File =>
       let pathLen = String.length(path);
-      if (pathLen > 2 && path.[0] == '/') {
-        let firstLetter = path.[1];
-        let secondCharacter = path.[2];
+      if (pathLen > 1) {
+        let firstLetter = path.[0];
+        let secondCharacter = path.[1];
         if (isDriveLetter(firstLetter) && secondCharacter == ':') {
           let firstLetterString =
             String.make(1, Char.lowercase_ascii(firstLetter));
-          firstLetterString ++ ":" ++ String.sub(path, 3, pathLen - 3);
+          firstLetterString ++ ":" ++ String.sub(path, 2, pathLen - 2);
         } else {
           path;
         };
@@ -104,7 +104,7 @@ module Internal = {
   };
 
   let referenceResolution = (scheme: Scheme.t, path: string) =>
-    path |> addSlash(scheme) |> normalizePath(scheme);
+    path |> normalizePath(scheme) |> addSlash(scheme);
 };
 
 let fromScheme = (~scheme: Scheme.t, ~query=?, path: string) => {

--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -56,21 +56,22 @@ module Internal = {
   let isDriveLetter = (candidate: Char.t) => {
     let aCode = Char.code('A');
     let zCode = Char.code('Z');
+    let upperCandidate = Char.uppercase_ascii(candidate);
 
-    Char.code(candidate) >= aCode && Char.code(candidate) <= zCode;
+    Char.code(upperCandidate) >= aCode && Char.code(upperCandidate) <= zCode;
   };
 
   let normalizePath = (scheme: Scheme.t, path: string) => {
     switch (scheme) {
     | File =>
       let pathLen = String.length(path);
-      if (pathLen > 1) {
-        let firstLetter = path.[0];
-        let secondCharacter = path.[1];
+      if (pathLen > 2 && path.[0] == '/') {
+        let firstLetter = path.[1];
+        let secondCharacter = path.[2];
         if (isDriveLetter(firstLetter) && secondCharacter == ':') {
           let firstLetterString =
             String.make(1, Char.lowercase_ascii(firstLetter));
-          firstLetterString ++ ":" ++ String.sub(path, 2, pathLen - 2);
+          firstLetterString ++ ":" ++ String.sub(path, 3, pathLen - 3);
         } else {
           path;
         };
@@ -103,7 +104,7 @@ module Internal = {
   };
 
   let referenceResolution = (scheme: Scheme.t, path: string) =>
-    path |> normalizePath(scheme) |> addSlash(scheme);
+    path |> addSlash(scheme) |> normalizePath(scheme);
 };
 
 let fromScheme = (~scheme: Scheme.t, ~query=?, path: string) => {
@@ -120,7 +121,7 @@ let toString = (uri: t) => {
 };
 
 let toFileSystemPath = (uri: t) => {
-  uri.path;
+  Internal.referenceResolution(uri.scheme, uri.path);
 };
 
 let getScheme = (uri: t) => uri.scheme;

--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -123,7 +123,24 @@ let toString = (uri: t) => {
 };
 
 let toFileSystemPath = (uri: t) => {
-  Internal.referenceResolution(uri.scheme, uri.path);
+  switch (uri.scheme) {
+  | File =>
+    let pathLen = String.length(uri.path);
+    if (pathLen > 2 && uri.path.[0] == '/') {
+      let firstLetter = uri.path.[1];
+      let secondCharacter = uri.path.[2];
+
+      // Remove the leading slash when using a Windows file system
+      if (Internal.isDriveLetter(firstLetter) && secondCharacter == ':') {
+        String.sub(uri.path, 1, pathLen - 1);
+      } else {
+        uri.path;
+      };
+    } else {
+      uri.path;
+    };
+  | _ => uri.path
+  };
 };
 
 let getScheme = (uri: t) => uri.scheme;

--- a/test/Core/UriTests.re
+++ b/test/Core/UriTests.re
@@ -26,6 +26,18 @@ describe("Uri", ({describe, _}) => {
       expect.string(Uri.toString(uri)).toEqual("file:///c:/test");
     })
   });
+  describe("toFileSystemPath", ({test, _}) => {
+    test("round-trip windows-style path", ({expect, _}) => {
+      let uri = Uri.fromPath("C:/test");
+      expect.string(Uri.toFileSystemPath(uri)).toEqual("c:/test");
+    });
+    test("round-trip posix path", ({expect, _}) => {
+      let uri = Uri.fromPath("/users/onivim/test");
+      expect.string(Uri.toFileSystemPath(uri)).toEqual(
+        "/users/onivim/test",
+      );
+    });
+  });
   describe("JSON", ({test, _}) => {
     test("parses with scheme as string", ({expect, _}) => {
       let scheme =


### PR DESCRIPTION
This resolves issue #1343, but I'm unable to test it on Linux or Mac