### PR TITLE
Theme revamp - part 2: Schema refactor

### DIFF
--- a/src/Core/ColorTheme.re
+++ b/src/Core/ColorTheme.re
@@ -43,27 +43,57 @@ let key = Internal.Key.create;
 // DEFAULTS
 
 module Defaults = {
-  type value =
+  // vscode: ColorValue
+  type expr =
     | Constant(Color.t)
-    | Reference(string)
-    | Computed((string => option(Color.t)) => option(Color.t)) // vscode: ColorFunction
+    | Reference(key)
+    | Computed((key => option(Color.t)) => option(Color.t)) // vscode: ColorFunction
     | Unspecified;
 
   // vscode: ColorDefaults
-  type entry = {
-    light: value,
-    dark: value,
-    hc: value,
+  type t = {
+    light: expr,
+    dark: expr,
+    hc: expr,
   };
 
-  type t = Internal.Lookup.t(entry);
+  let get = (variant, defaults) =>
+    switch (variant) {
+    | Light => defaults.light
+    | Dark => defaults.dark
+    | HighContrast => defaults.hc
+    };
+
+  let evaluate = resolve =>
+    fun
+    | Constant(color) => Some(color)
+    //| Reference(refKey) when refKey == key => failwith("infinite loop detetcted")
+    | Reference(refKey) => resolve(refKey)
+    | Computed(f) => f(resolve)
+    | Unspecified => None;
+};
+
+// RESOLVER
+
+type resolver =
+  key => [ | `Color(Color.t) | `Default(Defaults.expr) | `NotRegistered];
+
+// SCHEMA
+
+module Schema = {
+  type definition = {
+    key,
+    defaults: Defaults.t,
+    tryGet: resolver => option(Color.t),
+    get: resolver => Color.t,
+  };
+
+  type t = Internal.Lookup.t(definition);
 
   let fromList = entries =>
     entries
     |> List.to_seq
-    |> Seq.map(((keyName, entry)) =>
-         (Internal.Key.create(keyName), entry)
-       )
+    |> Seq.map(definition => (definition.key, definition))
     |> Internal.Lookup.of_seq;
 
   let get = Internal.Lookup.find_opt;
@@ -84,9 +114,11 @@ module Defaults = {
   // DSL
 
   module DSL = {
+    open Defaults;
+
     let hex = str => Constant(Color.hex(str));
     let color = color => Constant(color);
-    let ref = str => Reference(str);
+    let ref = def => Reference(def.key);
     let computed = f => Computed(f);
     //let darken =
     //let lighten =
@@ -106,6 +138,28 @@ module Defaults = {
     let unspecified = Unspecified;
 
     let uniform = value => {light: value, dark: value, hc: value};
+
+    let define = (keyName, defaults) => {
+      let key = Internal.Key.create(keyName);
+
+      let rec tryGet = (resolve, key) =>
+        switch (resolve(key)) {
+        | `Color(color) => Some(color)
+        | `Default(expr) => Defaults.evaluate(tryGet(resolve), expr)
+        | `NotRegistered =>
+          Log.warnf(m => m("Missing contributed default for `%s`", keyName));
+          Some(Colors.magenta);
+        };
+
+      {
+        key,
+        defaults,
+        tryGet: resolve => tryGet(resolve, key),
+        get: resolve =>
+          tryGet(resolve, key)
+          |> Option.value(~default=Colors.transparentWhite),
+      };
+    };
   };
 
   include DSL;
