### PR TITLE
Bugfix - OSX: Remove problematic files from codesigning

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -142,6 +142,18 @@ if (process.platform == "linux") {
   copy(getNodePath(), path.join(binaryDirectory, "node"));
   copy(getRlsPath(), path.join(binaryDirectory, "rls"));
 
+  // Folders to delete
+  // TODO: Move this into our VSCode packaging, there are a lot of files we don't need to bundle at all
+  let resourceFoldersToDelete = [
+     "node/node_modules/vscode-exthost/out/vs/workbench/services/search/test",
+  ];
+
+  resourceFoldersToDelete.forEach((p) => {
+   let deletePath = path.join(resourcesDirectory, p); 
+   console.log("Deleting path: " + deletePath);
+   fs.removeSync(deletePath);
+  });
+
   // Remove setup.json prior to remapping bundled files,
   // so it doesn't get symlinked.
   fs.removeSync(path.join(binaryDirectory, "setup.json"));


### PR DESCRIPTION
There was an error from the codesigning of  latest builds in the release portal:
```
Onivim2.app: a sealed resource is missing or invalid
file added: /Applications/Onivim2.app/Contents/Resources/node/node_modules/vscode-exthost/out/vs/workbench/services/search/test/node/fixtures/üm laut汉语/汉语.txt
file missing: /Applications/Onivim2.app/Contents/Resources/node/node_modules/vscode-exthost/out/vs/workbench/services/search/test/node/fixtures/üm laut汉语/汉语.txt
```

This removes the problematic files from our release bundle. A more complete fix that we need will be to remove all the test files from the `vscode-exthost` npm module - there's no reason to bundle this test code and fixtures with it, because they are totally unused.