### PR TITLE
Bugfix: Don't crash when opening single file with zen mode disabled

### DIFF
--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -12,7 +12,7 @@ let simpleState = {
 
   Reducer.reduce(
     state,
-    Actions.EditorGroupSetSize({
+    Actions.EditorGroupSizeChanged({
       id: EditorGroups.activeGroupId(state.editorGroups),
       width: 3440,
       height: 1440,

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -12,10 +12,11 @@ let simpleState = {
 
   Reducer.reduce(
     state,
-    Actions.EditorGroupSetSize(
-      EditorGroups.activeGroupId(state.editorGroups),
-      EditorSize.create(~pixelWidth=3440, ~pixelHeight=1440, ()),
-    ),
+    Actions.EditorGroupSetSize({
+      id: EditorGroups.activeGroupId(state.editorGroups),
+      width: 3440,
+      height: 1440,
+    }),
   );
 };
 

--- a/bench/lib/ReducerBench.re
+++ b/bench/lib/ReducerBench.re
@@ -1,4 +1,3 @@
-open Oni_Core;
 open Oni_Model;
 open Oni_Store;
 open BenchFramework;
@@ -17,10 +16,11 @@ let doubleEditorSize = () => {
   let _ =
     Reducer.reduce(
       state,
-      Actions.EditorGroupSetSize(
-        editorGroup.editorGroupId,
-        EditorSize.create(~pixelWidth=3200, ~pixelHeight=2400, ()),
-      ),
+      Actions.EditorGroupSetSize({
+        id: editorGroup.editorGroupId,
+        width: 3200,
+        height: 2400,
+      }),
     );
   ();
 };

--- a/bench/lib/ReducerBench.re
+++ b/bench/lib/ReducerBench.re
@@ -16,7 +16,7 @@ let doubleEditorSize = () => {
   let _ =
     Reducer.reduce(
       state,
-      Actions.EditorGroupSetSize({
+      Actions.EditorGroupSizeChanged({
         id: editorGroup.editorGroupId,
         width: 3200,
         height: 2400,

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -19,7 +19,6 @@ module ConfigurationTransformer = ConfigurationTransformer;
 module ConfigurationValues = ConfigurationValues;
 module Constants = Constants;
 module Diff = Diff;
-module EditorSize = EditorSize;
 module EnvironmentVariables = Kernel.EnvironmentVariables;
 module Filesystem = Filesystem;
 module Filter = Filter;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -81,7 +81,11 @@ type t =
   | WindowTitleSet(string)
   | WindowTreeSetSize(int, int)
   | EditorGroupAdd(EditorGroup.t)
-  | EditorGroupSetSize(int, EditorSize.t)
+  | EditorGroupSetSize({
+      id: int,
+      width: int,
+      height: int,
+    })
   | EditorCursorMove(Feature_Editor.EditorId.t, [@opaque] list(Vim.Cursor.t))
   | EditorSetScroll(Feature_Editor.EditorId.t, float)
   | EditorScroll(Feature_Editor.EditorId.t, float)

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -81,7 +81,7 @@ type t =
   | WindowTitleSet(string)
   | WindowTreeSetSize(int, int)
   | EditorGroupAdd(EditorGroup.t)
-  | EditorGroupSetSize({
+  | EditorGroupSizeChanged({
       id: int,
       width: int,
       height: int,

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -104,7 +104,7 @@ let reduce = (~defaultFont, model, action: Actions.t) => {
         IntMap.add(editorGroup.editorGroupId, editorGroup, model.idToGroup),
     };
 
-  | EditorGroupSetSize({id, _}) =>
+  | EditorGroupSizeChanged({id, _}) =>
     let idToGroup =
       IntMap.update(
         id,

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -104,10 +104,10 @@ let reduce = (~defaultFont, model, action: Actions.t) => {
         IntMap.add(editorGroup.editorGroupId, editorGroup, model.idToGroup),
     };
 
-  | EditorGroupSetSize(editorGroupId, _) =>
+  | EditorGroupSetSize({id, _}) =>
     let idToGroup =
       IntMap.update(
-        editorGroupId,
+        id,
         editorGroup =>
           switch (editorGroup) {
           | Some(group) =>

--- a/src/Model/EditorMetricsReducer.re
+++ b/src/Model/EditorMetricsReducer.re
@@ -7,8 +7,8 @@ open Feature_Editor;
 
 let reduce = (v: EditorMetrics.t, action) => {
   switch (action) {
-  | EditorGroupSetSize(_, {pixelWidth, pixelHeight}) =>
-    EditorMetrics.{pixelWidth, pixelHeight}
+  | EditorGroupSetSize({width, height, _}) =>
+    EditorMetrics.{pixelWidth: width, pixelHeight: height}
   | _ => v
   };
 };

--- a/src/Model/EditorMetricsReducer.re
+++ b/src/Model/EditorMetricsReducer.re
@@ -7,7 +7,7 @@ open Feature_Editor;
 
 let reduce = (v: EditorMetrics.t, action) => {
   switch (action) {
-  | EditorGroupSetSize({width, height, _}) =>
+  | EditorGroupSizeChanged({width, height, _}) =>
     EditorMetrics.{pixelWidth: width, pixelHeight: height}
   | _ => v
   };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -975,7 +975,7 @@ let start =
     | BufferEnter(_)
     | EditorFont(Service_Font.FontLoaded(_))
     | WindowSetActive(_, _)
-    | EditorGroupSetSize(_) => (state, synchronizeEditorEffect(state))
+    | EditorGroupSizeChanged(_) => (state, synchronizeEditorEffect(state))
     | BufferSetIndentation(_, indent) => (
         state,
         synchronizeIndentationEffect(indent),

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -975,7 +975,7 @@ let start =
     | BufferEnter(_)
     | EditorFont(Service_Font.FontLoaded(_))
     | WindowSetActive(_, _)
-    | EditorGroupSetSize(_, _) => (state, synchronizeEditorEffect(state))
+    | EditorGroupSetSize(_) => (state, synchronizeEditorEffect(state))
     | BufferSetIndentation(_, indent) => (
         state,
         synchronizeIndentationEffect(indent),

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -111,6 +111,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
   let onDimensionsChanged =
       ({width, height}: NodeEvents.DimensionsChangedEventParams.t) => {
     let height = showTabs ? height - Constants.tabHeight : height;
+    let height = max(height, 0); // BUGFIX: #1525
 
     GlobalContext.current().notifyEditorSizeChanged(
       ~editorGroupId=editorGroup.editorGroupId,

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -113,11 +113,8 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
     let height = showTabs ? height - Constants.tabHeight : height;
     let height = max(height, 0); // BUGFIX: #1525
 
-    GlobalContext.current().notifyEditorSizeChanged(
-      ~editorGroupId=editorGroup.editorGroupId,
-      ~width,
-      ~height,
-      (),
+    GlobalContext.current().dispatch(
+      EditorGroupSetSize({id: editorGroup.editorGroupId, width, height}),
     );
   };
 

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -114,7 +114,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
     let height = max(height, 0); // BUGFIX: #1525
 
     GlobalContext.current().dispatch(
-      EditorGroupSetSize({id: editorGroup.editorGroupId, width, height}),
+      EditorGroupSizeChanged({id: editorGroup.editorGroupId, width, height}),
     );
   };
 

--- a/src/UI/GlobalContext.re
+++ b/src/UI/GlobalContext.re
@@ -11,15 +11,12 @@ open Oni_Core;
 open Oni_Model;
 
 type notifyWindowTreeSizeChanged = (~width: int, ~height: int, unit) => unit;
-type notifyEditorSizeChanged =
-  (~editorGroupId: int, ~width: int, ~height: int, unit) => unit;
 type editorScrollDelta =
   (~editorId: Feature_Editor.EditorId.t, ~deltaY: float, unit) => unit;
 type editorSetScroll =
   (~editorId: Feature_Editor.EditorId.t, ~scrollY: float, unit) => unit;
 
 type t = {
-  notifyEditorSizeChanged,
   notifyWindowTreeSizeChanged,
   editorScrollDelta,
   editorSetScroll,
@@ -34,9 +31,6 @@ let viewNoop: Views.viewOperation =
 
 let default = {
   notifyWindowTreeSizeChanged: (~width as _, ~height as _, ()) => (),
-  notifyEditorSizeChanged:
-    (~editorGroupId as _, ~width as _, ~height as _, ()) =>
-    (),
   editorScrollDelta: (~editorId as _, ~deltaY as _, ()) => (),
   editorSetScroll: (~editorId as _, ~scrollY as _, ()) => (),
   openEditorById: _ => (),

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -198,14 +198,11 @@ if (cliOptions.syntaxHighlightService) {
         dispatch(Model.Actions.WindowTreeSetSize(width, height)),
       notifyEditorSizeChanged: (~editorGroupId, ~width, ~height, ()) =>
         dispatch(
-          Model.Actions.EditorGroupSetSize(
-            editorGroupId,
-            Core.EditorSize.create(
-              ~pixelWidth=width,
-              ~pixelHeight=height,
-              (),
-            ),
-          ),
+          Model.Actions.EditorGroupSetSize({
+            id: editorGroupId,
+            width,
+            height,
+          }),
         ),
       openEditorById: id => {
         dispatch(Model.Actions.ViewSetActiveEditor(id));

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -196,14 +196,6 @@ if (cliOptions.syntaxHighlightService) {
     GlobalContext.set({
       notifyWindowTreeSizeChanged: (~width, ~height, ()) =>
         dispatch(Model.Actions.WindowTreeSetSize(width, height)),
-      notifyEditorSizeChanged: (~editorGroupId, ~width, ~height, ()) =>
-        dispatch(
-          Model.Actions.EditorGroupSetSize({
-            id: editorGroupId,
-            width,
-            height,
-          }),
-        ),
       openEditorById: id => {
         dispatch(Model.Actions.ViewSetActiveEditor(id));
       },


### PR DESCRIPTION
Fixes #1525

*Issue*: With `"editor.zenMode.singleFile": false`, opening a single file caused a crash.

*Defect*: When initially rendered the size of the editor will be reported as 0, and when subtracting the height of the tabs will lead to a negative height, which when later used with `List.init` causes it to raise an `Invalid_argument` exception, thus crashing the editor.

*Fix*: Ensure the height, after subtracting the height of the tabs, is >= 0.

Note that a crash could also have been avoided here by using a standard library with saner behaviour, but that's a slightly more involved fix.

I also took the opportunity to do a bit of incremental house cleaning while I was in the general area.