### PR TITLE
Refactoring: Move scroll methods to Editor

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -163,3 +163,53 @@ let setSize = (~pixelWidth, ~pixelHeight, editor) => {
   pixelWidth,
   pixelHeight,
 };
+
+let scrollToPixelY = (~pixelY as newScrollY, view) => {
+  let {pixelHeight, _} = view;
+  let newScrollY = max(0., newScrollY);
+  let availableScroll =
+    max(float_of_int(view.viewLines - 1), 0.) *. getLineHeight(view);
+  let newScrollY = min(newScrollY, availableScroll);
+
+  let scrollPercentage =
+    newScrollY /. (availableScroll -. float_of_int(pixelHeight));
+  let minimapLineSize =
+    Constants.minimapCharacterWidth + Constants.minimapCharacterHeight;
+  let linesInMinimap = pixelHeight / minimapLineSize;
+  let availableMinimapScroll =
+    max(view.viewLines - linesInMinimap, 0) * minimapLineSize;
+  let newMinimapScroll =
+    scrollPercentage *. float_of_int(availableMinimapScroll);
+
+  {...view, minimapScrollY: newMinimapScroll, scrollY: newScrollY};
+};
+
+let scrollToLine = (~line, view) => {
+  let pixelY = float_of_int(line) *. getLineHeight(view);
+  scrollToPixelY(~pixelY, view);
+};
+
+let scrollToPixelX = (~pixelX as newScrollX, view) => {
+  let newScrollX = max(0., newScrollX);
+
+  let availableScroll =
+    max(
+      0.,
+      float_of_int(view.maxLineLength)
+      *. getCharacterWidth(view)
+      -. float(view.pixelWidth),
+    );
+  let scrollX = min(newScrollX, availableScroll);
+
+  {...view, scrollX};
+};
+
+let scrollToColumn = (~column, view) => {
+  let pixelX = float_of_int(column) *. getCharacterWidth(view);
+  scrollToPixelX(~pixelX, view);
+};
+
+let scrollDeltaPixelY = (~pixelY, view) => {
+  let pixelY = view.scrollY +. pixelY;
+  scrollToPixelY(~pixelY, view);
+};

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -43,6 +43,13 @@ let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let pixelPositionToLineColumn: (t, float, float) => (int, int);
 let getVimCursors: t => list(Vim.Cursor.t);
 
+let scrollToColumn: (~column: int, t) => t;
+let scrollToPixelX: (~pixelX: float, t) => t;
+
+let scrollToLine: (~line: int, t) => t;
+let scrollToPixelY: (~pixelY: float, t) => t;
+let scrollDeltaPixelY: (~pixelY: float, t) => t;
+
 let getCharacterWidth: t => float;
 let getLineHeight: t => float;
 

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -26,56 +26,6 @@ module Internal = {
   };
 };
 
-let scrollTo = (view, newScrollY) => {
-  let {pixelHeight, _} = view;
-  let newScrollY = max(0., newScrollY);
-  let availableScroll =
-    max(float_of_int(view.viewLines - 1), 0.) *. Editor.getLineHeight(view);
-  let newScrollY = min(newScrollY, availableScroll);
-
-  let scrollPercentage =
-    newScrollY /. (availableScroll -. float_of_int(pixelHeight));
-  let minimapLineSize =
-    Constants.minimapCharacterWidth + Constants.minimapCharacterHeight;
-  let linesInMinimap = pixelHeight / minimapLineSize;
-  let availableMinimapScroll =
-    max(view.viewLines - linesInMinimap, 0) * minimapLineSize;
-  let newMinimapScroll =
-    scrollPercentage *. float_of_int(availableMinimapScroll);
-
-  {...view, minimapScrollY: newMinimapScroll, scrollY: newScrollY};
-};
-
-let scrollToLine = (view, line) => {
-  let scrollAmount = float_of_int(line) *. Editor.getLineHeight(view);
-  scrollTo(view, scrollAmount);
-};
-
-let scrollToHorizontal = (view, newScrollX) => {
-  let newScrollX = max(0., newScrollX);
-
-  let availableScroll =
-    max(
-      0.,
-      float_of_int(view.maxLineLength)
-      *. Editor.getCharacterWidth(view)
-      -. float(view.pixelWidth),
-    );
-  let scrollX = min(newScrollX, availableScroll);
-
-  {...view, scrollX};
-};
-
-let scrollToColumn = (view, column) => {
-  let scrollAmount = float_of_int(column) *. Editor.getCharacterWidth(view);
-  scrollToHorizontal(view, scrollAmount);
-};
-
-let scroll = (view, scrollDeltaY) => {
-  let newScrollY = view.scrollY +. scrollDeltaY;
-  scrollTo(view, newScrollY);
-};
-
 let recalculate = (view, maybeBuffer) =>
   switch (maybeBuffer) {
   | Some(buffer) => {
@@ -94,13 +44,13 @@ let reduce = (view, action) =>
       ...view,
       cursors,
     }
-  | EditorSetScroll(id, scrollY) when EditorId.equals(view.editorId, id) =>
-    scrollTo(view, scrollY)
-  | EditorScroll(id, scrollDeltaY) when EditorId.equals(view.editorId, id) =>
-    scroll(view, scrollDeltaY)
+  | EditorSetScroll(id, pixelY) when EditorId.equals(view.editorId, id) =>
+    Editor.scrollToPixelY(~pixelY, view)
+  | EditorScroll(id, pixelY) when EditorId.equals(view.editorId, id) =>
+    Editor.scrollDeltaPixelY(~pixelY, view)
   | EditorScrollToLine(id, line) when EditorId.equals(view.editorId, id) =>
-    scrollToLine(view, line)
+    Editor.scrollToLine(~line, view)
   | EditorScrollToColumn(id, column) when EditorId.equals(view.editorId, id) =>
-    scrollToColumn(view, column)
+    Editor.scrollToColumn(~column, view)
   | _ => view
   };


### PR DESCRIPTION
Small refactoring to move the `scroll*` methods from the `EditorReducer` to the `Editor` - part of on-going work to centralize the `Editor.t` as the source of truth for the editor view / positioning.

As a next step, I'd like to remove the `recalculate` action by pushing some notion of the current buffer contents into the editor. Aside from removing the janky recalculate flow, this is needed for word wrap (for the editor to have more context around buffer updates, so that we can implement line wrapping in response to both changes in size and buffer updates)