### PR TITLE
Bugfix - ACP: Fix pass-through and deletion behavior with 'notIn' conditional

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d1c52c78d0aac350c2d1e5255593c3c6",
+  "checksum": "59f8af3ca3515b8bdff2208e7022c0ab",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -427,18 +427,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a897319",
+      "version": "github:onivim/reason-libvim#57c01dd",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a897319" ]
+        "source": [ "github:onivim/reason-libvim#57c01dd" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.31@d41d8cd9",
+        "libvim@8.10869.32@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.4.0@6976bb12",
         "@opam/dune@opam:2.4.0@639d28a3",
@@ -645,14 +645,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.31@d41d8cd9": {
-      "id": "libvim@8.10869.31@d41d8cd9",
+    "libvim@8.10869.32@d41d8cd9": {
+      "id": "libvim@8.10869.32@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.31",
+      "version": "8.10869.32",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.31.tgz#sha1:7d29e24ff75566e46f8d121ce0a5f1d96c6ddae3"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.32.tgz#sha1:29d13fa44b93efdaaef017806f88343cf95bc3df"
         ]
       },
       "overrides": [],
@@ -1194,7 +1194,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@2.3.1@d41d8cd9", "reason-sdl2@2.10.3020@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@3.0.0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d1c52c78d0aac350c2d1e5255593c3c6",
+  "checksum": "59f8af3ca3515b8bdff2208e7022c0ab",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -427,18 +427,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a897319",
+      "version": "github:onivim/reason-libvim#57c01dd",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a897319" ]
+        "source": [ "github:onivim/reason-libvim#57c01dd" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.31@d41d8cd9",
+        "libvim@8.10869.32@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.4.0@6976bb12",
         "@opam/dune@opam:2.4.0@639d28a3",
@@ -645,14 +645,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.31@d41d8cd9": {
-      "id": "libvim@8.10869.31@d41d8cd9",
+    "libvim@8.10869.32@d41d8cd9": {
+      "id": "libvim@8.10869.32@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.31",
+      "version": "8.10869.32",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.31.tgz#sha1:7d29e24ff75566e46f8d121ce0a5f1d96c6ddae3"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.32.tgz#sha1:29d13fa44b93efdaaef017806f88343cf95bc3df"
         ]
       },
       "overrides": [],
@@ -1193,7 +1193,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@2.3.1@d41d8cd9", "reason-sdl2@2.10.3020@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@3.0.0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d1c52c78d0aac350c2d1e5255593c3c6",
+  "checksum": "59f8af3ca3515b8bdff2208e7022c0ab",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -427,18 +427,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a897319",
+      "version": "github:onivim/reason-libvim#57c01dd",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a897319" ]
+        "source": [ "github:onivim/reason-libvim#57c01dd" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.31@d41d8cd9",
+        "libvim@8.10869.32@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.4.0@6976bb12",
         "@opam/dune@opam:2.4.0@639d28a3",
@@ -645,14 +645,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.31@d41d8cd9": {
-      "id": "libvim@8.10869.31@d41d8cd9",
+    "libvim@8.10869.32@d41d8cd9": {
+      "id": "libvim@8.10869.32@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.31",
+      "version": "8.10869.32",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.31.tgz#sha1:7d29e24ff75566e46f8d121ce0a5f1d96c6ddae3"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.32.tgz#sha1:29d13fa44b93efdaaef017806f88343cf95bc3df"
         ]
       },
       "overrides": [],
@@ -1193,7 +1193,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@2.3.1@d41d8cd9", "reason-sdl2@2.10.3020@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@3.0.0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "ocaml": "~4.7.0",
     "reason-sdl2": "^2.10.2020",
     "reason-jsonrpc": "1.5.0",
-    "reason-libvim": "github:onivim/reason-libvim#a897319",
+    "reason-libvim": "github:onivim/reason-libvim#57c01dd",
     "reason-native-crash-utils": "github:onivim/reason-native-crash-utils#ae1fd34",
     "reasonFuzz": "*",
     "rench": "1.7.1",

--- a/src/Extensions/LanguageConfiguration.re
+++ b/src/Extensions/LanguageConfiguration.re
@@ -123,18 +123,24 @@ module Decode = {
 let decode = Decode.configuration;
 
 let toVimAutoClosingPairs = (syntaxScope: SyntaxScope.t, configuration: t) => {
+  let toAutoPair = ({openPair, closePair, _}: AutoClosingPair.t) => {
+    Vim.AutoClosingPairs.AutoPair.{opening: openPair, closing: closePair};
+  };
+
   let pairs =
     configuration.autoClosingPairs
     |> List.filter(AutoClosingPair.isActive(syntaxScope))
-    |> List.map(({openPair, closePair, _}: AutoClosingPair.t) => {
-         Vim.AutoClosingPairs.AutoClosingPair.create(
-           ~opening=openPair,
-           ~closing=closePair,
-           (),
-         )
-       });
+    |> List.map(toAutoPair);
+
+  let passThrough =
+    configuration.autoClosingPairs
+    |> List.map(({closePair, _}: AutoClosingPair.t) => closePair);
+
+  let deletionPairs = configuration.autoClosingPairs |> List.map(toAutoPair);
 
   Vim.AutoClosingPairs.create(
+    ~passThrough,
+    ~deletionPairs,
     ~allowBefore=configuration.autoCloseBefore,
     pairs,
   );

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c87d7fad8815242cdf2269a417aeb2ec",
+  "checksum": "a444e9903dc0cba4fcb6137a68b782fe",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -427,18 +427,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a897319",
+      "version": "github:onivim/reason-libvim#57c01dd",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a897319" ]
+        "source": [ "github:onivim/reason-libvim#57c01dd" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.31@d41d8cd9",
+        "libvim@8.10869.32@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.4.0@6976bb12",
         "@opam/dune@opam:2.4.0@639d28a3",
@@ -645,14 +645,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.31@d41d8cd9": {
-      "id": "libvim@8.10869.31@d41d8cd9",
+    "libvim@8.10869.32@d41d8cd9": {
+      "id": "libvim@8.10869.32@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.31",
+      "version": "8.10869.32",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.31.tgz#sha1:7d29e24ff75566e46f8d121ce0a5f1d96c6ddae3"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.32.tgz#sha1:29d13fa44b93efdaaef017806f88343cf95bc3df"
         ]
       },
       "overrides": [],
@@ -1193,7 +1193,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@2.3.1@d41d8cd9", "reason-sdl2@2.10.3020@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a897319@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#57c01dd@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@3.0.0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",


### PR DESCRIPTION
__Issue:__

There were a couple of broken auto-closing pair cases, when the `notIn` conditional is used.

For example, in Reason, the configuration looks like this:
```
    { "open": "{", "close": "}" },
    { "open": "[", "close": "]" },
    { "open": "(", "close": ")" },
    { "open": "\"", "close": "\"", "notIn": [ "string" ] },
    { "open": "/**", "close": " */", "notIn": [ "string" ] }
```

In the case of typing a string, like `"|"`, pressing `<BS>` wouldn't delete the pairs, and pressing `"` wouldn't pass-through. This is because the `notIn` flag would be picked up (we'd properly detect we're in a string, and disable the closing pair). However, the disabling impacting the deletion and pass-through behaviors, which is a bug.

__Fix:__

Libvim doesn't know about the `notIn` parameter, or syntax scopes at all, so we filter the auto-closing pairs based on which ones are available in the current syntax scope. However, we shouldn't filter the pass-through or deletion parameters - so specify those independently and without the `notIn` filtering.