### PR TITLE
feat(workspace): keyboard window navigation

### DIFF
--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -1,11 +1,5 @@
 open Utility;
 
-type direction =
-  | Up
-  | Left
-  | Down
-  | Right;
-
 [@deriving show({with_path: false})]
 type size =
   | Weight(float);
@@ -290,26 +284,17 @@ let rec layout = (x, y, width, height, tree) => {
   };
 };
 
-let moveCore = (current, dirX, dirY, tree) => {
+let move = (current, dirX, dirY, tree) => {
   let layout = layout(0, 0, 200, 200, tree);
 
   Internal.move(current, dirX, dirY, layout)
   |> Option.value(~default=current);
 };
 
-let moveLeft = current => moveCore(current, -1, 0);
-let moveRight = current => moveCore(current, 1, 0);
-let moveUp = current => moveCore(current, 0, -1);
-let moveDown = current => moveCore(current, 0, 1);
-
-let move = (direction: direction, current, v) => {
-  switch (direction) {
-  | Up => moveUp(current, v)
-  | Down => moveDown(current, v)
-  | Left => moveLeft(current, v)
-  | Right => moveRight(current, v)
-  };
-};
+let moveLeft = current => move(current, -1, 0);
+let moveRight = current => move(current, 1, 0);
+let moveUp = current => move(current, 0, -1);
+let moveDown = current => move(current, 0, 1);
 
 let rotateForward = (target, tree) => {
   let f =

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -1,9 +1,3 @@
-type direction =
-  | Up
-  | Left
-  | Down
-  | Right;
-
 // definition only used for tests
 [@deriving show({with_path: false})]
 type size =
@@ -44,7 +38,7 @@ let removeWindow: ('id, t('id)) => t('id);
 
 let layout: (int, int, int, int, t('id)) => list(sizedWindow('id));
 
-let move: (direction, 'id, t('id)) => 'id;
+let move: ('id, int, int, t('id)) => 'id;
 let moveLeft: ('id, t('id)) => 'id;
 let moveRight: ('id, t('id)) => 'id;
 let moveUp: ('id, t('id)) => 'id;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -99,6 +99,13 @@ type t =
   | KeyboardInput(string)
   | WindowTitleSet(string)
   | EditorGroupSelected(int)
+  | WindowTreeSetSize(int, int)
+  | WindowMoveLeft
+  | WindowMoveRight
+  | WindowMoveUp
+  | WindowMoveDown
+  | WindowRotateForward
+  | WindowRotateBackward
   | EditorGroupSizeChanged({
       id: int,
       width: int,

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -53,6 +53,8 @@ let getFirstEditorGroup = ({idToGroup, _}) => {
 
 let getActiveEditorGroup = model => getEditorGroupById(model, model.activeId);
 
+let setActive = (id, model) => {...model, activeId: id};
+
 let isActive = (model, group: EditorGroup.t) =>
   group.editorGroupId == model.activeId;
 

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -5,6 +5,7 @@ let create: unit => t;
 let activeGroupId: t => int; // TODO: Should return an option, or be removed entirely
 let getEditorGroupById: (t, int) => option(EditorGroup.t);
 let getActiveEditorGroup: t => option(EditorGroup.t);
+let setActive: (int, t) => t;
 
 let getFirstEditorGroup: t => EditorGroup.t;
 

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -158,7 +158,7 @@ module Oni = {
         ~category="View",
         ~title="Rotate Windows (Forwards)",
         "view.rotateForward",
-        Command("view.rotateForward"),
+        WindowRotateForward,
       );
 
     let rotateBackward =
@@ -166,7 +166,39 @@ module Oni = {
         ~category="View",
         ~title="Rotate Windows (Backwards)",
         "view.rotateBackward",
-        Command("view.rotateBackward"),
+        WindowRotateBackward,
+      );
+
+    let moveLeft =
+      register(
+        ~category="View",
+        ~title="Move Window Focus Left",
+        "window.moveLeft",
+        WindowMoveLeft,
+      );
+
+    let moveRight =
+      register(
+        ~category="View",
+        ~title="Move Window Focus Right",
+        "window.moveRight",
+        WindowMoveRight,
+      );
+
+    let moveUp =
+      register(
+        ~category="View",
+        ~title="Move Window Focus Up",
+        "window.moveUp",
+        WindowMoveUp,
+      );
+
+    let moveDown =
+      register(
+        ~category="View",
+        ~title="Move Window Focus Down",
+        "window.moveDown",
+        WindowMoveDown,
       );
   };
 

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -48,22 +48,6 @@ let start = () => {
          });
     });
 
