### PR TITLE
CI: Restore build cache for OSX

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,7 @@ jobs:
   - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libtool libpng ragel
+  - template: .ci/restore-build-cache.yml
   - template: .ci/swap-xcode.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/esy-check-hygiene.yml
@@ -115,6 +116,7 @@ jobs:
   - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libtool libpng ragel
+  - template: .ci/restore-build-cache.yml
   - template: .ci/swap-xcode.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/esy-build-steps.yml


### PR DESCRIPTION
Looks like the restoration of build caches for OSX (our hygiene checks + macOS10.14 build) - weren't leveraging the build caches.