### PR TITLE
Bugfix: disappearing FlatList scrollbar

### DIFF
--- a/src/Components/FlatList.re
+++ b/src/Components/FlatList.re
@@ -15,6 +15,7 @@ module Constants = {
   let scrollWheelMultiplier = 25;
   let additionalRowsToRender = 1;
   let scrollBarThickness = 6;
+  let minimumThumbSize = 4;
 };
 
 module Styles = {
@@ -143,7 +144,10 @@ let%component make =
   let scrollbar = {
     let maxHeight = count * rowHeight - viewportHeight;
     let thumbHeight =
-      viewportHeight * viewportHeight / max(1, count * rowHeight);
+      viewportHeight
+      * viewportHeight
+      / max(1, count * rowHeight)
+      |> max(Constants.minimumThumbSize);
     let isVisible = maxHeight > 0;
 
     if (isVisible) {


### PR DESCRIPTION
**Issue:** With a sufficiently long list, and short FlatList viewport, the scrollbar seemed to disappear.

**Defect:** There was no minimum size for the scrollbar thumb, so it eventually ended up being 0.

**Fix:** Constrain the minimum thumb size to 4px.