### PR TITLE
Refactor: Context Keys

### DIFF
--- a/src/Core/WhenExpr/ContextKeys.re
+++ b/src/Core/WhenExpr/ContextKeys.re
@@ -1,0 +1,57 @@
+module Lookup = Kernel.KeyedStringMap;
+
+module Value = {
+  [@deriving show({with_path: false})]
+  type t =
+    | String(string)
+    | True
+    | False;
+
+  // Emulate JavaScript semantics
+  let asBool =
+    fun
+    | True => true
+    | False => false
+    | String("") => false
+    | String(_) => true;
+
+  // Emulate JavaScript semantics
+  let asString =
+    fun
+    | True => "true"
+    | False => "false"
+    | String(str) => str;
+};
+
+module Schema = {
+  type entry('model) = {
+    key: string,
+    get: 'model => Value.t,
+  };
+
+  let define = (key, get) => {key, get};
+  let bool = (key, get) =>
+    define(key, model => get(model) ? Value.True : Value.False);
+  let string = (key, get) => define(key, model => Value.String(get(model)));
+
+  type t('model) = Lookup.t(entry('model));
+
+  let fromList = entries =>
+    entries
+    |> List.to_seq
+    |> Seq.map(entry => (Lookup.key(entry.key), entry))
+    |> Lookup.of_seq;
+
+  let union = (xs, ys) => Lookup.union((_key, _x, y) => Some(y), xs, ys);
+
+  let unionMany = lookups => List.fold_left(union, Lookup.empty, lookups);
+};
+
+type t = Lookup.t(Value.t);
+
+let fromSchema = (schema, model) =>
+  Lookup.map(Schema.(entry => entry.get(model)), schema);
+
+let getValue = (lookup, key) =>
+  Lookup.find_opt(Lookup.key(key), lookup)
+  |> Option.value(~default=Value.False);

