### PR TITLE
Bugfix: list.focusForeground defaulted to transparency

### DIFF
--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -375,7 +375,8 @@ module List = {
       "list.focusBackground",
       {dark: hex("#062F4A"), light: hex("#D6EBFF"), hc: unspecified},
     );
-  let focusForeground = define("list.focusForeground", all(unspecified));
+  let focusForeground =
+    define("list.focusForeground", all(ref(foreground))); // actually: unspecified
   let activeSelectionBackground =
     define(
       "list.activeSelectionBackground",


### PR DESCRIPTION
Issue: In the file explorer, when focusing an item the text disappeared

Defect: `list.focusForeground` defaulted to `unspecified` which, unless otherwise handled, equals transparency. This is according to vscode's default definition, but they often then fall back to handling it in some other convoluted way.

Fix: Set the default for `list.focusForeground` to the color of `foreground`