### PR TITLE
Feature - Terminal: Preserve cell colors in transition to normal mode

### DIFF
--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -41,15 +41,18 @@ type msg =
   | BufferUpdated([@opaque] BufferUpdate.t)
   | Service(Service_Syntax.msg);
 
-type t = BufferMap.t(LineMap.t(list(ColorizedToken.t)));
+type t = {
+ highlights: BufferMap.t(LineMap.t(list(ColorizedToken.t))),
+ ignoredBuffers: BufferMap.t(bool)
+};
 
-let empty = BufferMap.empty;
+let empty = { ignoredBuffers: BufferMap.empty, highlights: BufferMap.empty };
 
 let noTokens = [];
 
 module ClientLog = (val Oni_Core.Log.withNamespace("Oni2.Feature.Syntax"));
 
-let getTokens = (~bufferId: int, ~line: Index.t, highlights: t) => {
+let getTokens = (~bufferId: int, ~line: Index.t, { highlights, _ }) => {
   highlights
   |> BufferMap.find_opt(bufferId)
   |> OptionEx.flatMap(LineMap.find_opt(line |> Index.toZeroBased))
@@ -57,8 +60,8 @@ let getTokens = (~bufferId: int, ~line: Index.t, highlights: t) => {
 };
 
 let getSyntaxScope =
-    (~bufferId: int, ~line: Index.t, ~bytePosition: int, highlights: t) => {
-  let tokens = getTokens(~bufferId, ~line, highlights);
+    (~bufferId: int, ~line: Index.t, ~bytePosition: int, bufferHighlights) => {
+  let tokens = getTokens(~bufferId, ~line, bufferHighlights);
 
   let rec loop = (syntaxScope, currentTokens) => {
     ColorizedToken.(
@@ -82,19 +85,20 @@ let setTokensForLine =
       ~bufferId: int,
       ~line: int,
       ~tokens: list(ColorizedToken.t),
-      highlights: t,
+      { highlights, ignoredBuffers }: t,
     ) => {
   let updateLineMap = (lineMap: LineMap.t(list(ColorizedToken.t))) => {
     LineMap.update(line, _ => Some(tokens), lineMap);
   };
 
-  BufferMap.update(
+  let highlights = BufferMap.update(
     bufferId,
     fun
     | None => Some(updateLineMap(LineMap.empty))
     | Some(v) => Some(updateLineMap(v)),
     highlights,
   );
+  { ignoredBuffers, highlights: highlights };
 };
 
 let setTokens = (tokenUpdates: list(Protocol.TokenUpdate.t), highlights: t) => {
@@ -114,9 +118,19 @@ let setTokens = (tokenUpdates: list(Protocol.TokenUpdate.t), highlights: t) => {
   );
 };
 
+let ignore = (~bufferId, bufferHighlights) => {
+  let ignoredBuffers = bufferHighlights.ignoredBuffers
+    |> BufferMap.add(bufferId, true);
+
+  { ...bufferHighlights, ignoredBuffers };
+}
+
 // When there is a buffer update, shift the lines to match
-let handleUpdate = (bufferUpdate: BufferUpdate.t, highlights: t) => {
-  BufferMap.update(
+let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) => {
+  if (BufferMap.mem(bufferUpdate.id, bufferHighlights.ignoredBuffers)) {
+    bufferHighlights 
+  } else {
+  let highlights = BufferMap.update(
     bufferUpdate.id,
     fun
     | None => None
@@ -130,8 +144,10 @@ let handleUpdate = (bufferUpdate: BufferUpdate.t, highlights: t) => {
           lineMap,
         ),
       ),
-    highlights,
+    bufferHighlights.highlights,
   );
+  { ...bufferHighlights, highlights: highlights };
+  };
 };
 
 let update = (highlights: t, msg) =>

--- a/src/Feature/Syntax/Feature_Syntax.rei
+++ b/src/Feature/Syntax/Feature_Syntax.rei
@@ -32,6 +32,11 @@ let setTokensForLine:
 
 let update: (t, msg) => t;
 
+// [ignore(~bufferId, syntax)] marks a buffer to be ignored.
+// The only syntax highlight adjustment will come from explicit
+// calls to [setTokensForLine];
+let ignore: (~bufferId: int, t) => t;
+
 let subscription:
   (
     ~enabled: bool,

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -301,7 +301,9 @@ let getFirstNonEmptyLineFromBottom = (lines: array(string)) => {
   getFirstNonEmptyLine(~start=Array.length(lines) - 1, ~direction=-1, lines);
 };
 
-let getLines = (~terminalId) => {
+type highlights = (int, list(ColorizedToken.t));
+
+let getLinesAndHighlights = (~terminalId) => {
   terminalId
   |> Service_Terminal.getScreen
   |> Option.map(screen => {
@@ -332,12 +334,14 @@ let getLines = (~terminalId) => {
        let startLine = getFirstNonEmptyLineFromTop(lines);
        let bottomLine = getFirstNonEmptyLineFromBottom(lines);
 
-       Utility.ArrayEx.slice(
+       let lines = Utility.ArrayEx.slice(
          ~start=startLine,
          ~length=bottomLine - startLine + 1,
          ~lines,
          (),
        );
+
+       (lines, []);
      })
-  |> Option.value(~default=[||]);
+  |> Option.value(~default=([||], []));
 };

--- a/src/Feature/Terminal/Feature_Terminal.rei
+++ b/src/Feature/Terminal/Feature_Terminal.rei
@@ -85,6 +85,7 @@ let theme: ColorTheme.resolver => ReveryTerminal.Theme.t;
 let defaultBackground: ColorTheme.resolver => Revery.Color.t;
 let defaultForeground: ColorTheme.resolver => Revery.Color.t;
 
-let getLines: (~terminalId: int) => array(string);
+type highlights = (int, list(ColorizedToken.t));
+let getLinesAndHighlights: (~terminalId: int) => (array(string), list(highlights));
 
 module Contributions: {let colors: list(ColorTheme.Schema.definition);};

--- a/src/Feature/Terminal/Feature_Terminal.rei
+++ b/src/Feature/Terminal/Feature_Terminal.rei
@@ -86,6 +86,8 @@ let defaultBackground: ColorTheme.resolver => Revery.Color.t;
 let defaultForeground: ColorTheme.resolver => Revery.Color.t;
 
 type highlights = (int, list(ColorizedToken.t));
-let getLinesAndHighlights: (~terminalId: int) => (array(string), list(highlights));
+let getLinesAndHighlights:
+  (~colorTheme: ColorTheme.resolver, ~terminalId: int) =>
+  (array(string), list(highlights));
 
 module Contributions: {let colors: list(ColorTheme.Schema.definition);};

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1016,8 +1016,26 @@ let start =
       let (state, effect) =
         OptionEx.map3(
           (bufferId, terminalId, editorId) => {
-            let lines = Feature_Terminal.getLines(~terminalId);
-            (state, setTerminalLinesEffect(~bufferId, ~editorId, lines));
+            let (lines, highlights) = Feature_Terminal.getLinesAndHighlights(~terminalId);
+            let syntaxHighlights =
+                    List.fold_left(
+                      (acc, curr) => {
+                        let (line, tokens) = curr;
+                        Feature_Syntax.setTokensForLine(
+                          ~bufferId,
+                          ~line,
+                          ~tokens,
+                          acc,
+                        );
+                      },
+                      state.syntaxHighlights,
+                      highlights,
+                    );
+
+            let syntaxHighlights =
+            syntaxHighlights
+            |> Feature_Syntax.ignore(~bufferId);
+            ({...state, syntaxHighlights}, setTerminalLinesEffect(~bufferId, ~editorId, lines));
           },
           maybeBufferId,
           maybeTerminalId,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1016,26 +1016,33 @@ let start =
       let (state, effect) =
         OptionEx.map3(
           (bufferId, terminalId, editorId) => {
-            let (lines, highlights) = Feature_Terminal.getLinesAndHighlights(~terminalId);
+            let colorTheme = Feature_Theme.resolver(state.colorTheme);
+            let (lines, highlights) =
+              Feature_Terminal.getLinesAndHighlights(
+                ~colorTheme,
+                ~terminalId,
+              );
             let syntaxHighlights =
-                    List.fold_left(
-                      (acc, curr) => {
-                        let (line, tokens) = curr;
-                        Feature_Syntax.setTokensForLine(
-                          ~bufferId,
-                          ~line,
-                          ~tokens,
-                          acc,
-                        );
-                      },
-                      state.syntaxHighlights,
-                      highlights,
-                    );
+              List.fold_left(
+                (acc, curr) => {
+                  let (line, tokens) = curr;
+                  Feature_Syntax.setTokensForLine(
+                    ~bufferId,
+                    ~line,
+                    ~tokens,
+                    acc,
+                  );
+                },
+                state.syntaxHighlights,
+                highlights,
+              );
 
             let syntaxHighlights =
-            syntaxHighlights
-            |> Feature_Syntax.ignore(~bufferId);
-            ({...state, syntaxHighlights}, setTerminalLinesEffect(~bufferId, ~editorId, lines));
+              syntaxHighlights |> Feature_Syntax.ignore(~bufferId);
+            (
+              {...state, syntaxHighlights},
+              setTerminalLinesEffect(~bufferId, ~editorId, lines),
+            );
           },
           maybeBufferId,
           maybeTerminalId,


### PR DESCRIPTION
This converts the terminal cell colors to syntax highlights when switching from insert -> normal mode:

![2020-03-28 16 16 46](https://user-images.githubusercontent.com/13532591/77836021-b696b680-710f-11ea-8ca8-f90a6d1ca5b7.gif)

It'll look even better when combined with #1517 (which preserves the font and uses the terminal background / foreground colors)