### PR TITLE
Fix #1461 - second terminal in same window has no output

### DIFF
--- a/src/UI/TerminalView.re
+++ b/src/UI/TerminalView.re
@@ -39,6 +39,11 @@ let%component make =
   let maybeFont = Revery.Font.load(font.fontFile) |> Stdlib.Result.to_option;
 
   let%hook lastDimensions = Hooks.ref(None);
+
+  // When the terminal id changes, we need to make sure we're dispatching the resized
+  // event, too. The ideal fix would be to have this component 'keyed' on the `terminal.id`
+  // but since we don't have the concept of a key prop, this `If` handler will be triggered
+  // when the `terminal.id` changes, so we have an opportunity to set the size for a new terminal.
   let%hook () =
     React.Hooks.effect(
       If((!=), terminal.id),


### PR DESCRIPTION
__Issue:__ When opening another terminal in the _same window_, there'd be no output - the terminal would be blank. However, opening a terminal in a different split works OK.

__Defect:__ The terminal relies on getting size information from the UI - when the `<TerminalView />` is rendered, it hooks up an `onDimensionsChanged` callback to listen for changes in the dimension - this gets called on first render, too. This pushes the current rows / columns for the current terminal, so it gets sized correctly.

However, in the case where a new terminal was rendering in the same `<TerminalView />`, the onDimensionsChanged wouldn't get triggered, because it is the same size. (To the reconciler - it's still the same element)

__Fix:__ The ideal fix would be to have a notion of a `key` like in React, to trigger a re-render based on the terminal ID. However, I don't believe we have that hooked up - so this sets up an `If` effect - when the terminal id changes, we also push dispatch the resized event.

Fixes #1461 & #1494 