### PR TITLE
Feature - Auto-Closing Brackets: Enable by default

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -23,6 +23,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 ### Editor
 
+- `editor.autoClosingBrackets` __(_"LanguageDefined"|"Never"_ default: `"LanguageDefined"`)__ - When set to `"LanguageDefined"`, Onivim will automatically close brackets and pairs, based on language configuration.
+
 - `editor.detectIndentation` __(_bool_ default: `true`)__ - Allow Onivim to auto-detect indentation settings (tab vs space, indent size)
 
 - `editor.fontFamily` __(_string_)__ - The font family used by the editor surface. This must be a monospace font. The font may be specified by either the name of the font, or an absolute path to the font file.

--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -141,6 +141,21 @@ let parseFontSmoothing: Yojson.Safe.t => ConfigurationValues.fontSmoothing =
     | _ => Default
     };
 
+let parseAutoClosingBrackets: Yojson.Safe.t => ConfigurationValues.autoClosingBrackets =
+  json =>
+    switch (json) {
+    | `Bool(true) => LanguageDefined
+    | `Bool(false) => Never
+    | `String(autoClosingBrackets) =>
+      let autoClosingBrackets = String.lowercase_ascii(autoClosingBrackets);
+      switch (autoClosingBrackets) {
+      | "never" => Never
+      | "languagedefined" => LanguageDefined
+      | _ => Never
+      };
+    | _ => Never
+    };
+
 let parseQuickSuggestions: Yojson.Safe.t => quickSuggestionsEnabled = {
   let decode =
     Json.Decode.(
@@ -182,6 +197,13 @@ type parseFunction =
 type configurationTuple = (string, parseFunction);
 
 let configurationParsers: list(configurationTuple) = [
+  (
+    "editor.autoClosingBrackets",
+    (config, json) => {
+      ...config,
+      editorAutoClosingBrackets: parseAutoClosingBrackets(json)
+    },
+  ),
   (
     "editor.fontFamily",
     (config, json) => {
@@ -419,13 +441,6 @@ let configurationParsers: list(configurationTuple) = [
   (
     "experimental.treeSitter",
     (config, json) => {...config, experimentalTreeSitter: parseBool(json)},
-  ),
-  (
-    "experimental.autoClosingPairs",
-    (config, json) => {
-      ...config,
-      experimentalAutoClosingPairs: parseBool(json),
-    },
   ),
   (
     "experimental.viml",

--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -141,7 +141,8 @@ let parseFontSmoothing: Yojson.Safe.t => ConfigurationValues.fontSmoothing =
     | _ => Default
     };
 
-let parseAutoClosingBrackets: Yojson.Safe.t => ConfigurationValues.autoClosingBrackets =
+let parseAutoClosingBrackets:
+  Yojson.Safe.t => ConfigurationValues.autoClosingBrackets =
   json =>
     switch (json) {
     | `Bool(true) => LanguageDefined
@@ -201,7 +202,7 @@ let configurationParsers: list(configurationTuple) = [
     "editor.autoClosingBrackets",
     (config, json) => {
       ...config,
-      editorAutoClosingBrackets: parseAutoClosingBrackets(json)
+      editorAutoClosingBrackets: parseAutoClosingBrackets(json),
     },
   ),
   (

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -84,7 +84,6 @@ type t = {
   // Turn on tree-sitter for supported filetypes:
   // - JSON
   experimentalTreeSitter: bool,
-  experimentalAutoClosingPairs: bool,
   experimentalVimL: list(string),
 };
 
@@ -141,6 +140,5 @@ let default = {
   zenModeSingleFile: true,
 
   experimentalTreeSitter: false,
-  experimentalAutoClosingPairs: false,
   experimentalVimL: [],
 };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -564,9 +564,11 @@ let start =
             c => c.editorAutoClosingBrackets,
             state.configuration,
           )
-          |> fun 
-          | LanguageDefined => true
-          | Never => false;
+          |> (
+            fun
+            | LanguageDefined => true
+            | Never => false
+          );
 
         let autoClosingPairs =
           if (acpEnabled) {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -561,9 +561,12 @@ let start =
 
         let acpEnabled =
           Core.Configuration.getValue(
-            c => c.experimentalAutoClosingPairs,
+            c => c.editorAutoClosingBrackets,
             state.configuration,
-          );
+          )
+          |> fun 
+          | LanguageDefined => true
+          | Never => false;
 
         let autoClosingPairs =
           if (acpEnabled) {


### PR DESCRIPTION
This promotes the auto-closing brackets from an experimental feature to on-by-default:

![2020-03-28 13 09 05](https://user-images.githubusercontent.com/13532591/77832748-7cb8b680-70f5-11ea-9079-e4cdefbd8344.gif)

Uses the `language-configuration.json` provided by extensions to pick up the list of pairs that should be completed.

If you prefer the previous behavior, please set this configuration setting:
```
"editor.autoClosingBrackets": "never",
```

