### PR TITLE
Fix #1607 - Stack overflow in Diagnostic.explode

### DIFF
--- a/src/Feature/LanguageSupport/Diagnostic.re
+++ b/src/Feature/LanguageSupport/Diagnostic.re
@@ -18,7 +18,6 @@ let create = (~range, ~message, ()) => {range, message};
 let maxDiagnosticLines = 1000;
 
 let explode = (buffer, diagnostic) => {
-  prerr_endline("Exploding range: " ++ Range.show(diagnostic.range));
   let lineCount = Buffer.getNumberOfLines(buffer);
   let measure = n => {
     Index.toZeroBased(n) < lineCount

--- a/src/Feature/LanguageSupport/Diagnostic.re
+++ b/src/Feature/LanguageSupport/Diagnostic.re
@@ -31,6 +31,6 @@ let explode = (buffer, diagnostic) => {
   };
 
   Range.explode(measure, diagnostic.range)
-  |> ListEx.firstk(maxDiagnosticLines)
+  |> ListEx.firstk(Constants.maxDiagnosticLines)
   |> ListEx.safeMap(range => create(~range, ~message=diagnostic.message, ()));
 };

--- a/src/Feature/LanguageSupport/Diagnostic.re
+++ b/src/Feature/LanguageSupport/Diagnostic.re
@@ -4,6 +4,7 @@
 
 open EditorCoreTypes;
 open Oni_Core;
+open Oni_Core.Utility;
 
 [@deriving show]
 type t = {
@@ -13,7 +14,11 @@ type t = {
 
 let create = (~range, ~message, ()) => {range, message};
 
+// Clamp the number of lines a diagnostic range can span to a tractable number.
+let maxDiagnosticLines = 1000;
+
 let explode = (buffer, diagnostic) => {
+  prerr_endline("Exploding range: " ++ Range.show(diagnostic.range));
   let lineCount = Buffer.getNumberOfLines(buffer);
   let measure = n => {
     Index.toZeroBased(n) < lineCount
@@ -24,5 +29,6 @@ let explode = (buffer, diagnostic) => {
   };
 
   Range.explode(measure, diagnostic.range)
-  |> List.map(range => create(~range, ~message=diagnostic.message, ()));
+  |> ListEx.firstk(maxDiagnosticLines)
+  |> ListEx.safeMap(range => create(~range, ~message=diagnostic.message, ()));
 };

--- a/src/Feature/LanguageSupport/Diagnostic.re
+++ b/src/Feature/LanguageSupport/Diagnostic.re
@@ -6,6 +6,12 @@ open EditorCoreTypes;
 open Oni_Core;
 open Oni_Core.Utility;
 
+module Constants = {
+  // Clamp the number of lines a diagnostic range can span to a tractable number.
+  // See: https://github.com/onivim/oni2/issues/1607
+  let maxDiagnosticLines = 1000;
+};
+
 [@deriving show]
 type t = {
   range: Range.t,
@@ -13,9 +19,6 @@ type t = {
 };
 
 let create = (~range, ~message, ()) => {range, message};
-
-// Clamp the number of lines a diagnostic range can span to a tractable number.
-let maxDiagnosticLines = 1000;
 
 let explode = (buffer, diagnostic) => {
   let lineCount = Buffer.getNumberOfLines(buffer);

--- a/src/Feature/LanguageSupport/Diagnostics.re
+++ b/src/Feature/LanguageSupport/Diagnostics.re
@@ -8,6 +8,7 @@
 
 open EditorCoreTypes;
 open Oni_Core;
+open Oni_Core.Utility;
 
 /*
  * The type for diagnostics is a nested map:
@@ -62,7 +63,7 @@ let _explodeDiagnostics = (buffer, diagnostics) => {
     );
   };
 
-  List.map(Diagnostic.explode(buffer), diagnostics)
+  ListEx.safeMap(Diagnostic.explode(buffer), diagnostics)
   |> List.flatten
   |> List.fold_left(f, IntMap.empty);
 };

--- a/test/Feature/LanguageSupport/DiagnosticTest.re
+++ b/test/Feature/LanguageSupport/DiagnosticTest.re
@@ -1,0 +1,22 @@
+open EditorCoreTypes;
+open Oni_Core;
+open TestFramework;
+open Feature_LanguageSupport;
+
+describe("Diagnostics", ({describe, _}) => {
+  describe("explode", ({test, _}) => {
+    test("Regression Test for #1607 - stack overflow", ({expect, _}) => {
+      let start = Location.{line: Index.zero, column: Index.zero};
+      let stop =
+        Location.{line: Index.(zero + 424242), column: Index.(zero + 424242)};
+
+      let range = Range.{start, stop};
+
+      let hugeDiagnostic =
+        Diagnostic.create(~range, ~message="test diagnostic", ());
+      let diags = Diagnostic.explode(Buffer.ofLines([||]), hugeDiagnostic);
+
+      expect.int(List.length(diags)).toBe(1000);
+    })
+  })
+});


### PR DESCRIPTION
__Issue:__ In certain conditions - like a diagnostic covering a very, very large range - we could crash when 'exploding' the diagnostic across lines.

__Defect:__ The `List.map` wasn't stack-safe, so for a very large list range, we'd hit a stackoverflow.

__Fix:__ Create a maximum acceptable length to 'explode', and use the stack-safe variant of `List.map`. Without clamping the list via `List.firstk`, we'd still hit a stack overflow in the consolidation of the Diagnostics in the `_explodeDiagnostics` when we go to flatten.

Fixes #1607 