### PR TITLE
#1397: OSX - Packaging: Add dyld env entitlement

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -179,7 +179,7 @@ if (process.platform == "linux") {
       "com.apple.security.cs.allow-unsigned-executable-memory": true,
       "com.apple.security.cs.disable-library-validation": true,
 
-// Allow dyld environment variables. Needed because Firefox uses
+// Allow dyld environment variables. Needed because Onivim 2 uses
 //         dyld variables (such as @executable_path) to load libaries from
 //         within the .app bundle.
 // See: https://github.com/onivim/oni2/issues/1397

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -178,6 +178,12 @@ if (process.platform == "linux") {
       "com.apple.security.cs.allow-jit": true,
       "com.apple.security.cs.allow-unsigned-executable-memory": true,
       "com.apple.security.cs.disable-library-validation": true,
+
+// Allow dyld environment variables. Needed because Firefox uses
+//         dyld variables (such as @executable_path) to load libaries from
+//         within the .app bundle.
+// See: https://github.com/onivim/oni2/issues/1397
+      "com.apple.security.cs.allow-dyld-environment-variables": true,
   };
   fs.writeFileSync(entitlementsPath, require("plist").build(entitlementsContents));
 


### PR DESCRIPTION
Add the `com.apple.security.cs.allow-dyld-environment-variables` entitlement, to allow loading via `dylib` `@executable_path`variables.

Related to (and hopefully fixes) #1397 