### PR TITLE
Carry severity and extension id from extension message to notification

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -94,14 +94,12 @@ function activate(context) {
         }
     }));
 
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with  registerCommand
-    // The commandId parameter must match the command field in package.json
-    cleanup(vscode.commands.registerCommand('developer.oni.showNotification', () => {
-        // The code you place here will be executed every time your command is executed
+    cleanup(vscode.commands.registerCommand('developer.oni.showWarning', () => {
+        vscode.window.showWarningMessage('This is a warning');
+    }));
 
-        // Display a message box to the user
-        vscode.window.showInformationMessage('Hello from extension!');
+    cleanup(vscode.commands.registerCommand('developer.oni.showError', () => {
+        vscode.window.showErrorMessage('Hello, this is error');
     }));
     
     cleanup(vscode.commands.registerCommand('developer.oni.showWorkspaceRootPath', () => {

--- a/development_extensions/oni-dev-extension/package.json
+++ b/development_extensions/oni-dev-extension/package.json
@@ -14,8 +14,12 @@
 	"contributes": {
 		"commands": [
 			{
-				"command": "developer.oni.showNotification",
-				"title": "Onivim - Developer: Show Notification"
+				"command": "developer.oni.showWarning",
+				"title": "Onivim - Developer: Show Warning"
+			},
+			{
+				"command": "developer.oni.showError",
+				"title": "Onivim - Developer: Show Error"
 			},
 			{
 				"command": "developer.oni.getBufferText",

--- a/integration_test/lib/TextSynchronization.re
+++ b/integration_test/lib/TextSynchronization.re
@@ -70,7 +70,7 @@ let validateTextIsSynchronized =
         | Some(str) => String.equal("fulltext:" ++ str, onivimBuffer)
         };
       expectedEqual
-      && String.equal(onivimBuffer, extHostBuffer)
+      && String.equal("oni-dev-extension: " ++ onivimBuffer, extHostBuffer)
       && String.equal(onivimBuffer, vimBuffer);
     },
   );

--- a/integration_test/lib/TextSynchronization.re
+++ b/integration_test/lib/TextSynchronization.re
@@ -70,7 +70,7 @@ let validateTextIsSynchronized =
         | Some(str) => String.equal("fulltext:" ++ str, onivimBuffer)
         };
       expectedEqual
-      && String.equal("oni-dev-extension: " ++ onivimBuffer, extHostBuffer)
+      && String.equal(onivimBuffer, extHostBuffer)
       && String.equal(onivimBuffer, vimBuffer);
     },
   );

--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -156,6 +156,11 @@ module Terminal: {
 type msg =
   | SCM(SCM.msg)
   | Terminal(Terminal.msg)
+  | ShowMessage({
+      severity: [ | `Ignore | `Info | `Warning | `Error],
+      message: string,
+      extensionId: option(string),
+    })
   | RegisterTextContentProvider({
       handle: int,
       scheme: string,
@@ -198,7 +203,6 @@ let start:
                                          =?,
     ~onRegisterReferencesProvider: (t, Protocol.BasicProvider.t) => unit=?,
     ~onRegisterSuggestProvider: (t, Protocol.SuggestProvider.t) => unit=?,
-    ~onShowMessage: string => unit=?,
     ~onStatusBarSetEntry: ((int, string, int, int)) => unit,
     ~dispatch: msg => unit,
     Core.Setup.t

--- a/src/Feature/Notification/Feature_Notification.rei
+++ b/src/Feature/Notification/Feature_Notification.rei
@@ -14,6 +14,7 @@ type notification = {
   id: int,
   kind,
   message: string,
+  source: option(string),
 };
 
 type model = list(notification);
@@ -30,7 +31,8 @@ let update: (model, msg) => model;
 // EFFECTS
 
 module Effects: {
-  let create: (~kind: kind=?, string) => Isolinear.Effect.t(msg);
+  let create:
+    (~kind: kind=?, ~source: string=?, string) => Isolinear.Effect.t(msg);
   let dismiss: notification => Isolinear.Effect.t(msg);
   let dismissAll: Isolinear.Effect.t(msg);
 };

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -89,7 +89,11 @@ type t =
   | EditorScrollToLine(Feature_Editor.EditorId.t, int)
   | EditorScrollToColumn(Feature_Editor.EditorId.t, int)
   | Notification(Feature_Notification.msg)
-  | ExtMessageReceived(string)
+  | ExtMessageReceived({
+      severity: [ | `Ignore | `Info | `Warning | `Error],
+      message: string,
+      extensionId: option(string),
+    })
   | FileExplorer(FileExplorer.action)
   | LanguageFeature(LanguageFeatures.action)
   | QuickmenuShow(quickmenuVariant)

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -272,6 +272,9 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       )
     | Terminal(msg) => Service_Terminal.handleExtensionMessage(msg)
 
+    | ShowMessage({severity, message, extensionId}) =>
+      dispatch(ExtMessageReceived({severity, message, extensionId}))
+
     | RegisterTextContentProvider({handle, scheme}) =>
       dispatch(NewTextContentProvider({handle, scheme}))
 
@@ -292,10 +295,6 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
 
   let onDidActivateExtension = id => {
     dispatch(Actions.Extension(Oni_Model.Extensions.Activated(id)));
-  };
-
-  let onShowMessage = message => {
-    dispatch(Actions.ExtMessageReceived(message));
   };
 
   let initData = ExtHostInitData.create(~extensions=extensionInfo, ());
@@ -320,7 +319,6 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       ~onRegisterDocumentSymbolProvider,
       ~onRegisterReferencesProvider,
       ~onRegisterSuggestProvider,
-      ~onShowMessage,
       ~onOutput,
       ~dispatch=onClientMessage,
       setup,

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -329,14 +329,14 @@ let start = (extensions, extHostClient) => {
         | `Warning => Warning
         | `Error => Error
         };
-      let message =
-        switch (extensionId) {
-        | Some(extensionId) => extensionId ++ ": " ++ message
-        | None => message
-        };
+
       (
         state,
-        Feature_Notification.Effects.create(~kind, message)
+        Feature_Notification.Effects.create(
+          ~kind,
+          ~source=?extensionId,
+          message,
+        )
         |> Isolinear.Effect.map(msg => Actions.Notification(msg)),
       );
 

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -321,11 +321,24 @@ let start = (extensions, extHostClient) => {
         Isolinear.Effect.none,
       )
 
-    | ExtMessageReceived(message) => (
+    | ExtMessageReceived({severity, message, extensionId}) =>
+      let kind: Feature_Notification.kind =
+        switch (severity) {
+        | `Ignore => Info
+        | `Info => Info
+        | `Warning => Warning
+        | `Error => Error
+        };
+      let message =
+        switch (extensionId) {
+        | Some(extensionId) => extensionId ++ ": " ++ message
+        | None => message
+        };
+      (
         state,
-        Feature_Notification.Effects.create(message)
+        Feature_Notification.Effects.create(~kind, message)
         |> Isolinear.Effect.map(msg => Actions.Notification(msg)),
-      )
+      );
 
     | _ => (state, Isolinear.Effect.none)
     };

--- a/test/Extensions/ExtensionClientHelper.re
+++ b/test/Extensions/ExtensionClientHelper.re
@@ -66,8 +66,8 @@ let withExtensionClient =
     (
       ~onStatusBarSetEntry=noop1,
       ~onDidActivateExtension=noop1,
-      ~onShowMessage=noop1,
       ~onRegisterCommand=noop1,
+      ~dispatch=_ => (),
       f: ExtHostClient.t => unit,
     ) => {
   let setup = Setup.init();
@@ -95,9 +95,8 @@ let withExtensionClient =
       ~onStatusBarSetEntry,
       ~onDidActivateExtension,
       ~onRegisterCommand,
-      ~onShowMessage,
       ~onClosed,
-      ~dispatch=_ => (),
+      ~dispatch,
       setup,
     );
 

--- a/test/Extensions/ExtensionClientTest.re
+++ b/test/Extensions/ExtensionClientTest.re
@@ -63,7 +63,11 @@ describe("ExtHostClient", ({describe, _}) => {
       let registeredCommands = empty();
       let messages = empty();
 
-      let onShowMessage = append(messages);
+      let dispatch =
+        fun
+        | ExtHostClient.ShowMessage({message, _}) =>
+          append(messages, message)
+        | _ => ();
       let onRegisterCommand = append(registeredCommands);
 
       let isExpectedCommandRegistered = () =>
@@ -72,7 +76,7 @@ describe("ExtHostClient", ({describe, _}) => {
       let anyMessages = any(messages);
 
       withExtensionClient(
-        ~onShowMessage,
+        ~dispatch,
         ~onRegisterCommand,
         client => {
           Waiters.wait(isExpectedCommandRegistered, client);
@@ -106,7 +110,11 @@ describe("ExtHostClient", ({describe, _}) => {
       let registeredCommands = empty();
       let messages = emptyInfoMsgs();
 
-      let onShowMessage = appendInfoMsg(messages);
+      let dispatch =
+        fun
+        | ExtHostClient.ShowMessage({message, _}) =>
+          appendInfoMsg(messages, message)
+        | _ => ();
       let onRegisterCommand = append(registeredCommands);
 
       let isExpectedCommandRegistered = () =>
@@ -123,7 +131,7 @@ describe("ExtHostClient", ({describe, _}) => {
 
       withExtensionClient(
         ~onRegisterCommand,
-        ~onShowMessage,
+        ~dispatch,
         client => {
           Waiters.wait(isExpectedCommandRegistered, client);
           expect.bool(isExpectedCommandRegistered()).toBe(true);
@@ -146,7 +154,11 @@ describe("ExtHostClient", ({describe, _}) => {
       let registeredCommands = empty();
       let messages = emptyInfoMsgs();
 
-      let onShowMessage = appendInfoMsg(messages);
+      let dispatch =
+        fun
+        | ExtHostClient.ShowMessage({message, _}) =>
+          appendInfoMsg(messages, message)
+        | _ => ();
       let onRegisterCommand = append(registeredCommands);
 
       let isExpectedCommandRegistered = () =>
@@ -178,7 +190,7 @@ describe("ExtHostClient", ({describe, _}) => {
         );
 
       withExtensionClient(
-        ~onShowMessage,
+        ~dispatch,
         ~onRegisterCommand,
         client => {
           Waiters.wait(isExpectedCommandRegistered, client);


### PR DESCRIPTION
This creates the appropriate notification based on the severity of the message coming from the extension, and appends the extension id to the message to be able to identify where the message comes from.

It's a bit of an intermediary improvement, as we should probably enrich the notification with a `source` field and need to add support for commands and such eventually.