### PR TITLE
Bugfix: Hover window doesn't fit diagnostic messages

### DIFF
--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -66,6 +66,19 @@ let trimRight = str => {
   aux(length - 1);
 };
 
+let indentation = str => {
+  let rec loop = i =>
+    if (i >= String.length(str)) {
+      i;
+    } else if (isSpace(str.[i])) {
+      loop(i + 1);
+    } else {
+      i;
+    };
+
+  loop(0);
+};
+
 let extractSnippet = (~maxLength, ~charStart, ~charEnd, text) => {
   let originalLength = String.length(text);
 

--- a/src/Feature/Editor/HoverView.re
+++ b/src/Feature/Editor/HoverView.re
@@ -96,8 +96,17 @@ let%component hoverItem =
     let height = {
       let fontHeight =
         int_of_float(Service_Font.getHeight(editorFont) +. (-1.5));
-      let elementHeight = fontHeight + Constants.innerPadding;
-      elementHeight * List.length(diagnostics) + Constants.padding * 2;
+      let contentHeight =
+        List.fold_left(
+          (acc, {message, _}: Diagnostic.t) => {
+            let lineCount =
+              String.split_on_char('\n', message) |> List.length;
+            acc + lineCount * fontHeight;
+          },
+          0,
+          diagnostics,
+        );
+      contentHeight + Constants.padding * 2;
     };
 
     let elements =

--- a/src/Feature/Editor/HoverView.re
+++ b/src/Feature/Editor/HoverView.re
@@ -109,10 +109,9 @@ let%component hoverItem =
         int_of_float(Service_Font.measure(~text, editorFont) +. 0.5);
       let maxElementWidth =
         List.fold_left(
-          (maxWidth, {message, _}: Diagnostic.t) =>
-            max(maxWidth, measure(message) + Constants.padding),
+          (acc, line) => max(acc, measure(line) + Constants.padding),
           0,
-          diagnostics,
+          lines,
         );
       maxElementWidth + Constants.padding * 2;
     };


### PR DESCRIPTION
**Issue:** When diagnostic messages spanned multiple lines, the hover window wouldn't fit the message. It wasn't tall enough, and compensated for this by being absurdly long.

**Defect:** Line breaks weren't taken into account when measuring the height and width of a piece of text. Instead it was just assumed that it would be rendered as a single line, with the height being the height of the font and the width being the number of characters multiplied by the font width.

**Fix:** Messages are now split into lines, which are measured individually and added up.

Additionally, this adds removal of extraneous indentation, i.e. indentation that occurs on every line of the message.

Fixes #1183