### PR TITLE
Fix: Remove y-axis offset of sneak items

### DIFF
--- a/src/UI/SneakView.re
+++ b/src/UI/SneakView.re
@@ -32,7 +32,7 @@ module Styles = {
     Style.[
       backgroundColor(theme.sneakBackground),
       position(`Absolute),
-      top(y - Constants.size / 2),
+      top(y),
       left(x + Constants.size / 2),
       Style.height(Constants.size),
       Style.width(Constants.size),


### PR DESCRIPTION
There is a Y-Axis offset for sneak items. This pushes the items partially out of the view as stated here: https://github.com/onivim/oni2/issues/1284
This PR removes the offset and fixes the first two bugs mentioned in the linked issue, which are:
- Tab navigation is half out of view
- The navigation for the directory tree (and left of) is slightly too high

I'm not sure if the offset is wanted. If it is, just reject the PR.

Old state:
![grafik](https://user-images.githubusercontent.com/36313322/75722870-5a40a280-5cdb-11ea-9445-3d9ac282639b.png)

New state:
![grafik](https://user-images.githubusercontent.com/36313322/75722889-67f62800-5cdb-11ea-9a7d-b7a226512f04.png)
