### PR TITLE
Feature: XML Theme and Grammar support

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4214bfc2d35d3ec106d7a16cd43ccc71",
+  "checksum": "bedd335944bd380ef5a6c9b0b84ea067",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,13 +308,15 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
-      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+    "reason-textmate@3.1.0@d41d8cd9": {
+      "id": "reason-textmate@3.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "github:onivim/reason-textmate#5269e5f",
+      "version": "3.1.0",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-textmate#5269e5f" ]
+        "source": [
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.1.0.tgz#sha1:1b2dcbaf0903c3802c9a7889e4644ea58973a866"
+        ]
       },
       "overrides": [],
       "dependencies": [
@@ -327,7 +329,7 @@
         "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+      "devDependencies": []
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1209,8 +1211,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
-        "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@3.1.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "840381da89f5dfaa1ba5d26a4967b1f5",
+  "checksum": "4214bfc2d35d3ec106d7a16cd43ccc71",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,15 +308,13 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@3.0.0@d41d8cd9": {
-      "id": "reason-textmate@3.0.0@d41d8cd9",
+    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
+      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
       "name": "reason-textmate",
-      "version": "3.0.0",
+      "version": "github:onivim/reason-textmate#5269e5f",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.0.0.tgz#sha1:0d6feb7ebac25ca04ef649bd170b0ed89100b118"
-        ]
+        "source": [ "github:onivim/reason-textmate#5269e5f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -326,10 +324,10 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/ppx_let@opam:v0.12.0@b52d29f3",
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
-        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": []
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1211,7 +1209,8 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.0.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+        "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
@@ -2406,6 +2405,33 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@b2a79ec0",
         "@opam/menhirLib@opam:20200211@93d0f001",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/markup@opam:0.8.2@87975241": {
+      "id": "@opam/markup@opam:0.8.2@87975241",
+      "name": "@opam/markup",
+      "version": "opam:0.8.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/0f/0fe6b3a04d941ca40a5efdd082f1183d#md5:0fe6b3a04d941ca40a5efdd082f1183d",
+          "archive:https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz#md5:0fe6b3a04d941ca40a5efdd082f1183d"
+        ],
+        "opam": {
+          "name": "markup",
+          "version": "0.8.2",
+          "path": "bench.esy.lock/opam/markup.0.8.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {

--- a/bench.esy.lock/opam/markup.0.8.2/opam
+++ b/bench.esy.lock/opam/markup.0.8.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+version: "0.8.2"
+license: "MIT"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "ounit" {dev}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz"
+  checksum: "md5=0fe6b3a04d941ca40a5efdd082f1183d"
+}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "840381da89f5dfaa1ba5d26a4967b1f5",
+  "checksum": "4214bfc2d35d3ec106d7a16cd43ccc71",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,15 +308,13 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@3.0.0@d41d8cd9": {
-      "id": "reason-textmate@3.0.0@d41d8cd9",
+    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
+      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
       "name": "reason-textmate",
