### PR TITLE
FontAwesome regular style tweaks

### DIFF
--- a/src/Components/FontAwesome.re
+++ b/src/Components/FontAwesome.re
@@ -4,7 +4,10 @@
  * Helper constants for FontAwesome
  */
 
-let fontFamily = "FontAwesome5FreeSolid.otf";
+module FontFamily = {
+  let solid = "FontAwesome5FreeSolid.otf";
+  let regular = "FontAwesome5FreeRegular.otf";
+};
 
 let ad = 0xf641;
 let addressBook = 0xf2b9;

--- a/src/Components/FontIcon.re
+++ b/src/Components/FontIcon.re
@@ -21,7 +21,13 @@ module Styles = {
 let codeToIcon = icon => ZedBundled.singleton(Uchar.of_int(icon));
 
 let make =
-    (~icon, ~fontFamily=FontAwesome.fontFamily, ~fontSize=15., ~color, ()) =>
+    (
+      ~icon,
+      ~fontFamily=FontAwesome.FontFamily.solid,
+      ~fontSize=15.,
+      ~color,
+      (),
+    ) =>
   <Text
     text={codeToIcon(icon)}
     style={Styles.text(~fontFamily, ~fontSize, ~color)}

--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -10,9 +10,6 @@ let defaultFontSize = 14.;
 let defaultFontFamily = "FiraCode-Regular.ttf";
 let defaultTerminalFontSize = 12.;
 
-let fontAwesomeRegularPath = "FontAwesome5FreeRegular.otf";
-let fontAwesomeSolidPath = "FontAwesome5FreeSolid.otf";
-
 let syntaxEagerMaxLines = 500;
 let syntaxEagerMaxLineLength = 1000;
 let syntaxEagerBudget = 0.25; /* 250 milliseconds */

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -4,6 +4,7 @@ open Revery.Draw;
 
 open Oni_Core;
 
+module FontAwesome = Oni_Components.FontAwesome;
 module FontIcon = Oni_Components.FontIcon;
 
 type context = {
@@ -216,9 +217,9 @@ let token =
       ~x=x +. context.charWidth /. 4. -. context.scrollX,
       ~y=y -. context.scrollY,
       ~color=theme.editorWhitespaceForeground,
-      ~fontFamily="FontAwesome5FreeSolid.otf",
+      ~fontFamily=FontAwesome.FontFamily.solid,
       ~fontSize=10.,
-      ~text=FontIcon.codeToIcon(0xf30b),
+      ~text=FontIcon.codeToIcon(FontAwesome.longArrowAltRight),
       context.canvasContext,
     )
 

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -33,15 +33,26 @@ module Styles = {
   ];
 };
 
-let%component item = (~onClick, ~theme, ~isActive, ~icon, ()) => {
+let%component item =
+              (~onClick, ~theme, ~isActive, ~icon, ~iconStyle=`Solid, ()) => {
   let%hook (isHovered, setHovered) = Hooks.state(false);
   let onMouseOver = _ => setHovered(_ => true);
   let onMouseOut = _ => setHovered(_ => false);
-  let iconColor = isActive ? Colors.foreground : Colors.inactiveForeground;
+
+  let icon = () => {
+    let color = isActive ? Colors.foreground : Colors.inactiveForeground;
+    let fontFamily =
+      switch (iconStyle) {
+      | `Solid => FontAwesome.FontFamily.solid
+      | `Regular => FontAwesome.FontFamily.regular
+      };
+
+    <FontIcon fontFamily color={color.from(theme)} fontSize=22. icon />;
+  };
 
   <View onMouseOver onMouseOut>
     <Sneakable onClick style={Styles.item(~isHovered, ~isActive, ~theme)}>
-      <FontIcon color={iconColor.from(theme)} fontSize=22. icon />
+      <icon />
     </Sneakable>
   </View>;
 };
@@ -88,6 +99,7 @@ let%component make =
       theme
       isActive={isSidebarVisible(FileExplorer)}
       icon=FontAwesome.copy
+      iconStyle=`Regular
     />
     <item
       onClick=onSearchClick


### PR DESCRIPTION
- Moves the regular fontFamily into the FontAwesome module alongside the solid one
- Uses the FontAwesome module to draw tab character in Editor instead of hard-coding it with magic numbers and such
- Switch the File Explorer Dock icon to use the more light-weight regular style

![2020-03-18-192842_70x196_scrot](https://user-images.githubusercontent.com/5207036/76994471-b7308f80-694e-11ea-8f2f-383e00fd7d0c.png)