--- a/src/Core/WhenExpr/ContextKeys.re
+++ b/src/Core/WhenExpr/ContextKeys.re
@@ -1,3 +1,5 @@
+module Log = (val Timber.Log.withNamespace("Oni2.Core.WhenExpr.ContextKeys"));
+
 module Lookup = Kernel.KeyedStringMap;
 
 module Value = {
@@ -42,7 +44,17 @@ module Schema = {
     |> Seq.map(entry => (Lookup.key(entry.key), entry))
     |> Lookup.of_seq;
 
-  let union = (xs, ys) => Lookup.union((_key, _x, y) => Some(y), xs, ys);
+  let union = (xs, ys) =>
+    Lookup.union(
+      (key, _x, y) => {
+        Log.errorf(m =>
+          m("Encountered duplicate context key: %s", Lookup.keyName(key))
+        );
+        Some(y);
+      },
+      xs,
+      ys,
+    );
   let unionMany = lookups => List.fold_left(union, Lookup.empty, lookups);
 
   let map = f =>

--- a/src/Core/WhenExpr/ContextKeys.re
+++ b/src/Core/WhenExpr/ContextKeys.re
@@ -43,8 +43,10 @@ module Schema = {
     |> Lookup.of_seq;
 
   let union = (xs, ys) => Lookup.union((_key, _x, y) => Some(y), xs, ys);
-
   let unionMany = lookups => List.fold_left(union, Lookup.empty, lookups);
+
+  let map = f =>
+    Lookup.map(entry => {...entry, get: model => entry.get(f(model))});
 };
 
 type t = Lookup.t(Value.t);

--- a/src/Core/WhenExpr/WhenExpr.re
+++ b/src/Core/WhenExpr/WhenExpr.re
@@ -1,25 +1,6 @@
-module Value = {
-  [@deriving show({with_path: false})]
-  type t =
-    | String(string)
-    | True
-    | False;
+module ContextKeys = ContextKeys;
 
-  // Emulate JavaScript semantics
-  let asBool =
-    fun
-    | True => true
-    | False => false
-    | String("") => false
-    | String(_) => true;
-
-  // Emulate JavaScript semantics
-  let asString =
-    fun
-    | True => "true"
-    | False => "false"
-    | String(str) => str;
-};
+module Value = ContextKeys.Value;
 
 [@deriving show({with_path: false})]
 type t =

--- a/src/Core/WhenExpr/WhenExpr.rei
+++ b/src/Core/WhenExpr/WhenExpr.rei
@@ -9,6 +9,25 @@ module Value: {
   let asString: t => string;
 };
 
+module ContextKeys: {
+  module Schema: {
+    type entry('model);
+    type t('model);
+
+    let define: (string, 'model => Value.t) => entry('model);
+    let bool: (string, 'model => bool) => entry('model);
+    let string: (string, 'model => string) => entry('model);
+
+    let fromList: list(entry('model)) => t('model);
+  };
+
+  type t;
+
+  let fromSchema: (Schema.t('model), 'model) => t;
+
+  let getValue: (t, string) => Value.t;
+};
+
 [@deriving show]
 type t =
   | Defined(string)

--- a/src/Core/WhenExpr/WhenExpr.rei
+++ b/src/Core/WhenExpr/WhenExpr.rei
@@ -19,6 +19,11 @@ module ContextKeys: {
     let string: (string, 'model => string) => entry('model);
 
     let fromList: list(entry('model)) => t('model);
+
+    let union: (t('model), t('model)) => t('model);
+    let unionMany: list(t('model)) => t('model);
+
+    let map: ('a => 'b, t('b)) => t('a);
   };
 
   type t;

--- a/src/Core/WhenExpr/dune
+++ b/src/Core/WhenExpr/dune
@@ -2,4 +2,4 @@
     (name WhenExpr)
     (public_name Oni2.core.whenExpr)
     (preprocess (pps ppx_deriving.show))
-    (libraries re))
+    (libraries Oni2.core.kernel re))

--- a/src/Core/WhenExpr/dune
+++ b/src/Core/WhenExpr/dune
@@ -2,4 +2,4 @@
     (name WhenExpr)
     (public_name Oni2.core.whenExpr)
     (preprocess (pps ppx_deriving.show))
-    (libraries Oni2.core.kernel re))
+    (libraries Oni2.core.kernel re timber))

--- a/src/Input/Keybindings.rei
+++ b/src/Input/Keybindings.rei
@@ -10,13 +10,13 @@ type effect =
 let count: t => int;
 
 let keyDown:
-  (~context: Hashtbl.t(string, bool), ~key: EditorInput.KeyPress.t, t) =>
+  (~context: WhenExpr.ContextKeys.t, ~key: EditorInput.KeyPress.t, t) =>
   (t, list(effect));
 
 let text: (~text: string, t) => (t, list(effect));
 
 let keyUp:
-  (~context: Hashtbl.t(string, bool), ~key: EditorInput.KeyPress.t, t) =>
+  (~context: WhenExpr.ContextKeys.t, ~key: EditorInput.KeyPress.t, t) =>
   (t, list(effect));
 
 type keybinding = {

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -1,0 +1,73 @@
+open Oni_Components;
+open WhenExpr.ContextKeys.Schema;
+
+let keys =
+  fromList(
+    State.[
+      bool("listFocus", state => state.quickmenu != None),
+      bool("inQuickOpen", state => state.quickmenu != None),
+      bool(
+        "quickmenuCursorEnd",
+        fun
+        | {quickmenu: Some({selection, query, _}), _}
+            when
+              Selection.isCollapsed(selection)
+              && selection.focus == String.length(query) =>
+          true
+        | _ => false,
+      ),
+      bool(
+        "inEditorsPicker",
+        fun
+        | {quickmenu: Some({variant: EditorsPicker, _}), _} => true
+        | _ => false,
+      ),
+      bool(
+        "suggestWidgetVisible",
+        fun
+        | {completions, _} when Completions.isActive(completions) => true
+        | _ => false,
+      ),
+      bool("insertMode", state =>
+        switch (ModeManager.current(state)) {
+        | TerminalInsert
+        | Insert => true
+        | _ => false
+        }
+      ),
+      bool("normalMode", state =>
+        switch (ModeManager.current(state)) {
+        | TerminalNormal
+        | Normal => true
+        | _ => false
+        }
+      ),
+      bool("visualMode", state =>
+        switch (ModeManager.current(state)) {
+        | TerminalVisual
+        | Visual => true
+        | _ => false
+        }
+      ),
+      bool("editorTextFocus", state =>
+        switch (ModeManager.current(state)) {
+        | TerminalInsert
+        | TerminalNormal
+        | TerminalVisual => false
+        | _ => true
+        }
+      ),
+      bool("terminalFocus", state =>
+        switch (ModeManager.current(state)) {
+        | TerminalInsert
+        | TerminalNormal
+        | TerminalVisual => true
+        | _ => false
+        }
+      ),
+      bool("commandLineFocus", state =>
+        ModeManager.current(state) == CommandLine
+      ),
+      bool("sneakMode", state => Sneak.isActive(state.sneak)),
+    ],
+  );

--- a/src/Model/Oni_Model.re
+++ b/src/Model/Oni_Model.re
@@ -13,6 +13,7 @@ module BufferRenderer = BufferRenderer;
 module BufferRenderers = BufferRenderers;
 module Command = Command;
 module Commands = Commands;
+module ContextKeys = ContextKeys;
 module DecorationProvider = DecorationProvider;
 module EditorGroup = EditorGroup;
 module EditorGroups = EditorGroups;

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -135,7 +135,7 @@ let start = (window: option(Revery.Window.t), runEffects) => {
    */
   let handleKeyPress = (state: State.t, key) => {
     let context =
-      WhenExpr.ContextKeys.fromSchema(Model.ContextKeys.keys, state);
+      WhenExpr.ContextKeys.fromSchema(Model.ContextKeys.all, state);
 
     let (keyBindings, effects) =
       Keybindings.keyDown(~context, ~key, state.keyBindings);
@@ -161,7 +161,7 @@ let start = (window: option(Revery.Window.t), runEffects) => {
 
   let handleKeyUp = (state: State.t, key) => {
     let context =
-      WhenExpr.ContextKeys.fromSchema(Model.ContextKeys.keys, state);
+      WhenExpr.ContextKeys.fromSchema(Model.ContextKeys.all, state);
 
     //let inputKey = reveryKeyToEditorKey(key);
     let (keyBindings, effects) =

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -6,7 +6,6 @@
 
 open Oni_Core;
 open Oni_Input;
-open Oni_Components;
 
 module Model = Oni_Model;
 module State = Model.State;
@@ -14,74 +13,6 @@ module Actions = Model.Actions;
 module Completions = Feature_LanguageSupport.Completions;
 
 module Log = (val Log.withNamespace("Oni2.Store.Input"));
-
-let isQuickmenuOpen = (state: State.t) => state.quickmenu != None;
-
-let conditionsOfState = (state: State.t) => {
-  // Not functional, but we'll use the hashtable for performance
-  let ret: Hashtbl.t(string, bool) = Hashtbl.create(16);
-
-  switch (state.quickmenu) {
-  | Some({variant, query, selection, _}) =>
-    Hashtbl.add(ret, "listFocus", true);
-    Hashtbl.add(ret, "inQuickOpen", true);
-
-    if (Selection.isCollapsed(selection)
-        && selection.focus == String.length(query)) {
-      Hashtbl.add(ret, "quickmenuCursorEnd", true);
-    };
-
-    if (variant == EditorsPicker) {
-      Hashtbl.add(ret, "inEditorsPicker", true);
-    };
-
-  | None => ()
-  };
-
-  if (Completions.isActive(state.completions)) {
-    Hashtbl.add(ret, "suggestWidgetVisible", true);
-  };
-
-  switch (state.configuration.default.editorAcceptSuggestionOnEnter) {
-  | `on
-  | `smart => Hashtbl.add(ret, "acceptSuggestionOnEnter", true)
-  | `off => ()
-  };
-
-  let mode = Model.ModeManager.current(state);
-
-  // HACK: Because we don't have AND conditions yet for input
-  // (the conditions array are OR's), we are making `insertMode`
-  // only true when the editor is insert mode AND we are in the
-  // editor (editorTextFocus is set)
-  switch (isQuickmenuOpen(state), mode) {
-  | (false, Mode.TerminalInsert) =>
-    Hashtbl.add(ret, "insertMode", true);
-    Hashtbl.add(ret, "terminalFocus", true);
-  | (false, Mode.TerminalNormal) =>
-    Hashtbl.add(ret, "normalMode", true);
-    Hashtbl.add(ret, "terminalFocus", true);
-  | (false, Mode.TerminalVisual) =>
-    Hashtbl.add(ret, "visualMode", true);
-    Hashtbl.add(ret, "terminalFocus", true);
-  | (false, Mode.Insert) =>
-    Hashtbl.add(ret, "insertMode", true);
-    Hashtbl.add(ret, "editorTextFocus", true);
-  | (false, Mode.Normal) =>
-    Hashtbl.add(ret, "normalMode", true);
-    Hashtbl.add(ret, "editorTextFocus", true);
-  | (false, Mode.Visual) => Hashtbl.add(ret, "visualMode", true)
-  | (false, _) => Hashtbl.add(ret, "editorTextFocus", true)
-  | (true, Mode.CommandLine) => Hashtbl.add(ret, "commandLineFocus", true)
-  | _ => ()
-  };
-
-  if (state.sneak |> Model.Sneak.isActive) {
-    Hashtbl.add(ret, "sneakMode", true);
-  };
-
-  ret;
-};
 
 let start = (window: option(Revery.Window.t), runEffects) => {
   let (stream, dispatch) = Isolinear.Stream.create();
@@ -203,10 +134,11 @@ let start = (window: option(Revery.Window.t), runEffects) => {
      a revery element is focused oni2 should defer to revery
    */
   let handleKeyPress = (state: State.t, key) => {
-    let conditions = conditionsOfState(state);
+    let context =
+      WhenExpr.ContextKeys.fromSchema(Model.ContextKeys.keys, state);
 
     let (keyBindings, effects) =
-      Keybindings.keyDown(~context=conditions, ~key, state.keyBindings);
+      Keybindings.keyDown(~context, ~key, state.keyBindings);
 
     let newState = {...state, keyBindings};
 
@@ -228,11 +160,12 @@ let start = (window: option(Revery.Window.t), runEffects) => {
   };
 
   let handleKeyUp = (state: State.t, key) => {
-    let conditions = conditionsOfState(state);
+    let context =
+      WhenExpr.ContextKeys.fromSchema(Model.ContextKeys.keys, state);
 
     //let inputKey = reveryKeyToEditorKey(key);
     let (keyBindings, effects) =
-      Keybindings.keyUp(~context=conditions, ~key, state.keyBindings);
+      Keybindings.keyUp(~context, ~key, state.keyBindings);
 
     let newState = {...state, keyBindings};
 

--- a/test/Input/KeybindingsTests.re
+++ b/test/Input/KeybindingsTests.re
@@ -56,7 +56,12 @@ let getKeyFromSDL: string => EditorInput.KeyPress.t =
   };
 
 let contextWithEditorTextFocus =
-  Seq.return(("editorTextFocus", true)) |> Hashtbl.of_seq;
+  WhenExpr.ContextKeys.(
+    fromSchema(
+      Schema.fromList(Schema.[bool("editorTextFocus", () => true)]),
+      (),
+    )
+  );
 
 let isOk = v =>
   switch (v) {


### PR DESCRIPTION
This creates a new context keys data structure and schema, so that context keys can be defined as contributions and extended with context-specific context keys (:roll_eyes:).