### PR TITLE
Fix #1434: Crash when vertical splitting terminal in zen mode

### DIFF
--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -54,7 +54,9 @@ module Sub = {
 
       let id = ({id, _}) => string_of_int(id);
 
+
       let init = (~params, ~dispatch) => {
+        prerr_endline ("Subscription init");
         let launchConfig =
           ExtHostClient.Terminal.ShellLaunchConfig.{
             name: "Terminal",
@@ -140,24 +142,31 @@ module Sub = {
       };
 
       let update = (~params: params, ~state: state, ~dispatch as _) => {
-        if (params.rows != state.rows || params.columns != state.columns) {
+          let rows = params.rows;
+          let columns = params.columns;
+        if (rows > 0 && columns >0 && (rows != state.rows || columns != state.columns)) {
+          prerr_endline(
+            Printf.sprintf("RESIZING - rows: %d columns: %d", rows, columns)
+          )
           ExtHostClient.Terminal.Requests.acceptProcessResize(
             params.id,
-            params.columns,
-            params.rows,
+            columns,
+            rows,
             params.extHostClient,
           );
 
           state.isResizing := true;
           ReveryTerminal.resize(
-            ~rows=params.rows,
-            ~columns=params.columns,
+            ~rows,
+            ~columns,
             state.terminal,
           );
           state.isResizing := false;
-        };
+        {...state, rows, columns };
+        } else {
+          state
+        }
 
-        {...state, rows: params.rows, columns: params.columns};
       };
 
       let dispose = (~params, ~state) => {

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -54,9 +54,7 @@ module Sub = {
 
       let id = ({id, _}) => string_of_int(id);
 
-
       let init = (~params, ~dispatch) => {
-        prerr_endline ("Subscription init");
         let launchConfig =
           ExtHostClient.Terminal.ShellLaunchConfig.{
             name: "Terminal",
@@ -142,12 +140,11 @@ module Sub = {
       };
 
       let update = (~params: params, ~state: state, ~dispatch as _) => {
-          let rows = params.rows;
-          let columns = params.columns;
-        if (rows > 0 && columns >0 && (rows != state.rows || columns != state.columns)) {
-          prerr_endline(
-            Printf.sprintf("RESIZING - rows: %d columns: %d", rows, columns)
-          )
+        let rows = params.rows;
+        let columns = params.columns;
+        if (rows > 0
+            && columns > 0
+            && (rows != state.rows || columns != state.columns)) {
           ExtHostClient.Terminal.Requests.acceptProcessResize(
             params.id,
             columns,
@@ -156,17 +153,12 @@ module Sub = {
           );
 
           state.isResizing := true;
-          ReveryTerminal.resize(
-            ~rows,
-            ~columns,
-            state.terminal,
-          );
+          ReveryTerminal.resize(~rows, ~columns, state.terminal);
           state.isResizing := false;
-        {...state, rows, columns };
+          {...state, rows, columns};
         } else {
-          state
-        }
-
+          state;
+        };
       };
 
       let dispose = (~params, ~state) => {

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -45,7 +45,6 @@ let make =
       (
         {height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t,
       ) => {
-    prerr_endline ("onDimensionsChanged!")
     // If we have a loaded font, figure out how many columns and rows we can show
     Option.iter(
       font => {
@@ -55,7 +54,6 @@ let make =
         let columns =
           float_of_int(width) /. terminalFont.characterWidth |> int_of_float;
 
-      prerr_endline (Printf.sprintf("Feature_Terminal.Resized - rows: %d columns: %d", rows, columns));
         GlobalContext.current().dispatch(
           Actions.Terminal(
             Feature_Terminal.Resized({id: terminal.id, rows, columns}),

--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -45,6 +45,7 @@ let make =
       (
         {height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t,
       ) => {
+    prerr_endline ("onDimensionsChanged!")
     // If we have a loaded font, figure out how many columns and rows we can show
     Option.iter(
       font => {
@@ -54,6 +55,7 @@ let make =
         let columns =
           float_of_int(width) /. terminalFont.characterWidth |> int_of_float;
 
+      prerr_endline (Printf.sprintf("Feature_Terminal.Resized - rows: %d columns: %d", rows, columns));
         GlobalContext.current().dispatch(
           Actions.Terminal(
             Feature_Terminal.Resized({id: terminal.id, rows, columns}),


### PR DESCRIPTION
__Issue:__ There would be a crash (segfault) when vertically splitting a terminal, while in Zen mode.

__Defect:__ In this case, we'd end up setting the terminal rows & columns to `0` - which would cause problems later when the terminal accepts input.

__Fix:__ Do not allow 0-sized terminal - clamp the rows/columns to `1` or higher.

Fixes #1434 