### PR TITLE
Bugfix: Dune 2.x proofing

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cca9c6a477de46f4cc7459668ae2b8e0",
+  "checksum": "74b667cde4d3b10ce52d8795c33d1d6d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/bench.json
+++ b/bench.json
@@ -9,8 +9,8 @@
         "reperf": "^1.3.0"
       },
       "install": [
-          "esy-installer Oni2.install",
-          "esy-installer OniBench.install"
+          "esy-installer #{self.target_dir}/default/Oni2.install",
+          "esy-installer #{self.target_dir}/default/OniBench.install"
       ]
   }
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cca9c6a477de46f4cc7459668ae2b8e0",
+  "checksum": "74b667cde4d3b10ce52d8795c33d1d6d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cca9c6a477de46f4cc7459668ae2b8e0",
+  "checksum": "74b667cde4d3b10ce52d8795c33d1d6d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/integrationtest.json
+++ b/integrationtest.json
@@ -6,8 +6,8 @@
   "override": {
       "build": ["dune build -p Oni2,OniIntegrationTests -j4"],
       "install": [
-          "esy-installer Oni2.install",
-          "esy-installer OniIntegrationTests.install"
+          "esy-installer #{self.target_dir}/default/Oni2.install",
+          "esy-installer #{self.target_dir}/default/OniIntegrationTests.install"
       ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "@esy-ocaml/reason": "3.5.2",
     "@opam/camomile": "^1.0.1",
     "@opam/charInfo_width": "*",
-    "@opam/dune": "*",
+    "@opam/dune": "^2.0.0",
     "@opam/lwt": "*",
     "@opam/ocamlbuild": "*",
     "@opam/ppx_deriving": "*",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8c172d7d39a745b93cacbb11e070a9c0",
+  "checksum": "7c9439eac5187d5cd0f69432c09c252a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/test.json
+++ b/test.json
@@ -13,8 +13,8 @@
         "@reason-native/rely": "1.3.1"
       },
       "install": [
-          "esy-installer Oni2.install",
-          "esy-installer OniUnitTestRunner.install"
+          "esy-installer #{self.target_dir}/default/Oni2.install",
+          "esy-installer #{self.target_dir}/default/OniUnitTestRunner.install"
       ]
   }
 }


### PR DESCRIPTION
Dune 2 no longer "promotes" install (and META) files to the source directory, so if we reference those the install will fail if it has not previously been built with dune 1.x. And even if it has, those files may then be stale. This fixes that by pointing to the install files in the build directory, and also requires dune 2.x.