### PR TITLE
Add keybindings for zoom in, zoom out and zoom reset

### DIFF
--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -443,7 +443,7 @@ let start = (getState, contributedCommands) => {
     ),
     (
       "workbench.action.zoomReset",
-      state => zoomEffect(state, zoom => Constants.defaultZoomValue),
+      state => zoomEffect(state, _zoom => Constants.defaultZoomValue),
     ),
   ];
 

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -5,6 +5,13 @@ open Oni_Model.Actions;
 
 module KeyDisplayer = Oni_Components.KeyDisplayer;
 
+module Constants = {
+  let zoomStep = 0.2;
+  let defaultZoomValue = 1.0;
+  let minZoomValue = 0.0;
+  let maxZoomValue = 2.8;
+};
+
 let pathSymlinkEnabled = (~addingLink) =>
   (
     Revery.Environment.os == Revery.Environment.Mac
@@ -265,6 +272,33 @@ let start = (getState, contributedCommands) => {
       },
     );
 
+  let zoomEffect = (state: State.t, getCalculatedZoomValue, _) =>
+    Isolinear.Effect.createWithDispatch(~name="window.zoom", dispatch => {
+      let configuration = state.configuration;
+      let currentZoomValue =
+        Configuration.getValue(c => c.uiZoom, configuration);
+
+      let calculatedZoomValue = getCalculatedZoomValue(currentZoomValue);
+      let newZoomValue =
+        Utility.IntEx.clamp(
+          calculatedZoomValue,
+          ~hi=Constants.maxZoomValue,
+          ~lo=Constants.minZoomValue,
+        );
+
+      if (newZoomValue != currentZoomValue) {
+        dispatch(
+          ConfigurationSet({
+            ...configuration,
+            default: {
+              ...configuration.default,
+              uiZoom: newZoomValue,
+            },
+          }),
+        );
+      };
+    });
+
   let commands = [
     ("keyDisplayer.enable", _ => singleActionEffect(EnableKeyDisplayer)),
     ("keyDisplayer.disable", _ => singleActionEffect(DisableKeyDisplayer)),
@@ -398,6 +432,18 @@ let start = (getState, contributedCommands) => {
           ),
         );
       },
+    ),
+    (
+      "workbench.action.zoomIn",
+      state => zoomEffect(state, zoom => zoom +. Constants.zoomStep),
+    ),
+    (
+      "workbench.action.zoomOut",
+      state => zoomEffect(state, zoom => zoom -. Constants.zoomStep),
+    ),
+    (
+      "workbench.action.zoomReset",
+      state => zoomEffect(state, zoom => Constants.defaultZoomValue),
     ),
   ];
 

--- a/src/Store/ConfigurationStoreConnector.re
+++ b/src/Store/ConfigurationStoreConnector.re
@@ -131,8 +131,7 @@ let start =
   let vsync = ref(Revery.Vsync.Immediate);
   let synchronizeConfigurationEffect = configuration =>
     Isolinear.Effect.create(~name="configuration.synchronize", () => {
-      let zoomValue =
-        max(1.0, Configuration.getValue(c => c.uiZoom, configuration));
+      let zoomValue = Configuration.getValue(c => c.uiZoom, configuration);
       if (zoomValue != zoom^) {
         Log.infof(m => m("Setting zoom: %f", zoomValue));
         setZoom(zoomValue);

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -259,6 +259,36 @@ let start = maybeKeyBindingsFilePath => {
         command: "workbench.action.previousEditor",
         condition: WhenExpr.Value(True),
       },
+      {
+        key: "<D-=>",
+        command: "workbench.action.zoomIn",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<C-=>",
+        command: "workbench.action.zoomIn",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-->",
+        command: "workbench.action.zoomOut",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<C-->",
+        command: "workbench.action.zoomOut",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-0>",
+        command: "workbench.action.zoomReset",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<C-0>",
+        command: "workbench.action.zoomReset",
+        condition: WhenExpr.Value(True),
+      },
       // TERMINAL
       // Binding to open normal mode
       {


### PR DESCRIPTION
Added keybindings for zoom in, zoom out and zoom reset according #1423 issue.

I checked zooming behavior in VSCode and they have next logic: default value is 0, minimum is -8 and maximum is 9. Zooming step is 1 which equals to 20%.

Short summary what was done in this PR:
1. Removed minimum value of 1.0 for zooming in ConfigurationStoreConnector;
2. Added keybindings to KeyBindingsStoreConnector for <kbd>Cmd</kbd> + <kbd>=</kbd>, <kbd>Ctrl</kbd> + <kbd>=</kbd>, <kbd>Cmd</kbd> + <kbd>-</kbd>, <kbd>Ctrl</kbd> + <kbd>-</kbd>, <kbd>Cmd</kbd> + <kbd>0</kbd>  and <kbd>Ctrl</kbd> + <kbd>0</kbd>;
3. Added Commands and zoom effect handler to VimStoreConnector.

Minimum value for zooming is 0 because on lower values there is no changes in UI.

And probably there should be some logic to process <kbd>Cmd</kbd> + <kbd>=</kbd> on Mac and <kbd>Ctrl</kbd> + <kbd>=</kbd> on Linux/Windows for example. Because with current implementation both of those combinations are working on Mac.

Would love to hear any comments and suggestion!

