### PR TITLE
Fix insertSpaces default value

### DIFF
--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -71,7 +71,7 @@ let largeFileOptimization =
 let highlightActiveIndentGuide =
   setting("editor.highlightActiveIndentGuide", bool, ~default=true);
 let indentSize = setting("editor.indentSize", int, ~default=4);
-let insertSpaces = setting("editor.insertSpaces", bool, ~default=false);
+let insertSpaces = setting("editor.insertSpaces", bool, ~default=true);
 let lineNumbers = setting("editor.lineNumbers", lineNumbers, ~default=`On);
 let matchBrackets = setting("editor.matchBrackets", bool, ~default=true);
 let renderIndentGuides =


### PR DESCRIPTION
[As stated in the docs](https://github.com/onivim/oni2/blob/master/docs/docs/configuration/settings.md), the default value for `insertSpaces` should be true, not false.