### PR TITLE
Bugfix: don't center diagnostic messages in hover view

### DIFF
--- a/src/Feature/Editor/HoverView.re
+++ b/src/Feature/Editor/HoverView.re
@@ -13,7 +13,6 @@ module Diagnostic = Feature_LanguageSupport.Diagnostic;
 
 module Constants = {
   let padding = 8;
-  let innerPadding = 1;
 };
 
 module Styles = {
@@ -51,8 +50,8 @@ module Styles = {
     Style.width(width),
     Style.height(height),
     flexDirection(`Column),
-    alignItems(`Center),
     justifyContent(`Center),
+    padding(Constants.padding),
     border(~color=colors.hoverWidgetBorder, ~width=1),
     backgroundColor(colors.hoverWidgetBackground),
   ];

--- a/src/Feature/Editor/HoverView.re
+++ b/src/Feature/Editor/HoverView.re
@@ -83,6 +83,7 @@ let%component hoverItem =
   } else {
     let lines =
       diagnostics
+      |> List.rev
       |> List.map(({message, _}: Diagnostic.t) => {
            let lines = String.split_on_char('\n', message);
 
@@ -127,7 +128,6 @@ let%component hoverItem =
       |> List.map(text =>
            <Text style={Styles.text(~colors, ~editorFont)} text />
          )
-      |> List.rev
       |> React.listToElement;
 
     <View style={Styles.outerPosition(~x, ~y)}>


### PR DESCRIPTION
**Issue:** Diagnistic messages were centered horizontally in the hover view, which didn't look great for lines with greatly varying lengths.

**Defect:** It seems like `alignItems(Cetenr)` was applied instead of padding under the assumption that there would be only a single line.

**Fix:** Remove centering, apply padding.

Edit: Also, don't reverse the lines of each element.