-      "version": "3.0.0",
+      "version": "github:onivim/reason-textmate#5269e5f",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.0.0.tgz#sha1:0d6feb7ebac25ca04ef649bd170b0ed89100b118"
-        ]
+        "source": [ "github:onivim/reason-textmate#5269e5f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -326,10 +324,10 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/ppx_let@opam:v0.12.0@b52d29f3",
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
-        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": []
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1210,7 +1208,8 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.0.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+        "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
@@ -2405,6 +2404,33 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@b2a79ec0",
         "@opam/menhirLib@opam:20200211@93d0f001",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/markup@opam:0.8.2@87975241": {
+      "id": "@opam/markup@opam:0.8.2@87975241",
+      "name": "@opam/markup",
+      "version": "opam:0.8.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/0f/0fe6b3a04d941ca40a5efdd082f1183d#md5:0fe6b3a04d941ca40a5efdd082f1183d",
+          "archive:https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz#md5:0fe6b3a04d941ca40a5efdd082f1183d"
+        ],
+        "opam": {
+          "name": "markup",
+          "version": "0.8.2",
+          "path": "esy.lock/opam/markup.0.8.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4214bfc2d35d3ec106d7a16cd43ccc71",
+  "checksum": "bedd335944bd380ef5a6c9b0b84ea067",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,13 +308,15 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
-      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+    "reason-textmate@3.1.0@d41d8cd9": {
+      "id": "reason-textmate@3.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "github:onivim/reason-textmate#5269e5f",
+      "version": "3.1.0",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-textmate#5269e5f" ]
+        "source": [
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.1.0.tgz#sha1:1b2dcbaf0903c3802c9a7889e4644ea58973a866"
+        ]
       },
       "overrides": [],
       "dependencies": [
@@ -327,7 +329,7 @@
         "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+      "devDependencies": []
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1208,8 +1210,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
-        "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@3.1.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",

--- a/esy.lock/opam/markup.0.8.2/opam
+++ b/esy.lock/opam/markup.0.8.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+version: "0.8.2"
+license: "MIT"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "ounit" {dev}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz"
+  checksum: "md5=0fe6b3a04d941ca40a5efdd082f1183d"
+}

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "840381da89f5dfaa1ba5d26a4967b1f5",
+  "checksum": "4214bfc2d35d3ec106d7a16cd43ccc71",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,15 +308,13 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@3.0.0@d41d8cd9": {
-      "id": "reason-textmate@3.0.0@d41d8cd9",
+    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
+      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
       "name": "reason-textmate",
-      "version": "3.0.0",
+      "version": "github:onivim/reason-textmate#5269e5f",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.0.0.tgz#sha1:0d6feb7ebac25ca04ef649bd170b0ed89100b118"
-        ]
+        "source": [ "github:onivim/reason-textmate#5269e5f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -326,10 +324,10 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/ppx_let@opam:v0.12.0@b52d29f3",
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
-        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": []
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1210,7 +1208,8 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.0.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+        "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
@@ -2406,6 +2405,33 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@b2a79ec0",
         "@opam/menhirLib@opam:20200211@93d0f001",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/markup@opam:0.8.2@87975241": {
+      "id": "@opam/markup@opam:0.8.2@87975241",
+      "name": "@opam/markup",
+      "version": "opam:0.8.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/0f/0fe6b3a04d941ca40a5efdd082f1183d#md5:0fe6b3a04d941ca40a5efdd082f1183d",
+          "archive:https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz#md5:0fe6b3a04d941ca40a5efdd082f1183d"
+        ],
+        "opam": {
+          "name": "markup",
+          "version": "0.8.2",
+          "path": "integrationtest.esy.lock/opam/markup.0.8.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4214bfc2d35d3ec106d7a16cd43ccc71",
+  "checksum": "bedd335944bd380ef5a6c9b0b84ea067",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,13 +308,15 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
-      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+    "reason-textmate@3.1.0@d41d8cd9": {
+      "id": "reason-textmate@3.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "github:onivim/reason-textmate#5269e5f",
+      "version": "3.1.0",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-textmate#5269e5f" ]
+        "source": [
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.1.0.tgz#sha1:1b2dcbaf0903c3802c9a7889e4644ea58973a866"
+        ]
       },
       "overrides": [],
       "dependencies": [
@@ -327,7 +329,7 @@
         "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+      "devDependencies": []
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1208,8 +1210,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
-        "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@3.1.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",

--- a/integrationtest.esy.lock/opam/markup.0.8.2/opam
+++ b/integrationtest.esy.lock/opam/markup.0.8.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+version: "0.8.2"
+license: "MIT"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "ounit" {dev}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz"
+  checksum: "md5=0fe6b3a04d941ca40a5efdd082f1183d"
+}

--- a/package.json
+++ b/package.json
@@ -252,7 +252,8 @@
     "esy-oniguruma": "onivim/esy-oniguruma#4698ce4",
     "editor-input": "onivim/editor-input#c494950",
     "isolinear": "revery-ui/isolinear#b17ce17",
-    "revery-terminal": "revery-ui/revery-terminal#2ef1c65"
+    "revery-terminal": "revery-ui/revery-terminal#2ef1c65",
+    "reason-textmate": "onivim/reason-textmate#5269e5f"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "revery": "0.30.0",
     "revery-terminal": "*",
     "reason-tree-sitter": "^1.0.1001",
-    "reason-textmate": "^3.0.0",
+    "reason-textmate": "^3.1.0",
     "esy-sdl2": "*",
     "esy-skia": "*",
     "@opam/fmt": "^0.8.8",
@@ -252,8 +252,7 @@
     "esy-oniguruma": "onivim/esy-oniguruma#4698ce4",
     "editor-input": "onivim/editor-input#c494950",
     "isolinear": "revery-ui/isolinear#b17ce17",
-    "revery-terminal": "revery-ui/revery-terminal#2ef1c65",
-    "reason-textmate": "onivim/reason-textmate#5269e5f"
+    "revery-terminal": "revery-ui/revery-terminal#2ef1c65"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "09e56bab7d2b2a48befd1a16c8728b67",
+  "checksum": "9cb31b5902bc4e35dd8da20d0c6443e1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,13 +308,15 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
-      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+    "reason-textmate@3.1.0@d41d8cd9": {
+      "id": "reason-textmate@3.1.0@d41d8cd9",
       "name": "reason-textmate",
-      "version": "github:onivim/reason-textmate#5269e5f",
+      "version": "3.1.0",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-textmate#5269e5f" ]
+        "source": [
+          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.1.0.tgz#sha1:1b2dcbaf0903c3802c9a7889e4644ea58973a866"
+        ]
       },
       "overrides": [],
       "dependencies": [
@@ -327,7 +329,7 @@
         "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+      "devDependencies": []
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1208,8 +1210,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
-        "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@3.1.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "be0e66a09a63d784bd7b3b200a8136ab",
+  "checksum": "09e56bab7d2b2a48befd1a16c8728b67",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -308,15 +308,13 @@
       ],
       "devDependencies": []
     },
