### PR TITLE
Fix #1546 - Error in mapping Vim key to terminal key

### DIFF
--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -196,7 +196,7 @@ module Effect = {
       ("<UP>", Up),
       ("<LEFT>", Left),
       ("<RIGHT>", Right),
-      ("<DOWN>", Right),
+      ("<DOWN>", Down),
       ("<ESC>", Escape),
     ]
     |> List.to_seq


### PR DESCRIPTION
__Issue:__ In the terminal, the 'down' arrow key was moving to the right...

__Defect:__ Our mapping of key -> terminal key was incorrect.

__Fix:__ Correctly map the down key to the down terminal key.

Fixes #1546 