### PR TITLE
Bugfix: Cursor background default

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cb900499e5f2d0af107b41a1da0b7c73",
+  "checksum": "295b7c93562de697a117d40568b36aae",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#4f08701@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#4f08701",
+      "version": "github:glennsl/revery#ef05d3a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#4f08701" ]
+        "source": [ "github:glennsl/revery#ef05d3a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "295b7c93562de697a117d40568b36aae",
+  "checksum": "eeed8b6b090d9dd98f954896b7ef853e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+    "revery@github:revery-ui/revery#6fd117a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#ef05d3a",
+      "version": "github:revery-ui/revery#6fd117a",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#ef05d3a" ]
+        "source": [ "github:revery-ui/revery#6fd117a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "295b7c93562de697a117d40568b36aae",
+  "checksum": "eeed8b6b090d9dd98f954896b7ef853e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+    "revery@github:revery-ui/revery#6fd117a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#ef05d3a",
+      "version": "github:revery-ui/revery#6fd117a",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#ef05d3a" ]
+        "source": [ "github:revery-ui/revery#6fd117a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cb900499e5f2d0af107b41a1da0b7c73",
+  "checksum": "295b7c93562de697a117d40568b36aae",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#4f08701@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#4f08701",
+      "version": "github:glennsl/revery#ef05d3a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#4f08701" ]
+        "source": [ "github:glennsl/revery#ef05d3a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cb900499e5f2d0af107b41a1da0b7c73",
+  "checksum": "295b7c93562de697a117d40568b36aae",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#4f08701@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#4f08701",
+      "version": "github:glennsl/revery#ef05d3a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#4f08701" ]
+        "source": [ "github:glennsl/revery#ef05d3a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "295b7c93562de697a117d40568b36aae",
+  "checksum": "eeed8b6b090d9dd98f954896b7ef853e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+    "revery@github:revery-ui/revery#6fd117a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#ef05d3a",
+      "version": "github:revery-ui/revery#6fd117a",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#ef05d3a" ]
+        "source": [ "github:revery-ui/revery#6fd117a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "@opam/easy-format": "1.3.1",
     "@opam/lwt_ppx": "1.2.2",
     "@opam/merlin-extend": "0.4",
-    "revery": "glennsl/revery#ef05d3a",
+    "revery": "revery-ui/revery#6fd117a",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-skia": "revery-ui/esy-skia#07c13a9",

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "@opam/easy-format": "1.3.1",
     "@opam/lwt_ppx": "1.2.2",
     "@opam/merlin-extend": "0.4",
-    "revery": "revery-ui/revery#4f08701",
+    "revery": "glennsl/revery#ef05d3a",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-skia": "revery-ui/esy-skia#07c13a9",

--- a/src/Core/ColorTheme.re
+++ b/src/Core/ColorTheme.re
@@ -99,6 +99,8 @@ module Schema = {
     let color = color => Constant(color);
     let ref = def => Reference(def.key);
     let computed = f => Computed(f);
+    let unspecified = Unspecified;
+
     //let darken =
     //let lighten =
     let transparent = (factor, value) => {
@@ -112,9 +114,19 @@ module Schema = {
       | Unspecified => Unspecified
       };
     };
+    let opposite = value => {
+      let apply = Color.opposite;
+
+      switch (value) {
+      | Constant(color) => Constant(color |> apply)
+      | Reference(name) =>
+        Computed(resolve => resolve(name) |> Option.map(apply))
+      | Computed(f) => Computed(resolve => f(resolve) |> Option.map(apply))
+      | Unspecified => Unspecified
+      };
+    };
     //let oneOf =
     //let lessProminent =
-    let unspecified = Unspecified;
 
     let all = value => {light: value, dark: value, hc: value};
 

--- a/src/Core/ColorTheme.rei
+++ b/src/Core/ColorTheme.rei
@@ -59,7 +59,10 @@ module Schema: {
     let computed:
       ((key => option(Revery.Color.t)) => option(Revery.Color.t)) =>
       Defaults.expr;
+    let unspecified: Defaults.expr;
+
     let transparent: (float, Defaults.expr) => Defaults.expr;
+    let opposite: Defaults.expr => Defaults.expr;
 
     let all: Defaults.expr => Defaults.t;
 
@@ -74,8 +77,10 @@ module Schema: {
   let computed:
     ((key => option(Revery.Color.t)) => option(Revery.Color.t)) =>
     Defaults.expr;
-  let transparent: (float, Defaults.expr) => Defaults.expr;
   let unspecified: Defaults.expr;
+
+  let transparent: (float, Defaults.expr) => Defaults.expr;
+  let opposite: Defaults.expr => Defaults.expr;
 
   let all: Defaults.expr => Defaults.t;
 

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -120,12 +120,13 @@ module Editor = {
 };
 
 module EditorCursor = {
-  let background = define("editorCursor.background", all(unspecified));
   let foreground =
     define(
       "editorCursor.foreground",
       {dark: hex("#AEAFAD"), light: hex("#000"), hc: hex("#FFF")},
     );
+  let background =
+    define("editorCursor.background", all(opposite(ref(foreground)))); // actually: all(unspecified)
 
   let defaults = [background, foreground];
 };

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "45b478136e462988d8fb67f1d309c896",
+  "checksum": "23fef6b248cda0631f181cdf33cf512a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#4f08701@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
+      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#4f08701",
+      "version": "github:glennsl/revery#ef05d3a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#4f08701" ]
+        "source": [ "github:glennsl/revery#ef05d3a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:revery-ui/revery#4f08701@d41d8cd9",
+        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "23fef6b248cda0631f181cdf33cf512a",
+  "checksum": "53340f96ef6e3553b16c2c6a46f3374b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:glennsl/revery#ef05d3a@d41d8cd9": {
-      "id": "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+    "revery@github:revery-ui/revery#6fd117a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
       "name": "revery",
-      "version": "github:glennsl/revery#ef05d3a",
+      "version": "github:revery-ui/revery#6fd117a",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/revery#ef05d3a" ]
+        "source": [ "github:revery-ui/revery#6fd117a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1205,7 +1205,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#2ef1c65@d41d8cd9",
-        "revery@github:glennsl/revery#ef05d3a@d41d8cd9",
+        "revery@github:revery-ui/revery#6fd117a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",


### PR DESCRIPTION
**Issue**: The text under the cursor wasn't being rendered (visibly) with some themes

**Defect**: The default cursor background color was unspecified, which is according to vscode's default, but where vscode has view code that handles this, we just fall back to transparent.

**Fix**: Set the default to the opposite of the foreground color. This is what vscode does in its view code, and this just does using a default computed function instead.