### PR TITLE
Fix #496: Crash when pasting from commandline

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fa41d5e49c82bbdd4a894a5fbca1baa9",
+  "checksum": "554169c475f87104451450ea115bd0f4",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -124,7 +124,7 @@ Onivim-specific contexts:
 | Context Name | True When | 
 | --- | --- |
 | `insertMode` |  The active editor is in `insert` mode |
-| `commandLineMode` | The Vim commandline is open |
+| `commandLineFocus` | The Vim commandline is open |
 | `menuFocus` | A pop-up menu has focus |
 
 ## Commands

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -124,7 +124,7 @@ Onivim-specific contexts:
 | Context Name | True When | 
 | --- | --- |
 | `insertMode` |  The active editor is in `insert` mode |
-| `commandLineFocus` | The Vim commandline is open |
+| `commandLineMode` | The Vim commandline is open |
 | `menuFocus` | A pop-up menu has focus |
 
 ## Commands

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fa41d5e49c82bbdd4a894a5fbca1baa9",
+  "checksum": "554169c475f87104451450ea115bd0f4",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fa41d5e49c82bbdd4a894a5fbca1baa9",
+  "checksum": "554169c475f87104451450ea115bd0f4",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "ocaml": "~4.7.0",
     "reason-sdl2": "^2.10.2020",
     "reason-jsonrpc": "1.5.0",
-    "reason-libvim": "onivim/reason-libvim#0640e6b",
+    "reason-libvim": "onivim/reason-libvim#4588084",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#ae1fd34",
     "reasonFuzz": "*",
     "rench": "1.7.1",

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -59,9 +59,7 @@ let conditionsOfState = (state: State.t) => {
   | (false, Vim.Types.Visual) => Hashtbl.add(ret, "visualMode", true)
   | (false, _) => Hashtbl.add(ret, "editorTextFocus", true)
   | (true, Vim.Types.CommandLine) =>
-    // LEGACY: Support `commandLineFocus` too.
-    Hashtbl.add(ret, "commandLineFocus", true);
-    Hashtbl.add(ret, "commandLineMode", true);
+    Hashtbl.add(ret, "commandLineFocus", true)
   | _ => ()
   };
 

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -58,6 +58,10 @@ let conditionsOfState = (state: State.t) => {
     Hashtbl.add(ret, "editorTextFocus", true);
   | (false, Vim.Types.Visual) => Hashtbl.add(ret, "visualMode", true)
   | (false, _) => Hashtbl.add(ret, "editorTextFocus", true)
+  | (true, Vim.Types.CommandLine) =>
+    // LEGACY: Support `commandLineFocus` too.
+    Hashtbl.add(ret, "commandLineFocus", true);
+    Hashtbl.add(ret, "commandLineMode", true);
   | _ => ()
   };
 

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -66,12 +66,12 @@ let start = maybeKeyBindingsFilePath => {
       {
         key: "<C-V>",
         command: "editor.action.clipboardPasteAction",
-        condition: "insertMode" |> WhenExpr.parse,
+        condition: "insertMode || commandLineMode" |> WhenExpr.parse,
       },
       {
         key: "<D-V>",
         command: "editor.action.clipboardPasteAction",
-        condition: "insertMode" |> WhenExpr.parse,
+        condition: "insertMode || commandLineMode" |> WhenExpr.parse,
       },
       {
         key: "<ESC>",

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -66,12 +66,12 @@ let start = maybeKeyBindingsFilePath => {
       {
         key: "<C-V>",
         command: "editor.action.clipboardPasteAction",
-        condition: "insertMode || commandLineMode" |> WhenExpr.parse,
+        condition: "insertMode || commandLineFocus" |> WhenExpr.parse,
       },
       {
         key: "<D-V>",
         command: "editor.action.clipboardPasteAction",
-        condition: "insertMode || commandLineMode" |> WhenExpr.parse,
+        condition: "insertMode || commandLineFocus" |> WhenExpr.parse,
       },
       {
         key: "<ESC>",

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -804,24 +804,25 @@ let start =
       if (isInsertMode || isCmdLineMode) {
         getClipboardText()
         |> Option.iter(text => {
-          if (!isCmdLineMode) {
-            Vim.command("set paste");
-          };
+             if (!isCmdLineMode) {
+               Vim.command("set paste");
+             };
 
-          let latestCursors = ref([]);
-          Zed_utf8.iter(
-            s => {
-              latestCursors := Vim.input(~cursors=[], Zed_utf8.singleton(s));
-              ();
-            },
-            text,
-          );
+             let latestCursors = ref([]);
+             Zed_utf8.iter(
+               s => {
+                 latestCursors :=
+                   Vim.input(~cursors=[], Zed_utf8.singleton(s));
+                 ();
+               },
+               text,
+             );
 
-          if (!isCmdLineMode) {
-            updateActiveEditorCursors(latestCursors^);
-            Vim.command("set nopaste");
-          };
-        });
+             if (!isCmdLineMode) {
+               updateActiveEditorCursors(latestCursors^);
+               Vim.command("set nopaste");
+             };
+           });
       };
     });
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -79,10 +79,8 @@ let start =
     let splitNewLines = s => String.split_on_char('\n', s) |> Array.of_list;
 
     let getClipboardValue = () => {
-      switch (getClipboardText()) {
-      | None => None
-      | Some(v) => Some(v |> removeWindowsNewLines |> splitNewLines)
-      };
+      getClipboardText()
+      |> Option.map(text => text |> removeWindowsNewLines |> splitNewLines);
     };
 
     let starReg = Char.code('*');
@@ -804,8 +802,8 @@ let start =
       let isInsertMode = Vim.Mode.getCurrent() == Vim.Types.Insert;
 
       if (isInsertMode || isCmdLineMode) {
-        switch (getClipboardText()) {
-        | Some(text) =>
+        getClipboardText()
+        |> Option.iter(text => {
           if (!isCmdLineMode) {
             Vim.command("set paste");
           };
@@ -823,8 +821,7 @@ let start =
             updateActiveEditorCursors(latestCursors^);
             Vim.command("set nopaste");
           };
-        | None => ()
-        };
+        });
       };
     });
 

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "398ce41b91decf1a6dbb7e79ed160004",
+  "checksum": "459da0ec908b1a00e32d763a103f6b04",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {


### PR DESCRIPTION
__Issue:__ When pasting via `<C-v>` in the command line, we'd crash.

__Defect:__ `<C-v>` in the command line actually engages the 'insert-literal' behavior, which blocks for input (causing a hang). This root cause is addressed in https://github.com/onivim/libvim/pull/191 , removing that functionality (we can bring it back in the Onivim 2 input layer if it is desired).

__Fix:__ In the Onivim 2 side, hook up our paste command to work with the command line too.

Related to #1233 , and might not be necessary at all with that change (especially if we move more of the command line behavior to Onivim 2)

__TODO:__

- [x] Depends on https://github.com/onivim/libvim/pull/191 
- [x] ...and being brought in via `reason-libvim`

Fixes #496 