### PR TITLE
Fix #538 - Show version info

### DIFF
--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -34,6 +34,7 @@ let getMediumFriendlyName =
   |> Option.map(filePath =>
        switch (BufferPath.parse(filePath)) {
        | Welcome => "Welcome"
+       | Version => "Version"
        | Terminal({cmd, _}) => "Terminal - " ++ cmd
        | FilePath(fp) =>
          switch (workingDirectory) {
@@ -49,6 +50,7 @@ let getLongFriendlyName = ({filePath: maybeFilePath, _}) => {
   |> Option.map(filePath => {
        switch (BufferPath.parse(filePath)) {
        | Welcome => "Welcome"
+       | Version => "Version"
        | Terminal({cmd, _}) => "Terminal - " ++ cmd
        | FilePath(fp) => fp
        }

--- a/src/Core/BufferPath.re
+++ b/src/Core/BufferPath.re
@@ -12,14 +12,18 @@ type t =
       bufferId: int,
       cmd: string,
     })
-  | Welcome;
+  | Welcome
+  | Version;
 
 let welcome = "oni://Welcome";
+let version = "oni://Version";
 let terminalRegex = OnigRegExp.create("oni://terminal/([0-9]*)/(.*)");
 
 let parse = bufferPath =>
   if (String.equal(bufferPath, welcome)) {
     Welcome;
+  } else if (String.equal(bufferPath, version)) {
+    Version
   } else {
     terminalRegex
     |> Result.to_option

--- a/src/Core/BufferPath.re
+++ b/src/Core/BufferPath.re
@@ -23,7 +23,7 @@ let parse = bufferPath =>
   if (String.equal(bufferPath, welcome)) {
     Welcome;
   } else if (String.equal(bufferPath, version)) {
-    Version
+    Version;
   } else {
     terminalRegex
     |> Result.to_option

--- a/src/Model/BufferRenderer.re
+++ b/src/Model/BufferRenderer.re
@@ -21,6 +21,7 @@ type terminal = {
 type t =
   | Editor
   | Welcome
+  | Version
   | Terminal(terminal);
 
 [@deriving show({with_path: false})]

--- a/src/Store/BufferRendererReducer.re
+++ b/src/Store/BufferRendererReducer.re
@@ -38,6 +38,7 @@ let reduce = (state: BufferRenderers.t, action) => {
           | Actions.BufferUpdate(bu) when bu.update.id == id => Editor
           | _ => Welcome
           }
+        | Version => Version
         | Editor => Editor
         | Terminal(term) => Terminal(terminalReducer(term, action))
         }

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -100,6 +100,15 @@ let start =
   });
 
   let _: unit => unit =
+    Vim.onVersion(() => {
+       Actions.OpenFileByPath(
+         "oni://Version",
+         None,
+         None,
+       ) |> dispatch;
+    });
+
+  let _: unit => unit =
     Vim.onGoto((_position, _definitionType) => {
       Log.debug("Goto definition requested");
       // Get buffer and cursor position
@@ -670,6 +679,15 @@ let start =
                 id: bufferId,
                 insertMode: true,
               }),
+            ),
+          ),
+        )
+      | Version => 
+        dispatch(
+          Actions.BufferRenderer(
+            BufferRenderer.RendererAvailable(
+              metadata.id,
+              BufferRenderer.Version
             ),
           ),
         )

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -101,11 +101,7 @@ let start =
 
   let _: unit => unit =
     Vim.onVersion(() => {
-       Actions.OpenFileByPath(
-         "oni://Version",
-         None,
-         None,
-       ) |> dispatch;
+      Actions.OpenFileByPath("oni://Version", None, None) |> dispatch
     });
 
   let _: unit => unit =
@@ -682,12 +678,12 @@ let start =
             ),
           ),
         )
-      | Version => 
+      | Version =>
         dispatch(
           Actions.BufferRenderer(
             BufferRenderer.RendererAvailable(
               metadata.id,
-              BufferRenderer.Version
+              BufferRenderer.Version,
             ),
           ),
         )

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -200,6 +200,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             config={Feature_Configuration.resolver(state.config)}
           />;
         | BufferRenderer.Welcome => <WelcomeView state />
+        | BufferRenderer.Version => <WelcomeView state />
         | BufferRenderer.Terminal({id, _}) =>
           state.terminals
           |> Feature_Terminal.getTerminalOpt(id)

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -200,7 +200,7 @@ let make = (~state: State.t, ~windowId: int, ~editorGroup: EditorGroup.t, ()) =>
             config={Feature_Configuration.resolver(state.config)}
           />;
         | BufferRenderer.Welcome => <WelcomeView state />
