### PR TITLE
Refactor - Editor: Per-editor font setting

### DIFF
--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -33,7 +33,6 @@ let editorSurfaceMinimalState = hwnd => {
       definition={thousandLineState.definition}
       mode={thousandLineState.vimMode}
       theme={Feature_Theme.resolver(thousandLineState.colorTheme)}
-      editorFont={thousandLineState.editorFont}
       windowIsFocused=true
       config={configResolver(Config.Settings.empty)}
     />,
@@ -59,7 +58,6 @@ let editorSurfaceThousandLineState = hwnd => {
       definition={thousandLineState.definition}
       mode={thousandLineState.vimMode}
       theme={Feature_Theme.resolver(thousandLineState.colorTheme)}
-      editorFont={thousandLineState.editorFont}
       windowIsFocused=true
       config={configResolver(Config.Settings.empty)}
     />,
@@ -85,7 +83,6 @@ let editorSurfaceThousandLineStateWithIndents = hwnd => {
       definition={thousandLineState.definition}
       mode={thousandLineState.vimMode}
       theme={Feature_Theme.resolver(thousandLineState.colorTheme)}
-      editorFont={thousandLineState.editorFont}
       windowIsFocused=true
       config={configResolver(
         Config.Settings.fromList([
@@ -115,7 +112,6 @@ let editorSurfaceHundredThousandLineStateNoMinimap = hwnd => {
       definition={thousandLineState.definition}
       mode={thousandLineState.vimMode}
       theme={Feature_Theme.resolver(thousandLineState.colorTheme)}
-      editorFont={thousandLineState.editorFont}
       windowIsFocused=true
       config={configResolver(
         Config.Settings.fromList([
@@ -145,7 +141,6 @@ let editorSurfaceHundredThousandLineState = hwnd => {
       definition={thousandLineState.definition}
       mode={thousandLineState.vimMode}
       theme={Feature_Theme.resolver(thousandLineState.colorTheme)}
-      editorFont={thousandLineState.editorFont}
       windowIsFocused=true
       config={configResolver(Config.Settings.empty)}
     />,

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -4,11 +4,7 @@ open Oni_Model;
 open Oni_Store;
 open Feature_Editor;
 
-let metrics =
-  EditorMetrics.{
-    pixelWidth: 3440,
-    pixelHeight: 1440,
-  };
+let metrics = EditorMetrics.{pixelWidth: 3440, pixelHeight: 1440};
 
 /* Create a state with some editor size */
 let simpleState = {
@@ -23,23 +19,20 @@ let simpleState = {
   );
 };
 
-let defaultFont: Service_Font.font = { 
-        fontFile:
-          Revery.Environment.executingDirectory ++ "FiraCode-Regular.ttf",
-        fontSize: 10.,
-        measuredWidth: 10.,
-        measuredHeight: 10.,
-        descenderHeight: 1.,
-        smoothing: Revery.Font.Smoothing.default,
+let defaultFont: Service_Font.font = {
+  fontFile: Revery.Environment.executingDirectory ++ "FiraCode-Regular.ttf",
+  fontSize: 10.,
+  measuredWidth: 10.,
+  measuredHeight: 10.,
+  descenderHeight: 1.,
+  smoothing: Revery.Font.Smoothing.default,
 };
 
 let simpleState =
   Reducer.reduce(
     simpleState,
-    Actions.EditorFont(Service_Font.FontLoaded(
-      defaultFont
-    )
-  ));
+    Actions.EditorFont(Service_Font.FontLoaded(defaultFont)),
+  );
 
 let simpleEditor = Editor.create(~font=defaultFont, ());
 let editorGroup =

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -8,8 +8,6 @@ let metrics =
   EditorMetrics.{
     pixelWidth: 3440,
     pixelHeight: 1440,
-    lineHeight: 10.,
-    characterWidth: 10.,
   };
 
 /* Create a state with some editor size */
@@ -25,11 +23,7 @@ let simpleState = {
   );
 };
 
-let simpleState =
-  Reducer.reduce(
-    simpleState,
-    Actions.EditorFont(
-      Service_Font.FontLoaded({
+let defaultFont: Service_Font.font = { 
         fontFile:
           Revery.Environment.executingDirectory ++ "FiraCode-Regular.ttf",
         fontSize: 10.,
@@ -37,11 +31,17 @@ let simpleState =
         measuredHeight: 10.,
         descenderHeight: 1.,
         smoothing: Revery.Font.Smoothing.default,
-      }),
-    ),
-  );
+};
 
-let simpleEditor = Editor.create();
+let simpleState =
+  Reducer.reduce(
+    simpleState,
+    Actions.EditorFont(Service_Font.FontLoaded(
+      defaultFont
+    )
+  ));
+
+let simpleEditor = Editor.create(~font=defaultFont, ());
 let editorGroup =
   EditorGroups.getActiveEditorGroup(simpleState.editorGroups)
   |> Option.value(~default=EditorGroup.create());

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -71,8 +71,7 @@ let getId = model => model.editorId;
 let getLineHeight = editor => editor.font.measuredHeight;
 let getCharacterWidth = editor => editor.font.measuredWidth;
 
-let pixelPositionToLineColumn =
-    (view, pixelX, pixelY) => {
+let pixelPositionToLineColumn = (view, pixelX, pixelY) => {
   let line = int_of_float((pixelY +. view.scrollY) /. getLineHeight(view));
   let column =
     int_of_float((pixelX +. view.scrollX) /. getCharacterWidth(view));
@@ -101,8 +100,7 @@ let getVerticalScrollbarMetrics =
   {thumbSize, thumbOffset, visible: true};
 };
 
-let getHorizontalScrollbarMetrics =
-    (view, availableWidth) => {
+let getHorizontalScrollbarMetrics = (view, availableWidth) => {
   let totalViewWidthInPixels =
     float_of_int(view.maxLineLength) *. getCharacterWidth(view);
   let availableWidthF = float_of_int(availableWidth);

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -19,7 +19,6 @@ type t = {
   viewLines: int,
   cursors: [@opaque] list(Vim.Cursor.t),
   selection: [@opaque] VisualRange.t,
-
   font: [@opaque] Service_Font.font,
 };
 
@@ -69,8 +68,8 @@ let getPrimaryCursor = model =>
 
 let getId = model => model.editorId;
 
-let getLineHeight = (editor) => editor.font.measuredHeight;
-let getCharacterWidth = (editor) => editor.font.measuredWidth;
+let getLineHeight = editor => editor.font.measuredHeight;
+let getCharacterWidth = editor => editor.font.measuredWidth;
 
 let pixelPositionToLineColumn =
     (view, metrics: EditorMetrics.t, pixelX, pixelY) => {
@@ -82,9 +81,9 @@ let pixelPositionToLineColumn =
 };
 
 let getVisibleView = (editor, metrics: EditorMetrics.t) =>
-  int_of_float(float_of_int(metrics.pixelHeight) /. getLineHeight(editor))
+  int_of_float(float_of_int(metrics.pixelHeight) /. getLineHeight(editor));
 
-let getTotalSizeInPixels = (editor) =>
+let getTotalSizeInPixels = editor =>
   int_of_float(float_of_int(editor.viewLines) *. getLineHeight(editor));
 
 let getVerticalScrollbarMetrics =
@@ -137,11 +136,11 @@ let getLayout = (view, metrics: EditorMetrics.t) => {
   layout;
 };
 
-let getLeftVisibleColumn = (view) => {
+let getLeftVisibleColumn = view => {
   int_of_float(view.scrollX /. getCharacterWidth(view));
 };
 
-let getTopVisibleLine = (view) =>
+let getTopVisibleLine = view =>
   int_of_float(view.scrollY /. getLineHeight(view)) + 1;
 
 let getBottomVisibleLine = (view, metrics: EditorMetrics.t) => {
@@ -153,3 +152,5 @@ let getBottomVisibleLine = (view, metrics: EditorMetrics.t) => {
 
   absoluteBottomLine > view.viewLines ? view.viewLines : absoluteBottomLine;
 };
+
+let setFont = (~font, editor) => {...editor, font};

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -72,7 +72,7 @@ let getLineHeight = editor => editor.font.measuredHeight;
 let getCharacterWidth = editor => editor.font.measuredWidth;
 
 let pixelPositionToLineColumn =
-    (view, metrics: EditorMetrics.t, pixelX, pixelY) => {
+    (view, pixelX, pixelY) => {
   let line = int_of_float((pixelY +. view.scrollY) /. getLineHeight(view));
   let column =
     int_of_float((pixelX +. view.scrollX) /. getCharacterWidth(view));
@@ -102,7 +102,7 @@ let getVerticalScrollbarMetrics =
 };
 
 let getHorizontalScrollbarMetrics =
-    (view, availableWidth, metrics: EditorMetrics.t) => {
+    (view, availableWidth) => {
   let totalViewWidthInPixels =
     float_of_int(view.maxLineLength) *. getCharacterWidth(view);
   let availableWidthF = float_of_int(availableWidth);

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -19,9 +19,11 @@ type t = {
   viewLines: int,
   cursors: [@opaque] list(Vim.Cursor.t),
   selection: [@opaque] VisualRange.t,
+
+  font: [@opaque] Service_Font.font,
 };
 
-let create = (~bufferId=0, ()) => {
+let create = (~font, ~bufferId=0, ()) => {
   let id = lastId^;
   incr(lastId);
 
@@ -47,6 +49,7 @@ let create = (~bufferId=0, ()) => {
           stop: Location.{line: Index.zero, column: Index.zero},
         },
       ),
+    font,
   };
 };
 
@@ -66,25 +69,28 @@ let getPrimaryCursor = model =>
 
 let getId = model => model.editorId;
 
+let getLineHeight = (editor) => editor.font.measuredHeight;
+let getCharacterWidth = (editor) => editor.font.measuredWidth;
+
 let pixelPositionToLineColumn =
     (view, metrics: EditorMetrics.t, pixelX, pixelY) => {
-  let line = int_of_float((pixelY +. view.scrollY) /. metrics.lineHeight);
+  let line = int_of_float((pixelY +. view.scrollY) /. getLineHeight(view));
   let column =
-    int_of_float((pixelX +. view.scrollX) /. metrics.characterWidth);
+    int_of_float((pixelX +. view.scrollX) /. getCharacterWidth(view));
 
   (line, column);
 };
 
-let getVisibleView = (metrics: EditorMetrics.t) =>
-  int_of_float(float_of_int(metrics.pixelHeight) /. metrics.lineHeight);
+let getVisibleView = (editor, metrics: EditorMetrics.t) =>
+  int_of_float(float_of_int(metrics.pixelHeight) /. getLineHeight(editor))
 
-let getTotalSizeInPixels = (view, metrics: EditorMetrics.t) =>
-  int_of_float(float_of_int(view.viewLines) *. metrics.lineHeight);
+let getTotalSizeInPixels = (editor) =>
+  int_of_float(float_of_int(editor.viewLines) *. getLineHeight(editor));
 
 let getVerticalScrollbarMetrics =
     (view, scrollBarHeight, metrics: EditorMetrics.t) => {
   let totalViewSizeInPixels =
-    float_of_int(getTotalSizeInPixels(view, metrics) + metrics.pixelHeight);
+    float_of_int(getTotalSizeInPixels(view) + metrics.pixelHeight);
   let thumbPercentage =
     float_of_int(metrics.pixelHeight) /. totalViewSizeInPixels;
   let thumbSize =
@@ -99,7 +105,7 @@ let getVerticalScrollbarMetrics =
 let getHorizontalScrollbarMetrics =
     (view, availableWidth, metrics: EditorMetrics.t) => {
   let totalViewWidthInPixels =
-    float_of_int(view.maxLineLength) *. metrics.characterWidth;
+    float_of_int(view.maxLineLength) *. getCharacterWidth(view);
   let availableWidthF = float_of_int(availableWidth);
 
   totalViewWidthInPixels <= availableWidthF
@@ -122,8 +128,8 @@ let getLayout = (view, metrics: EditorMetrics.t) => {
       ~pixelWidth=float_of_int(metrics.pixelWidth),
       ~pixelHeight=float_of_int(metrics.pixelHeight),
       ~isMinimapShown=true,
-      ~characterWidth=metrics.characterWidth,
-      ~characterHeight=metrics.lineHeight,
+      ~characterWidth=getCharacterWidth(view),
+      ~characterHeight=getLineHeight(view),
       ~bufferLineCount=view.viewLines,
       (),
     );
@@ -131,18 +137,18 @@ let getLayout = (view, metrics: EditorMetrics.t) => {
   layout;
 };
 
-let getLeftVisibleColumn = (view, metrics: EditorMetrics.t) => {
-  int_of_float(view.scrollX /. metrics.characterWidth);
+let getLeftVisibleColumn = (view) => {
+  int_of_float(view.scrollX /. getCharacterWidth(view));
 };
 
-let getTopVisibleLine = (view, metrics: EditorMetrics.t) =>
-  int_of_float(view.scrollY /. metrics.lineHeight) + 1;
+let getTopVisibleLine = (view) =>
+  int_of_float(view.scrollY /. getLineHeight(view)) + 1;
 
 let getBottomVisibleLine = (view, metrics: EditorMetrics.t) => {
   let absoluteBottomLine =
     int_of_float(
       (view.scrollY +. float_of_int(metrics.pixelHeight))
-      /. metrics.lineHeight,
+      /. getLineHeight(view),
     );
 
   absoluteBottomLine > view.viewLines ? view.viewLines : absoluteBottomLine;

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -17,6 +17,8 @@ type t = {
   viewLines: int,
   cursors: [@opaque] list(Vim.Cursor.t),
   selection: [@opaque] VisualRange.t,
+
+  font: [@opaque] Service_Font.font,
 };
 
 type scrollbarMetrics = {
@@ -25,19 +27,22 @@ type scrollbarMetrics = {
   thumbOffset: int,
 };
 
-let create: (~bufferId: int=?, unit) => t;
+let create: (~font: Service_Font.font, ~bufferId: int=?, unit) => t;
 
 let getId: t => int;
-let getTopVisibleLine: (t, EditorMetrics.t) => int;
+let getTopVisibleLine: (t) => int;
 let getBottomVisibleLine: (t, EditorMetrics.t) => int;
-let getLeftVisibleColumn: (t, EditorMetrics.t) => int;
+let getLeftVisibleColumn: (t) => int;
 let getLayout: (t, EditorMetrics.t) => EditorLayout.t;
 let getPrimaryCursor: t => Location.t;
-let getVisibleView: EditorMetrics.t => int; // TODO: Move to EditorMetrics?
-let getTotalSizeInPixels: (t, EditorMetrics.t) => int;
+let getVisibleView: (t, EditorMetrics.t) => int; // TODO: Move to EditorMetrics?
+let getTotalSizeInPixels: (t) => int;
 let getVerticalScrollbarMetrics: (t, int, EditorMetrics.t) => scrollbarMetrics;
 let getHorizontalScrollbarMetrics:
   (t, int, EditorMetrics.t) => scrollbarMetrics;
 let pixelPositionToLineColumn:
   (t, EditorMetrics.t, float, float) => (int, int);
 let getVimCursors: t => list(Vim.Cursor.t);
+
+let getCharacterWidth: t => float;
+let getLineHeight: t => float;

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -17,7 +17,6 @@ type t = {
   viewLines: int,
   cursors: [@opaque] list(Vim.Cursor.t),
   selection: [@opaque] VisualRange.t,
-
   font: [@opaque] Service_Font.font,
 };
 
@@ -30,13 +29,13 @@ type scrollbarMetrics = {
 let create: (~font: Service_Font.font, ~bufferId: int=?, unit) => t;
 
 let getId: t => int;
-let getTopVisibleLine: (t) => int;
+let getTopVisibleLine: t => int;
 let getBottomVisibleLine: (t, EditorMetrics.t) => int;
-let getLeftVisibleColumn: (t) => int;
+let getLeftVisibleColumn: t => int;
 let getLayout: (t, EditorMetrics.t) => EditorLayout.t;
 let getPrimaryCursor: t => Location.t;
 let getVisibleView: (t, EditorMetrics.t) => int; // TODO: Move to EditorMetrics?
-let getTotalSizeInPixels: (t) => int;
+let getTotalSizeInPixels: t => int;
 let getVerticalScrollbarMetrics: (t, int, EditorMetrics.t) => scrollbarMetrics;
 let getHorizontalScrollbarMetrics:
   (t, int, EditorMetrics.t) => scrollbarMetrics;
@@ -46,3 +45,5 @@ let getVimCursors: t => list(Vim.Cursor.t);
 
 let getCharacterWidth: t => float;
 let getLineHeight: t => float;
+
+let setFont: (~font: Service_Font.font, t) => t;

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -34,13 +34,13 @@ let getBottomVisibleLine: (t, EditorMetrics.t) => int;
 let getLeftVisibleColumn: t => int;
 let getLayout: (t, EditorMetrics.t) => EditorLayout.t;
 let getPrimaryCursor: t => Location.t;
-let getVisibleView: (t, EditorMetrics.t) => int; // TODO: Move to EditorMetrics?
+let getVisibleView: (t, EditorMetrics.t) => int;
 let getTotalSizeInPixels: t => int;
 let getVerticalScrollbarMetrics: (t, int, EditorMetrics.t) => scrollbarMetrics;
 let getHorizontalScrollbarMetrics:
-  (t, int, EditorMetrics.t) => scrollbarMetrics;
+  (t, int) => scrollbarMetrics;
 let pixelPositionToLineColumn:
-  (t, EditorMetrics.t, float, float) => (int, int);
+  (t, float, float) => (int, int);
 let getVimCursors: t => list(Vim.Cursor.t);
 
 let getCharacterWidth: t => float;

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -37,10 +37,8 @@ let getPrimaryCursor: t => Location.t;
 let getVisibleView: (t, EditorMetrics.t) => int;
 let getTotalSizeInPixels: t => int;
 let getVerticalScrollbarMetrics: (t, int, EditorMetrics.t) => scrollbarMetrics;
-let getHorizontalScrollbarMetrics:
-  (t, int) => scrollbarMetrics;
-let pixelPositionToLineColumn:
-  (t, float, float) => (int, int);
+let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
+let pixelPositionToLineColumn: (t, float, float) => (int, int);
 let getVimCursors: t => list(Vim.Cursor.t);
 
 let getCharacterWidth: t => float;

--- a/src/Feature/Editor/EditorHorizontalScrollbar.re
+++ b/src/Feature/Editor/EditorHorizontalScrollbar.re
@@ -7,8 +7,7 @@ open Revery.UI;
 let absoluteStyle =
   Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
-let make =
-    (~editor: Editor.t, ~width as totalWidth, ~colors: Colors.t, ()) => {
+let make = (~editor: Editor.t, ~width as totalWidth, ~colors: Colors.t, ()) => {
   let scrollMetrics =
     Editor.getHorizontalScrollbarMetrics(editor, totalWidth);
 

--- a/src/Feature/Editor/EditorHorizontalScrollbar.re
+++ b/src/Feature/Editor/EditorHorizontalScrollbar.re
@@ -8,9 +8,9 @@ let absoluteStyle =
   Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
 let make =
-    (~editor: Editor.t, ~width as totalWidth, ~metrics, ~colors: Colors.t, ()) => {
+    (~editor: Editor.t, ~width as totalWidth, ~colors: Colors.t, ()) => {
   let scrollMetrics =
-    Editor.getHorizontalScrollbarMetrics(editor, totalWidth, metrics);
+    Editor.getHorizontalScrollbarMetrics(editor, totalWidth);
 
   let scrollThumbStyle =
     Style.[

--- a/src/Feature/Editor/EditorMetrics.re
+++ b/src/Feature/Editor/EditorMetrics.re
@@ -8,10 +8,8 @@
 type t = {
   pixelWidth: int,
   pixelHeight: int,
-  lineHeight: float,
-  characterWidth: float,
 };
 
 let create = () => {
-  {pixelWidth: 1000, pixelHeight: 1000, lineHeight: 1., characterWidth: 1.};
+  {pixelWidth: 1000, pixelHeight: 1000 };
 };

--- a/src/Feature/Editor/EditorMetrics.re
+++ b/src/Feature/Editor/EditorMetrics.re
@@ -11,5 +11,5 @@ type t = {
 };
 
 let create = () => {
-  {pixelWidth: 1000, pixelHeight: 1000 };
+  {pixelWidth: 1000, pixelHeight: 1000};
 };

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -119,7 +119,6 @@ let make =
       ~metrics: EditorMetrics.t,
       ~editor: Editor.t,
       ~theme,
-      ~editorFont: Service_Font.font,
       ~mode: Vim.Mode.t,
       ~bufferHighlights,
       ~bufferSyntaxHighlights,
@@ -136,8 +135,10 @@ let make =
   let colors = Colors.precompute(theme);
   let lineCount = Buffer.getNumberOfLines(buffer);
 
-  let leftVisibleColumn = Editor.getLeftVisibleColumn(editor, metrics);
-  let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
+  let editorFont = editor.font;
+
+  let leftVisibleColumn = Editor.getLeftVisibleColumn(editor);
+  let topVisibleLine = Editor.getTopVisibleLine(editor);
   let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);
 
   let cursorPosition = Editor.getPrimaryCursor(editor);
@@ -177,7 +178,7 @@ let make =
       height={metrics.pixelHeight}
       colors
       scrollY={editor.scrollY}
-      lineHeight={metrics.lineHeight}
+      lineHeight={editorFont.measuredHeight}
       count=lineCount
       editorFont
       cursorLine={Index.toZeroBased(cursorPosition.line)}

--- a/src/Feature/Editor/EditorVerticalScrollbar.re
+++ b/src/Feature/Editor/EditorVerticalScrollbar.re
@@ -39,7 +39,7 @@ let make =
     ];
 
   let totalPixel =
-    Editor.getTotalSizeInPixels(editor, metrics) |> float_of_int;
+    Editor.getTotalSizeInPixels(editor) |> float_of_int;
 
   let bufferLineToScrollbarPixel = line => {
     let pixelY = float_of_int(line) *. editorFont.measuredHeight;

--- a/src/Feature/Editor/EditorVerticalScrollbar.re
+++ b/src/Feature/Editor/EditorVerticalScrollbar.re
@@ -38,8 +38,7 @@ let make =
       backgroundColor(colors.scrollbarSliderBackground),
     ];
 
-  let totalPixel =
-    Editor.getTotalSizeInPixels(editor) |> float_of_int;
+  let totalPixel = Editor.getTotalSizeInPixels(editor) |> float_of_int;
 
   let bufferLineToScrollbarPixel = line => {
     let pixelY = float_of_int(line) *. editorFont.measuredHeight;

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -84,7 +84,7 @@ let absoluteStyle =
   ];
 
 let getMinimapSize = (view: Editor.t, metrics) => {
-  let currentViewSize = Editor.getVisibleView(metrics);
+  let currentViewSize = Editor.getVisibleView(view, metrics);
 
   view.viewLines < currentViewSize ? 0 : currentViewSize + 1;
 };
@@ -125,8 +125,8 @@ let%component make =
     React.Hooks.reducer(~initialState, reducer);
 
   let getScrollTo = (mouseY: float) => {
-    let totalHeight: int = Editor.getTotalSizeInPixels(editor, metrics);
-    let visibleHeight: int = metrics.pixelHeight;
+    let totalHeight: int = Editor.getTotalSizeInPixels(editor);
+    let visibleHeight: int = EditorMetrics.(metrics.pixelHeight);
     let offsetMouseY: int = int_of_float(mouseY) - Constants.tabHeight;
     float(offsetMouseY) /. float(visibleHeight) *. float(totalHeight);
   };
@@ -186,7 +186,7 @@ let%component make =
             ~left=0.,
             ~top=
               rowHeight
-              *. float(Editor.getTopVisibleLine(editor, metrics) - 1)
+              *. float(Editor.getTopVisibleLine(editor) - 1)
               -. scrollY,
             ~height=rowHeight *. float(getMinimapSize(editor, metrics)),
             ~width=float(width),

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -91,8 +91,7 @@ let%component make =
       let relX = evt.mouseX -. minX;
 
       let numberOfLines = Buffer.getNumberOfLines(buffer);
-      let (line, col) =
-        Editor.pixelPositionToLineColumn(editor, relX, relY);
+      let (line, col) = Editor.pixelPositionToLineColumn(editor, relX, relY);
 
       if (line < numberOfLines) {
         Log.tracef(m => m("  topVisibleLine is %i", topVisibleLine));
@@ -186,11 +185,7 @@ let%component make =
       }}
     />
     <View style=Styles.horizontalScrollBar>
-      <EditorHorizontalScrollbar
-        editor
-        width={metrics.pixelWidth}
-        colors
-      />
+      <EditorHorizontalScrollbar editor width={metrics.pixelWidth} colors />
     </View>
   </View>;
 };

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -92,7 +92,7 @@ let%component make =
 
       let numberOfLines = Buffer.getNumberOfLines(buffer);
       let (line, col) =
-        Editor.pixelPositionToLineColumn(editor, metrics, relX, relY);
+        Editor.pixelPositionToLineColumn(editor, relX, relY);
 
       if (line < numberOfLines) {
         Log.tracef(m => m("  topVisibleLine is %i", topVisibleLine));
@@ -119,14 +119,14 @@ let%component make =
     ref={node => elementRef := Some(node)}
     style={Styles.bufferViewClipped(
       gutterWidth,
-      float(metrics.pixelWidth) -. gutterWidth,
+      float(EditorMetrics.(metrics.pixelWidth)) -. gutterWidth,
     )}
     onMouseUp
     onMouseWheel>
     <Canvas
       style={Styles.bufferViewClipped(
         0.,
-        float(metrics.pixelWidth) -. gutterWidth,
+        float(EditorMetrics.(metrics.pixelWidth)) -. gutterWidth,
       )}
       render={canvasContext => {
         let context =
@@ -188,7 +188,6 @@ let%component make =
     <View style=Styles.horizontalScrollBar>
       <EditorHorizontalScrollbar
         editor
-        metrics
         width={metrics.pixelWidth}
         colors
       />

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -45,11 +45,25 @@ let setActiveEditor = (model, editorId) => {
   activeEditorId: Some(editorId),
 };
 
-let getOrCreateEditorForBuffer = (state, bufferId) => {
+let setBufferFont = (~bufferId, ~font, group) => {
+  let editors =
+    group.editors
+    |> IntMap.map((editor: Feature_Editor.Editor.t) =>
+         if (editor.bufferId == bufferId) {
+           Editor.setFont(~font, editor);
+         } else {
+           editor;
+         }
+       );
+
+  {...group, editors};
+};
+
+let getOrCreateEditorForBuffer = (~font, ~bufferId, state) => {
   switch (IntMap.find_opt(bufferId, state.bufferIdToEditorId)) {
   | Some(editor) => (state, editor)
   | None =>
-    let newEditor = Editor.create(~font=Service_Font.default, ~bufferId, ());
+    let newEditor = Editor.create(~font, ~bufferId, ());
     let newState = {
       ...state,
       editors: IntMap.add(newEditor.editorId, newEditor, state.editors),

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -49,7 +49,7 @@ let getOrCreateEditorForBuffer = (state, bufferId) => {
   switch (IntMap.find_opt(bufferId, state.bufferIdToEditorId)) {
   | Some(editor) => (state, editor)
   | None =>
-    let newEditor = Editor.create(~bufferId, ());
+    let newEditor = Editor.create(~font=Service_Font.default, ~bufferId, ());
     let newState = {
       ...state,
       editors: IntMap.add(newEditor.editorId, newEditor, state.editors),

--- a/src/Model/EditorGroup.rei
+++ b/src/Model/EditorGroup.rei
@@ -16,9 +16,13 @@ let getMetrics: t => Feature_Editor.EditorMetrics.t;
 let getActiveEditor: t => option(Feature_Editor.Editor.t);
 let setActiveEditor: (t, int) => t;
 let getEditorById: (int, t) => option(Feature_Editor.Editor.t);
-let getOrCreateEditorForBuffer: (t, int) => (t, Feature_Editor.EditorId.t);
+let getOrCreateEditorForBuffer:
+  (~font: Service_Font.font, ~bufferId: int, t) =>
+  (t, Feature_Editor.EditorId.t);
 let nextEditor: t => t;
 let previousEditor: t => t;
 let removeEditorById: (t, int) => t;
+
+let setBufferFont: (~bufferId: int, ~font: Service_Font.font, t) => t;
 
 let isEmpty: t => bool;

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -28,7 +28,7 @@ let reduce = (~defaultFont, v: EditorGroup.t, action: Actions.t) => {
           editors,
         ),
     }
-  | BufferEnter({id, fileType, _}, _) =>
+  | BufferEnter({id, _}, _) =>
     let (newState, activeEditorId) =
       EditorGroup.getOrCreateEditorForBuffer(
         ~font=defaultFont,

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -6,7 +6,7 @@
 
 open Oni_Core;
 
-let reduce = (v: EditorGroup.t, action: Actions.t) => {
+let reduce = (~defaultFont, v: EditorGroup.t, action: Actions.t) => {
   let metrics = EditorMetricsReducer.reduce(v.metrics, action);
 
   /* Only send updates to _active_ editor */
@@ -20,9 +20,22 @@ let reduce = (v: EditorGroup.t, action: Actions.t) => {
   let v = {...v, metrics, editors};
 
   switch (action) {
-  | BufferEnter({id, _}, _) =>
+  | EditorFont(Service_Font.FontLoaded(font)) => {
+      ...v,
+      editors:
+        IntMap.map(
+          editor => Feature_Editor.Editor.setFont(~font, editor),
+          editors,
+        ),
+    }
+  | BufferEnter({id, fileType, _}, _) =>
     let (newState, activeEditorId) =
-      EditorGroup.getOrCreateEditorForBuffer(v, id);
+      EditorGroup.getOrCreateEditorForBuffer(
+        ~font=defaultFont,
+        ~bufferId=id,
+        v,
+      );
+
     {...newState, activeEditorId: Some(activeEditorId)};
   | Command("workbench.action.nextEditor") => EditorGroup.nextEditor(v)
   | Command("workbench.action.previousEditor") =>

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -9,4 +9,6 @@ let getActiveEditorGroup: t => option(EditorGroup.t);
 let isActive: (t, EditorGroup.t) => bool;
 let isEmpty: (int, t) => bool;
 
-let reduce: (t, Actions.t) => t;
+let reduce: (~defaultFont: Service_Font.font, t, Actions.t) => t;
+
+let setBufferFont: (~bufferId: int, ~font: Service_Font.font, t) => t;

--- a/src/Model/EditorMetricsReducer.re
+++ b/src/Model/EditorMetricsReducer.re
@@ -7,16 +7,14 @@ open Feature_Editor;
 
 let reduce = (v: EditorMetrics.t, action) => {
   switch (action) {
-  | EditorGroupSetSize(_, {pixelWidth, pixelHeight}) => EditorMetrics.{
-      pixelWidth,
-      pixelHeight,
-    };
-// TODO: Move elsewhere
-/*  | EditorFont(Service_Font.FontLoaded({measuredHeight, measuredWidth, _})) => {
-      ...v,
-      lineHeight: measuredHeight,
-      characterWidth: measuredWidth,
-    }*/
+  | EditorGroupSetSize(_, {pixelWidth, pixelHeight}) =>
+    EditorMetrics.{pixelWidth, pixelHeight}
+  // TODO: Move elsewhere
+  /*  | EditorFont(Service_Font.FontLoaded({measuredHeight, measuredWidth, _})) => {
+        ...v,
+        lineHeight: measuredHeight,
+        characterWidth: measuredWidth,
+      }*/
   | _ => v
   };
 };

--- a/src/Model/EditorMetricsReducer.re
+++ b/src/Model/EditorMetricsReducer.re
@@ -7,16 +7,16 @@ open Feature_Editor;
 
 let reduce = (v: EditorMetrics.t, action) => {
   switch (action) {
-  | EditorGroupSetSize(_, {pixelWidth, pixelHeight}) => {
-      ...v,
+  | EditorGroupSetSize(_, {pixelWidth, pixelHeight}) => EditorMetrics.{
       pixelWidth,
       pixelHeight,
-    }
-  | EditorFont(Service_Font.FontLoaded({measuredHeight, measuredWidth, _})) => {
+    };
+// TODO: Move elsewhere
+/*  | EditorFont(Service_Font.FontLoaded({measuredHeight, measuredWidth, _})) => {
       ...v,
       lineHeight: measuredHeight,
       characterWidth: measuredWidth,
-    }
+    }*/
   | _ => v
   };
 };

--- a/src/Model/EditorMetricsReducer.re
+++ b/src/Model/EditorMetricsReducer.re
@@ -9,12 +9,6 @@ let reduce = (v: EditorMetrics.t, action) => {
   switch (action) {
   | EditorGroupSetSize(_, {pixelWidth, pixelHeight}) =>
     EditorMetrics.{pixelWidth, pixelHeight}
-  // TODO: Move elsewhere
-  /*  | EditorFont(Service_Font.FontLoaded({measuredHeight, measuredWidth, _})) => {
-        ...v,
-        lineHeight: measuredHeight,
-        characterWidth: measuredWidth,
-      }*/
   | _ => v
   };
 };

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -29,7 +29,7 @@ module Internal = {
 let scrollTo = (view, newScrollY, metrics: EditorMetrics.t) => {
   let newScrollY = max(0., newScrollY);
   let availableScroll =
-    max(float_of_int(view.viewLines - 1), 0.) *. Editor.getLineHeight(view)
+    max(float_of_int(view.viewLines - 1), 0.) *. Editor.getLineHeight(view);
   let newScrollY = min(newScrollY, availableScroll);
 
   let scrollPercentage =

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -29,7 +29,7 @@ module Internal = {
 let scrollTo = (view, newScrollY, metrics: EditorMetrics.t) => {
   let newScrollY = max(0., newScrollY);
   let availableScroll =
-    max(float_of_int(view.viewLines - 1), 0.) *. metrics.lineHeight;
+    max(float_of_int(view.viewLines - 1), 0.) *. Editor.getLineHeight(view)
   let newScrollY = min(newScrollY, availableScroll);
 
   let scrollPercentage =
@@ -46,7 +46,7 @@ let scrollTo = (view, newScrollY, metrics: EditorMetrics.t) => {
 };
 
 let scrollToLine = (view, line, metrics: EditorMetrics.t) => {
-  let scrollAmount = float_of_int(line) *. metrics.lineHeight;
+  let scrollAmount = float_of_int(line) *. Editor.getLineHeight(view);
   scrollTo(view, scrollAmount, metrics);
 };
 
@@ -57,7 +57,7 @@ let scrollToHorizontal = (view, newScrollX, metrics: EditorMetrics.t) => {
     max(
       0.,
       float_of_int(view.maxLineLength)
-      *. metrics.characterWidth
+      *. Editor.getCharacterWidth(view)
       -. float(metrics.pixelWidth),
     );
   let scrollX = min(newScrollX, availableScroll);
@@ -66,7 +66,7 @@ let scrollToHorizontal = (view, newScrollX, metrics: EditorMetrics.t) => {
 };
 
 let scrollToColumn = (view, column, metrics: EditorMetrics.t) => {
-  let scrollAmount = float_of_int(column) *. metrics.characterWidth;
+  let scrollAmount = float_of_int(column) *. Editor.getCharacterWidth(view);
   scrollToHorizontal(view, scrollAmount, metrics);
 };
 

--- a/src/Model/EditorVisibleRanges.re
+++ b/src/Model/EditorVisibleRanges.re
@@ -11,10 +11,10 @@ type individualRange = {
 };
 
 let getVisibleRangesForEditor = (editor: Editor.t, metrics: EditorMetrics.t) => {
-  let topVisibleLine = Editor.getTopVisibleLine(editor, metrics);
+  let topVisibleLine = Editor.getTopVisibleLine(editor);
   let bottomVisibleLine = Editor.getBottomVisibleLine(editor, metrics);
 
-  let leftVisibleColumn = Editor.getLeftVisibleColumn(editor, metrics);
+  let leftVisibleColumn = Editor.getLeftVisibleColumn(editor);
 
   let {bufferWidthInCharacters, minimapWidthInCharacters, _}: EditorLayout.t =
     Editor.getLayout(editor, metrics);

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -207,7 +207,11 @@ let start = (getState, contributedCommands) => {
         | Some(b) =>
           let ec = EditorGroup.create();
           let (g, editorId) =
-            EditorGroup.getOrCreateEditorForBuffer(ec, Buffer.getId(b));
+            EditorGroup.getOrCreateEditorForBuffer(
+              ~font=state.editorFont,
+              ~bufferId=Buffer.getId(b),
+              ec,
+            );
           let g = EditorGroup.setActiveEditor(g, editorId);
           g;
         | None => EditorGroup.create()

--- a/src/Store/Reducer.re
+++ b/src/Store/Reducer.re
@@ -22,7 +22,8 @@ let reduce: (State.t, Actions.t) => State.t =
         bufferRenderers: BufferRendererReducer.reduce(s.bufferRenderers, a),
         commands: Commands.reduce(s.commands, a),
         definition: DefinitionReducer.reduce(a, s.definition),
-        editorGroups: EditorGroups.reduce(s.editorGroups, a),
+        editorGroups:
+          EditorGroups.reduce(~defaultFont=s.editorFont, s.editorGroups, a),
         extensions: ExtensionsReducer.reduce(a, s.extensions),
         languageFeatures:
           LanguageFeaturesReducer.reduce(a, s.languageFeatures),

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -533,16 +533,9 @@ let start =
         let () =
           editor
           |> Option.iter(e => {
-               let () =
-                 state
-                 |> Selectors.getActiveEditorGroup
-                 |> Option.map(EditorGroup.getMetrics)
-                 |> Option.iter(metrics => {
                       let topLine = Editor.getTopVisibleLine(e);
                       let leftCol = Editor.getLeftVisibleColumn(e);
                       Vim.Window.setTopLeft(topLine, leftCol);
-                    });
-               ();
              });
 
         let syntaxScope =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -533,9 +533,9 @@ let start =
         let () =
           editor
           |> Option.iter(e => {
-                      let topLine = Editor.getTopVisibleLine(e);
-                      let leftCol = Editor.getLeftVisibleColumn(e);
-                      Vim.Window.setTopLeft(topLine, leftCol);
+               let topLine = Editor.getTopVisibleLine(e);
+               let leftCol = Editor.getLeftVisibleColumn(e);
+               Vim.Window.setTopLeft(topLine, leftCol);
              });
 
         let syntaxScope =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -538,8 +538,8 @@ let start =
                  |> Selectors.getActiveEditorGroup
                  |> Option.map(EditorGroup.getMetrics)
                  |> Option.iter(metrics => {
-                      let topLine = Editor.getTopVisibleLine(e, metrics);
-                      let leftCol = Editor.getLeftVisibleColumn(e, metrics);
+                      let topLine = Editor.getTopVisibleLine(e);
+                      let leftCol = Editor.getLeftVisibleColumn(e);
                       Vim.Window.setTopLeft(topLine, leftCol);
                     });
                ();

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -159,7 +159,6 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             onDimensionsChanged={_ => ()}
             onScroll
             theme
-            editorFont={state.editorFont}
             mode
             bufferHighlights={state.bufferHighlights}
             bufferSyntaxHighlights={state.syntaxHighlights}


### PR DESCRIPTION
This is a refactoring in preparation for terminal-normal mode - we currently have two different font settings (one for the editor, and one for the terminal). 

However, for the terminal, it's a bit jarring if we're switching back and forth between those fonts - without any changes, we'd switch from the terminal font to the editor font when entering 'terminal normal mode'.

This is an incremental refactoring - to allow editors to have individual settings for fonts. This decouples the font-sizing from the `EditorMetrics.t` (which hopefully we can get rid of completely, soon - and allow `Editor.t` to stand on its own!)