-  let windowMoveEffect = (state: State.t, direction, _) => {
-    Isolinear.Effect.createWithDispatch(~name="window.move", dispatch => {
-      let maybeEditorGroupId =
-        EditorGroups.getActiveEditorGroup(state.editorGroups)
-        |> Option.map((group: EditorGroup.t) =>
-             Feature_Layout.move(direction, group.editorGroupId, state.layout)
-           );
-
-      switch (maybeEditorGroupId) {
-      | Some(editorGroupId) =>
-        dispatch(Actions.EditorGroupSelected(editorGroupId))
-      | None => ()
-      };
-    });
-  };
-
   let togglePathEffect = name =>
     Isolinear.Effect.create(
       ~name,
@@ -115,10 +99,6 @@ let start = () => {
     ("view.closeEditor", state => closeEditorEffect(state)),
     ("view.splitVertical", state => splitEditorEffect(state, `Vertical)),
     ("view.splitHorizontal", state => splitEditorEffect(state, `Horizontal)),
-    ("window.moveLeft", state => windowMoveEffect(state, Left)),
-    ("window.moveRight", state => windowMoveEffect(state, Right)),
-    ("window.moveUp", state => windowMoveEffect(state, Up)),
-    ("window.moveDown", state => windowMoveEffect(state, Down)),
     (
       "workbench.action.zoomIn",
       state => zoomEffect(state, zoom => zoom +. Constants.zoomStep),

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -5,17 +5,16 @@
  */
 
 module Core = Oni_Core;
-module Model = Oni_Model;
 
-open Model;
-open Model.Actions;
+open Oni_Model;
+open Actions;
 
 module OptionEx = Core.Utility.OptionEx;
 
 let start = () => {
   let quitEffect =
     Isolinear.Effect.createWithDispatch(~name="windows.quitEffect", dispatch =>
-      dispatch(Model.Actions.Quit(false))
+      dispatch(Actions.Quit(false))
     );
 
   let resize = (axis, factor, state: State.t) =>
@@ -33,79 +32,144 @@ let start = () => {
     | None => state
     };
 
-  let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
+  let windowUpdater = (state: State.t, action: Actions.t) =>
     switch (action) {
-    | EditorGroupSelected(_) => FocusManager.push(Editor, s)
+    | EditorGroupSelected(_) => FocusManager.push(Editor, state)
+
+    | WindowMoveLeft =>
+      switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
+      | Some((editorGroup: EditorGroup.t)) => {
+          ...state,
+          editorGroups:
+            EditorGroups.setActive(
+              Feature_Layout.moveLeft(
+                editorGroup.editorGroupId,
+                state.layout,
+              ),
+              state.editorGroups,
+            ),
+        }
+      | None => state
+      }
+
+    | WindowMoveRight =>
+      switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
+      | Some((editorGroup: EditorGroup.t)) => {
+          ...state,
+          editorGroups:
+            EditorGroups.setActive(
+              Feature_Layout.moveRight(
+                editorGroup.editorGroupId,
+                state.layout,
+              ),
+              state.editorGroups,
+            ),
+        }
+      | None => state
+      }
+
+    | WindowMoveUp =>
+      switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
+      | Some((editorGroup: EditorGroup.t)) => {
+          ...state,
+          editorGroups:
+            EditorGroups.setActive(
+              Feature_Layout.moveUp(editorGroup.editorGroupId, state.layout),
+              state.editorGroups,
+            ),
+        }
+      | None => state
+      }
+
+    | WindowMoveDown =>
+      switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
+      | Some((editorGroup: EditorGroup.t)) => {
+          ...state,
+          editorGroups:
+            EditorGroups.setActive(
+              Feature_Layout.moveDown(
+                editorGroup.editorGroupId,
+                state.layout,
+              ),
+              state.editorGroups,
+            ),
+        }
+      | None => state
+      }
+
     | ViewCloseEditor(_) =>
       /* When an editor is closed... lets see if any window splits are empty */
 
       /* Remove splits */
       let layout =
-        s.layout
+        state.layout
         |> Feature_Layout.windows
         |> List.filter(editorGroupId =>
-             Model.EditorGroups.isEmpty(editorGroupId, s.editorGroups)
+             EditorGroups.isEmpty(editorGroupId, state.editorGroups)
            )
         |> List.fold_left(
              (acc, editorGroupId) =>
                Feature_Layout.removeWindow(editorGroupId, acc),
-             s.layout,
+             state.layout,
            );
 
-      {...s, layout};
+      {...state, layout};
 
-    | OpenFileByPath(_) => FocusManager.push(Editor, s)
+    | OpenFileByPath(_) => FocusManager.push(Editor, state)
 
-    | Command("view.rotateForward") =>
-      switch (EditorGroups.getActiveEditorGroup(s.editorGroups)) {
+    | WindowRotateForward =>
+      switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
       | Some((editorGroup: EditorGroup.t)) => {
-          ...s,
+          ...state,
           layout:
-            Feature_Layout.rotateForward(editorGroup.editorGroupId, s.layout),
+            Feature_Layout.rotateForward(
+              editorGroup.editorGroupId,
+              state.layout,
+            ),
         }
-      | None => s
+      | None => state
       }
 
-    | Command("view.rotateBackward") =>
-      switch (EditorGroups.getActiveEditorGroup(s.editorGroups)) {
+    | WindowRotateBackward =>
+      switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
       | Some((editorGroup: EditorGroup.t)) => {
-          ...s,
+          ...state,
           layout:
             Feature_Layout.rotateBackward(
               editorGroup.editorGroupId,
-              s.layout,
+              state.layout,
             ),
         }
-      | None => s
+      | None => state
       }
 
     | Command("workbench.action.decreaseViewSize") =>
-      s |> resize(`Horizontal, 0.95) |> resize(`Vertical, 0.95)
+      state |> resize(`Horizontal, 0.95) |> resize(`Vertical, 0.95)
 
     | Command("workbench.action.increaseViewSize") =>
-      s |> resize(`Horizontal, 1.05) |> resize(`Vertical, 1.05)
+      state |> resize(`Horizontal, 1.05) |> resize(`Vertical, 1.05)
 
     | Command("vim.decreaseHorizontalWindowSize") =>
-      s |> resize(`Horizontal, 0.95)
+      state |> resize(`Horizontal, 0.95)
 
     | Command("vim.increaseHorizontalWindowSize") =>
-      s |> resize(`Horizontal, 1.05)
+      state |> resize(`Horizontal, 1.05)
 
     | Command("vim.decreaseVerticalWindowSize") =>
-      s |> resize(`Vertical, 0.95)
+      state |> resize(`Vertical, 0.95)
 
     | Command("vim.increaseVerticalWindowSize") =>
-      s |> resize(`Vertical, 1.05)
+      state |> resize(`Vertical, 1.05)
 
     | Command("workbench.action.evenEditorWidths") => {
-        ...s,
-        layout: Feature_Layout.resetWeights(s.layout),
+        ...state,
+        layout: Feature_Layout.resetWeights(state.layout),
       }
 
-    | _ => s
+    | _ => state
     };
 
-  let updater = (state: Model.State.t, action: Model.Actions.t) => {
+  let updater = (state: State.t, action: Actions.t) => {
     let state = windowUpdater(state, action);
 
     let effect =


### PR DESCRIPTION
Don't get too excited! This is blocked hard by a bug that likely involves som timing dependency that's really tricky to pin down (at least for me).

To reproduce:
- Split the editor
- Open another editor in the newly created group
- Select the first group, by mouse or by keyboard
- Select the second group again
- Observe that the active editor of the second group moves back to the first editor

It's also possible to get an editor to open from another group. It seems like the underlying issue is that the vim and oni gets out of sync. But I don't understand why, as from what I can tell the refactoring done so far should preserve the order of operations.

Before refactoring, the active editor was calculated before dispatching `WindowSetActive`, which would update the state in `WindowStore` and then synchronize in `VimStore`. After refactoring, `WindowMove*` is dispatched immediately, which will both calculate the active editor and update the state in `WindowStore`, and then synchronize in `VimStore`. That's really the gist of it, and I can't see how that could cause this. And yet it does...