### PR TITLE
Bugfix: Harfbuzz memory leak

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "65fa4002122316d878234ed85b36f21c",
+  "checksum": "0f5aee0f52843e805e3509b7974ebd2a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#6c32299",
+      "version": "github:revery-ui/reason-harfbuzz#4a26775",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
       },
       "overrides": [],
       "dependencies": [

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a9f6b3eb3bf76b944b0632d534cb74f6",
+  "checksum": "cd8a3f934a99db338de38f84de0de5f1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#701a818",
+      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#701a818" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
       },
       "overrides": [],
       "dependencies": [

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0f5aee0f52843e805e3509b7974ebd2a",
+  "checksum": "e695347774eccbdd37fbf245e2e5786c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#4a26775",
+      "version": "github:revery-ui/reason-harfbuzz#eca58ea",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#eca58ea" ]
       },
       "overrides": [],
       "dependencies": [

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cd8a3f934a99db338de38f84de0de5f1",
+  "checksum": "65fa4002122316d878234ed85b36f21c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
+      "version": "github:revery-ui/reason-harfbuzz#6c32299",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "65fa4002122316d878234ed85b36f21c",
+  "checksum": "0f5aee0f52843e805e3509b7974ebd2a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#6c32299",
+      "version": "github:revery-ui/reason-harfbuzz#4a26775",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a9f6b3eb3bf76b944b0632d534cb74f6",
+  "checksum": "cd8a3f934a99db338de38f84de0de5f1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#701a818",
+      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#701a818" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0f5aee0f52843e805e3509b7974ebd2a",
+  "checksum": "e695347774eccbdd37fbf245e2e5786c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#4a26775",
+      "version": "github:revery-ui/reason-harfbuzz#eca58ea",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#eca58ea" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cd8a3f934a99db338de38f84de0de5f1",
+  "checksum": "65fa4002122316d878234ed85b36f21c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
+      "version": "github:revery-ui/reason-harfbuzz#6c32299",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
       },
       "overrides": [],
       "dependencies": [

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "65fa4002122316d878234ed85b36f21c",
+  "checksum": "0f5aee0f52843e805e3509b7974ebd2a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#6c32299",
+      "version": "github:revery-ui/reason-harfbuzz#4a26775",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
       },
       "overrides": [],
       "dependencies": [

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a9f6b3eb3bf76b944b0632d534cb74f6",
+  "checksum": "cd8a3f934a99db338de38f84de0de5f1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#701a818",
+      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#701a818" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
       },
       "overrides": [],
       "dependencies": [

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0f5aee0f52843e805e3509b7974ebd2a",
+  "checksum": "e695347774eccbdd37fbf245e2e5786c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#4a26775",
+      "version": "github:revery-ui/reason-harfbuzz#eca58ea",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#eca58ea" ]
       },
       "overrides": [],
       "dependencies": [

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cd8a3f934a99db338de38f84de0de5f1",
+  "checksum": "65fa4002122316d878234ed85b36f21c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
+      "version": "github:revery-ui/reason-harfbuzz#6c32299",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
       },
       "overrides": [],
       "dependencies": [

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@esy-ocaml/reason": "facebook/reason#8f71db0",
     "reason-textmate": "onivim/reason-textmate#5f0dc38",
     "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
-    "reason-harfbuzz": "revery-ui/reason-harfbuzz#4a26775"
+    "reason-harfbuzz": "revery-ui/reason-harfbuzz#eca58ea"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@esy-ocaml/reason": "facebook/reason#8f71db0",
     "reason-textmate": "onivim/reason-textmate#5f0dc38",
     "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
-    "reason-harfbuzz": "revery-ui/reason-harfbuzz#e5e7ac0"
+    "reason-harfbuzz": "revery-ui/reason-harfbuzz#6c32299"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@esy-ocaml/reason": "facebook/reason#8f71db0",
     "reason-textmate": "onivim/reason-textmate#5f0dc38",
     "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
-    "reason-harfbuzz": "revery-ui/reason-harfbuzz#6c32299"
+    "reason-harfbuzz": "revery-ui/reason-harfbuzz#4a26775"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@esy-ocaml/reason": "facebook/reason#8f71db0",
     "reason-textmate": "onivim/reason-textmate#5f0dc38",
     "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
-    "reason-harfbuzz": "revery-ui/reason-harfbuzz#701a818"
+    "reason-harfbuzz": "revery-ui/reason-harfbuzz#e5e7ac0"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c7b56eee7823e98118caeeb4c6587b86",
+  "checksum": "82958bda0b40a48e44200a073ca1e3c5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
+      "version": "github:revery-ui/reason-harfbuzz#6c32299",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
       },
       "overrides": [],
       "dependencies": [

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "faf6c7cae495b3cf1bb877df065c1d79",
+  "checksum": "3b6756fa28c40f0a9e71f4d03d548e19",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#eca58ea@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#4a26775",
+      "version": "github:revery-ui/reason-harfbuzz#eca58ea",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#eca58ea" ]
       },
       "overrides": [],
       "dependencies": [

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "72c108a06179ac2b7ca47bb43bf7e8eb",
+  "checksum": "c7b56eee7823e98118caeeb4c6587b86",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#701a818@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#e5e7ac0@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#701a818",
+      "version": "github:revery-ui/reason-harfbuzz#e5e7ac0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#701a818" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#e5e7ac0" ]
       },
       "overrides": [],
       "dependencies": [

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "82958bda0b40a48e44200a073ca1e3c5",
+  "checksum": "faf6c7cae495b3cf1bb877df065c1d79",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -150,7 +150,7 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#48ee835@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@1.3.1@d41d8cd9",
@@ -469,14 +469,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9": {
+    "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9": {
       "id":
-        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#6c32299@d41d8cd9",
+        "reason-harfbuzz@github:revery-ui/reason-harfbuzz#4a26775@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "github:revery-ui/reason-harfbuzz#6c32299",
+      "version": "github:revery-ui/reason-harfbuzz#4a26775",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-harfbuzz#6c32299" ]
+        "source": [ "github:revery-ui/reason-harfbuzz#4a26775" ]
       },
       "overrides": [],
       "dependencies": [


### PR DESCRIPTION
Pick up fix for memory leak in harfbuzz:
```
=================================================================
==24296==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0x7fcb89a3c79a in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x9879a)
    #1 0x7fcb88e9792e in hb_blob_create (/usr/lib/x86_64-linux-gnu/libharfbuzz.so.0+0x692e)

Indirect leak of 227848 byte(s) in 1 object(s) allocated from:
    #0 0x7fcb89a3c602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x8f1a3d in get_font_ot /home/vsts/.esy/3/b/reason_harfbuzz-d8c087a9/default/src/harfbuzz.cpp:52
    #2 0x8f1c7d in rehb_new_face /home/vsts/.esy/3/b/reason_harfbuzz-d8c087a9/default/src/harfbuzz.cpp:85
    #3 0x7137b2 in camlHarfbuzz__hb_new_face_90 (/home/vsts/work/1/s/_esy/integrationtest/store/b/oni2-de07e1fd/default/integration_test/ExtHostCompletionTest.exe+0x7137b2)

SUMMARY: AddressSanitizer: 228000 byte(s) leaked in 2 allocation(s).
```
