### PR TITLE
Remove assets/configuration/dune

### DIFF
--- a/assets/configuration/dune
+++ b/assets/configuration/dune
@@ -1,4 +1,0 @@
-(install
- (section bin)
- (package Oni2)
- (files setup.json))


### PR DESCRIPTION
After nuking my local repository dune-configurator has suddenly started complaining about there being no rule for "setup.json", referenced in this file. Since there doesn't seem to be any reason for this any longer it should probably be removed.