### PR TITLE
Remove extension tests from core test project

### DIFF
--- a/test/Extensions/ExtHostProtocolTests.re
+++ b/test/Extensions/ExtHostProtocolTests.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Oni_Core_Test;
 open Oni_Extensions;
 
 open ExtHostProtocol;

--- a/test/Extensions/ExtHostTransportTests.re
+++ b/test/Extensions/ExtHostTransportTests.re
@@ -1,9 +1,10 @@
 open Oni_Core;
 open Utility;
-open Oni_Core_Test;
 open Oni_Extensions;
 
 open TestFramework;
+
+module Helpers = Oni_Core_Test.Helpers;
 
 let initialConfiguration = Oni_Extensions.Configuration.empty;
 let initData = ExtHostInitData.create();

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -1,6 +1,5 @@
 open EditorCoreTypes;
 open Oni_Core;
-open Oni_Core_Test;
 open Oni_Extensions;
 
 open TestFramework;

--- a/test/Extensions/LanguageConfigurationTest.re
+++ b/test/Extensions/LanguageConfigurationTest.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Oni_Core_Test;
 open Oni_Extensions;
 
 open TestFramework;


### PR DESCRIPTION
The extension tests were opening `Oni_Core_Test`, which caused the following `open TestFramework` to open the core test framework and therefore register as core tests instead of extension tests. And since (some of) these tests are very slow and not very unit-test-like, they were really slowing down the feedback loop when working on the core tests.

This removed the unnecessary `open Oni_Core_Test`  and instead brings in in `Oni_Core_Test.Helpers` in only the one place where it is actually used.