-        | BufferRenderer.Version => <WelcomeView state />
+        | BufferRenderer.Version => <VersionView state />
         | BufferRenderer.Terminal({id, _}) =>
           state.terminals
           |> Feature_Terminal.getTerminalOpt(id)

--- a/src/UI/VersionView.re
+++ b/src/UI/VersionView.re
@@ -125,14 +125,14 @@ let make = (~state: State.t, ()) => {
   let header = HeaderView.make(~state);
 
   <View style={Styles.container(~theme)}>
-    <header text="Onivim 2:" />
+    <header text="Onivim 2" />
     <version name="Version" version=Oni_Core.BuildInfo.version />
     <version name="Commit" version=Oni_Core.BuildInfo.commitId />
     // spacer
-    <header text="OCaml:" />
+    <header text="OCaml" />
     <version name="Compiler Version " version=Sys.ocaml_version />
     // spacer
-    <header text="SDL:" />
+    <header text="SDL" />
     <version
       name="SDL Compiled"
       version={Sdl2.Version.getCompiled() |> sdlVersionToString}
@@ -142,7 +142,7 @@ let make = (~state: State.t, ()) => {
       version={Sdl2.Version.getLinked() |> sdlVersionToString}
     />
     // spacer
-    <header text="OpenGL:" />
+    <header text="OpenGL" />
     <version name="Version" version={Sdl2.Gl.getString(Sdl2.Gl.Version)} />
     <version name="Vendor" version={Sdl2.Gl.getString(Sdl2.Gl.Vendor)} />
     <version name="Renderer" version={Sdl2.Gl.getString(Sdl2.Gl.Renderer)} />

--- a/src/UI/VersionView.re
+++ b/src/UI/VersionView.re
@@ -33,7 +33,6 @@ module Styles = {
 
 module HeaderView = {
   module Styles = {
-    open Style;
     let header = (~uiFont: UiFont.t) =>
       Style.[
         flexGrow(0),

--- a/src/UI/VersionView.re
+++ b/src/UI/VersionView.re
@@ -72,8 +72,9 @@ module VersionView = {
       color(theme.foreground),
     ];
 
+    let versionValue = [flexGrow(0), alignItems(`FlexEnd)];
+
     let spacer = Style.[flexGrow(1)];
-    let tempSpacer = Style.[flexGrow(1)];
   };
 
   let make = (~name: string, ~version: string, ~state: State.t, ()) => {
@@ -89,8 +90,8 @@ module VersionView = {
         text=name
       />
       <View style=Styles.spacer />
-      <View style=Styles.tempSpacer>
-        <View style=Style.[flexGrow(0), alignItems(`FlexEnd)]>
+      <View style=Styles.spacer>
+        <View style=Styles.versionValue>
           <Text
             style={Styles.versionText(
               ~theme,

--- a/src/UI/VersionView.re
+++ b/src/UI/VersionView.re
@@ -1,0 +1,149 @@
+/*
+ * VersionView.re
+ *
+ * Component for the 'version' buffer renderer
+ */
+
+open Revery.UI;
+open Oni_Model;
+open Oni_Core;
+
+module Model = Oni_Model;
+
+module Styles = {
+  let container = (~theme: Theme.t) =>
+    Style.[
+      backgroundColor(theme.editorBackground),
+      color(theme.foreground),
+      flexGrow(1),
+      flexDirection(`Column),
+      justifyContent(`Center),
+      alignItems(`Center),
+      overflow(`Hidden),
+      backgroundColor(Revery.Colors.red),
+    ];
+
+  let titleText = (~theme: Theme.t, ~font: UiFont.t) =>
+    Style.[
+      fontFamily(font.fontFile),
+      fontSize(14.),
+      color(theme.foreground),
+      marginTop(0),
+    ];
+
+  let versionText = (~theme: Theme.t, ~font: UiFont.t) =>
+    Style.[
+      fontFamily(font.fontFile),
+      fontSize(12.),
+      color(theme.foreground),
+      marginTop(0),
+    ];
+
+  let commandText = (~theme: Theme.t, ~font: UiFont.t) =>
+    Style.[
+      fontFamily(font.fontFile),
+      fontSize(12.),
+      color(theme.foreground),
+    ];
+
+  let header =
+    Style.[
+      flexGrow(1),
+      flexDirection(`Column),
+      justifyContent(`Center),
+      alignItems(`Center),
+      margin(0),
+    ];
+};
+
+module VersionView = {
+  module Styles = {
+    open Style;
+
+    let container = [
+      flexDirection(`Row),
+      justifyContent(`Center),
+      alignItems(`Center),
+      height(16),
+      maxWidth(500),
+      minWidth(150),
+      backgroundColor(Revery.Colors.blue),
+    ];
+
+    let versionText = (~theme: Theme.t, ~fontFile, ~fontSize) => [
+      fontFamily(fontFile),
+      Style.fontSize(fontSize),
+      color(theme.foreground),
+    ];
+
+    let spacer = Style.[flexGrow(1)];
+  };
+
+  let make = (~name: string, ~version: string, ~state: State.t, ()) => {
+    let {theme, editorFont, uiFont, _}: State.t = state;
+
+    <View style=Styles.container>
+        <Text
+          style={Styles.versionText(
+            ~theme,
+            ~fontFile=uiFont.fontFile,
+            ~fontSize=12.,
+          )}
+          text=name
+        />
+      <View style=Styles.spacer />
+      <View style=Styles.spacer>
+      <Text
+        style={Styles.versionText(
+          ~theme,
+          ~fontFile=editorFont.fontFile,
+          ~fontSize=11.,
+        )}
+        text=version
+      />
+      </View>
+    </View>;
+  };
+};
+
+let animation =
+  Revery.UI.Animation.(
+    animate(Revery.Time.milliseconds(250))
+    |> ease(Easing.ease)
+    |> tween(0., 1.)
+    |> delay(Revery.Time.milliseconds(150))
+  );
+
+let osString = Revery.Environment.os
+|> fun
+| Windows => "Windows"
+| Mac => "OSX"
+| _ => "Linux";
+
+let sdlVersionToString = ({major, minor, patch}: Sdl2.Version.t) => {
+  Printf.sprintf("%d.%d.%d", major, minor, patch);
+};
+
+let%component make = (~state: State.t, ()) => {
+  let theme = state.theme;
+
+  let%hook (transition, _animationState, _reset) =
+    Hooks.animation(animation, ~active=true);
+
+  let version = VersionView.make(~state);
+
+  <View style={Styles.container(~theme)}>
+        <version name="Version:" version=Oni_Core.BuildInfo.version />
+        <version name="Commit:" version=Oni_Core.BuildInfo.commitId />
+        // spacer
+        <version name="OCaml:" version=Sys.ocaml_version />
+        // spacer
+        <version name="SDL Compiled:" version={Sdl2.Version.getCompiled() |> sdlVersionToString} />
+        <version name="SDL Linked:" version={Sdl2.Version.getLinked() |> sdlVersionToString} />
+        // spacer
+        <version name="GL Version:" version={Sdl2.Gl.getString(Sdl2.Gl.Version)} />
+        <version name="GL Vendor:" version={Sdl2.Gl.getString(Sdl2.Gl.Vendor)} />
+        <version name="GL Renderer:" version={Sdl2.Gl.getString(Sdl2.Gl.Renderer)} />
+        <version name="GL GLSL:" version={Sdl2.Gl.getString(Sdl2.Gl.ShadingLanguageVersion)} />
+  </View>;
+};

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -30,6 +30,14 @@ module Styles = {
       marginTop(-40),
     ];
 
+  let versionText = (~theme: Theme.t, ~font: UiFont.t) =>
+    Style.[
+      fontFamily(font.fontFile),
+      fontSize(12.),
+      color(theme.foreground),
+      marginTop(0),
+    ];
+
   let commandText = (~theme: Theme.t, ~font: UiFont.t) =>
     Style.[
       fontFamily(font.fontFile),
@@ -130,6 +138,10 @@ let%component make = (~state: State.t, ()) => {
         <Text
           style={Styles.titleText(~theme, ~font=state.uiFont)}
           text="Modal Editing from the Future"
+        />
+        <Text
+          style={Styles.versionText(~theme, ~font=state.uiFont)}
+          text=Printf.sprintf("Version %s", Oni_Core.BuildInfo.version)
         />
       </View>
       <View style=Styles.controls>

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -141,7 +141,7 @@ let%component make = (~state: State.t, ()) => {
         />
         <Text
           style={Styles.versionText(~theme, ~font=state.uiFont)}
-          text=Printf.sprintf("Version %s", Oni_Core.BuildInfo.version)
+          text={Printf.sprintf("Version %s", Oni_Core.BuildInfo.version)}
         />
       </View>
       <View style=Styles.controls>


### PR DESCRIPTION
This hooks up the `:version` command to show a screen that displays the version of Onivim 2, as well as various components:

![image](https://user-images.githubusercontent.com/13532591/78055186-0061e580-7338-11ea-961e-92ba86a76b97.png)

__Potential Next steps:__
- Add a sneak-able button to copy and paste
- Allow editing in read-only mode (switch to a buffer in visual mode)
- Add additional version info:
  - Harfbuzz compiled / linked version
  - libvim compilation flags

Fixes #538 