### PR TITLE
Feature: Menu contributions

### DIFF
--- a/src/Core/Command.re
+++ b/src/Core/Command.re
@@ -41,7 +41,7 @@ module Lookup = {
     KeyedStringMap.union(
       (key, _x, y) => {
         Log.warnf(m =>
-          m("Encountered duplicate default: %s", KeyedStringMap.keyName(key))
+          m("Encountered duplicate command: %s", KeyedStringMap.keyName(key))
         );
         Some(y);
       },

--- a/src/Core/Menu.re
+++ b/src/Core/Menu.re
@@ -52,6 +52,21 @@ type item = {
   command: string,
 };
 
+let fromSchemaItem = (commands, item: Schema.item) =>
+  Command.Lookup.get(item.command, commands)
+  |> Option.map((command: Command.t(_)) =>
+       {
+         label: command.title |> Option.value(~default=command.id),
+         category: command.category,
+         icon: command.icon,
+         isEnabledWhen: command.isEnabledWhen,
+         isVisibleWhen: item.isVisibleWhen,
+         group: item.group,
+         index: item.index,
+         command: command.id,
+       }
+     );
+
 // LOOKUP
 
 module Lookup = {
@@ -62,6 +77,16 @@ module Lookup = {
     |> List.to_seq
     |> Seq.map(((id, items)) => (KeyedStringMap.key(id), items))
     |> KeyedStringMap.of_seq;
+
+  let fromSchema = (commands, definitions) =>
+    definitions
+    |> List.map((definition: Schema.definition) =>
+         (
+           definition.id,
+           definition.items |> List.filter_map(fromSchemaItem(commands)),
+         )
+       )
+    |> fromList;
 
   let get = (id, lookup) =>
     KeyedStringMap.find_opt(KeyedStringMap.key(id), lookup)

--- a/src/Core/Menu.re
+++ b/src/Core/Menu.re
@@ -2,6 +2,44 @@ open Kernel;
 
 module Log = (val Log.withNamespace("Oni2.Core.Menu"));
 
+// SCHEMA
+
+module Schema = {
+  [@deriving show]
+  type item = {
+    isVisibleWhen: WhenExpr.t,
+    group: option(string),
+    index: option(int),
+    command: string,
+    alt: option(string) // currently unused
+  };
+
+  type group = list(item);
+
+  [@deriving show]
+  type definition = {
+    id: string,
+    items: list(item),
+  };
+
+  let extend = (id, groups) => {id, items: List.concat(groups)};
+
+  let group = (id, items) =>
+    List.map(item => {...item, group: Some(id)}, items);
+
+  let ungrouped = items => items;
+
+  let item = (~index=?, ~alt=?, ~isVisibleWhen=WhenExpr.Value(True), command) => {
+    isVisibleWhen,
+    index,
+    command,
+    alt,
+    group: None,
+  };
+};
+
+// MODEL
+
 [@deriving show]
 type item = {
   label: string,
@@ -13,6 +51,8 @@ type item = {
   index: option(int),
   command: string,
 };
+
+// LOOKUP
 
 module Lookup = {
   type t = KeyedStringMap.t(list(item));

--- a/src/Core/Menu.re
+++ b/src/Core/Menu.re
@@ -1,0 +1,35 @@
+open Kernel;
+
+module Log = (val Log.withNamespace("Oni2.Core.Menu"));
+
+[@deriving show]
+type item = {
+  label: string,
+  category: option(string),
+  icon: [@opaque] option(IconTheme.IconDefinition.t),
+  isEnabledWhen: [@opaque] WhenExpr.t,
+  isVisibleWhen: [@opaque] WhenExpr.t,
+  group: option(string),
+  index: option(int),
+  command: string,
+};
+
+module Lookup = {
+  type t = KeyedStringMap.t(list(item));
+
+  let fromList = entries =>
+    entries
+    |> List.to_seq
+    |> Seq.map(((id, items)) => (KeyedStringMap.key(id), items))
+    |> KeyedStringMap.of_seq;
+
+  let get = (id, lookup) =>
+    KeyedStringMap.find_opt(KeyedStringMap.key(id), lookup)
+    |> Option.value(~default=[]);
+
+  let union = (xs, ys) =>
+    KeyedStringMap.union((_key, x, y) => Some(x @ y), xs, ys);
+
+  let unionMany = lookups =>
+    List.fold_left(union, KeyedStringMap.empty, lookups);
+};

--- a/src/Core/Menu.rei
+++ b/src/Core/Menu.rei
@@ -1,0 +1,22 @@
+[@deriving show]
+type item = {
+  label: string,
+  category: option(string),
+  icon: [@opaque] option(IconTheme.IconDefinition.t),
+  isEnabledWhen: [@opaque] WhenExpr.t,
+  isVisibleWhen: [@opaque] WhenExpr.t,
+  group: option(string),
+  index: option(int),
+  command: string,
+};
+
+module Lookup: {
+  type t;
+
+  let fromList: list((string, list(item))) => t;
+
+  let get: (string, t) => list(item);
+
+  let union: (t, t) => t;
+  let unionMany: list(t) => t;
+};

--- a/src/Core/Menu.rei
+++ b/src/Core/Menu.rei
@@ -42,12 +42,15 @@ type item = {
   command: string,
 };
 
+let fromSchemaItem: (Command.Lookup.t(_), Schema.item) => option(item);
+
 // LOOKUP
 
 module Lookup: {
   type t;
 
   let fromList: list((string, list(item))) => t;
+  let fromSchema: (Command.Lookup.t(_), list(Schema.definition)) => t;
 
   let get: (string, t) => list(item);
 

--- a/src/Core/Menu.rei
+++ b/src/Core/Menu.rei
@@ -1,3 +1,35 @@
+// SCHEMA
+
+module Schema: {
+  [@deriving show]
+  type item = {
+    isVisibleWhen: WhenExpr.t,
+    group: option(string),
+    index: option(int),
+    command: string,
+    alt: option(string) // currently unused
+  };
+
+  type group;
+
+  [@deriving show]
+  type definition = {
+    id: string,
+    items: list(item),
+  };
+
+  let extend: (string, list(group)) => definition;
+
+  let group: (string, list(item)) => group;
+  let ungrouped: list(item) => group;
+
+  let item:
+    (~index: int=?, ~alt: string=?, ~isVisibleWhen: WhenExpr.t=?, string) =>
+    item;
+};
+
+// MODEL
+
 [@deriving show]
 type item = {
   label: string,
@@ -9,6 +41,8 @@ type item = {
   index: option(int),
   command: string,
 };
+
+// LOOKUP
 
 module Lookup: {
   type t;

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -33,6 +33,7 @@ module Job = Job;
 module LazyLoader = LazyLoader;
 module LineNumber = LineNumber;
 module Log = Kernel.Log;
+module Menu = Menu;
 module Mode = Mode;
 module Ripgrep = Ripgrep;
 module Scheduler = Scheduler;

--- a/src/Extensions/dune
+++ b/src/Extensions/dune
@@ -15,6 +15,7 @@
         reason-jsonrpc
         oniguruma
         Oni2.core
+        Oni2.core.whenExpr
         isolinear
     )
     (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Feature/Menus/Feature_Menus.re
+++ b/src/Feature/Menus/Feature_Menus.re
@@ -1,0 +1,100 @@
+open Oni_Core;
+
+module Log = (val Log.withNamespace("Oni.Feature.Menus"));
+
+// BUILT-IN MENUS
+
+let explorerContext = Menu.Lookup.get("explorer/context");
+let editorContext = Menu.Lookup.get("editor/context");
+let editorTitle = Menu.Lookup.get("editor/title");
+let editorTitleContext = Menu.Lookup.get("editor/title/context");
+let debugCallstackContext = Menu.Lookup.get("debug/callstack/context");
+let debugToolbar = Menu.Lookup.get("debug/toolbar");
+let scmTitle = Menu.Lookup.get("scm/title");
+let scmResourceGroupContext = Menu.Lookup.get("scm/resourceGroup/context");
+let scmResourceStateContext = Menu.Lookup.get("scm/resourceState/context");
+let scmChangeTitle = Menu.Lookup.get("scm/change/title");
+let viewTitle = Menu.Lookup.get("view/title");
+let viewItemContext = Menu.Lookup.get("view/item/context");
+let touchBar = Menu.Lookup.get("touchBar");
+let commentThreadTitle = Menu.Lookup.get("comments/commentThread/title");
+let commentThreadContext = Menu.Lookup.get("comments/commentThread/context");
+let commentTitle = Menu.Lookup.get("comments/comment/title");
+let commentContext = Menu.Lookup.get("comments/comment/context");
+
+let commandPalette = (contextKeys, commands, menus: Menu.Lookup.t) => {
+  // The command palette should contain all commands that are enabled and have
+  // not been explicitly hidden by an associated menu item
+
+  // Get enabled commands and convert them to menu items
+  let commandItems =
+    commands
+    |> Command.Lookup.toList
+    |> List.to_seq
+    |> Seq.filter_map(
+         Command.(
+           command =>
+             switch (command.title) {
+             | Some(title)
+                 when
+                   WhenExpr.evaluate(
+                     command.isEnabledWhen,
+                     WhenExpr.ContextKeys.getValue(contextKeys),
+                   ) =>
+               Some((
+                 command.id,
+                 Menu.{
+                   label: title,
+                   category: command.category,
+                   icon: command.icon,
+                   isEnabledWhen: WhenExpr.Value(True), // disabled filtered out before
+                   isVisibleWhen: WhenExpr.Value(True),
+                   group: None,
+                   index: None,
+                   command: command.id,
+                 },
+               ))
+
+             | _ => None
+             }
+         ),
+       )
+    |> StringMap.of_seq;
+
+  // Get "commandPalette" menu definition
+  let menuItems =
+    Menu.Lookup.get("commandPalette", menus)
+    |> List.to_seq
+    |> Seq.map(Menu.(item => (item.command, item)))
+    |> StringMap.of_seq;
+
+  // Merge the two sets, hiding any commands explicitly hidden by a menu item
+  StringMap.merge(
+    (_id, commandItem, menuItem) =>
+      switch (commandItem, menuItem) {
+      | (Some(_), Some((menuItem: Menu.item)))
+          when
+            WhenExpr.evaluate(
+              menuItem.isVisibleWhen,
+              WhenExpr.ContextKeys.getValue(contextKeys),
+            ) =>
+        None
+
+      | (Some(commandItem), Some((menuItem: Menu.item))) =>
+        Some(
+          Menu.{...commandItem, group: menuItem.group, index: menuItem.index},
+        )
+
+      | (Some(commandItem), None) => Some(commandItem)
+
+      | (None, Some(_)) => None // Should have been filtered out already
+
+      | (None, None) => failwith("unreachable")
+      },
+    commandItems,
+    menuItems,
+  )
+  |> StringMap.to_seq
+  |> Seq.map(snd)
+  |> List.of_seq;
+};

--- a/src/Feature/Menus/Feature_Menus.rei
+++ b/src/Feature/Menus/Feature_Menus.rei
@@ -1,0 +1,23 @@
+open Oni_Core;
+
+let explorerContext: Menu.Lookup.t => list(Menu.item);
+let editorContext: Menu.Lookup.t => list(Menu.item);
+let editorTitle: Menu.Lookup.t => list(Menu.item);
+let editorTitleContext: Menu.Lookup.t => list(Menu.item);
+let debugCallstackContext: Menu.Lookup.t => list(Menu.item);
+let debugToolbar: Menu.Lookup.t => list(Menu.item);
+let scmTitle: Menu.Lookup.t => list(Menu.item);
+let scmResourceGroupContext: Menu.Lookup.t => list(Menu.item);
+let scmResourceStateContext: Menu.Lookup.t => list(Menu.item);
+let scmChangeTitle: Menu.Lookup.t => list(Menu.item);
+let viewTitle: Menu.Lookup.t => list(Menu.item);
+let viewItemContext: Menu.Lookup.t => list(Menu.item);
+let touchBar: Menu.Lookup.t => list(Menu.item);
+let commentThreadTitle: Menu.Lookup.t => list(Menu.item);
+let commentThreadContext: Menu.Lookup.t => list(Menu.item);
+let commentTitle: Menu.Lookup.t => list(Menu.item);
+let commentContext: Menu.Lookup.t => list(Menu.item);
+
+let commandPalette:
+  (WhenExpr.ContextKeys.t, Command.Lookup.t(_), Menu.Lookup.t) =>
+  list(Menu.item);

--- a/src/Feature/Menus/dune
+++ b/src/Feature/Menus/dune
@@ -1,0 +1,13 @@
+(library
+    (name Feature_Menus)
+    (public_name Oni2.feature.menus)
+    (libraries 
+      editor-core-types
+      Oni2.core
+      Oni2.core.whenExpr
+      Oni2.extensions
+      Oni2.feature.commands
+      isolinear
+      base
+    )
+    (preprocess (pps ppx_let ppx_deriving.show)))

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -91,4 +91,8 @@ let other =
   );
 
 let all =
-  unionMany(State.[menus |> map(state => state.quickmenu), editors, other]);
+  unionMany([
+    menus |> map((state: State.t) => state.quickmenu),
+    editors,
+    other,
+  ]);

--- a/src/Model/Extensions.re
+++ b/src/Model/Extensions.re
@@ -78,3 +78,21 @@ let commands = model => {
        }
      );
 };
+
+let menus = model =>
+  // Combine menu items contributed to common menus from different extensions
+  List.fold_left(
+    (acc, extension: ExtensionScanner.t) =>
+      List.fold_left(
+        (acc, menu: Menu.Schema.definition) =>
+          StringMap.add(menu.id, menu.items, acc),
+        StringMap.empty,
+        extension.manifest.contributes.menus,
+      )
+      |> StringMap.union((_, xs, ys) => Some(xs @ ys), acc),
+    StringMap.empty,
+    model.extensions,
+  )
+  |> StringMap.to_seq
+  |> Seq.map(((id, items)) => Menu.Schema.{id, items})
+  |> List.of_seq;

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -141,3 +141,9 @@ let commands = state =>
     |> Command.Lookup.fromList
     |> Command.Lookup.map(msg => Actions.Extension(msg)),
   ]);
+
+let menus = state => {
+  let commands = commands(state);
+
+  Extensions.menus(state.extensions) |> Menu.Lookup.fromSchema(commands);
+};

--- a/src/Store/dune
+++ b/src/Store/dune
@@ -22,6 +22,7 @@
         Oni2.components
         Oni2.ui
         Oni2.feature.commands
+        Oni2.feature.menus
         Oni2.feature.notification
         Oni2.feature.theme
         Oni2.feature.terminal


### PR DESCRIPTION
This adds infrastructure to support menus that can be contributed to from both extensions and feature projects. It currently integrates the command palette, and also sets us up for showing menus with commands contributed by extensions, in particular SCM providers which rely heavily on this feature.

Depends on #1595.

TODO (in a future PR):
- [ ] Alt commands (not sure how this actually works yet, as I don't know of any examples of it in vscode)
- [ ] Proper handling of groups and positioning by index within groups