### PR TITLE
Refactor - Syntax: Move theme / configuration to subscription

### DIFF
--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -162,9 +162,9 @@ let update = (highlights: t, msg) =>
   | Service(_) => highlights
   };
 
-let subscription = (~enabled, ~quitting, ~languageInfo, ~setup, _highlights) =>
+let subscription = (~enabled, ~quitting, ~languageInfo, ~setup, ~tokenTheme, _highlights) =>
   if (enabled && !quitting) {
-    Service_Syntax.Sub.create(~languageInfo, ~setup)
+    Service_Syntax.Sub.create(~languageInfo, ~setup, ~tokenTheme)
     |> Isolinear.Sub.map(
          fun
          | Service_Syntax.ServerStarted(client) => ServerStarted(client)

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -162,9 +162,23 @@ let update = (highlights: t, msg) =>
   | Service(_) => highlights
   };
 
-let subscription = (~enabled, ~quitting, ~languageInfo, ~setup, ~tokenTheme, _highlights) =>
+let subscription =
+    (
+      ~configuration,
+      ~enabled,
+      ~quitting,
+      ~languageInfo,
+      ~setup,
+      ~tokenTheme,
+      _highlights,
+    ) =>
   if (enabled && !quitting) {
-    Service_Syntax.Sub.create(~languageInfo, ~setup, ~tokenTheme)
+    Service_Syntax.Sub.create(
+      ~configuration,
+      ~languageInfo,
+      ~setup,
+      ~tokenTheme,
+    )
     |> Isolinear.Sub.map(
          fun
          | Service_Syntax.ServerStarted(client) => ServerStarted(client)

--- a/src/Feature/Syntax/Feature_Syntax.rei
+++ b/src/Feature/Syntax/Feature_Syntax.rei
@@ -39,6 +39,7 @@ let ignore: (~bufferId: int, t) => t;
 
 let subscription:
   (
+    ~configuration: Configuration.t,
     ~enabled: bool,
     ~quitting: bool,
     ~languageInfo: Oni_Extensions.LanguageInfo.t,

--- a/src/Feature/Syntax/Feature_Syntax.rei
+++ b/src/Feature/Syntax/Feature_Syntax.rei
@@ -43,6 +43,7 @@ let subscription:
     ~quitting: bool,
     ~languageInfo: Oni_Extensions.LanguageInfo.t,
     ~setup: Setup.t,
+    ~tokenTheme: Oni_Syntax.TokenTheme.t,
     t
   ) =>
   Isolinear.Sub.t(msg);

--- a/src/Service/Syntax/Service_Syntax.re
+++ b/src/Service/Syntax/Service_Syntax.re
@@ -113,16 +113,6 @@ module Effect = {
       )
     });
 
-  let themeChange = (maybeSyntaxClient, theme) =>
-    Isolinear.Effect.create(~name="syntax.theme", () => {
-      Option.iter(
-        syntaxClient => {
-          Oni_Syntax_Client.notifyThemeChanged(syntaxClient, theme)
-        },
-        maybeSyntaxClient,
-      )
-    });
-
   let visibilityChanged = (maybeSyntaxClient, visibleRanges) =>
     Isolinear.Effect.create(~name="syntax.visibilityChange", () => {
       Option.iter(

--- a/src/Service/Syntax/Service_Syntax.rei
+++ b/src/Service/Syntax/Service_Syntax.rei
@@ -1,5 +1,6 @@
 open EditorCoreTypes;
 open Oni_Core;
+open Oni_Syntax;
 
 [@deriving show({with_path: false})]
 type msg =
@@ -10,6 +11,7 @@ type msg =
 module Sub: {
   let create:
     (~languageInfo: Oni_Extensions.LanguageInfo.t, ~setup: Oni_Core.Setup.t,
+    ~tokenTheme: TokenTheme.t,
     ) =>
     Isolinear.Sub.t(msg);
 };
@@ -34,10 +36,6 @@ module Effect: {
 
   let configurationChange:
     (option(Oni_Syntax_Client.t), Configuration.t) => Isolinear.Effect.t(msg);
-
-  let themeChange:
-    (option(Oni_Syntax_Client.t), Oni_Syntax.TokenTheme.t) =>
-    Isolinear.Effect.t(msg);
 
   let visibilityChanged:
     (option(Oni_Syntax_Client.t), list((int, list(Range.t)))) =>

--- a/src/Service/Syntax/Service_Syntax.rei
+++ b/src/Service/Syntax/Service_Syntax.rei
@@ -9,7 +9,8 @@ type msg =
 
 module Sub: {
   let create:
-    (~languageInfo: Oni_Extensions.LanguageInfo.t, ~setup: Oni_Core.Setup.t) =>
+    (~languageInfo: Oni_Extensions.LanguageInfo.t, ~setup: Oni_Core.Setup.t,
+    ) =>
     Isolinear.Sub.t(msg);
 };
 

--- a/src/Service/Syntax/Service_Syntax.rei
+++ b/src/Service/Syntax/Service_Syntax.rei
@@ -10,8 +10,11 @@ type msg =
 
 module Sub: {
   let create:
-    (~languageInfo: Oni_Extensions.LanguageInfo.t, ~setup: Oni_Core.Setup.t,
-    ~tokenTheme: TokenTheme.t,
+    (
+      ~configuration: Configuration.t,
+      ~languageInfo: Oni_Extensions.LanguageInfo.t,
+      ~setup: Oni_Core.Setup.t,
+      ~tokenTheme: TokenTheme.t
     ) =>
     Isolinear.Sub.t(msg);
 };
@@ -33,9 +36,6 @@ module Effect: {
   let bufferEnter:
     (option(Oni_Syntax_Client.t), int, option(string)) =>
     Isolinear.Effect.t(msg);
-
-  let configurationChange:
-    (option(Oni_Syntax_Client.t), Configuration.t) => Isolinear.Effect.t(msg);
 
   let visibilityChanged:
     (option(Oni_Syntax_Client.t), list((int, list(Range.t)))) =>

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -180,6 +180,7 @@ let start =
         ~quitting=state.isQuitting,
         ~languageInfo,
         ~setup,
+        ~tokenTheme=state.tokenTheme,
         state.syntaxHighlights,
       )
       |> Isolinear.Sub.map(msg => Model.Actions.Syntax(msg));

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -176,6 +176,7 @@ let start =
   let subscriptions = (state: Model.State.t) => {
     let syntaxSubscription =
       Feature_Syntax.subscription(
+        ~configuration=state.configuration,
         ~enabled=cliOptions.shouldSyntaxHighlight,
         ~quitting=state.isQuitting,
         ~languageInfo,

--- a/src/Store/SyntaxHighlightingStoreConnector.re
+++ b/src/Store/SyntaxHighlightingStoreConnector.re
@@ -99,11 +99,6 @@ let start = (~enabled, languageInfo: Ext.LanguageInfo.t) => {
         Service_Syntax.Effect.configurationChange(state.syntaxClient, config)
         |> mapServiceEffect,
       )
-    | Model.Actions.TokenThemeLoaded(tokenTheme) => (
-        state,
-        Service_Syntax.Effect.themeChange(state.syntaxClient, tokenTheme)
-        |> mapServiceEffect,
-      )
     | Model.Actions.BufferEnter({metadata, fileType, _}) =>
       let visibleBuffers =
         Model.EditorVisibleRanges.getVisibleBuffersAndRanges(state);

--- a/src/Store/SyntaxHighlightingStoreConnector.re
+++ b/src/Store/SyntaxHighlightingStoreConnector.re
@@ -94,11 +94,6 @@ let start = (~enabled, languageInfo: Ext.LanguageInfo.t) => {
         {...state, syntaxClient: Some(client)},
         Isolinear.Effect.none,
       )
-    | Model.Actions.ConfigurationSet(config) => (
-        state,
-        Service_Syntax.Effect.configurationChange(state.syntaxClient, config)
-        |> mapServiceEffect,
-      )
     | Model.Actions.BufferEnter({metadata, fileType, _}) =>
       let visibleBuffers =
         Model.EditorVisibleRanges.getVisibleBuffersAndRanges(state);

--- a/src/Syntax/NativeSyntaxHighlights.re
+++ b/src/Syntax/NativeSyntaxHighlights.re
@@ -33,7 +33,7 @@ type t =
     })
     : t;
 
-let _hasTreeSitterScope = (useTreeSitter, scope: string) => {
+let _hasTreeSitterScope = (useTreeSitter, scope: string) =>
   if (!useTreeSitter) {
     false;
   } else {
@@ -44,7 +44,6 @@ let _hasTreeSitterScope = (useTreeSitter, scope: string) => {
     | _ => false
     };
   };
-};
 
 let anyPendingWork = hl => {
   let Highlighter({highlighter: (module SyntaxHighlighter), state}) = hl;

--- a/src/Syntax/NativeSyntaxHighlights.re
+++ b/src/Syntax/NativeSyntaxHighlights.re
@@ -33,11 +33,8 @@ type t =
     })
     : t;
 
-let _hasTreeSitterScope = (configuration, scope: string) => {
-  let treeSitterEnabled =
-    Core.Configuration.getValue(c => c.experimentalTreeSitter, configuration);
-
-  if (!treeSitterEnabled) {
+let _hasTreeSitterScope = (useTreeSitter, scope: string) => {
+  if (!useTreeSitter) {
     false;
   } else {
     switch (scope) {
@@ -79,7 +76,7 @@ let updateTheme = (theme, hl) => {
 let create =
     (
       ~bufferUpdate,
-      ~configuration,
+      ~useTreeSitter,
       ~scope,
       ~theme,
       ~getTreesitterScope,
@@ -89,12 +86,7 @@ let create =
   ignore(bufferUpdate);
   let maybeScopeConverter = getTreesitterScope(scope);
 
-  let allowTreeSitter =
-    Core.Configuration.getValue(
-      config => config.experimentalTreeSitter,
-      configuration,
-    )
-    && _hasTreeSitterScope(configuration, scope);
+  let allowTreeSitter = _hasTreeSitterScope(useTreeSitter, scope);
 
   switch (maybeScopeConverter) {
   | Some(scopeConverter) when allowTreeSitter =>

--- a/src/Syntax/Protocol.re
+++ b/src/Syntax/Protocol.re
@@ -53,7 +53,7 @@ module ClientToServer = {
         [@opaque] array(string),
         string,
       )
-    | ConfigurationChanged([@opaque] Configuration.t)
+    | UseTreeSitter(bool)
     | ThemeChanged([@opaque] TokenTheme.t)
     | RunHealthCheck
     | VisibleRangesChanged(

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -220,7 +220,11 @@ let notifyThemeChanged = (v: t, theme: TokenTheme.t) => {
 };
 
 let notifyConfigurationChanged = (v: t, configuration: Configuration.t) => {
-  write(v, Protocol.ClientToServer.ConfigurationChanged(configuration));
+  ClientLog.info("Notifying configuration changed.");
+  let useTreeSitter =
+  configuration
+  |> Configuration.getValue(c => c.experimentalTreeSitter);
+  write(v, Protocol.ClientToServer.UseTreeSitter(useTreeSitter));
 };
 
 let healthCheck = (v: t) => {

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -222,8 +222,7 @@ let notifyThemeChanged = (v: t, theme: TokenTheme.t) => {
 let notifyConfigurationChanged = (v: t, configuration: Configuration.t) => {
   ClientLog.info("Notifying configuration changed.");
   let useTreeSitter =
-  configuration
-  |> Configuration.getValue(c => c.experimentalTreeSitter);
+    configuration |> Configuration.getValue(c => c.experimentalTreeSitter);
   write(v, Protocol.ClientToServer.UseTreeSitter(useTreeSitter));
 };
 

--- a/src/Syntax_Server/Oni_Syntax_Server.re
+++ b/src/Syntax_Server/Oni_Syntax_Server.re
@@ -111,7 +111,7 @@ let start = (~healthCheck) => {
                 map(State.setUseTreeSitter(useTreeSitter));
                 log(
                   "got new config - treesitter enabled:"
-                  ++ string_of_bool(useTreeSitter)
+                  ++ string_of_bool(useTreeSitter),
                 );
               }
             | ThemeChanged(theme) => {
@@ -177,8 +177,10 @@ let start = (~healthCheck) => {
               };
 
               let tokenUpdates = State.getTokenUpdates(state^);
-              write(Protocol.ServerToClient.TokenUpdate(tokenUpdates));
-              log("Token updates sent.");
+              if (tokenUpdates !== []) {
+                write(Protocol.ServerToClient.TokenUpdate(tokenUpdates));
+                log("Token updates sent.");
+              };
               map(State.clearTokenUpdates);
             }
           ) {

--- a/src/Syntax_Server/Oni_Syntax_Server.re
+++ b/src/Syntax_Server/Oni_Syntax_Server.re
@@ -107,16 +107,11 @@ let start = (~healthCheck) => {
                 );
                 map(State.bufferEnter(id));
               }
-            | ConfigurationChanged(config) => {
-                map(State.updateConfiguration(config));
-                let treeSitterEnabled =
-                  Oni_Core.Configuration.getValue(
-                    c => c.experimentalTreeSitter,
-                    config,
-                  );
+            | UseTreeSitter(useTreeSitter) => {
+                map(State.setUseTreeSitter(useTreeSitter));
                 log(
                   "got new config - treesitter enabled:"
-                  ++ (treeSitterEnabled ? "true" : "false"),
+                  ++ string_of_bool(useTreeSitter)
                 );
               }
             | ThemeChanged(theme) => {

--- a/src/Syntax_Server/State.re
+++ b/src/Syntax_Server/State.re
@@ -13,7 +13,7 @@ module Ext = Oni_Extensions;
 type logFunc = string => unit;
 
 type t = {
-  configuration: Configuration.t,
+  useTreeSitter: bool,
   setup: option(Setup.t),
   languageInfo: Ext.LanguageInfo.t,
   treesitterRepository: TreesitterRepository.t,
@@ -24,7 +24,7 @@ type t = {
 };
 
 let empty = {
-  configuration: Configuration.default,
+  useTreeSitter: false,
   setup: None,
   visibleBuffers: [],
   highlightsMap: IntMap.empty,
@@ -74,8 +74,8 @@ let updateTheme = (theme, state) => {
   {...state, theme, highlightsMap};
 };
 
-let updateConfiguration = (configuration, state) => {
-  {...state, configuration};
+let setUseTreeSitter = (useTreeSitter, state) => {
+  {...state, useTreeSitter};
 };
 
 let doPendingWork = state => {
@@ -162,7 +162,7 @@ let bufferUpdate =
 
           Some(
             NativeSyntaxHighlights.create(
-              ~configuration=state.configuration,
+              ~useTreeSitter=state.useTreeSitter,
               ~bufferUpdate,
               ~theme=state.theme,
               ~scope,

--- a/src/Syntax_Server/State.rei
+++ b/src/Syntax_Server/State.rei
@@ -29,7 +29,7 @@ let bufferUpdate:
   t;
 
 let updateTheme: (TokenTheme.t, t) => t;
-let updateConfiguration: (Configuration.t, t) => t;
+let setUseTreeSitter: (bool, t) => t;
 
 /* [updateVisibility(bufferRangeList)] sets the ranges that are visible per-buffer, which allows syntax highlight to only run necessary work */
 let updateVisibility: (list((int, list(Range.t))), t) => t;


### PR DESCRIPTION
#1613 exposed a timing issue with the server (because the syntax server starts later than it did in the prior strategy) - we'd lose the theme and configuration events because they'd be sent before initialization.

A more robust strategy, and in-line with the ultimate goal of removing the `SyntaxStoreConnector` and having it purely be pure-buffer based subscriptions, is to move the theme and configuration info into the subscription. This way, we can handle the synchronization as a detail in the subscription - the consumer just pushes the theme/configuration and the subscription handles the synchronization, which is simpler to work with and manage for the consumer, as well as solving that particular timing issue in #1613. 