### PR TITLE
Bugfix: (Experimental) Smooth scroll - Line number / minimap 

### DIFF
--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -31,9 +31,6 @@ module Styles = {
   ];
 };
 
-let scrollSpringOptions =
-  Spring.Options.create(~stiffness=310., ~damping=30., ());
-
 let drawCurrentLineHighlight = (~context, ~colors: Colors.t, line) =>
   Draw.lineHighlight(~context, ~color=colors.lineHighlightBackground, line);
 
@@ -82,6 +79,8 @@ let%component make =
   let onMouseWheel = (wheelEvent: NodeEvents.mouseWheelEventParams) =>
     onScroll(wheelEvent.deltaY *. (-50.));
 
+  let {scrollX, scrollY, _}: Editor.t = editor;
+
   let onMouseUp = (evt: NodeEvents.mouseButtonEventParams) => {
     Log.trace("editorMouseUp");
 
@@ -116,23 +115,6 @@ let%component make =
       };
     };
   };
-
-  let smoothScroll = Config.Experimental.editorSmoothScroll.get(config);
-
-  let%hook (scrollY, _setScrollYImmediately) =
-    Hooks.spring(
-      ~target=editor.scrollY,
-      ~restThreshold=100.,
-      ~enabled=smoothScroll,
-      scrollSpringOptions,
-    );
-  let%hook (scrollX, _setScrollXImmediately) =
-    Hooks.spring(
-      ~target=editor.scrollX,
-      ~restThreshold=100.,
-      ~enabled=smoothScroll,
-      scrollSpringOptions,
-    );
 
   <View
     ref={node => elementRef := Some(node)}


### PR DESCRIPTION
When `experimental.editor.smoothScroll` is enabled, the editor surface would scroll smoothly, but the line number and minimap did not. The line number was particularly jarring and could sometimes detract from the smooth scroll effect.

This moves the spring hooks up to a component above, so that the animated `scrollX` and `scrollY` can be used by line numbers / minimap.