### PR TITLE
Window Splits: Change default split direction to right / down

### DIFF
--- a/src/Model/WindowTree.re
+++ b/src/Model/WindowTree.re
@@ -9,6 +9,10 @@ type direction =
   | Horizontal
   | Vertical;
 
+type position =
+  | Before
+  | After;
+
 [@deriving show({with_path: false})]
 type split = {
   id: int,
@@ -68,7 +72,7 @@ let rec getEditorGroupIdFromSplitId = (splitId: int, currentTree) => {
   };
 };
 
-let addSplit = (~target=None, direction, newSplit, currentTree) => {
+let addSplit = (~target=None, ~position, direction, newSplit, currentTree) => {
   let rec f = (targetId, parent, split) => {
     switch (split) {
     | Parent(d, tree) => [
@@ -76,14 +80,19 @@ let addSplit = (~target=None, direction, newSplit, currentTree) => {
       ]
     | Leaf(v) =>
       if (v.id == targetId) {
+        let children =
+          switch (position) {
+          | Before => [Leaf(newSplit), Leaf(v)]
+          | After => [Leaf(v), Leaf(newSplit)]
+          };
         switch (parent) {
         | Some(Parent(dir, _)) =>
           if (dir == direction) {
-            [Leaf(newSplit), Leaf(v)];
+            children;
           } else {
-            [Parent(direction, [Leaf(newSplit), Leaf(v)])];
+            [Parent(direction, children)];
           }
-        | _ => [Leaf(newSplit), Leaf(v)]
+        | _ => children
         };
       } else {
         [Leaf(v)];

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -58,7 +58,7 @@ let start = () => {
           windowTree:
             WindowTree.addSplit(
               ~target=Some(s.windowManager.activeWindowId),
-              ~position=End,
+              ~position=After,
               direction,
               split,
               s.windowManager.windowTree,

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -58,6 +58,7 @@ let start = () => {
           windowTree:
             WindowTree.addSplit(
               ~target=Some(s.windowManager.activeWindowId),
+              ~position=End,
               direction,
               split,
               s.windowManager.windowTree,

--- a/test/Model/WindowTreeLayoutTests.re
+++ b/test/Model/WindowTreeLayoutTests.re
@@ -19,9 +19,19 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       let splits =
         WindowTree.empty
-        |> addSplit(~target=None, Horizontal, split1)
-        |> addSplit(~target=Some(split1.id), Horizontal, split2)
-        |> addSplit(~target=Some(split2.id), Horizontal, split3);
+        |> addSplit(~target=None, ~position=Before, Horizontal, split1)
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Horizontal,
+             split2,
+           )
+        |> addSplit(
+             ~target=Some(split2.id),
+             ~position=Before,
+             Horizontal,
+             split3,
+           );
 
       let layoutItems = WindowTreeLayout.layout(0, 0, 300, 300, splits);
 
@@ -62,8 +72,13 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       let splits =
         WindowTree.empty
-        |> addSplit(~target=None, Vertical, split1)
-        |> addSplit(~target=Some(split1.id), Vertical, split2);
+        |> addSplit(~target=None, ~position=Before, Vertical, split1)
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Vertical,
+             split2,
+           );
 
       let layoutItems = WindowTreeLayout.layout(0, 0, 200, 200, splits);
 
@@ -85,8 +100,13 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       let splits =
         WindowTree.empty
-        |> addSplit(~target=None, Horizontal, split1)
-        |> addSplit(~target=Some(split1.id), Horizontal, split2);
+        |> addSplit(~target=None, ~position=Before, Horizontal, split1)
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Horizontal,
+             split2,
+           );
 
       let layoutItems = WindowTreeLayout.layout(0, 0, 200, 200, splits);
 
@@ -108,9 +128,19 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       let splits =
         WindowTree.empty
-        |> addSplit(~target=None, Horizontal, split1)
-        |> addSplit(~target=Some(split1.id), Horizontal, split2)
-        |> addSplit(~target=Some(split1.id), Vertical, split3);
+        |> addSplit(~target=None, ~position=Before, Horizontal, split1)
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Horizontal,
+             split2,
+           )
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Vertical,
+             split3,
+           );
 
       let layoutItems = WindowTreeLayout.layout(0, 0, 200, 200, splits);
 

--- a/test/Model/WindowTreeTests.re
+++ b/test/Model/WindowTreeTests.re
@@ -18,10 +18,25 @@ describe("WindowTreeTests", ({describe, _}) => {
 
       let splits =
         splits
-        |> addSplit(~target=None, Vertical, split1)
-        |> addSplit(~target=Some(split1.id), Vertical, split2)
-        |> addSplit(~target=Some(split2.id), Horizontal, split3)
-        |> addSplit(~target=Some(split1.id), Horizontal, split4);
+        |> addSplit(~target=None, ~position=Before, Vertical, split1)
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Vertical,
+             split2,
+           )
+        |> addSplit(
+             ~target=Some(split2.id),
+             ~position=Before,
+             Horizontal,
+             split3,
+           )
+        |> addSplit(
+             ~target=Some(split1.id),
+             ~position=Before,
+             Horizontal,
+             split4,
+           );
 
       let newSplits =
         splits
@@ -44,15 +59,51 @@ describe("WindowTreeTests", ({describe, _}) => {
       let split = createSplit(~editorGroupId=1, ());
       let targetId = split.id;
 
-      let splits = addSplit(~target=None, Vertical, split, splits);
+      let splits =
+        addSplit(~target=None, ~position=Before, Vertical, split, splits);
 
       expect.bool(splits == Parent(Vertical, [Leaf(split)])).toBe(true);
 
       let split2 = createSplit(~editorGroupId=2, ());
 
       let splits =
-        addSplit(~target=Some(targetId), Vertical, split2, splits);
+        addSplit(
+          ~target=Some(targetId),
+          ~position=Before,
+          Vertical,
+          split2,
+          splits,
+        );
       expect.bool(splits == Parent(Vertical, [Leaf(split2), Leaf(split)])).
+        toBe(
+        true,
+      );
+    });
+
+    test("add vertical split - after", ({expect}) => {
+      let splits = WindowTree.empty;
+
+      expect.bool(splits == Parent(Vertical, [Empty])).toBe(true);
+
+      let split = createSplit(~editorGroupId=1, ());
+      let targetId = split.id;
+
+      let splits =
+        addSplit(~target=None, ~position=After, Vertical, split, splits);
+
+      expect.bool(splits == Parent(Vertical, [Leaf(split)])).toBe(true);
+
+      let split2 = createSplit(~editorGroupId=2, ());
+
+      let splits =
+        addSplit(
+          ~target=Some(targetId),
+          ~position=After,
+          Vertical,
+          split2,
+          splits,
+        );
+      expect.bool(splits == Parent(Vertical, [Leaf(split), Leaf(split2)])).
         toBe(
         true,
       );
@@ -68,9 +119,16 @@ describe("WindowTreeTests", ({describe, _}) => {
       let split2 = createSplit(~editorGroupId=2, ());
       let split3 = createSplit(~editorGroupId=3, ());
 
-      let splits = addSplit(~target=None, Horizontal, split1, splits);
       let splits =
-        addSplit(~target=Some(targetId), Horizontal, split2, splits);
+        addSplit(~target=None, ~position=Before, Horizontal, split1, splits);
+      let splits =
+        addSplit(
+          ~target=Some(targetId),
+          ~position=Before,
+          Horizontal,
+          split2,
+          splits,
+        );
 
       expect.bool(
         splits
@@ -84,7 +142,13 @@ describe("WindowTreeTests", ({describe, _}) => {
       );
 
       let splits =
-        addSplit(~target=Some(targetId), Vertical, split3, splits);
+        addSplit(
+          ~target=Some(targetId),
+          ~position=Before,
+          Vertical,
+          split3,
+          splits,
+        );
 
       expect.bool(
         splits
@@ -115,9 +179,9 @@ describe("rotateForward", ({test, _}) => {
     let splitC = createSplit(~editorGroupId=3, ());
     let tree =
       WindowTree.empty
-      |> addSplit(Vertical, splitA)
-      |> addSplit(Vertical, splitB)
-      |> addSplit(Vertical, splitC);
+      |> addSplit(~position=Before, Vertical, splitA)
+      |> addSplit(~position=Before, Vertical, splitB)
+      |> addSplit(~position=Before, Vertical, splitC);
 
     expect.bool(
       tree == Parent(Vertical, [Leaf(splitC), Leaf(splitB), Leaf(splitA)]),
@@ -144,10 +208,20 @@ describe("rotateForward", ({test, _}) => {
     let splitD = createSplit(~editorGroupId=4, ());
     let tree =
       WindowTree.empty
-      |> addSplit(Vertical, splitA)
-      |> addSplit(Horizontal, splitB, ~target=Some(splitA.id))
-      |> addSplit(Horizontal, splitC, ~target=Some(splitB.id))
-      |> addSplit(Vertical, splitD);
+      |> addSplit(~position=Before, Vertical, splitA)
+      |> addSplit(
+           ~position=Before,
+           Horizontal,
+           splitB,
+           ~target=Some(splitA.id),
+         )
+      |> addSplit(
+           ~position=Before,
+           Horizontal,
+           splitC,
+           ~target=Some(splitB.id),
+         )
+      |> addSplit(~position=Before, Vertical, splitD);
 
     expect.bool(
       tree
@@ -194,9 +268,9 @@ describe("rotateBackward", ({test, _}) => {
     let splitC = createSplit(~editorGroupId=3, ());
     let tree =
       WindowTree.empty
-      |> addSplit(Vertical, splitA)
-      |> addSplit(Vertical, splitB)
-      |> addSplit(Vertical, splitC);
+      |> addSplit(~position=Before, Vertical, splitA)
+      |> addSplit(~position=Before, Vertical, splitB)
+      |> addSplit(~position=Before, Vertical, splitC);
 
     expect.bool(
       tree == Parent(Vertical, [Leaf(splitC), Leaf(splitB), Leaf(splitA)]),
@@ -223,10 +297,20 @@ describe("rotateBackward", ({test, _}) => {
     let splitD = createSplit(~editorGroupId=4, ());
     let tree =
       WindowTree.empty
-      |> addSplit(Vertical, splitA)
-      |> addSplit(Horizontal, splitB, ~target=Some(splitA.id))
-      |> addSplit(Horizontal, splitC, ~target=Some(splitB.id))
-      |> addSplit(Vertical, splitD);
+      |> addSplit(~position=Before, Vertical, splitA)
+      |> addSplit(
+           ~position=Before,
+           Horizontal,
+           splitB,
+           ~target=Some(splitA.id),
+         )
+      |> addSplit(
+           ~position=Before,
+           Horizontal,
+           splitC,
+           ~target=Some(splitB.id),
+         )
+      |> addSplit(~position=Before, Vertical, splitD);
 
     expect.bool(
       tree


### PR DESCRIPTION
When creating a window split, via `:vsp` or a command, this changes the default to create the split to the right of the current split (for `:vsp`), or below the current split (for `sp`). This is a more natural default than what we had before.

As a next step, once #1436 is in, I'd like to make this configurable as well.