### PR TITLE
Bugfix: SideBar color defaults

### DIFF
--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -12,7 +12,7 @@ open ColorTheme.Schema;
 let foreground =
   define(
     "foreground",
-    {light: hex("#CCC"), dark: hex("#616161"), hc: hex("#FFF")},
+    {dark: hex("#CCC"), light: hex("#616161"), hc: hex("#FFF")},
   );
 let focusBorder =
   define(
@@ -446,10 +446,10 @@ module ScrollbarSlider = {
 module SideBar = {
   let background =
     define(
-      "sidebar.background",
+      "sideBar.background",
       {dark: hex("#252526"), light: hex("#F3F3F3"), hc: hex("#000")},
     );
-  let foreground = define("sidebar.foreground", all(unspecified));
+  let foreground = define("sideBar.foreground", all(ref(foreground))); // actually: all(unspecified)
 
   let defaults = [background, foreground];
 };


### PR DESCRIPTION
**Issue**: Text in the SCM pane wasn't being rendered (visibly) with some themes

**Defect**: The default SideBar foreground color was unspecified, which is according to vscode's default, but where vscode has view code that handles this, we just fall back to transparent.

**Fix**: Set the default to the "global" foreground color.; This might cause problems down the line if for som reason we need to distinguish the default as unspecified, but we'll cross that bridge when we get there. This also fixes the global foreground color, which had the light and dark colors switched around.