### PR TITLE
Render non-solid cursor when window is unfocused

### DIFF
--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -31,6 +31,7 @@ let editorSurfaceMinimalState = hwnd => {
       mode={thousandLineState.mode}
       theme={thousandLineState.theme}
       editorFont={thousandLineState.editorFont}
+      windowIsFocused=true
     />,
   );
 };
@@ -55,6 +56,7 @@ let editorSurfaceThousandLineState = hwnd => {
       mode={thousandLineState.mode}
       theme={thousandLineState.theme}
       editorFont={thousandLineState.editorFont}
+      windowIsFocused=true
     />,
   );
 };
@@ -80,6 +82,7 @@ let editorSurfaceThousandLineStateWithIndents = hwnd => {
       theme={thousandLineState.theme}
       editorFont={thousandLineState.editorFont}
       shouldRenderIndentGuides=true
+      windowIsFocused=true
     />,
   );
   ();
@@ -105,6 +108,7 @@ let editorSurfaceHundredThousandLineStateNoMinimap = hwnd => {
       theme={thousandLineState.theme}
       editorFont={thousandLineState.editorFont}
       showMinimap=false
+      windowIsFocused=true
     />,
   );
 };
@@ -129,6 +133,7 @@ let editorSurfaceHundredThousandLineState = hwnd => {
       mode={thousandLineState.mode}
       theme={thousandLineState.theme}
       editorFont={thousandLineState.editorFont}
+      windowIsFocused=true
     />,
   );
 };

--- a/src/Feature/Editor/CursorView.re
+++ b/src/Feature/Editor/CursorView.re
@@ -16,7 +16,7 @@ let render =
   let column = Index.toZeroBased(cursorPosition.column);
   let lineCount = Buffer.getNumberOfLines(buffer);
 
-  if (lineCount <= 0 || line >= lineCount) {
+  if (lineCount <= 0 || line >= lineCount || !isActiveSplit) {
     ();
   } else {
     let bufferLine = Buffer.getLine(line, buffer);
@@ -49,9 +49,6 @@ let render =
         ~height,
         ~color=foreground,
       );
-    } else if (mode == Insert && isActiveSplit) {
-      let width = 2.;
-      Draw.rect(~context, ~x, ~y, ~width, ~height, ~color=foreground);
     } else {
       let width = float(characterWidth) *. context.charWidth;
       Draw.rect(~context, ~x, ~y, ~width, ~height, ~color=foreground);

--- a/src/Feature/Editor/CursorView.re
+++ b/src/Feature/Editor/CursorView.re
@@ -10,6 +10,7 @@ let render =
       ~isActiveSplit,
       ~cursorPosition: Location.t,
       ~theme: Theme.t,
+      ~windowIsFocused,
     ) => {
   let line = Index.toZeroBased(cursorPosition.line);
   let column = Index.toZeroBased(cursorPosition.column);
@@ -28,12 +29,30 @@ let render =
     let background = theme.editorCursorBackground;
     let foreground = theme.editorCursorForeground;
 
-    switch (mode, isActiveSplit) {
-    | (Insert, true) =>
+    if (!windowIsFocused) {
+      let width = float(characterWidth) *. context.charWidth;
+      Draw.rect(~context, ~x, ~y, ~width=1., ~height, ~color=foreground);
+      Draw.rect(~context, ~x, ~y, ~width, ~height=1., ~color=foreground);
+      Draw.rect(
+        ~context,
+        ~x,
+        ~y=y +. height -. 1.,
+        ~width,
+        ~height=1.,
+        ~color=foreground,
+      );
+      Draw.rect(
+        ~context,
+        ~x=x +. width -. 1.,
+        ~y,
+        ~width=1.,
+        ~height,
+        ~color=foreground,
+      );
+    } else if (mode == Insert && isActiveSplit) {
       let width = 2.;
       Draw.rect(~context, ~x, ~y, ~width, ~height, ~color=foreground);
-
-    | _ =>
+    } else {
       let width = float(characterWidth) *. context.charWidth;
       Draw.rect(~context, ~x, ~y, ~width, ~height, ~color=foreground);
 

--- a/src/Feature/Editor/CursorView.re
+++ b/src/Feature/Editor/CursorView.re
@@ -6,7 +6,6 @@ let render =
     (
       ~context: Draw.context,
       ~buffer,
-      ~mode: Vim.Mode.t,
       ~isActiveSplit,
       ~cursorPosition: Location.t,
       ~theme: Theme.t,

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -141,6 +141,7 @@ let make =
       ~shouldRenderWhitespace: ConfigurationValues.editorRenderWhitespace=ConfigurationValues.None,
       ~shouldRenderIndentGuides=false,
       ~shouldHighlightActiveIndentGuides=false,
+      ~windowIsFocused,
       (),
     ) => {
   let lineCount = Buffer.getNumberOfLines(buffer);
@@ -221,6 +222,7 @@ let make =
       isActiveSplit
       gutterWidth
       bufferWidthInCharacters={layout.bufferWidthInCharacters}
+      windowIsFocused
     />
     {showMinimap
        ? <minimap

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -218,7 +218,6 @@ let make =
       shouldRenderIndentGuides
       bottomVisibleLine
       shouldHighlightActiveIndentGuides
-      mode
       isActiveSplit
       gutterWidth
       bufferWidthInCharacters={layout.bufferWidthInCharacters}

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -65,7 +65,6 @@ let%component make =
                 ~shouldRenderIndentGuides,
                 ~bottomVisibleLine,
                 ~shouldHighlightActiveIndentGuides,
-                ~mode,
                 ~isActiveSplit,
                 ~gutterWidth,
                 ~bufferWidthInCharacters,
@@ -182,7 +181,6 @@ let%component make =
         CursorView.render(
           ~context,
           ~buffer,
-          ~mode,
           ~isActiveSplit,
           ~cursorPosition,
           ~theme,

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -69,6 +69,7 @@ let%component make =
                 ~isActiveSplit,
                 ~gutterWidth,
                 ~bufferWidthInCharacters,
+                ~windowIsFocused,
                 (),
               ) => {
   let%hook elementRef = React.Hooks.ref(None);
@@ -185,6 +186,7 @@ let%component make =
           ~isActiveSplit,
           ~cursorPosition,
           ~theme,
+          ~windowIsFocused,
         );
       }}
     />

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -225,6 +225,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             isHoverEnabled
             shouldRenderIndentGuides
             shouldHighlightActiveIndentGuides
+            windowIsFocused={state.windowIsFocused}
           />;
         | BufferRenderer.Welcome => <WelcomeView state />
         | BufferRenderer.Terminal({id, _}) =>


### PR DESCRIPTION
Also skips rendering the cursor in inactive splits, which is consistent with both vim and vscode.