### PR TITLE
Implement the next/previous editor commands and keybindings

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -128,8 +128,6 @@ type t =
   | StatusBarDisposeItem(int)
   | StatusBar(StatusBarModel.action)
   | ViewCloseEditor(int)
-  | ViewNextEditor
-  | ViewPreviousEditor
   | ViewSetActiveEditor(int)
   | EnableZenMode
   | DisableZenMode

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -128,6 +128,8 @@ type t =
   | StatusBarDisposeItem(int)
   | StatusBar(StatusBarModel.action)
   | ViewCloseEditor(int)
+  | ViewNextEditor
+  | ViewPreviousEditor
   | ViewSetActiveEditor(int)
   | EnableZenMode
   | DisableZenMode

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -82,6 +82,38 @@ let _getAdjacentEditor = (editor: int, reverseTabOrder: list(int)) => {
   };
 };
 
+let setActiveEditorByIndexDiff = (diff, model) => {
+  let tabs = model.reverseTabOrder;
+  let count = List.length(tabs);
+
+  if (count <= 1) {
+    // Nothing to change
+    model
+  } else {
+    switch (model.activeEditorId) {
+    | Some(activeEditorId) =>
+      switch (_getIndexOfElement(activeEditorId, tabs)) {
+      | (-1) => model
+      | idx =>
+        let newIndex =
+          switch (idx + diff) {
+          // Wrapping negative, go to end
+          | -1 => count - 1
+          // If this is past the end, go to zero, otherwise this index is fine
+          | i => i >= count ? 0 : i
+          };
+
+        {...model, activeEditorId: List.nth_opt(tabs, newIndex)};
+      }
+    | None => model
+    };
+  };
+}
+
+// The diff amounts are inverted because the list is in reverse order
+let nextEditor = setActiveEditorByIndexDiff(-1);
+let previousEditor = setActiveEditorByIndexDiff(1);
+
 let isEmpty = model => IntMap.is_empty(model.editors);
 
 let removeEditorById = (state, editorId) => {

--- a/src/Model/EditorGroup.rei
+++ b/src/Model/EditorGroup.rei
@@ -17,6 +17,8 @@ let getActiveEditor: t => option(Feature_Editor.Editor.t);
 let setActiveEditor: (t, int) => t;
 let getEditorById: (int, t) => option(Feature_Editor.Editor.t);
 let getOrCreateEditorForBuffer: (t, int) => (t, Feature_Editor.EditorId.t);
+let nextEditor: t => t;
+let previousEditor: t => t;
 let removeEditorById: (t, int) => t;
 
 let isEmpty: t => bool;

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -25,7 +25,8 @@ let reduce = (v: EditorGroup.t, action: Actions.t) => {
       EditorGroup.getOrCreateEditorForBuffer(v, id);
     {...newState, activeEditorId: Some(activeEditorId)};
   | Command("workbench.action.nextEditor") => EditorGroup.nextEditor(v)
-  | Command("workbench.action.previousEditor") => EditorGroup.previousEditor(v)
+  | Command("workbench.action.previousEditor") =>
+    EditorGroup.previousEditor(v)
   | ViewCloseEditor(id) => EditorGroup.removeEditorById(v, id)
   | ViewSetActiveEditor(id) =>
     switch (IntMap.find_opt(id, v.editors)) {

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -25,6 +25,8 @@ let reduce = (v: EditorGroup.t, action: Actions.t) => {
       EditorGroup.getOrCreateEditorForBuffer(v, id);
     {...newState, activeEditorId: Some(activeEditorId)};
   | ViewCloseEditor(id) => EditorGroup.removeEditorById(v, id)
+  | ViewNextEditor => EditorGroup.nextEditor(v)
+  | ViewPreviousEditor => EditorGroup.previousEditor(v)
   | ViewSetActiveEditor(id) =>
     switch (IntMap.find_opt(id, v.editors)) {
     | None => v

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -24,9 +24,9 @@ let reduce = (v: EditorGroup.t, action: Actions.t) => {
     let (newState, activeEditorId) =
       EditorGroup.getOrCreateEditorForBuffer(v, id);
     {...newState, activeEditorId: Some(activeEditorId)};
+  | Command("workbench.action.nextEditor") => EditorGroup.nextEditor(v)
+  | Command("workbench.action.previousEditor") => EditorGroup.previousEditor(v)
   | ViewCloseEditor(id) => EditorGroup.removeEditorById(v, id)
-  | ViewNextEditor => EditorGroup.nextEditor(v)
-  | ViewPreviousEditor => EditorGroup.previousEditor(v)
   | ViewSetActiveEditor(id) =>
     switch (IntMap.find_opt(id, v.editors)) {
     | None => v

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -47,6 +47,18 @@ let createDefaultCommands = getState => {
       ),
       Command.create(
         ~category=Some("View"),
+        ~name="Open Next Editor",
+        ~action=Command("workbench.action.nextEditor"),
+        (),
+      ),
+      Command.create(
+        ~category=Some("View"),
+        ~name="Open Previous Editor",
+        ~action=Command("workbench.action.previousEditor"),
+        (),
+      ),
+      Command.create(
+        ~category=Some("View"),
         ~name="Toggle Problems (Errors, Warnings)",
         ~action=Command("workbench.actions.view.problems"),
         (),
@@ -319,6 +331,8 @@ let start = (getState, contributedCommands) => {
     ("list.select", _ => singleActionEffect(ListSelect)),
     ("list.selectBackground", _ => singleActionEffect(ListSelectBackground)),
     ("view.closeEditor", state => closeEditorEffect(state)),
+    ("workbench.action.nextEditor", _ => singleActionEffect(ViewNextEditor)),
+    ("workbench.action.previousEditor", _ => singleActionEffect(ViewPreviousEditor)),
     ("view.splitVertical", state => splitEditorEffect(state, Vertical)),
     ("view.splitHorizontal", state => splitEditorEffect(state, Horizontal)),
     (

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -331,8 +331,6 @@ let start = (getState, contributedCommands) => {
     ("list.select", _ => singleActionEffect(ListSelect)),
     ("list.selectBackground", _ => singleActionEffect(ListSelectBackground)),
     ("view.closeEditor", state => closeEditorEffect(state)),
-    ("workbench.action.nextEditor", _ => singleActionEffect(ViewNextEditor)),
-    ("workbench.action.previousEditor", _ => singleActionEffect(ViewPreviousEditor)),
     ("view.splitVertical", state => splitEditorEffect(state, Vertical)),
     ("view.splitHorizontal", state => splitEditorEffect(state, Horizontal)),
     (

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -204,6 +204,26 @@ let start = () => {
         command: "view.closeEditor",
         condition: WhenExpr.Value(True),
       },
+      {
+        key: "<C-PAGEDOWN>",
+        command: "workbench.action.nextEditor",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-S-]>",
+        command: "workbench.action.nextEditor",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<C-PAGEUP>",
+        command: "workbench.action.previousEditor",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-S-[>",
+        command: "workbench.action.previousEditor",
+        condition: WhenExpr.Value(True),
+      },
     ];
 
   let reloadConfigOnWritePost = (~configPath, dispatch) => {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -904,6 +904,8 @@ let start =
       )
     | ViewSetActiveEditor(_) => (state, synchronizeEditorEffect(state))
     | ViewCloseEditor(_) => (state, synchronizeEditorEffect(state))
+    | ViewNextEditor => (state, synchronizeEditorEffect(state))
+    | ViewPreviousEditor => (state, synchronizeEditorEffect(state))
     | KeyboardInput(s) => (state, inputEffect(s))
     | CopyActiveFilepathToClipboard => (
         state,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -904,8 +904,14 @@ let start =
       )
     | ViewSetActiveEditor(_) => (state, synchronizeEditorEffect(state))
     | ViewCloseEditor(_) => (state, synchronizeEditorEffect(state))
-    | Command("workbench.action.nextEditor") => (state, synchronizeEditorEffect(state))
-    | Command("workbench.action.previousEditor") => (state, synchronizeEditorEffect(state))
+    | Command("workbench.action.nextEditor") => (
+        state,
+        synchronizeEditorEffect(state),
+      )
+    | Command("workbench.action.previousEditor") => (
+        state,
+        synchronizeEditorEffect(state),
+      )
     | KeyboardInput(s) => (state, inputEffect(s))
     | CopyActiveFilepathToClipboard => (
         state,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -904,8 +904,8 @@ let start =
       )
     | ViewSetActiveEditor(_) => (state, synchronizeEditorEffect(state))
     | ViewCloseEditor(_) => (state, synchronizeEditorEffect(state))
-    | ViewNextEditor => (state, synchronizeEditorEffect(state))
-    | ViewPreviousEditor => (state, synchronizeEditorEffect(state))
+    | Command("workbench.action.nextEditor") => (state, synchronizeEditorEffect(state))
+    | Command("workbench.action.previousEditor") => (state, synchronizeEditorEffect(state))
     | KeyboardInput(s) => (state, inputEffect(s))
     | CopyActiveFilepathToClipboard => (
         state,


### PR DESCRIPTION
This wraps around like VSCode.

Fixes #778 and part of #1423.