### PR TITLE
Always load Windows config from %LOCALAPPDATA%

### DIFF
--- a/src/Core/Filesystem.re
+++ b/src/Core/Filesystem.re
@@ -213,31 +213,31 @@ let rmdir = path =>
     }
   );
 
-let unsafeFindHome = () =>
+let getUserDataDirectoryExn = () =>
   Revery.(
     switch (Environment.os) {
     | Environment.Windows => Sys.getenv("LOCALAPPDATA")
     | _ =>
       switch (Sys.getenv_opt("HOME")) {
       | Some(dir) => dir
-      | None => failwith("Could not find HOME dir")
+      | None => failwith("Could not find user data directory")
       }
     }
   );
 
-let getOniDirectory = home =>
+let getOniDirectory = dataDirectory =>
   Revery.(
     switch (Environment.os) {
-    | Environment.Windows => Path.join([home, "Oni2"]) |> return
-    | _ => Path.join([home, ".config", "oni2"]) |> return
+    | Environment.Windows => Path.join([dataDirectory, "Oni2"]) |> return
+    | _ => Path.join([dataDirectory, ".config", "oni2"]) |> return
     }
   );
 
-let getHomeDirectory = () =>
+let getUserDataDirectory = () =>
   Unix.(
-    try(unsafeFindHome() |> return) {
+    try(getUserDataDirectoryExn() |> return) {
     | Unix_error(err, _, _) =>
-      error("Cannot find home because: '%s'", error_message(err))
+      error("Cannot find data directory because: '%s'", error_message(err))
     | Failure(reason) => error("The OS could not be identified %s", reason)
     }
   );
@@ -362,7 +362,7 @@ let getOrCreateConfigFolder = configDir =>
   );
 
 let getExtensionsFolder = () =>
-  getHomeDirectory()
+  getUserDataDirectory()
   >>= getOniDirectory
   >>= (dir => getPath(dir, "extensions"))
   >>= getOrCreateConfigFolder;
@@ -384,7 +384,7 @@ let rec getOrCreateConfigFile = (~overridePath=?, filename) => {
     }
   | None =>
     /* Get Oni Directory */
-    getHomeDirectory()
+    getUserDataDirectory()
     >>= getOniDirectory
     >>= (
       configDir =>

--- a/src/Core/Filesystem.re
+++ b/src/Core/Filesystem.re
@@ -215,10 +215,13 @@ let rmdir = path =>
 
 let unsafeFindHome = () =>
   Revery.(
-    switch (Sys.getenv_opt("HOME"), Environment.os) {
-    | (Some(dir), _) => dir
-    | (None, Environment.Windows) => Sys.getenv("LOCALAPPDATA")
-    | (None, _) => failwith("Could not find HOME dir")
+    switch (Environment.os) {
+    | Environment.Windows => Sys.getenv("LOCALAPPDATA")
+    | _ =>
+      switch (Sys.getenv_opt("HOME")) {
+      | Some(dir) => dir
+      | None => failwith("Could not find HOME dir")
+      }
     }
   );
 

--- a/src/Core/Filesystem.rei
+++ b/src/Core/Filesystem.rei
@@ -10,7 +10,7 @@ let hasGroup: (int, Unix.stats) => t(unit);
 
 let hasPerm: (int, Unix.stats) => t(unit);
 
-let getHomeDirectory: unit => t(string);
+let getUserDataDirectory: unit => t(string);
 
 let getGroupId: unit => t(int);
 
@@ -28,7 +28,7 @@ let mkTempDir: (~prefix: string=?, unit) => string;
 
 let rmdir: string => t(unit);
 
-let unsafeFindHome: unit => string;
+let getUserDataDirectoryExn: unit => string;
 
 let getOniDirectory: string => t(string);
 

--- a/src/Extensions/ExtHostInitData.re
+++ b/src/Extensions/ExtHostInitData.re
@@ -94,7 +94,8 @@ module Environment = {
   [@deriving show({with_path: false})]
   type t = {globalStorageHomePath: string};
 
-  let create = (~globalStorageHomePath=Filesystem.unsafeFindHome(), ()) => {
+  let create =
+      (~globalStorageHomePath=Filesystem.getUserDataDirectoryExn(), ()) => {
     let ret: t = {globalStorageHomePath: globalStorageHomePath};
     ret;
   };
@@ -120,7 +121,7 @@ let create =
       ~parentPid=Process.pid(),
       ~extensions=[],
       ~environment=Environment.create(),
-      ~logsLocationPath=Filesystem.unsafeFindHome(),
+      ~logsLocationPath=Filesystem.getUserDataDirectoryExn(),
       ~autoStart=true,
       (),
     ) => {

--- a/src/bin_editor/PreflightChecks.re
+++ b/src/bin_editor/PreflightChecks.re
@@ -7,11 +7,11 @@
 
 open Oni_Core;
 
-let checkHomeDirectoryOrThrow = () => {
-  let _ = Filesystem.unsafeFindHome();
+let checkUserDataDirectoryOrThrow = () => {
+  let _ = Filesystem.getUserDataDirectoryExn();
   ();
 };
 
 let run = () => {
-  checkHomeDirectoryOrThrow();
+  checkUserDataDirectoryOrThrow();
 };


### PR DESCRIPTION
This change means that the Windows config is always loaded from `%LOCALAPPDATA%/Oni2`, regardless of the shell used.

Previously, cmd and powershell would both load correctly but other shells such as git-bash, powershell-core and more would load from a different location, due to `HOME` being set (as far as I can tell).


EDIT: Oh I guess this is technically a breaking change...so we'll need to make sure this is advertised properly, as otherwise people who mainly used Oni2 from say git-bash, will be confused why their config gave up.