### PR TITLE
Documentation - Fix Terminal Normal Command

### DIFF
--- a/docs/docs/using-onivim/integrated-terminal.md
+++ b/docs/docs/using-onivim/integrated-terminal.md
@@ -56,7 +56,7 @@ To change the current working directory, which will also update the file explore
 
 To switch to `Terminal Normal` mode, use the following command:
 
-- <kbd>Ctrl</kbd>+<kbd>/</kbd>, <kbd>Ctrl</kbd>+<kbd>N</kbd>
+- <kbd>Ctrl</kbd>+<kbd>\\</kbd>, <kbd>Ctrl</kbd>+<kbd>N</kbd>
 
 > __NOTE:__ In `Terminal Normal` mode, the buffer is _read-only_.
 


### PR DESCRIPTION
I noticed the video and docs were out of sync for going to terminal normal mode. The video has the right command, so this change updates the [integrated terminal docs](https://onivim.github.io/docs/using-onivim/integrated-terminal#normal-mode) to match.