### PR TITLE
Feature - Terminal: Use terminal font + background / foreground color

### DIFF
--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -113,6 +113,9 @@ let minimap =
 
 let make =
     (
+      ~showDiffMarkers=true,
+      ~backgroundColor: option(Revery.Color.t)=?,
+      ~foregroundColor: option(Revery.Color.t)=?,
       ~buffer,
       ~onDimensionsChanged,
       ~isActiveSplit: bool,
@@ -133,6 +136,18 @@ let make =
       (),
     ) => {
   let colors = Colors.precompute(theme);
+
+  let colors =
+    backgroundColor
+    |> Option.map(editorBackground =>
+         {...colors, gutterBackground: editorBackground, editorBackground}
+       )
+    |> Option.value(~default=colors);
+  let colors =
+    foregroundColor
+    |> Option.map(editorForeground => {...colors, editorForeground})
+    |> Option.value(~default=colors);
+
   let lineCount = Buffer.getNumberOfLines(buffer);
 
   let editorFont = editor.font;
@@ -169,7 +184,7 @@ let make =
     Selection.getRanges(editor.selection, buffer) |> Range.toHash;
 
   let diffMarkers =
-    lineCount < Constants.diffMarkersMaxLineCount
+    lineCount < Constants.diffMarkersMaxLineCount && showDiffMarkers
       ? EditorDiffMarkers.generate(buffer) : None;
 
   let (gutterWidth, gutterView) =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1012,7 +1012,18 @@ let start =
         OptionEx.map3(
           (bufferId, terminalId, editorId) => {
             let lines = Feature_Terminal.getLines(~terminalId);
-            (state, setTerminalLinesEffect(~bufferId, ~editorId, lines));
+
+            let editorGroups =
+              state.editorGroups
+              |> EditorGroups.setBufferFont(
+                   ~bufferId,
+                   ~font=state.terminalFont,
+                 );
+
+            (
+              {...state, editorGroups},
+              setTerminalLinesEffect(~bufferId, ~editorId, lines),
+            );
           },
           maybeBufferId,
           maybeTerminalId,

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -150,7 +150,15 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             Selectors.getBufferForEditor(state, editor)
             |> Option.value(~default=Buffer.initial);
 
+          let defaultTerminalBackground =
+            Feature_Terminal.defaultBackground(theme);
+          let defaultTerminalForeground =
+            Feature_Terminal.defaultForeground(theme);
+
           <EditorSurface
+            backgroundColor=defaultTerminalBackground
+            foregroundColor=defaultTerminalForeground
+            showDiffMarkers=false
             isActiveSplit=isActive
             metrics
             editor


### PR DESCRIPTION
When switching to "Terminal Normal" mode, this uses the terminal font and terminal background/foreground color (overriding the default editor colors), to help smooth the transition. It also disables the diff markers in this mode:

![2020-03-28 13 58 42](https://user-images.githubusercontent.com/13532591/77833660-62cea200-70fc-11ea-96a6-79b734ad010a.gif)