-    "reason-textmate@3.0.0@d41d8cd9": {
-      "id": "reason-textmate@3.0.0@d41d8cd9",
+    "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9": {
+      "id": "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
       "name": "reason-textmate",
-      "version": "3.0.0",
+      "version": "github:onivim/reason-textmate#5269e5f",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/reason-textmate/-/reason-textmate-3.0.0.tgz#sha1:0d6feb7ebac25ca04ef649bd170b0ed89100b118"
-        ]
+        "source": [ "github:onivim/reason-textmate#5269e5f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -326,10 +324,10 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/ppx_let@opam:v0.12.0@b52d29f3",
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
-        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/dune@opam:2.5.0@aef1678b",
         "@esy-ocaml/reason@github:facebook/reason#8f71db0@d41d8cd9"
       ],
-      "devDependencies": []
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9": {
       "id": "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
@@ -1210,7 +1208,8 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.0.0@d41d8cd9", "reason-sdl2@2.10.3021@d41d8cd9",
+        "reason-textmate@github:onivim/reason-textmate#5269e5f@d41d8cd9",
+        "reason-sdl2@2.10.3021@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#e791e3a@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
@@ -2405,6 +2404,33 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@b2a79ec0",
         "@opam/menhirLib@opam:20200211@93d0f001",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/markup@opam:0.8.2@87975241": {
+      "id": "@opam/markup@opam:0.8.2@87975241",
+      "name": "@opam/markup",
+      "version": "opam:0.8.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/0f/0fe6b3a04d941ca40a5efdd082f1183d#md5:0fe6b3a04d941ca40a5efdd082f1183d",
+          "archive:https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz#md5:0fe6b3a04d941ca40a5efdd082f1183d"
+        ],
+        "opam": {
+          "name": "markup",
+          "version": "0.8.2",
+          "path": "test.esy.lock/opam/markup.0.8.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {

--- a/test.esy.lock/opam/markup.0.8.2/opam
+++ b/test.esy.lock/opam/markup.0.8.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+version: "0.8.2"
+license: "MIT"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "ounit" {dev}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.2.tar.gz"
+  checksum: "md5=0fe6b3a04d941ca40a5efdd082f1183d"
+}


### PR DESCRIPTION
Brings in the changes https://github.com/onivim/reason-textmate/pull/54 and https://github.com/onivim/reason-textmate/pull/55 which added parsing of XML grammars and themes, respectively, to reason-textmate.

Has so far been tested to work with:

- https://github.com/chiragpat/tomorrow-and-tomorrow-night-operator-mono-theme
- https://github.com/glennsl/vscode-duotone-dark-faithful
- https://github.com/JustusAdam/language-haskell

Let me know if there's anything else we should test.

Fixes #912 
Probably fixes #1486 
Addresses #1471, but does not completely fix it. See comment below