### PR TITLE
Bugfix: #1471 - updateSourceControl crash

### DIFF
--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -13,6 +13,7 @@ module SCM: {
   type command = {
     id: string,
     title: string,
+    tooltip: option(string),
     arguments: list(Core.Json.t),
   };
 

--- a/src/Extensions/ExtHostClient_SCM.re
+++ b/src/Extensions/ExtHostClient_SCM.re
@@ -103,7 +103,7 @@ module Decode = {
         tooltip: obj |> member("tooltip") |> to_string_option,
         arguments: obj |> member("arguments") |> listOrEmpty,
       })
-    | _ => None
+    | _ => None;
 };
 
 // UPDATE
@@ -173,9 +173,7 @@ let handleMessage = (~dispatch, method, args) =>
             commitTemplate:
               features |> member("commitTemplate") |> to_string_option,
             acceptInputCommand:
-              features
-              |> member("acceptInputCommand")
-              |> Decode.command,
+              features |> member("acceptInputCommand") |> Decode.command,
           }),
         )
       )

--- a/src/Extensions/ExtHostClient_SCM.re
+++ b/src/Extensions/ExtHostClient_SCM.re
@@ -8,6 +8,7 @@ module Log = (val Log.withNamespace("Oni2.Extensions.SCM"));
 type command = {
   id: string,
   title: string,
+  tooltip: option(string),
   arguments: list([@opaque] Json.t),
 };
 
@@ -99,6 +100,7 @@ module Decode = {
       Some({
         id: obj |> member("id") |> to_string,
         title: obj |> member("title") |> to_string,
+        tooltip: obj |> member("tooltip") |> to_string_option,
         arguments: obj |> member("arguments") |> listOrEmpty,
       })
     | _ => None


### PR DESCRIPTION
Addresses #1471. The SCM extension used (fossil) exercised a scenario we hadn't encountered before, where a command is sent over without the arguments field. This is compeletely valid, but the decoder used would reject this instead of returning an empty list. This therefore adds a new custom decoder to handle this correctly.