### PR TITLE
Revert Notification Color Defaults To Pre-Revamp Colors

### DIFF
--- a/src/Feature/Notification/Feature_Notification.re
+++ b/src/Feature/Notification/Feature_Notification.re
@@ -77,35 +77,17 @@ module Colors = {
   let foreground = foreground;
 
   let infoBackground =
-    define(
-      "oni.notification.infoBackground",
-      all(ref(EditorInfo.foreground)),
-    );
+    define("oni.notification.infoBackground", all(hex("#209CEE")));
   let infoForeground =
-    define(
-      "oni.notification.infoForeground",
-      all(ref(StatusBar.foreground)),
-    );
+    define("oni.notification.infoForeground", all(hex("#FFF")));
   let warningBackground =
-    define(
-      "oni.notification.warningBackground",
-      all(ref(EditorWarning.foreground)),
-    );
+    define("oni.notification.warningBackground", all(hex("#FFDD57")));
   let warningForeground =
-    define(
-      "oni.notification.warningForeground",
-      all(ref(StatusBar.foreground)),
-    );
+    define("oni.notification.warningForeground", all(hex("#333")));
   let errorBackground =
-    define(
-      "oni.notification.errorBackground",
-      all(ref(EditorError.foreground)),
-    );
+    define("oni.notification.errorBackground", all(hex("#FF3860")));
   let errorForeground =
-    define(
-      "oni.notification.errorForeground",
-      all(ref(StatusBar.foreground)),
-    );
+    define("oni.notification.errorForeground", all(hex("#FFF")));
 
   let backgroundFor = notification =>
     switch (notification.kind) {


### PR DESCRIPTION
Follow-up to #1591 

This reverts the notification colors to what we had pre-revamp, with one exception. I changed the warning foreground from white to almost black, because white on bright yellow isn't very legible.

Note also that in #1591 I prefixed the keys with `oni.` to distinguish them from the "standard" vscode colors. I'm trying to do that with all the keys, to prevent future collisions, so that users get a better idea of which colors won't be themed by vscode themes and that they therefore might have to tweak themselves, and for us to have a better idea of what we can freely change without breaking vscode compatibility and not have to dig around in the vscode source for.