@@ -133,10 +187,4 @@ module Colors = {
 type t = {
   variant,
   colors: Colors.t,
-};
-
-type resolver = {
-  .
-  tryColor: string => option(Revery.Color.t),
-  color: string => Revery.Color.t,
 };

--- a/src/Core/ColorTheme.re
+++ b/src/Core/ColorTheme.re
@@ -137,7 +137,7 @@ module Schema = {
     //let lessProminent =
     let unspecified = Unspecified;
 
-    let uniform = value => {light: value, dark: value, hc: value};
+    let all = value => {light: value, dark: value, hc: value};
 
     let define = (keyName, defaults) => {
       let key = Internal.Key.create(keyName);

--- a/src/Core/ColorTheme.re
+++ b/src/Core/ColorTheme.re
@@ -84,8 +84,8 @@ module Schema = {
   type definition = {
     key,
     defaults: Defaults.t,
-    tryGet: resolver => option(Color.t),
-    get: resolver => Color.t,
+    tryFrom: resolver => option(Color.t),
+    from: resolver => Color.t,
   };
 
   type t = Internal.Lookup.t(definition);
@@ -154,8 +154,8 @@ module Schema = {
       {
         key,
         defaults,
-        tryGet: resolve => tryGet(resolve, key),
-        get: resolve =>
+        tryFrom: resolve => tryGet(resolve, key),
+        from: resolve =>
           tryGet(resolve, key)
           |> Option.value(~default=Colors.transparentWhite),
       };

--- a/src/Core/ColorTheme.rei
+++ b/src/Core/ColorTheme.rei
@@ -59,7 +59,7 @@ module Schema: {
       Defaults.expr;
     let transparent: (float, Defaults.expr) => Defaults.expr;
 
-    let uniform: Defaults.expr => Defaults.t;
+    let all: Defaults.expr => Defaults.t;
 
     let define: (string, Defaults.t) => definition;
   };
@@ -73,7 +73,7 @@ module Schema: {
   let transparent: (float, Defaults.expr) => Defaults.expr;
   let unspecified: Defaults.expr;
 
-  let uniform: Defaults.expr => Defaults.t;
+  let all: Defaults.expr => Defaults.t;
 
   let define: (string, Defaults.t) => definition;
 };

--- a/src/Core/ColorTheme.rei
+++ b/src/Core/ColorTheme.rei
@@ -37,8 +37,8 @@ module Schema: {
   type definition = {
     key,
     defaults: Defaults.t,
-    tryGet: resolver => option(Revery.Color.t),
-    get: resolver => Revery.Color.t,
+    tryFrom: resolver => option(Revery.Color.t),
+    from: resolver => Revery.Color.t,
   };
 
   type t;

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -415,7 +415,7 @@ module Pane = {
     let text = (~theme, ~font: UiFont.t) => [
       fontSize(font.fontSize),
       fontFamily(font.fontFile),
-      color(Colors.foreground.get(theme)),
+      color(Colors.foreground.from(theme)),
       textWrap(TextWrapping.NoWrap),
       textOverflow(`Ellipsis),
     ];
@@ -423,7 +423,7 @@ module Pane = {
     let input = (~theme, ~font: UiFont.t) => [
       border(~width=2, ~color=Color.rgba(0., 0., 0., 0.1)),
       backgroundColor(Color.rgba(0., 0., 0., 0.3)),
-      color(Colors.foreground.get(theme)),
+      color(Colors.foreground.from(theme)),
       fontFamily(font.fontFile),
       fontSize(font.fontSize),
       flexGrow(1),
@@ -436,7 +436,7 @@ module Pane = {
     let groupLabelText = (~theme, ~font: UiFont.t) => [
       fontSize(font.fontSize *. 0.85),
       fontFamily(font.fontFileBold),
-      color(Colors.foreground.get(theme)),
+      color(Colors.foreground.from(theme)),
       textWrap(TextWrapping.NoWrap),
       textOverflow(`Ellipsis),
     ];
@@ -445,8 +445,8 @@ module Pane = {
 
     let item = (~isHovered, ~theme) => [
       isHovered
-        ? backgroundColor(Colors.hoverBackground.get(theme))
-        : backgroundColor(Colors.background.get(theme)),
+        ? backgroundColor(Colors.hoverBackground.from(theme))
+        : backgroundColor(Colors.background.from(theme)),
       paddingVertical(2),
       cursor(MouseCursors.pointer),
     ];
@@ -541,7 +541,7 @@ module Pane = {
     <ScrollView style=Styles.container>
       <Input
         style={Styles.input(~theme, ~font)}
-        cursorColor={Colors.foreground.get(theme)}
+        cursorColor={Colors.foreground.from(theme)}
         value={model.inputBox.value}
         selection={model.inputBox.selection}
         placeholder={model.inputBox.placeholder}

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -415,7 +415,7 @@ module Pane = {
     let text = (~theme, ~font: UiFont.t) => [
       fontSize(font.fontSize),
       fontFamily(font.fontFile),
-      color(theme#color(Colors.foreground)),
+      color(Colors.foreground.get(theme)),
       textWrap(TextWrapping.NoWrap),
       textOverflow(`Ellipsis),
     ];
@@ -423,7 +423,7 @@ module Pane = {
     let input = (~theme, ~font: UiFont.t) => [
       border(~width=2, ~color=Color.rgba(0., 0., 0., 0.1)),
       backgroundColor(Color.rgba(0., 0., 0., 0.3)),
-      color(theme#color(Colors.foreground)),
+      color(Colors.foreground.get(theme)),
       fontFamily(font.fontFile),
       fontSize(font.fontSize),
       flexGrow(1),
@@ -436,7 +436,7 @@ module Pane = {
     let groupLabelText = (~theme, ~font: UiFont.t) => [
       fontSize(font.fontSize *. 0.85),
       fontFamily(font.fontFileBold),
-      color(theme#color(Colors.foreground)),
+      color(Colors.foreground.get(theme)),
       textWrap(TextWrapping.NoWrap),
       textOverflow(`Ellipsis),
     ];
@@ -445,8 +445,8 @@ module Pane = {
 
     let item = (~isHovered, ~theme) => [
       isHovered
-        ? backgroundColor(theme#color(Colors.hoverBackground))
-        : backgroundColor(theme#color(Colors.background)),
+        ? backgroundColor(Colors.hoverBackground.get(theme))
+        : backgroundColor(Colors.background.get(theme)),
       paddingVertical(2),
       cursor(MouseCursors.pointer),
     ];
@@ -541,7 +541,7 @@ module Pane = {
     <ScrollView style=Styles.container>
       <Input
         style={Styles.input(~theme, ~font)}
-        cursorColor={theme#color(Colors.foreground)}
+        cursorColor={Colors.foreground.get(theme)}
         value={model.inputBox.value}
         selection={model.inputBox.selection}
         placeholder={model.inputBox.placeholder}

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -151,53 +151,117 @@ let subscription = (~workspaceUri, extHostClient, model: t) => {
 };
 
 module Colors = {
-  let background = "terminal.background";
-  let foreground = "terminal.foreground";
-  let ansiBlack = "terminal.ansiBlack";
-  let ansiRed = "terminal.ansiRed";
-  let ansiGreen = "terminal.ansiGreen";
-  let ansiYellow = "terminal.ansiYellow";
-  let ansiBlue = "terminal.ansiBlue";
-  let ansiMagenta = "terminal.ansiMagenta";
-  let ansiCyan = "terminal.ansiCyan";
-  let ansiWhite = "terminal.ansiWhite";
-  let ansiBrightBlack = "terminal.ansiBrightBlack";
-  let ansiBrightRed = "terminal.ansiBrightRed";
-  let ansiBrightGreen = "terminal.ansiBrightGreen";
-  let ansiBrightYellow = "terminal.ansiBrightYellow";
-  let ansiBrightBlue = "terminal.ansiBrightBlue";
-  let ansiBrightMagenta = "terminal.ansiBrightMagenta";
-  let ansiBrightCyan = "terminal.ansiBrightCyan";
-  let ansiBrightWhite = "terminal.ansiBrightWhite";
+  open Revery;
+  open ColorTheme.Schema;
+
+  let background =
+    define("terminal.background", color(Color.rgb_int(0, 0, 0)) |> uniform);
+  let foreground =
+    define(
+      "terminal.foreground",
+      color(Color.rgb_int(233, 235, 235)) |> uniform,
+    );
+  let ansiBlack =
+    define("terminal.ansiBlack", color(Color.rgb_int(0, 0, 0)) |> uniform);
+  let ansiRed =
+    define(
+      "terminal.ansiRed",
+      color(Color.rgb_int(194, 54, 33)) |> uniform,
+    );
+  let ansiGreen =
+    define(
+      "terminal.ansiGreen",
+      color(Color.rgb_int(37, 188, 36)) |> uniform,
+    );
+  let ansiYellow =
+    define(
+      "terminal.ansiYellow",
+      color(Color.rgb_int(173, 173, 39)) |> uniform,
+    );
+  let ansiBlue =
+    define(
+      "terminal.ansiBlue",
+      color(Color.rgb_int(73, 46, 225)) |> uniform,
+    );
+  let ansiMagenta =
+    define(
+      "terminal.ansiMagenta",
+      color(Color.rgb_int(211, 56, 211)) |> uniform,
+    );
+  let ansiCyan =
+    define(
+      "terminal.ansiCyan",
+      color(Color.rgb_int(51, 197, 200)) |> uniform,
+    );
+  let ansiWhite =
+    define(
+      "terminal.ansiWhite",
+      color(Color.rgb_int(203, 204, 205)) |> uniform,
+    );
+  let ansiBrightBlack =
+    define(
+      "terminal.ansiBrightBlack",
+      color(Color.rgb_int(129, 131, 131)) |> uniform,
+    );
+  let ansiBrightRed =
+    define(
+      "terminal.ansiBrightRed",
+      color(Color.rgb_int(252, 57, 31)) |> uniform,
+    );
+  let ansiBrightGreen =
+    define(
+      "terminal.ansiBrightGreen",
+      color(Color.rgb_int(49, 231, 34)) |> uniform,
+    );
+  let ansiBrightYellow =
+    define(
+      "terminal.ansiBrightYellow",
+      color(Color.rgb_int(234, 236, 35)) |> uniform,
+    );
+  let ansiBrightBlue =
+    define(
+      "terminal.ansiBrightBlue",
+      color(Color.rgb_int(88, 51, 255)) |> uniform,
+    );
+  let ansiBrightMagenta =
+    define(
+      "terminal.ansiBrightMagenta",
+      color(Color.rgb_int(20, 240, 240)) |> uniform,
+    );
+  let ansiBrightCyan =
+    define(
+      "terminal.ansiBrightCyan",
+      color(Color.rgb_int(20, 240, 240)) |> uniform,
+    );
+  let ansiBrightWhite =
+    define(
+      "terminal.ansiBrightWhite",
+      color(Color.rgb_int(233, 235, 235)) |> uniform,
+    );
 };
 
 // CONTRIBUTIONS
 
 module Contributions = {
-  module Color = Revery.Color;
-
   let colors =
-    ColorTheme.Defaults.(
-      Colors.[
-        (background, color(Color.rgb_int(0, 0, 0)) |> uniform),
-        (foreground, color(Color.rgb_int(233, 235, 235)) |> uniform),
-        (ansiBlack, color(Color.rgb_int(0, 0, 0)) |> uniform),
-        (ansiRed, color(Color.rgb_int(194, 54, 33)) |> uniform),
-        (ansiGreen, color(Color.rgb_int(37, 188, 36)) |> uniform),
-        (ansiYellow, color(Color.rgb_int(173, 173, 39)) |> uniform),
-        (ansiBlue, color(Color.rgb_int(73, 46, 225)) |> uniform),
-        (ansiMagenta, color(Color.rgb_int(211, 56, 211)) |> uniform),
-        (ansiCyan, color(Color.rgb_int(51, 197, 200)) |> uniform),
-        (ansiWhite, color(Color.rgb_int(203, 204, 205)) |> uniform),
-        (ansiBrightBlack, color(Color.rgb_int(129, 131, 131)) |> uniform),
-        (ansiBrightRed, color(Color.rgb_int(252, 57, 31)) |> uniform),
-        (ansiBrightGreen, color(Color.rgb_int(49, 231, 34)) |> uniform),
-        (ansiBrightYellow, color(Color.rgb_int(234, 236, 35)) |> uniform),
-        (ansiBrightBlue, color(Color.rgb_int(88, 51, 255)) |> uniform),
-        (ansiBrightCyan, color(Color.rgb_int(20, 240, 240)) |> uniform),
-        (ansiBrightMagenta, color(Color.rgb_int(20, 240, 240)) |> uniform),
-        (ansiBrightWhite, color(Color.rgb_int(233, 235, 235)) |> uniform),
-      ]
-      |> fromList
-    );
+    Colors.[
+      background,
+      foreground,
+      ansiBlack,
+      ansiRed,
+      ansiGreen,
+      ansiYellow,
+      ansiBlue,
+      ansiMagenta,
+      ansiCyan,
+      ansiWhite,
+      ansiBrightBlack,
+      ansiBrightRed,
+      ansiBrightGreen,
+      ansiBrightYellow,
+      ansiBrightBlue,
+      ansiBrightCyan,
+      ansiBrightMagenta,
+      ansiBrightWhite,
+    ];
 };

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -155,88 +155,76 @@ module Colors = {
   open ColorTheme.Schema;
 
   let background =
-    define("terminal.background", color(Color.rgb_int(0, 0, 0)) |> uniform);
+    define("terminal.background", color(Color.rgb_int(0, 0, 0)) |> all);
   let foreground =
     define(
       "terminal.foreground",
-      color(Color.rgb_int(233, 235, 235)) |> uniform,
+      color(Color.rgb_int(233, 235, 235)) |> all,
     );
   let ansiBlack =
-    define("terminal.ansiBlack", color(Color.rgb_int(0, 0, 0)) |> uniform);
+    define("terminal.ansiBlack", color(Color.rgb_int(0, 0, 0)) |> all);
   let ansiRed =
-    define(
-      "terminal.ansiRed",
-      color(Color.rgb_int(194, 54, 33)) |> uniform,
-    );
+    define("terminal.ansiRed", color(Color.rgb_int(194, 54, 33)) |> all);
   let ansiGreen =
-    define(
-      "terminal.ansiGreen",
-      color(Color.rgb_int(37, 188, 36)) |> uniform,
-    );
+    define("terminal.ansiGreen", color(Color.rgb_int(37, 188, 36)) |> all);
   let ansiYellow =
     define(
       "terminal.ansiYellow",
-      color(Color.rgb_int(173, 173, 39)) |> uniform,
+      color(Color.rgb_int(173, 173, 39)) |> all,
     );
   let ansiBlue =
-    define(
-      "terminal.ansiBlue",
-      color(Color.rgb_int(73, 46, 225)) |> uniform,
-    );
+    define("terminal.ansiBlue", color(Color.rgb_int(73, 46, 225)) |> all);
   let ansiMagenta =
     define(
       "terminal.ansiMagenta",
-      color(Color.rgb_int(211, 56, 211)) |> uniform,
+      color(Color.rgb_int(211, 56, 211)) |> all,
     );
   let ansiCyan =
-    define(
-      "terminal.ansiCyan",
-      color(Color.rgb_int(51, 197, 200)) |> uniform,
-    );
+    define("terminal.ansiCyan", color(Color.rgb_int(51, 197, 200)) |> all);
   let ansiWhite =
     define(
       "terminal.ansiWhite",
-      color(Color.rgb_int(203, 204, 205)) |> uniform,
+      color(Color.rgb_int(203, 204, 205)) |> all,
     );
   let ansiBrightBlack =
     define(
       "terminal.ansiBrightBlack",
-      color(Color.rgb_int(129, 131, 131)) |> uniform,
+      color(Color.rgb_int(129, 131, 131)) |> all,
     );
   let ansiBrightRed =
     define(
       "terminal.ansiBrightRed",
-      color(Color.rgb_int(252, 57, 31)) |> uniform,
+      color(Color.rgb_int(252, 57, 31)) |> all,
     );
   let ansiBrightGreen =
     define(
       "terminal.ansiBrightGreen",
-      color(Color.rgb_int(49, 231, 34)) |> uniform,
+      color(Color.rgb_int(49, 231, 34)) |> all,
     );
   let ansiBrightYellow =
     define(
       "terminal.ansiBrightYellow",
-      color(Color.rgb_int(234, 236, 35)) |> uniform,
+      color(Color.rgb_int(234, 236, 35)) |> all,
     );
   let ansiBrightBlue =
     define(
       "terminal.ansiBrightBlue",
-      color(Color.rgb_int(88, 51, 255)) |> uniform,
+      color(Color.rgb_int(88, 51, 255)) |> all,
     );
   let ansiBrightMagenta =
     define(
       "terminal.ansiBrightMagenta",
-      color(Color.rgb_int(20, 240, 240)) |> uniform,
+      color(Color.rgb_int(20, 240, 240)) |> all,
     );
   let ansiBrightCyan =
     define(
       "terminal.ansiBrightCyan",
-      color(Color.rgb_int(20, 240, 240)) |> uniform,
+      color(Color.rgb_int(20, 240, 240)) |> all,
     );
   let ansiBrightWhite =
     define(
       "terminal.ansiBrightWhite",
-      color(Color.rgb_int(233, 235, 235)) |> uniform,
+      color(Color.rgb_int(233, 235, 235)) |> all,
     );
 };
 

--- a/src/Feature/Terminal/Feature_Terminal.rei
+++ b/src/Feature/Terminal/Feature_Terminal.rei
@@ -61,24 +61,24 @@ let subscription:
 let shellCmd: string;
 
 module Colors: {
-  let background: string;
-  let foreground: string;
-  let ansiBlack: string;
-  let ansiRed: string;
-  let ansiGreen: string;
-  let ansiYellow: string;
-  let ansiBlue: string;
-  let ansiMagenta: string;
-  let ansiCyan: string;
-  let ansiWhite: string;
-  let ansiBrightBlack: string;
-  let ansiBrightRed: string;
-  let ansiBrightGreen: string;
-  let ansiBrightYellow: string;
-  let ansiBrightBlue: string;
-  let ansiBrightMagenta: string;
-  let ansiBrightCyan: string;
-  let ansiBrightWhite: string;
+  let background: ColorTheme.Schema.definition;
+  let foreground: ColorTheme.Schema.definition;
+  let ansiBlack: ColorTheme.Schema.definition;
+  let ansiRed: ColorTheme.Schema.definition;
+  let ansiGreen: ColorTheme.Schema.definition;
+  let ansiYellow: ColorTheme.Schema.definition;
+  let ansiBlue: ColorTheme.Schema.definition;
+  let ansiMagenta: ColorTheme.Schema.definition;
+  let ansiCyan: ColorTheme.Schema.definition;
+  let ansiWhite: ColorTheme.Schema.definition;
+  let ansiBrightBlack: ColorTheme.Schema.definition;
+  let ansiBrightRed: ColorTheme.Schema.definition;
+  let ansiBrightGreen: ColorTheme.Schema.definition;
+  let ansiBrightYellow: ColorTheme.Schema.definition;
+  let ansiBrightBlue: ColorTheme.Schema.definition;
+  let ansiBrightMagenta: ColorTheme.Schema.definition;
+  let ansiBrightCyan: ColorTheme.Schema.definition;
+  let ansiBrightWhite: ColorTheme.Schema.definition;
 };
 
-module Contributions: {let colors: ColorTheme.Defaults.t;};
+module Contributions: {let colors: list(ColorTheme.Schema.definition);};

--- a/src/Feature/Theme/Feature_Theme.rei
+++ b/src/Feature/Theme/Feature_Theme.rei
@@ -4,7 +4,7 @@ module Colors = GlobalColors;
 
 type model;
 
-let initial: list(ColorTheme.Defaults.t) => model;
+let initial: list(list(ColorTheme.Schema.definition)) => model;
 
 [@deriving show]
 type msg =

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -19,7 +19,7 @@ module ActivityBar = {
       "activityBar.background",
       {dark: hex("#333"), light: hex("#2C2C2C"), hc: hex("#000")},
     );
-  let foreground = define("acitvityBar.foreground", hex("#fff") |> uniform);
+  let foreground = define("acitvityBar.foreground", hex("#fff") |> all);
   let border =
     define(
       "activityBar.border",
@@ -40,7 +40,7 @@ module ActivityBar = {
       },
     );
   let activeBackground =
-    define("activityBar.activeBackground", unspecified |> uniform);
+    define("activityBar.activeBackground", all(unspecified));
 
   let defaults = [
     background,
@@ -53,8 +53,8 @@ module ActivityBar = {
 };
 
 module Editor = {
-  let background = define("editor.background", hex("#2F3440") |> uniform);
-  let foreground = define("editor.foreground", hex("#DCDCDC") |> uniform);
+  let background = define("editor.background", hex("#2F3440") |> all);
+  let foreground = define("editor.foreground", hex("#DCDCDC") |> all);
 
   let defaults = [background, foreground];
 };
@@ -71,13 +71,13 @@ module EditorGroupHeader = {
 
 module List = {
   let focusBackground =
-    define("list.focusBackground", hex("#495162") |> uniform);
+    define("list.focusBackground", hex("#495162") |> all);
   let focusForeground =
-    define("list.focusForeground", hex("#FFFFFF") |> uniform);
+    define("list.focusForeground", hex("#FFFFFF") |> all);
   let hoverBackground =
-    define("list.hoverBackground", hex("#495162") |> uniform);
+    define("list.hoverBackground", hex("#495162") |> all);
   let hoverForeground =
-    define("list.hoverForeground", hex("#FFFFFF") |> uniform);
+    define("list.hoverForeground", hex("#FFFFFF") |> all);
 
   let defaults = [
     focusBackground,
@@ -89,29 +89,29 @@ module List = {
 
 module Oni = {
   let visualModeBackground =
-    define("oni.visualModeBackground", hex("#56b6c2") |> uniform);
+    define("oni.visualModeBackground", hex("#56b6c2") |> all);
   let insertModeBackground =
-    define("oni.insertModeBackground", hex("#98c379") |> uniform);
+    define("oni.insertModeBackground", hex("#98c379") |> all);
   let replaceModeBackground =
-    define("oni.replaceModeBackground", hex("#d19a66") |> uniform);
+    define("oni.replaceModeBackground", hex("#d19a66") |> all);
   let normalModeBackground =
-    define("oni.normalModeBackground", hex("#61afef") |> uniform);
+    define("oni.normalModeBackground", hex("#61afef") |> all);
   let operatorModeBackground =
-    define("oni.operatorModeBackground", hex("#d19a66") |> uniform);
+    define("oni.operatorModeBackground", hex("#d19a66") |> all);
   let commandlineModeBackground =
-    define("oni.commandlineModeBackground", hex("#61afef") |> uniform);
+    define("oni.commandlineModeBackground", hex("#61afef") |> all);
   let visualModeForeground =
-    define("oni.visualModeForeground", hex("#282c34") |> uniform);
+    define("oni.visualModeForeground", hex("#282c34") |> all);
   let insertModeForeground =
-    define("oni.insertModeForeground", hex("#282c34") |> uniform);
+    define("oni.insertModeForeground", hex("#282c34") |> all);
   let replaceModeForeground =
-    define("oni.replaceModeForeground", hex("#282c34") |> uniform);
+    define("oni.replaceModeForeground", hex("#282c34") |> all);
   let normalModeForeground =
-    define("oni.normalModeForeground", hex("#282c34") |> uniform);
+    define("oni.normalModeForeground", hex("#282c34") |> all);
   let operatorModeForeground =
-    define("oni.operatorModeForeground", hex("#282c34") |> uniform);
+    define("oni.operatorModeForeground", hex("#282c34") |> all);
   let commandlineModeForeground =
-    define("oni.commandlineModeForeground", hex("#282c34") |> uniform);
+    define("oni.commandlineModeForeground", hex("#282c34") |> all);
 
   let backgroundFor = (mode: Vim.Mode.t, theme) =>
     (
@@ -160,8 +160,8 @@ module Oni = {
 };
 
 module SideBar = {
-  let background = define("sidebar.background", hex("#21252b") |> uniform);
-  let foreground = define("sidebar.foreground", hex("#ECEFF4") |> uniform);
+  let background = define("sidebar.background", hex("#21252b") |> all);
+  let foreground = define("sidebar.foreground", hex("#ECEFF4") |> all);
 
   let defaults = [background, foreground];
 };
@@ -179,16 +179,13 @@ module Tab = {
       },
     );
   let unfocusedActiveBackground =
-    define(
-      "tab.unfocusedActiveBackground",
-      ref(activeBackground) |> uniform,
-    );
+    define("tab.unfocusedActiveBackground", ref(activeBackground) |> all);
   let inactiveBackground =
     define(
       "tab.inactiveBackground",
       {dark: hex("#2D2D2D"), light: hex("#ECECEC"), hc: unspecified},
     );
-  let hoverBackground = define("tab.hoverBackground", unspecified |> uniform);
+  let hoverBackground = define("tab.hoverBackground", all(unspecified));
   let unfocusedHoverBackground =
     define(
       "tab.unfocusedHoverBackground",
@@ -210,7 +207,7 @@ module Tab = {
         hc: ref(contrastBorder),
       },
     );
-  let activeBorder = define("tab.activeBorder", unspecified |> uniform);
+  let activeBorder = define("tab.activeBorder", all(unspecified));
   let unfocusedActiveBorder =
     define(
       "tab.unfocusedActiveBorder",
@@ -220,7 +217,7 @@ module Tab = {
         hc: unspecified,
       },
     );
-  let activeBorderTop = define("tab.activeBorderTop", unspecified |> uniform);
+  let activeBorderTop = define("tab.activeBorderTop", all(unspecified));
   let unfocusedActiveBorderTop =
     define(
       "tab.unfocusedActiveBorderTop",
@@ -267,7 +264,7 @@ module Tab = {
         hc: hex("#FFF"),
       },
     );
-  let hoverBorder = define("tab.hoverBorder", unspecified |> uniform);
+  let hoverBorder = define("tab.hoverBorder", all(unspecified));
   let unfocusedHoverBorder =
     define(
       "tab.unfocusedHoverBorder",
@@ -343,79 +340,73 @@ module Tab = {
 let defaults = [foreground, contrastBorder];
 
 let remaining = [
-  define("editorCursor.background", hex("#2F3440") |> uniform),
-  define("editorCursor.foreground", hex("#DCDCDC") |> uniform),
-  define("editor.findMatchBackground", hex("#42557b") |> uniform),
-  define("editor.findMatchBorder", hex("#457dff") |> uniform),
-  define("editor.findMatchHighlightBackground", hex("#314365") |> uniform),
-  define("editor.hoverWidgetBackground", hex("#FFFFFF") |> uniform),
-  define("editor.hoverWidgetBorder", hex("#FFFFFF") |> uniform),
-  define("editor.lineHighlightBackground", hex("#495162") |> uniform),
+  define("editorCursor.background", hex("#2F3440") |> all),
+  define("editorCursor.foreground", hex("#DCDCDC") |> all),
+  define("editor.findMatchBackground", hex("#42557b") |> all),
+  define("editor.findMatchBorder", hex("#457dff") |> all),
+  define("editor.findMatchHighlightBackground", hex("#314365") |> all),
+  define("editor.hoverWidgetBackground", hex("#FFFFFF") |> all),
+  define("editor.hoverWidgetBorder", hex("#FFFFFF") |> all),
+  define("editor.lineHighlightBackground", hex("#495162") |> all),
   //define("editorLineNumberBackground", hex("#2F3440")),
-  define("editorLineNumber.foreground", hex("#495162") |> uniform),
-  define("editorLineNumber.activeForeground", hex("#737984") |> uniform),
+  define("editorLineNumber.foreground", hex("#495162") |> all),
+  define("editorLineNumber.activeForeground", hex("#737984") |> all),
   define(
     "editorRuler.foreground",
-    color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> uniform,
+    color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> all,
   ),
-  define("editorSuggestWidget.background", hex("#282C35") |> uniform),
-  define("editorSuggestWidget,border", hex("#ECEFF4") |> uniform),
-  define(
-    "editorSuggestWidget.highlightForeground",
-    hex("#ECEFF4") |> uniform,
-  ),
-  define(
-    "editorSuggestWidget.selectedBackground",
-    hex("#282C35") |> uniform,
-  ),
+  define("editorSuggestWidget.background", hex("#282C35") |> all),
+  define("editorSuggestWidget,border", hex("#ECEFF4") |> all),
+  define("editorSuggestWidget.highlightForeground", hex("#ECEFF4") |> all),
+  define("editorSuggestWidget.selectedBackground", hex("#282C35") |> all),
   define(
     "editorOverviewRuler.bracketMatchForeground",
-    hex("#A0A0A0") |> uniform,
+    hex("#A0A0A0") |> all,
   ),
   //define("editorctiveLineNumberForeground", hex("#737984")),
-  define("editor.selectionBackground", hex("#687595") |> uniform),
-  define("list.activeSelectionBackground", hex("#495162") |> uniform),
-  define("list.activeSelectionForeground", hex("#FFFFFF") |> uniform),
+  define("editor.selectionBackground", hex("#687595") |> all),
+  define("list.activeSelectionBackground", hex("#495162") |> all),
+  define("list.activeSelectionForeground", hex("#FFFFFF") |> all),
   define(
     "scrollbarSlider.background",
-    color(Color.rgba(0., 0., 0., 0.2)) |> uniform,
+    color(Color.rgba(0., 0., 0., 0.2)) |> all,
   ),
-  define("scrollbarSlider.activeBackground", hex("#2F3440") |> uniform),
-  define("editorIndentGuide.background", hex("#3b4048") |> uniform),
+  define("scrollbarSlider.activeBackground", hex("#2F3440") |> all),
+  define("editorIndentGuide.background", hex("#3b4048") |> all),
   define(
     "editorIndentGuide.activeBackground",
-    color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> uniform,
+    color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> all,
   ),
-  define("menu.background", hex("#2F3440") |> uniform),
-  define("menu.foreground", hex("#FFFFFF") |> uniform),
-  define("menu.selectionBackground", hex("#495162") |> uniform),
-  define("editorWhitespace.foreground", hex("#3b4048") |> uniform),
+  define("menu.background", hex("#2F3440") |> all),
+  define("menu.foreground", hex("#FFFFFF") |> all),
+  define("menu.selectionBackground", hex("#495162") |> all),
+  define("editorWhitespace.foreground", hex("#3b4048") |> all),
   define(
     "statusBar.background",
     {dark: hex("#007aCC"), light: hex("#007aCC"), hc: unspecified},
   ),
-  define("statusBar.foreground", hex("#fff") |> uniform),
+  define("statusBar.foreground", hex("#fff") |> all),
   define(
     "scrollbarSlider.hoverBackground",
-    color(Color.rgba(123.0, 123.0, 123.0, 0.1)) |> uniform,
+    color(Color.rgba(123.0, 123.0, 123.0, 0.1)) |> all,
   ),
   //define("notificationSuccessBackground", hex("#23d160")),
   //define("notificationSuccessForeground", hex("#fff")),
-  define("notification.infoBackground", hex("#209cee") |> uniform),
-  define("notification.infoForeground", hex("#fff") |> uniform),
-  define("notification.warningBackground", hex("#ffdd57") |> uniform),
-  define("notification.warningForeground", hex("#fff") |> uniform),
-  define("notification.errorBackground", hex("#ff3860") |> uniform),
-  define("notification.errorForeground", hex("#fff") |> uniform),
+  define("notification.infoBackground", hex("#209cee") |> all),
+  define("notification.infoForeground", hex("#fff") |> all),
+  define("notification.warningBackground", hex("#ffdd57") |> all),
+  define("notification.warningForeground", hex("#fff") |> all),
+  define("notification.errorBackground", hex("#ff3860") |> all),
+  define("notification.errorForeground", hex("#fff") |> all),
   //define("sneakBackground", Revery.Colors.red),
   //define("sneakForeground", hex("#fff")),
   //define("sneakHighlight", hex("#fff")),
-  define("titleBar.activeBackground", hex("#282C35") |> uniform),
-  define("titleBar.activeForeground", hex("#ECEFF4") |> uniform),
-  define("titleBar.inactiveBackground", hex("#282C35") |> uniform),
-  define("titleBar.inactiveForeground", hex("#ECEFF4") |> uniform),
-  define("titleBar.border", hex("#fff0") |> uniform),
-  define("editorGutter.modifiedBackground", hex("#0C7D9D") |> uniform),
-  define("editorGutter.addedBackground", hex("#587C0C") |> uniform),
-  define("editorGutter.deletedBackground", hex("#94151B") |> uniform),
+  define("titleBar.activeBackground", hex("#282C35") |> all),
+  define("titleBar.activeForeground", hex("#ECEFF4") |> all),
+  define("titleBar.inactiveBackground", hex("#282C35") |> all),
+  define("titleBar.inactiveForeground", hex("#ECEFF4") |> all),
+  define("titleBar.border", hex("#fff0") |> all),
+  define("editorGutter.modifiedBackground", hex("#0C7D9D") |> all),
+  define("editorGutter.addedBackground", hex("#587C0C") |> all),
+  define("editorGutter.deletedBackground", hex("#94151B") |> all),
 ];

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -113,35 +113,25 @@ module Oni = {
   let commandlineModeForeground =
     define("oni.commandlineModeForeground", hex("#282c34") |> all);
 
-  let backgroundFor = (mode: Vim.Mode.t, theme) =>
-    (
-      switch (mode) {
-      | Visual => visualModeBackground
-      | CommandLine => commandlineModeBackground
-      | Operator => operatorModeBackground
-      | Insert => insertModeBackground
-      | Replace => replaceModeBackground
-      | Normal => normalModeBackground
-      }
-    ).
-      get(
-      theme,
-    );
+  let backgroundFor = (mode: Vim.Mode.t) =>
+    switch (mode) {
+    | Visual => visualModeBackground
+    | CommandLine => commandlineModeBackground
+    | Operator => operatorModeBackground
+    | Insert => insertModeBackground
+    | Replace => replaceModeBackground
+    | Normal => normalModeBackground
+    };
 
-  let foregroundFor = (mode: Vim.Mode.t, theme) =>
-    (
-      switch (mode) {
-      | Visual => visualModeForeground
-      | CommandLine => commandlineModeForeground
-      | Operator => operatorModeForeground
-      | Insert => insertModeForeground
-      | Replace => replaceModeForeground
-      | Normal => normalModeForeground
-      }
-    ).
-      get(
-      theme,
-    );
+  let foregroundFor = (mode: Vim.Mode.t) =>
+    switch (mode) {
+    | Visual => visualModeForeground
+    | CommandLine => commandlineModeForeground
+    | Operator => operatorModeForeground
+    | Insert => insertModeForeground
+    | Replace => replaceModeForeground
+    | Normal => normalModeForeground
+    };
 
   let defaults = [
     visualModeBackground,

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -1,372 +1,421 @@
 open Oni_Core;
 open Revery;
+open ColorTheme.Schema;
 
-let foreground = "foreground";
-let contrastBorder = "contrastBorder";
+let foreground =
+  define(
+    "foreground",
+    {light: hex("#CCC"), dark: hex("#616161"), hc: hex("#FFF")},
+  );
+let contrastBorder =
+  define(
+    "contrastBorder",
+    {light: unspecified, dark: unspecified, hc: hex("#6FC3DF")},
+  );
 
 module ActivityBar = {
-  let background = "activityBar.background";
-  let foreground = "activityBar.foreground";
-  let border = "activityBar.border";
-  let activeBorder = "activityBar.activeBorder";
-  let inactiveForeground = "activityBar.inactiveForeground";
-  let activeBackground = "activityBar.activeBackground";
+  let background =
+    define(
+      "activityBar.background",
+      {dark: hex("#333"), light: hex("#2C2C2C"), hc: hex("#000")},
+    );
+  let foreground = define("acitvityBar.foreground", hex("#fff") |> uniform);
+  let border =
+    define(
+      "activityBar.border",
+      {dark: unspecified, light: unspecified, hc: ref(contrastBorder)},
+    );
+  let activeBorder =
+    define(
+      "activityBar.activeBorder",
+      {dark: ref(foreground), light: ref(foreground), hc: unspecified},
+    );
+  let inactiveForeground =
+    define(
+      "activityBar.inactiveForeground",
+      {
+        dark: transparent(0.4, ref(foreground)),
+        light: transparent(0.4, ref(foreground)),
+        hc: hex("#FFF"),
+      },
+    );
+  let activeBackground =
+    define("activityBar.activeBackground", unspecified |> uniform);
 
-  let defaults =
-    ColorTheme.Defaults.[
-      (
-        background,
-        {dark: hex("#333"), light: hex("#2C2C2C"), hc: hex("#000")},
-      ),
-      (foreground, hex("#fff") |> uniform),
-      (
-        border,
-        {dark: unspecified, light: unspecified, hc: ref(contrastBorder)},
-      ),
-      (
-        activeBorder,
-        {dark: ref(foreground), light: ref(foreground), hc: unspecified},
-      ),
-      (
-        inactiveForeground,
-        {
-          dark: transparent(0.4, ref(foreground)),
-          light: transparent(0.4, ref(foreground)),
-          hc: hex("#FFF"),
-        },
-      ),
-      (activeBackground, unspecified |> uniform),
-    ];
+  let defaults = [
+    background,
+    foreground,
+    border,
+    activeBorder,
+    inactiveForeground,
+    activeBackground,
+  ];
 };
 
 module Editor = {
-  let background = "editor.background";
-  let foreground = "editor.foreground";
+  let background = define("editor.background", hex("#2F3440") |> uniform);
+  let foreground = define("editor.foreground", hex("#DCDCDC") |> uniform);
 
-  let defaults =
-    ColorTheme.Defaults.[
-      (background, hex("#2F3440") |> uniform),
-      (foreground, hex("#DCDCDC") |> uniform),
-    ];
+  let defaults = [background, foreground];
 };
 
 module EditorGroupHeader = {
-  let tabsBackground = "editorGroupHeader.tabsBackground";
+  let tabsBackground =
+    define(
+      "editorGroupHeader.tabsBackground",
+      {dark: hex("#252526"), light: hex("#F3F3F3"), hc: unspecified},
+    );
 
-  let defaults =
-    ColorTheme.Defaults.[
-      (
-        tabsBackground,
-        {dark: hex("#252526"), light: hex("#F3F3F3"), hc: unspecified},
-      ),
-    ];
+  let defaults = [tabsBackground];
 };
 
 module List = {
-  let focusBackground = "list.focusBackground";
-  let focusForeground = "list.focusForeground";
-  let hoverBackground = "list.hoverBackground";
-  let hoverForeground = "list.hoverForeground";
+  let focusBackground =
+    define("list.focusBackground", hex("#495162") |> uniform);
+  let focusForeground =
+    define("list.focusForeground", hex("#FFFFFF") |> uniform);
+  let hoverBackground =
+    define("list.hoverBackground", hex("#495162") |> uniform);
+  let hoverForeground =
+    define("list.hoverForeground", hex("#FFFFFF") |> uniform);
 
-  let defaults =
-    ColorTheme.Defaults.[
-      (focusBackground, hex("#495162") |> uniform),
-      (focusForeground, hex("#FFFFFF") |> uniform),
-      (hoverBackground, hex("#495162") |> uniform),
-      (hoverForeground, hex("#FFFFFF") |> uniform),
-    ];
+  let defaults = [
+    focusBackground,
+    focusForeground,
+    hoverBackground,
+    hoverForeground,
+  ];
 };
 
 module Oni = {
-  let visualModeBackground = "oni.visualModeBackground";
-  let insertModeBackground = "oni.insertModeBackground";
-  let replaceModeBackground = "oni.replaceModeBackground";
-  let normalModeBackground = "oni.normalModeBackground";
-  let operatorModeBackground = "oni.operatorModeBackground";
-  let commandlineModeBackground = "oni.commandlineModeBackground";
-  let visualModeForeground = "oni.visualModeForeground";
-  let insertModeForeground = "oni.insertModeForeground";
-  let replaceModeForeground = "oni.replaceModeForeground";
-  let normalModeForeground = "oni.normalModeForeground";
-  let operatorModeForeground = "oni.operatorModeForeground";
-  let commandlineModeForeground = "oni.commandlineModeForeground";
+  let visualModeBackground =
+    define("oni.visualModeBackground", hex("#56b6c2") |> uniform);
+  let insertModeBackground =
+    define("oni.insertModeBackground", hex("#98c379") |> uniform);
+  let replaceModeBackground =
+    define("oni.replaceModeBackground", hex("#d19a66") |> uniform);
+  let normalModeBackground =
+    define("oni.normalModeBackground", hex("#61afef") |> uniform);
+  let operatorModeBackground =
+    define("oni.operatorModeBackground", hex("#d19a66") |> uniform);
+  let commandlineModeBackground =
+    define("oni.commandlineModeBackground", hex("#61afef") |> uniform);
+  let visualModeForeground =
+    define("oni.visualModeForeground", hex("#282c34") |> uniform);
+  let insertModeForeground =
+    define("oni.insertModeForeground", hex("#282c34") |> uniform);
+  let replaceModeForeground =
+    define("oni.replaceModeForeground", hex("#282c34") |> uniform);
+  let normalModeForeground =
+    define("oni.normalModeForeground", hex("#282c34") |> uniform);
+  let operatorModeForeground =
+    define("oni.operatorModeForeground", hex("#282c34") |> uniform);
+  let commandlineModeForeground =
+    define("oni.commandlineModeForeground", hex("#282c34") |> uniform);
 
-  let backgroundFor = (mode: Vim.Mode.t) =>
-    switch (mode) {
-    | Visual => visualModeBackground
-    | CommandLine => commandlineModeBackground
-    | Operator => operatorModeBackground
-    | Insert => insertModeBackground
-    | Replace => replaceModeBackground
-    | Normal => normalModeBackground
-    };
+  let backgroundFor = (mode: Vim.Mode.t, theme) =>
+    (
+      switch (mode) {
+      | Visual => visualModeBackground
+      | CommandLine => commandlineModeBackground
+      | Operator => operatorModeBackground
+      | Insert => insertModeBackground
+      | Replace => replaceModeBackground
+      | Normal => normalModeBackground
+      }
+    ).
+      get(
+      theme,
+    );
 
-  let foregroundFor = (mode: Vim.Mode.t) =>
-    switch (mode) {
-    | Visual => visualModeForeground
-    | CommandLine => commandlineModeForeground
-    | Operator => operatorModeForeground
-    | Insert => insertModeForeground
-    | Replace => replaceModeForeground
-    | Normal => normalModeForeground
-    };
+  let foregroundFor = (mode: Vim.Mode.t, theme) =>
+    (
+      switch (mode) {
+      | Visual => visualModeForeground
+      | CommandLine => commandlineModeForeground
+      | Operator => operatorModeForeground
+      | Insert => insertModeForeground
+      | Replace => replaceModeForeground
+      | Normal => normalModeForeground
+      }
+    ).
+      get(
+      theme,
+    );
 
-  let defaults =
-    ColorTheme.Defaults.[
-      (visualModeBackground, hex("#56b6c2") |> uniform),
-      (insertModeBackground, hex("#98c379") |> uniform),
-      (replaceModeBackground, hex("#d19a66") |> uniform),
-      (normalModeBackground, hex("#61afef") |> uniform),
-      (operatorModeBackground, hex("#d19a66") |> uniform),
-      (commandlineModeBackground, hex("#61afef") |> uniform),
-      (visualModeForeground, hex("#282c34") |> uniform),
-      (insertModeForeground, hex("#282c34") |> uniform),
-      (replaceModeForeground, hex("#282c34") |> uniform),
-      (normalModeForeground, hex("#282c34") |> uniform),
-      (operatorModeForeground, hex("#282c34") |> uniform),
-      (commandlineModeForeground, hex("#282c34") |> uniform),
-    ];
+  let defaults = [
+    visualModeBackground,
+    insertModeBackground,
+    replaceModeBackground,
+    normalModeBackground,
+    operatorModeBackground,
+    commandlineModeBackground,
+    visualModeForeground,
+    insertModeForeground,
+    replaceModeForeground,
+    normalModeForeground,
+    operatorModeForeground,
+    commandlineModeForeground,
+  ];
 };
 
 module SideBar = {
-  let background = "sidebar.background";
-  let foreground = "sidebar.foreground";
+  let background = define("sidebar.background", hex("#21252b") |> uniform);
+  let foreground = define("sidebar.foreground", hex("#ECEFF4") |> uniform);
 
-  let defaults =
-    ColorTheme.Defaults.[
-      (background, hex("#21252b") |> uniform),
-      (foreground, hex("#ECEFF4") |> uniform),
-    ];
+  let defaults = [background, foreground];
 };
 
 module Tab = {
-  let activeBackground = "tab.activeBackground";
-  let unfocusedActiveBackground = "tab.unfocusedActiveBackground";
-  let inactiveBackground = "tab.inactiveBackground";
-  let hoverBackground = "tab.hoverBackground";
-  let unfocusedHoverBackground = "tab.unfocuseHoverBackground";
-  let border = "tab.border";
-  let activeBorder = "tab.activeBorder";
-  let unfocusedActiveBorder = "tab.unfocusedActiveBorder";
-  let activeBorderTop = "tab.activeBorderTop";
-  let unfocusedActiveBorderTop = "tab.unfocusedActiveBorderTop";
-  let activeModifiedBorder = "tab.activeModifiedBorder";
-  let inactiveModifiedBorder = "tab.inactiveModifiedBorder";
-  let unfocusedActiveModifiedBorder = "tab.unfocusedActiveModifiedBorder";
-  let unfocusedInactiveModifiedBorder = "tab.unfocusedInactiveModifiedBorder";
-  let hoverBorder = "tab.hoverBorder";
-  let unfocusedHoverBorder = "tab.unfocusedHoverBorder";
-  let activeForeground = "tab.activeForeground";
-  let inactiveForeground = "tab.inactiveForeground";
-  let unfocusedActiveForeground = "tab.unfocusedActiveForeground";
-  let unfocusedInactiveForeground = "tab.unfocusedInactiveForeground";
+  // BACKGROUND
 
-  let defaults =
-    ColorTheme.Defaults.[
-      // BACKGROUND
-      (
-        activeBackground,
-        {
-          dark: ref(Editor.background),
-          light: ref(Editor.background),
-          hc: ref(Editor.background),
-        },
-      ),
-      (unfocusedActiveBackground, ref(activeBackground) |> uniform),
-      (
-        inactiveBackground,
-        {dark: hex("#2D2D2D"), light: hex("#ECECEC"), hc: unspecified},
-      ),
-      (hoverBackground, unspecified |> uniform),
-      (
-        unfocusedHoverBackground,
-        {
-          dark: transparent(0.5, ref(hoverBackground)),
-          light: transparent(0.7, ref(hoverBackground)),
-          hc: unspecified,
-        },
-      ),
-      // BORDER
-      (
-        border,
-        {
-          dark: hex("#252526"),
-          light: hex("#F3F3F3"),
-          hc: ref(contrastBorder),
-        },
-      ),
-      (activeBorder, unspecified |> uniform),
-      (
-        unfocusedActiveBorder,
-        {
-          dark: transparent(0.5, ref(activeBorder)),
-          light: transparent(0.7, ref(activeBorder)),
-          hc: unspecified,
-        },
-      ),
-      (activeBorderTop, unspecified |> uniform),
-      (
-        unfocusedActiveBorderTop,
-        {
-          dark: transparent(0.5, ref(activeBorderTop)),
-          light: transparent(0.7, ref(activeBorderTop)),
-          hc: unspecified,
-        },
-      ),
-      (
-        activeModifiedBorder,
-        {
-          dark: hex("#252526"),
-          light: hex("#F3F3F3"),
-          hc: ref(contrastBorder),
-        },
-      ),
-      (
-        inactiveModifiedBorder,
-        {
-          dark: transparent(0.5, ref(activeModifiedBorder)),
-          light: transparent(0.7, ref(activeModifiedBorder)),
-          hc: hex("#FFF"),
-        },
-      ),
-      (
-        unfocusedActiveModifiedBorder,
-        {
-          dark: transparent(0.5, ref(activeModifiedBorder)),
-          light: transparent(0.7, ref(activeModifiedBorder)),
-          hc: hex("#FFF"),
-        },
-      ),
-      (
-        unfocusedInactiveModifiedBorder,
-        {
-          dark: transparent(0.5, ref(inactiveModifiedBorder)),
-          light: transparent(0.5, ref(inactiveModifiedBorder)),
-          hc: hex("#FFF"),
-        },
-      ),
-      (hoverBorder, unspecified |> uniform),
-      (
-        unfocusedHoverBorder,
-        {
-          dark: transparent(0.5, ref(hoverBorder)),
-          light: transparent(0.7, ref(hoverBorder)),
-          hc: unspecified,
-        },
-      ),
-      // FOREGROUND
-      (
-        activeForeground,
-        {dark: hex("#FFF"), light: hex("#333"), hc: hex("#FFF")},
-      ),
-      (
-        inactiveForeground,
-        {
-          dark: transparent(0.5, ref(activeForeground)),
-          light: transparent(0.7, ref(activeForeground)),
-          hc: hex("#FFF"),
-        },
-      ),
-      (
-        unfocusedActiveForeground,
-        {
-          dark: transparent(0.5, ref(activeForeground)),
-          light: transparent(0.7, ref(activeForeground)),
-          hc: hex("#FFF"),
-        },
-      ),
-      (
-        unfocusedInactiveForeground,
-        {
-          dark: transparent(0.5, ref(inactiveForeground)),
-          light: transparent(0.5, ref(inactiveForeground)),
-          hc: hex("#FFF"),
-        },
-      ),
-    ];
+  let activeBackground =
+    define(
+      "tab.activeBackground",
+      {
+        dark: ref(Editor.background),
+        light: ref(Editor.background),
+        hc: ref(Editor.background),
+      },
+    );
+  let unfocusedActiveBackground =
+    define(
+      "tab.unfocusedActiveBackground",
+      ref(activeBackground) |> uniform,
+    );
+  let inactiveBackground =
+    define(
+      "tab.inactiveBackground",
+      {dark: hex("#2D2D2D"), light: hex("#ECECEC"), hc: unspecified},
+    );
+  let hoverBackground = define("tab.hoverBackground", unspecified |> uniform);
+  let unfocusedHoverBackground =
+    define(
+      "tab.unfocusedHoverBackground",
+      {
+        dark: transparent(0.5, ref(hoverBackground)),
+        light: transparent(0.7, ref(hoverBackground)),
+        hc: unspecified,
+      },
+    );
+
+  // BORDER
+
+  let border =
+    define(
+      "tab.border",
+      {
+        dark: hex("#252526"),
+        light: hex("#F3F3F3"),
+        hc: ref(contrastBorder),
+      },
+    );
+  let activeBorder = define("tab.activeBorder", unspecified |> uniform);
+  let unfocusedActiveBorder =
+    define(
+      "tab.unfocusedActiveBorder",
+      {
+        dark: transparent(0.5, ref(activeBorder)),
+        light: transparent(0.7, ref(activeBorder)),
+        hc: unspecified,
+      },
+    );
+  let activeBorderTop = define("tab.activeBorderTop", unspecified |> uniform);
+  let unfocusedActiveBorderTop =
+    define(
+      "tab.unfocusedActiveBorderTop",
+      {
+        dark: transparent(0.5, ref(activeBorderTop)),
+        light: transparent(0.7, ref(activeBorderTop)),
+        hc: unspecified,
+      },
+    );
+  let activeModifiedBorder =
+    define(
+      "tab.activeModifiedBorder",
+      {
+        dark: hex("#252526"),
+        light: hex("#F3F3F3"),
+        hc: ref(contrastBorder),
+      },
+    );
+  let inactiveModifiedBorder =
+    define(
+      "tab.inactiveModifiedBorder",
+      {
+        dark: transparent(0.5, ref(activeModifiedBorder)),
+        light: transparent(0.7, ref(activeModifiedBorder)),
+        hc: hex("#FFF"),
+      },
+    );
+
+  let unfocusedActiveModifiedBorder =
+    define(
+      "tab.unfocusedActiveModifiedBorder",
+      {
+        dark: transparent(0.5, ref(activeModifiedBorder)),
+        light: transparent(0.7, ref(activeModifiedBorder)),
+        hc: hex("#FFF"),
+      },
+    );
+  let unfocusedInactiveModifiedBorder =
+    define(
+      "tab.unfocusedInactiveModifiedBorder",
+      {
+        dark: transparent(0.5, ref(inactiveModifiedBorder)),
+        light: transparent(0.5, ref(inactiveModifiedBorder)),
+        hc: hex("#FFF"),
+      },
+    );
+  let hoverBorder = define("tab.hoverBorder", unspecified |> uniform);
+  let unfocusedHoverBorder =
+    define(
+      "tab.unfocusedHoverBorder",
+      {
+        dark: transparent(0.5, ref(hoverBorder)),
+        light: transparent(0.7, ref(hoverBorder)),
+        hc: unspecified,
+      },
+    );
+
+  // FOREGROUND
+
+  let activeForeground =
+    define(
+      "tab.activeForeground",
+      {dark: hex("#FFF"), light: hex("#333"), hc: hex("#FFF")},
+    );
+  let inactiveForeground =
+    define(
+      "tab.inactiveForeground",
+      {
+        dark: transparent(0.5, ref(activeForeground)),
+        light: transparent(0.7, ref(activeForeground)),
+        hc: hex("#FFF"),
+      },
+    );
+  let unfocusedActiveForeground =
+    define(
+      "tab.unfocusedActiveForeground",
+      {
+        dark: transparent(0.5, ref(activeForeground)),
+        light: transparent(0.7, ref(activeForeground)),
+        hc: hex("#FFF"),
+      },
+    );
+  let unfocusedInactiveForeground =
+    define(
+      "tab.unfocusedInactiveForeground",
+      {
+        dark: transparent(0.5, ref(inactiveForeground)),
+        light: transparent(0.5, ref(inactiveForeground)),
+        hc: hex("#FFF"),
+      },
+    );
+
+  let defaults = [
+    // BACKGROUND
+    activeBackground,
+    unfocusedActiveBackground,
+    inactiveBackground,
+    hoverBackground,
+    unfocusedHoverBackground,
+    // BORDER
+    border,
+    activeBorder,
+    unfocusedActiveBorder,
+    activeBorderTop,
+    unfocusedActiveBorderTop,
+    activeModifiedBorder,
+    inactiveModifiedBorder,
+    unfocusedActiveModifiedBorder,
+    unfocusedInactiveModifiedBorder,
+    hoverBorder,
+    unfocusedHoverBorder,
+    // FOREGROUND
+    activeForeground,
+    inactiveForeground,
+    unfocusedActiveForeground,
+    unfocusedInactiveForeground,
+  ];
 };
 
-let defaults =
-  ColorTheme.Defaults.[
-    (
-      foreground,
-      {light: hex("#CCC"), dark: hex("#616161"), hc: hex("#FFF")},
-    ),
-    (
-      contrastBorder,
-      {light: unspecified, dark: unspecified, hc: hex("#6FC3DF")},
-    ),
-  ];
+let defaults = [foreground, contrastBorder];
 
-let remaining =
-  ColorTheme.Defaults.[
-    ("editorCursor.background", hex("#2F3440") |> uniform),
-    ("editorCursor.foreground", hex("#DCDCDC") |> uniform),
-    ("editor.findMatchBackground", hex("#42557b") |> uniform),
-    ("editor.findMatchBorder", hex("#457dff") |> uniform),
-    ("editor.findMatchHighlightBackground", hex("#314365") |> uniform),
-    ("editor.hoverWidgetBackground", hex("#FFFFFF") |> uniform),
-    ("editor.hoverWidgetBorder", hex("#FFFFFF") |> uniform),
-    ("editor.lineHighlightBackground", hex("#495162") |> uniform),
-    //("editorLineNumberBackground", hex("#2F3440")),
-    ("editorLineNumber.foreground", hex("#495162") |> uniform),
-    ("editorLineNumber.activeForeground", hex("#737984") |> uniform),
-    (
-      "editorRuler.foreground",
-      color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> uniform,
-    ),
-    ("editorSuggestWidget.background", hex("#282C35") |> uniform),
-    ("editorSuggestWidget,border", hex("#ECEFF4") |> uniform),
-    ("editorSuggestWidget.highlightForeground", hex("#ECEFF4") |> uniform),
-    ("editorSuggestWidget.selectedBackground", hex("#282C35") |> uniform),
-    (
-      "editorOverviewRuler.bracketMatchForeground",
-      hex("#A0A0A0") |> uniform,
-    ),
-    //("editorctiveLineNumberForeground", hex("#737984")),
-    ("editor.selectionBackground", hex("#687595") |> uniform),
-    ("list.activeSelectionBackground", hex("#495162") |> uniform),
-    ("list.activeSelectionForeground", hex("#FFFFFF") |> uniform),
-    (
-      "scrollbarSlider.background",
-      color(Color.rgba(0., 0., 0., 0.2)) |> uniform,
-    ),
-    ("scrollbarSlider.activeBackground", hex("#2F3440") |> uniform),
-    ("editorIndentGuide.background", hex("#3b4048") |> uniform),
-    (
-      "editorIndentGuide.activeBackground",
-      color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> uniform,
-    ),
-    ("menu.background", hex("#2F3440") |> uniform),
-    ("menu.foreground", hex("#FFFFFF") |> uniform),
-    ("menu.selectionBackground", hex("#495162") |> uniform),
-    ("editorWhitespace.foreground", hex("#3b4048") |> uniform),
-    (
-      "statusBar.background",
-      {dark: hex("#007aCC"), light: hex("#007aCC"), hc: unspecified},
-    ),
-    ("statusBar.foreground", hex("#fff") |> uniform),
-    (
-      "scrollbarSlider.hoverBackground",
-      color(Color.rgba(123.0, 123.0, 123.0, 0.1)) |> uniform,
-    ),
-    //("notificationSuccessBackground", hex("#23d160")),
-    //("notificationSuccessForeground", hex("#fff")),
-    ("notification.infoBackground", hex("#209cee") |> uniform),
-    ("notification.infoForeground", hex("#fff") |> uniform),
-    ("notification.warningBackground", hex("#ffdd57") |> uniform),
-    ("notification.warningForeground", hex("#fff") |> uniform),
-    ("notification.errorBackground", hex("#ff3860") |> uniform),
-    ("notification.errorForeground", hex("#fff") |> uniform),
-    //("sneakBackground", Revery.Colors.red),
-    //("sneakForeground", hex("#fff")),
-    //("sneakHighlight", hex("#fff")),
-    ("titleBar.activeBackground", hex("#282C35") |> uniform),
-    ("titleBar.activeForeground", hex("#ECEFF4") |> uniform),
-    ("titleBar.inactiveBackground", hex("#282C35") |> uniform),
-    ("titleBar.inactiveForeground", hex("#ECEFF4") |> uniform),
-    ("titleBar.border", hex("#fff0") |> uniform),
-    ("editorGutter.modifiedBackground", hex("#0C7D9D") |> uniform),
-    ("editorGutter.addedBackground", hex("#587C0C") |> uniform),
-    ("editorGutter.deletedBackground", hex("#94151B") |> uniform),
-  ];
+let remaining = [
+  define("editorCursor.background", hex("#2F3440") |> uniform),
+  define("editorCursor.foreground", hex("#DCDCDC") |> uniform),
+  define("editor.findMatchBackground", hex("#42557b") |> uniform),
+  define("editor.findMatchBorder", hex("#457dff") |> uniform),
+  define("editor.findMatchHighlightBackground", hex("#314365") |> uniform),
+  define("editor.hoverWidgetBackground", hex("#FFFFFF") |> uniform),
+  define("editor.hoverWidgetBorder", hex("#FFFFFF") |> uniform),
+  define("editor.lineHighlightBackground", hex("#495162") |> uniform),
+  //define("editorLineNumberBackground", hex("#2F3440")),
+  define("editorLineNumber.foreground", hex("#495162") |> uniform),
+  define("editorLineNumber.activeForeground", hex("#737984") |> uniform),
+  define(
+    "editorRuler.foreground",
+    color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> uniform,
+  ),
+  define("editorSuggestWidget.background", hex("#282C35") |> uniform),
+  define("editorSuggestWidget,border", hex("#ECEFF4") |> uniform),
+  define(
+    "editorSuggestWidget.highlightForeground",
+    hex("#ECEFF4") |> uniform,
+  ),
+  define(
+    "editorSuggestWidget.selectedBackground",
+    hex("#282C35") |> uniform,
+  ),
+  define(
+    "editorOverviewRuler.bracketMatchForeground",
+    hex("#A0A0A0") |> uniform,
+  ),
+  //define("editorctiveLineNumberForeground", hex("#737984")),
+  define("editor.selectionBackground", hex("#687595") |> uniform),
+  define("list.activeSelectionBackground", hex("#495162") |> uniform),
+  define("list.activeSelectionForeground", hex("#FFFFFF") |> uniform),
+  define(
+    "scrollbarSlider.background",
+    color(Color.rgba(0., 0., 0., 0.2)) |> uniform,
+  ),
+  define("scrollbarSlider.activeBackground", hex("#2F3440") |> uniform),
+  define("editorIndentGuide.background", hex("#3b4048") |> uniform),
+  define(
+    "editorIndentGuide.activeBackground",
+    color(Color.rgba(0.78, 0.78, 0.78, 0.78)) |> uniform,
+  ),
+  define("menu.background", hex("#2F3440") |> uniform),
+  define("menu.foreground", hex("#FFFFFF") |> uniform),
+  define("menu.selectionBackground", hex("#495162") |> uniform),
+  define("editorWhitespace.foreground", hex("#3b4048") |> uniform),
+  define(
+    "statusBar.background",
+    {dark: hex("#007aCC"), light: hex("#007aCC"), hc: unspecified},
+  ),
+  define("statusBar.foreground", hex("#fff") |> uniform),
+  define(
+    "scrollbarSlider.hoverBackground",
+    color(Color.rgba(123.0, 123.0, 123.0, 0.1)) |> uniform,
+  ),
+  //define("notificationSuccessBackground", hex("#23d160")),
+  //define("notificationSuccessForeground", hex("#fff")),
+  define("notification.infoBackground", hex("#209cee") |> uniform),
+  define("notification.infoForeground", hex("#fff") |> uniform),
+  define("notification.warningBackground", hex("#ffdd57") |> uniform),
+  define("notification.warningForeground", hex("#fff") |> uniform),
+  define("notification.errorBackground", hex("#ff3860") |> uniform),
+  define("notification.errorForeground", hex("#fff") |> uniform),
+  //define("sneakBackground", Revery.Colors.red),
+  //define("sneakForeground", hex("#fff")),
+  //define("sneakHighlight", hex("#fff")),
+  define("titleBar.activeBackground", hex("#282C35") |> uniform),
+  define("titleBar.activeForeground", hex("#ECEFF4") |> uniform),
+  define("titleBar.inactiveBackground", hex("#282C35") |> uniform),
+  define("titleBar.inactiveForeground", hex("#ECEFF4") |> uniform),
+  define("titleBar.border", hex("#fff0") |> uniform),
+  define("editorGutter.modifiedBackground", hex("#0C7D9D") |> uniform),
+  define("editorGutter.addedBackground", hex("#587C0C") |> uniform),
+  define("editorGutter.deletedBackground", hex("#94151B") |> uniform),
+];

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -13,7 +13,7 @@ module Styles = {
   let container = (~theme, ~offsetX) => [
     top(0),
     bottom(0),
-    backgroundColor(Colors.background.get(theme)),
+    backgroundColor(Colors.background.from(theme)),
     alignItems(`Center),
     transform(Transform.[TranslateX(offsetX)]),
   ];
@@ -25,10 +25,10 @@ module Styles = {
     alignItems(`Center),
     borderLeft(
       ~width=2,
-      ~color=(isActive ? Colors.activeBorder : Colors.border).get(theme),
+      ~color=(isActive ? Colors.activeBorder : Colors.border).from(theme),
     ),
     backgroundColor(
-      theme |> (isHovered ? Colors.activeBackground : Colors.background).get,
+      theme |> (isHovered ? Colors.activeBackground : Colors.background).from,
     ),
   ];
 };
@@ -37,18 +37,11 @@ let%component item = (~onClick, ~theme, ~isActive, ~icon, ()) => {
   let%hook (isHovered, setHovered) = Hooks.state(false);
   let onMouseOver = _ => setHovered(_ => true);
   let onMouseOut = _ => setHovered(_ => false);
+  let iconColor = isActive ? Colors.foreground : Colors.inactiveForeground;
 
   <View onMouseOver onMouseOut>
     <Sneakable onClick style={Styles.item(~isHovered, ~isActive, ~theme)}>
-      <FontIcon
-        color={
-          (isActive ? Colors.foreground : Colors.inactiveForeground).get(
-            theme,
-          )
-        }
-        fontSize=22.
-        icon
-      />
+      <FontIcon color={iconColor.from(theme)} fontSize=22. icon />
     </Sneakable>
   </View>;
 };

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -13,7 +13,7 @@ module Styles = {
   let container = (~theme, ~offsetX) => [
     top(0),
     bottom(0),
-    backgroundColor(theme#color(Colors.background)),
+    backgroundColor(Colors.background.get(theme)),
     alignItems(`Center),
     transform(Transform.[TranslateX(offsetX)]),
   ];
@@ -25,10 +25,10 @@ module Styles = {
     alignItems(`Center),
     borderLeft(
       ~width=2,
-      ~color=theme#color(isActive ? Colors.activeBorder : Colors.border),
+      ~color=(isActive ? Colors.activeBorder : Colors.border).get(theme),
     ),
     backgroundColor(
-      theme#color(isHovered ? Colors.activeBackground : Colors.background),
+      theme |> (isHovered ? Colors.activeBackground : Colors.background).get,
     ),
   ];
 };
@@ -42,8 +42,8 @@ let%component item = (~onClick, ~theme, ~isActive, ~icon, ()) => {
     <Sneakable onClick style={Styles.item(~isHovered, ~isActive, ~theme)}>
       <FontIcon
         color={
-          theme#color(
-            isActive ? Colors.foreground : Colors.inactiveForeground,
+          (isActive ? Colors.foreground : Colors.inactiveForeground).get(
+            theme,
           )
         }
         fontSize=22.

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -238,7 +238,7 @@ let textItem = (~background, ~font, ~colorTheme, ~text, ()) =>
   <item>
     <Text
       style={Styles.text(
-        ~color=Colors.StatusBar.foreground.get(colorTheme),
+        ~color=Colors.StatusBar.foreground.from(colorTheme),
         ~background,
         font,
       )}
@@ -311,7 +311,7 @@ let notificationCount =
 };
 
 let diagnosticCount = (~font, ~background, ~colorTheme, ~diagnostics, ()) => {
-  let color = Colors.StatusBar.foreground.get(colorTheme);
+  let color = Colors.StatusBar.foreground.from(colorTheme);
   let text = diagnostics |> Diagnostics.count |> string_of_int;
 
   let onClick = () =>
@@ -333,8 +333,8 @@ let diagnosticCount = (~font, ~background, ~colorTheme, ~diagnostics, ()) => {
 };
 
 let modeIndicator = (~font, ~colorTheme, ~mode, ()) => {
-  let background = Theme.Colors.Oni.backgroundFor(mode, colorTheme);
-  let foreground = Theme.Colors.Oni.foregroundFor(mode, colorTheme);
+  let background = Theme.Colors.Oni.backgroundFor(mode).from(colorTheme);
+  let foreground = Theme.Colors.Oni.foregroundFor(mode).from(colorTheme);
 
   <item backgroundColor=background>
     <Text
@@ -374,13 +374,13 @@ let%component make =
     switch (activeNotifications) {
     | [] =>
       Colors.StatusBar.(
-        background.get(colorTheme),
-        foreground.get(colorTheme),
+        background.from(colorTheme),
+        foreground.from(colorTheme),
       )
     | [last, ..._] =>
       Colors.Notification.(
-        backgroundFor(last).get(colorTheme),
-        foregroundFor(last).get(colorTheme),
+        backgroundFor(last).from(colorTheme),
+        foregroundFor(last).from(colorTheme),
       )
     };
 

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -26,17 +26,27 @@ module Editor = Feature_Editor.Editor;
 module Theme = Feature_Theme;
 
 module Colors = {
+  open ColorTheme.Schema;
+
   let transparent = Colors.transparentWhite;
 
   module Notification = {
-    let successBackground = "notification.successBackground";
-    let successForeground = "notification.successForeground";
-    let infoBackground = "notification.infoBackground";
-    let infoForeground = "notification.infoForeground";
-    let warningBackground = "notification.warningBackground";
-    let warningForeground = "notification.warningForeground";
-    let errorBackground = "notification.errorBackground";
-    let errorForeground = "notification.errorForeground";
+    let successBackground =
+      define("notification.successBackground", uniform(unspecified));
+    let successForeground =
+      define("notification.successForeground", uniform(unspecified));
+    let infoBackground =
+      define("notification.infoBackground", uniform(unspecified));
+    let infoForeground =
+      define("notification.infoForeground", uniform(unspecified));
+    let warningBackground =
+      define("notification.warningBackground", uniform(unspecified));
+    let warningForeground =
+      define("notification.warningForeground", uniform(unspecified));
+    let errorBackground =
+      define("notification.errorBackground", uniform(unspecified));
+    let errorForeground =
+      define("notification.errorForeground", uniform(unspecified));
 
     let backgroundFor = (item: Notification.t) =>
       switch (item.kind) {
@@ -56,8 +66,8 @@ module Colors = {
   };
 
   module StatusBar = {
-    let background = "statusBar.background";
-    let foreground = "statusBar.foreground";
+    let background = define("statusBar.background", uniform(unspecified));
+    let foreground = define("statusBar.foreground", uniform(unspecified));
   };
 };
 
@@ -228,7 +238,7 @@ let textItem = (~background, ~font, ~colorTheme, ~text, ()) =>
   <item>
     <Text
       style={Styles.text(
-        ~color=colorTheme#color(Colors.StatusBar.foreground),
+        ~color=Colors.StatusBar.foreground.get(colorTheme),
         ~background,
         font,
       )}
@@ -301,7 +311,7 @@ let notificationCount =
 };
 
 let diagnosticCount = (~font, ~background, ~colorTheme, ~diagnostics, ()) => {
-  let color = colorTheme#color(Colors.StatusBar.foreground);
+  let color = Colors.StatusBar.foreground.get(colorTheme);
   let text = diagnostics |> Diagnostics.count |> string_of_int;
 
   let onClick = () =>
@@ -323,8 +333,8 @@ let diagnosticCount = (~font, ~background, ~colorTheme, ~diagnostics, ()) => {
 };
 
 let modeIndicator = (~font, ~colorTheme, ~mode, ()) => {
-  let background = Theme.Colors.Oni.backgroundFor(mode) |> colorTheme#color;
-  let foreground = Theme.Colors.Oni.foregroundFor(mode) |> colorTheme#color;
+  let background = Theme.Colors.Oni.backgroundFor(mode, colorTheme);
+  let foreground = Theme.Colors.Oni.foregroundFor(mode, colorTheme);
 
   <item backgroundColor=background>
     <Text
@@ -364,13 +374,13 @@ let%component make =
     switch (activeNotifications) {
     | [] =>
       Colors.StatusBar.(
-        background |> colorTheme#color,
-        foreground |> colorTheme#color,
+        background.get(colorTheme),
+        foreground.get(colorTheme),
       )
     | [last, ..._] =>
       Colors.Notification.(
-        backgroundFor(last) |> colorTheme#color,
-        foregroundFor(last) |> colorTheme#color,
+        backgroundFor(last).get(colorTheme),
+        foregroundFor(last).get(colorTheme),
       )
     };
 

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -32,21 +32,21 @@ module Colors = {
 
   module Notification = {
     let successBackground =
-      define("notification.successBackground", uniform(unspecified));
+      define("notification.successBackground", all(unspecified));
     let successForeground =
-      define("notification.successForeground", uniform(unspecified));
+      define("notification.successForeground", all(unspecified));
     let infoBackground =
-      define("notification.infoBackground", uniform(unspecified));
+      define("notification.infoBackground", all(unspecified));
     let infoForeground =
-      define("notification.infoForeground", uniform(unspecified));
+      define("notification.infoForeground", all(unspecified));
     let warningBackground =
-      define("notification.warningBackground", uniform(unspecified));
+      define("notification.warningBackground", all(unspecified));
     let warningForeground =
-      define("notification.warningForeground", uniform(unspecified));
+      define("notification.warningForeground", all(unspecified));
     let errorBackground =
-      define("notification.errorBackground", uniform(unspecified));
+      define("notification.errorBackground", all(unspecified));
     let errorForeground =
-      define("notification.errorForeground", uniform(unspecified));
+      define("notification.errorForeground", all(unspecified));
 
     let backgroundFor = (item: Notification.t) =>
       switch (item.kind) {
@@ -66,8 +66,8 @@ module Colors = {
   };
 
   module StatusBar = {
-    let background = define("statusBar.background", uniform(unspecified));
-    let foreground = define("statusBar.foreground", uniform(unspecified));
+    let background = define("statusBar.background", all(unspecified));
+    let foreground = define("statusBar.foreground", all(unspecified));
   };
 };
 

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -47,16 +47,13 @@ module Styles = {
         };
 
       if (isHovered) {
-        (
+        let color =
           isGroupFocused
-            ? Colors.unfocusedHoverBackground : Colors.hoverBackground
-        ).
-          tryGet(
-          theme,
-        )
-        |> Option.value(~default=unhovered.get(theme));
+            ? Colors.unfocusedHoverBackground : Colors.hoverBackground;
+
+        color.tryFrom(theme) |> Option.value(~default=unhovered.from(theme));
       } else {
-        unhovered.get(theme);
+        unhovered.from(theme);
       };
     };
 
@@ -65,14 +62,11 @@ module Styles = {
         if (isActive) {
           background;
         } else {
-          (
+          let color =
             isGroupFocused
-              ? Colors.activeBorderTop : Colors.unfocusedActiveBorderTop
-          ).
-            tryGet(
-            theme,
-          )
-          |> Option.value(~default=background);
+              ? Colors.activeBorderTop : Colors.unfocusedActiveBorderTop;
+
+          color.tryFrom(theme) |> Option.value(~default=background);
         };
 
       borderTop(~color, ~width=2);
@@ -92,17 +86,16 @@ module Styles = {
             | (true, true, false) => Colors.activeBorder
             }
           ).
-            tryGet(
+            tryFrom(
             theme,
           )
           |> Option.value(~default=background);
 
         if (isHovered) {
-          (isGroupFocused ? Colors.unfocusedHoverBorder : Colors.hoverBorder).
-            tryGet(
-            theme,
-          )
-          |> Option.value(~default=unhovered);
+          let color =
+            isGroupFocused ? Colors.unfocusedHoverBorder : Colors.hoverBorder;
+
+          color.tryFrom(theme) |> Option.value(~default=unhovered);
         } else {
           unhovered;
         };
@@ -140,7 +133,7 @@ module Styles = {
         isGroupFocused && isActive ? uiFont.fontFileItalic : uiFont.fontFile,
       ),
       fontSize(uiFont.fontSize),
-      color(foreground.get(theme)),
+      color(foreground.from(theme)),
       justifyContent(`Center),
       alignItems(`Center),
     ];
@@ -227,9 +220,9 @@ let%component make =
       <FontIcon
         icon={isModified ? FontAwesome.circle : FontAwesome.times}
         color={
-          (isActive ? Colors.activeForeground : Colors.inactiveForeground).get(
-            theme,
-          )
+          isActive
+            ? Colors.activeForeground.from(theme)
+            : Colors.inactiveForeground.from(theme)
         }
         fontSize={isModified ? 10. : 12.}
       />

--- a/src/UI/Tab.re
+++ b/src/UI/Tab.re
@@ -47,13 +47,16 @@ module Styles = {
         };
 
       if (isHovered) {
-        theme#tryColor(
+        (
           isGroupFocused
-            ? Colors.unfocusedHoverBackground : Colors.hoverBackground,
+            ? Colors.unfocusedHoverBackground : Colors.hoverBackground
+        ).
+          tryGet(
+          theme,
         )
-        |> Option.value(~default=theme#color(unhovered));
+        |> Option.value(~default=unhovered.get(theme));
       } else {
-        theme#color(unhovered);
+        unhovered.get(theme);
       };
     };
 
@@ -62,9 +65,12 @@ module Styles = {
         if (isActive) {
           background;
         } else {
-          theme#tryColor(
+          (
             isGroupFocused
-              ? Colors.activeBorderTop : Colors.unfocusedActiveBorderTop,
+              ? Colors.activeBorderTop : Colors.unfocusedActiveBorderTop
+          ).
+            tryGet(
+            theme,
           )
           |> Option.value(~default=background);
         };
@@ -85,13 +91,17 @@ module Styles = {
             | (true, false, false) => Colors.unfocusedActiveBorder
             | (true, true, false) => Colors.activeBorder
             }
+          ).
+            tryGet(
+            theme,
           )
-          |> theme#tryColor
           |> Option.value(~default=background);
 
         if (isHovered) {
-          (isGroupFocused ? Colors.unfocusedHoverBorder : Colors.hoverBorder)
-          |> theme#tryColor
+          (isGroupFocused ? Colors.unfocusedHoverBorder : Colors.hoverBorder).
+            tryGet(
+            theme,
+          )
           |> Option.value(~default=unhovered);
         } else {
           unhovered;
@@ -130,7 +140,7 @@ module Styles = {
         isGroupFocused && isActive ? uiFont.fontFileItalic : uiFont.fontFile,
       ),
       fontSize(uiFont.fontSize),
-      color(foreground |> theme#color),
+      color(foreground.get(theme)),
       justifyContent(`Center),
       alignItems(`Center),
     ];
@@ -217,8 +227,8 @@ let%component make =
       <FontIcon
         icon={isModified ? FontAwesome.circle : FontAwesome.times}
         color={
-          theme#color(
-            isActive ? Colors.activeForeground : Colors.inactiveForeground,
+          (isActive ? Colors.activeForeground : Colors.inactiveForeground).get(
+            theme,
           )
         }
         fontSize={isModified ? 10. : 12.}

--- a/src/UI/Tabs.re
+++ b/src/UI/Tabs.re
@@ -160,7 +160,7 @@ let%component make =
       flexDirection(`Row),
       overflow(`Scroll),
       backgroundColor(
-        Theme.Colors.EditorGroupHeader.tabsBackground.get(theme),
+        Theme.Colors.EditorGroupHeader.tabsBackground.from(theme),
       ),
     ];
 

--- a/src/UI/Tabs.re
+++ b/src/UI/Tabs.re
@@ -160,7 +160,7 @@ let%component make =
       flexDirection(`Row),
       overflow(`Scroll),
       backgroundColor(
-        theme#color(Theme.Colors.EditorGroupHeader.tabsBackground),
+        Theme.Colors.EditorGroupHeader.tabsBackground.get(theme),
       ),
     ];
 

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -66,27 +66,27 @@ let make =
 
   let terminalTheme =
     fun
-    | 0 => Colors.ansiBlack.get(theme)
-    | 1 => Colors.ansiRed.get(theme)
-    | 2 => Colors.ansiGreen.get(theme)
-    | 3 => Colors.ansiYellow.get(theme)
-    | 4 => Colors.ansiBlue.get(theme)
-    | 5 => Colors.ansiMagenta.get(theme)
-    | 6 => Colors.ansiCyan.get(theme)
-    | 7 => Colors.ansiWhite.get(theme)
-    | 8 => Colors.ansiBrightBlack.get(theme)
-    | 9 => Colors.ansiBrightRed.get(theme)
-    | 10 => Colors.ansiBrightGreen.get(theme)
-    | 11 => Colors.ansiBrightYellow.get(theme)
-    | 12 => Colors.ansiBrightBlue.get(theme)
-    | 13 => Colors.ansiBrightMagenta.get(theme)
-    | 14 => Colors.ansiBrightCyan.get(theme)
-    | 15 => Colors.ansiBrightWhite.get(theme)
+    | 0 => Colors.ansiBlack.from(theme)
+    | 1 => Colors.ansiRed.from(theme)
+    | 2 => Colors.ansiGreen.from(theme)
+    | 3 => Colors.ansiYellow.from(theme)
+    | 4 => Colors.ansiBlue.from(theme)
+    | 5 => Colors.ansiMagenta.from(theme)
+    | 6 => Colors.ansiCyan.from(theme)
+    | 7 => Colors.ansiWhite.from(theme)
+    | 8 => Colors.ansiBrightBlack.from(theme)
+    | 9 => Colors.ansiBrightRed.from(theme)
+    | 10 => Colors.ansiBrightGreen.from(theme)
+    | 11 => Colors.ansiBrightYellow.from(theme)
+    | 12 => Colors.ansiBrightBlue.from(theme)
+    | 13 => Colors.ansiBrightMagenta.from(theme)
+    | 14 => Colors.ansiBrightCyan.from(theme)
+    | 15 => Colors.ansiBrightWhite.from(theme)
     // For 256 colors, fall back to defaults
     | idx => ReveryTerminal.Theme.default(idx);
 
-  let defaultBackground = Colors.background.get(theme);
-  let defaultForeground = Colors.foreground.get(theme);
+  let defaultBackground = Colors.background.from(theme);
+  let defaultForeground = Colors.foreground.from(theme);
 
   let element =
     Option.map(

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -66,27 +66,27 @@ let make =
 
   let terminalTheme =
     fun
-    | 0 => theme#color(Colors.ansiBlack)
-    | 1 => theme#color(Colors.ansiRed)
-    | 2 => theme#color(Colors.ansiGreen)
-    | 3 => theme#color(Colors.ansiYellow)
-    | 4 => theme#color(Colors.ansiBlue)
-    | 5 => theme#color(Colors.ansiMagenta)
-    | 6 => theme#color(Colors.ansiCyan)
-    | 7 => theme#color(Colors.ansiWhite)
-    | 8 => theme#color(Colors.ansiBrightBlack)
-    | 9 => theme#color(Colors.ansiBrightRed)
-    | 10 => theme#color(Colors.ansiBrightGreen)
-    | 11 => theme#color(Colors.ansiBrightYellow)
-    | 12 => theme#color(Colors.ansiBrightBlue)
-    | 13 => theme#color(Colors.ansiBrightMagenta)
-    | 14 => theme#color(Colors.ansiBrightCyan)
-    | 15 => theme#color(Colors.ansiBrightWhite)
+    | 0 => Colors.ansiBlack.get(theme)
+    | 1 => Colors.ansiRed.get(theme)
+    | 2 => Colors.ansiGreen.get(theme)
+    | 3 => Colors.ansiYellow.get(theme)
+    | 4 => Colors.ansiBlue.get(theme)
+    | 5 => Colors.ansiMagenta.get(theme)
+    | 6 => Colors.ansiCyan.get(theme)
+    | 7 => Colors.ansiWhite.get(theme)
+    | 8 => Colors.ansiBrightBlack.get(theme)
+    | 9 => Colors.ansiBrightRed.get(theme)
+    | 10 => Colors.ansiBrightGreen.get(theme)
+    | 11 => Colors.ansiBrightYellow.get(theme)
+    | 12 => Colors.ansiBrightBlue.get(theme)
+    | 13 => Colors.ansiBrightMagenta.get(theme)
+    | 14 => Colors.ansiBrightCyan.get(theme)
+    | 15 => Colors.ansiBrightWhite.get(theme)
     // For 256 colors, fall back to defaults
     | idx => ReveryTerminal.Theme.default(idx);
 
-  let defaultBackground = theme#color(Colors.background);
-  let defaultForeground = theme#color(Colors.foreground);
+  let defaultBackground = Colors.background.get(theme);
+  let defaultForeground = Colors.foreground.get(theme);
 
   let element =
     Option.map(


### PR DESCRIPTION
Refactors the ColorTheme API to (more or less) use the same `Schema` mechanism as introduced in #1436, as well as some other minor refinements.