### PR TITLE
Perf - Syntax: Delta buffer updates 

### DIFF
--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -161,25 +161,11 @@ let applyUpdate =
   let updateLines = update.lines |> Array.map(BufferLine.make(~indentation));
   let startLine = update.startLine |> Index.toZeroBased;
   let endLine = update.endLine |> Index.toZeroBased;
-  if (Array.length(lines) == 0) {
-    updateLines;
-  } else if (startLine >= Array.length(lines)) {
-    let ret = Array.concat([lines, updateLines]);
-    ret;
-  } else {
-    let prev = ArrayEx.slice(~lines, ~start=0, ~length=startLine, ());
-    let post =
-      ArrayEx.slice(
-        ~lines,
-        ~start=endLine,
-        ~length=Array.length(lines) - endLine,
-        (),
-      );
-
-    let lines = updateLines;
-
-    Array.concat([prev, lines, post]);
-  };
+  ArrayEx.replace(
+  ~replacement=updateLines,
+  ~start=startLine,
+  ~stop=endLine,
+  lines);
 };
 
 let isIndentationSet = buf => {

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -162,10 +162,11 @@ let applyUpdate =
   let startLine = update.startLine |> Index.toZeroBased;
   let endLine = update.endLine |> Index.toZeroBased;
   ArrayEx.replace(
-  ~replacement=updateLines,
-  ~start=startLine,
-  ~stop=endLine,
-  lines);
+    ~replacement=updateLines,
+    ~start=startLine,
+    ~stop=endLine,
+    lines,
+  );
 };
 
 let isIndentationSet = buf => {

--- a/src/Core/Utility/ArrayEx.re
+++ b/src/Core/Utility/ArrayEx.re
@@ -29,18 +29,17 @@ let slice = (~lines: array(_), ~start, ~length, ()) => {
   };
 };
 
-let replace = (~replacement, ~start, ~stop, arr) => {
+let replace = (~replacement, ~start, ~stop, arr) =>
   if (Array.length(arr) == 0) {
-    replacement
+    replacement;
   } else if (start >= Array.length(arr)) {
-    Array.concat([arr, replacement])
+    Array.concat([arr, replacement]);
   } else {
     // Get beginning of array
     let prev = slice(~lines=arr, ~start=0, ~length=start, ());
 
-    let post = slice(~lines=arr, ~start=stop, ~length=
-    Array.length(arr) - stop, ());
+    let post =
+      slice(~lines=arr, ~start=stop, ~length=Array.length(arr) - stop, ());
 
     Array.concat([prev, replacement, post]);
-  }
-};
+  };

--- a/src/Core/Utility/ArrayEx.re
+++ b/src/Core/Utility/ArrayEx.re
@@ -28,3 +28,19 @@ let slice = (~lines: array(_), ~start, ~length, ()) => {
     };
   };
 };
+
+let replace = (~replacement, ~start, ~stop, arr) => {
+  if (Array.length(arr) == 0) {
+    replacement
+  } else if (start >= Array.length(arr)) {
+    Array.concat([arr, replacement])
+  } else {
+    // Get beginning of array
+    let prev = slice(~lines=arr, ~start=0, ~length=start, ());
+
+    let post = slice(~lines=arr, ~start=stop, ~length=
+    Array.length(arr) - stop, ());
+
+    Array.concat([prev, replacement, post]);
+  }
+};

--- a/src/Syntax/Protocol.re
+++ b/src/Syntax/Protocol.re
@@ -48,7 +48,8 @@ module ClientToServer = {
     | Initialize([@opaque] Ext.LanguageInfo.t, Setup.t)
     | BufferEnter(int, string)
     | BufferLeave(int)
-    | BufferUpdate(
+    | BufferDeltaUpdate([@opaque] Oni_Core.BufferUpdate.t)
+    | BufferFullUpdate(
         [@opaque] Oni_Core.BufferUpdate.t,
         [@opaque] array(string),
         string,

--- a/src/Syntax/Protocol.re
+++ b/src/Syntax/Protocol.re
@@ -48,12 +48,7 @@ module ClientToServer = {
     | Initialize([@opaque] Ext.LanguageInfo.t, Setup.t)
     | BufferEnter(int, string)
     | BufferLeave(int)
-    | BufferDeltaUpdate([@opaque] Oni_Core.BufferUpdate.t)
-    | BufferFullUpdate(
-        [@opaque] Oni_Core.BufferUpdate.t,
-        [@opaque] array(string),
-        string,
-      )
+    | BufferUpdate([@opaque] Oni_Core.BufferUpdate.t, string)
     | UseTreeSitter(bool)
     | ThemeChanged([@opaque] TokenTheme.t)
     | RunHealthCheck

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -231,9 +231,9 @@ let healthCheck = (v: t) => {
 };
 
 let notifyBufferUpdate =
-    (v: t, bufferUpdate: BufferUpdate.t, lines: array(string), scope) => {
+    (v: t, bufferUpdate: BufferUpdate.t, _lines: array(string), scope) => {
   ClientLog.trace("Sending bufferUpdate notification...");
-  write(v, Protocol.ClientToServer.BufferFullUpdate(bufferUpdate, lines, scope));
+  write(v, Protocol.ClientToServer.BufferUpdate(bufferUpdate, scope));
 };
 
 let notifyVisibilityChanged = (v: t, visibility) => {

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -233,7 +233,7 @@ let healthCheck = (v: t) => {
 let notifyBufferUpdate =
     (v: t, bufferUpdate: BufferUpdate.t, lines: array(string), scope) => {
   ClientLog.trace("Sending bufferUpdate notification...");
-  write(v, Protocol.ClientToServer.BufferUpdate(bufferUpdate, lines, scope));
+  write(v, Protocol.ClientToServer.BufferFullUpdate(bufferUpdate, lines, scope));
 };
 
 let notifyVisibilityChanged = (v: t, visibility) => {

--- a/src/Syntax_Server/Oni_Syntax_Server.re
+++ b/src/Syntax_Server/Oni_Syntax_Server.re
@@ -118,7 +118,8 @@ let start = (~healthCheck) => {
                 map(State.updateTheme(theme));
                 log("handled theme changed");
               }
-            | BufferUpdate(bufferUpdate, lines, scope) => {
+            | BufferDeltaUpdate(_) => log("delta update")
+            | BufferFullUpdate(bufferUpdate, lines, scope) => {
                 map(State.bufferUpdate(~bufferUpdate, ~lines, ~scope));
                 log(
                   Printf.sprintf(

--- a/src/Syntax_Server/Oni_Syntax_Server.re
+++ b/src/Syntax_Server/Oni_Syntax_Server.re
@@ -132,7 +132,7 @@ let start = (~healthCheck) => {
                 | Ok(newState) =>
                   state := newState;
                   log("Buffer update successfully applied.");
-                | Error(msg) => log("Buffer update failed: " ++ msg);
+                | Error(msg) => log("Buffer update failed: " ++ msg)
                 };
               }
             | VisibleRangesChanged(visibilityUpdate) => {

--- a/src/Syntax_Server/Oni_Syntax_Server.re
+++ b/src/Syntax_Server/Oni_Syntax_Server.re
@@ -118,16 +118,22 @@ let start = (~healthCheck) => {
                 map(State.updateTheme(theme));
                 log("handled theme changed");
               }
-            | BufferDeltaUpdate(_) => log("delta update")
-            | BufferFullUpdate(bufferUpdate, lines, scope) => {
-                map(State.bufferUpdate(~bufferUpdate, ~lines, ~scope));
+            | BufferUpdate((bufferUpdate: Oni_Core.BufferUpdate.t), scope) => {
+                let delta = bufferUpdate.isFull ? "(FULL)" : "(DELTA)";
                 log(
                   Printf.sprintf(
-                    "Received buffer update - %d | %d lines",
+                    "Received buffer update - %d | %d lines %s",
                     bufferUpdate.id,
-                    Array.length(lines),
+                    Array.length(bufferUpdate.lines),
+                    delta,
                   ),
                 );
+                switch (State.bufferUpdate(~bufferUpdate, ~scope, state^)) {
+                | Ok(newState) =>
+                  state := newState;
+                  log("Buffer update successfully applied.");
+                | Error(msg) => log("Buffer update failed: " ++ msg);
+                };
               }
             | VisibleRangesChanged(visibilityUpdate) => {
                 map(State.updateVisibility(visibilityUpdate));

--- a/src/Syntax_Server/State.re
+++ b/src/Syntax_Server/State.re
@@ -6,15 +6,22 @@
 
 open EditorCoreTypes;
 open Oni_Core;
+open Oni_Core.Utility;
 open Oni_Syntax;
 
 module Ext = Oni_Extensions;
 
 type logFunc = string => unit;
 
+type bufferInfo = {
+  lines: array(string),
+  version: int,
+};
+
 type t = {
   useTreeSitter: bool,
   setup: option(Setup.t),
+  bufferInfo: IntMap.t(bufferInfo),
   languageInfo: Ext.LanguageInfo.t,
   treesitterRepository: TreesitterRepository.t,
   grammarRepository: GrammarRepository.t,
@@ -26,6 +33,7 @@ type t = {
 let empty = {
   useTreeSitter: false,
   setup: None,
+  bufferInfo: IntMap.empty,
   visibleBuffers: [],
   highlightsMap: IntMap.empty,
   theme: TokenTheme.empty,
@@ -143,40 +151,82 @@ let clearTokenUpdates = state => {
   {...state, highlightsMap};
 };
 
-let bufferUpdate =
-    (~scope, ~bufferUpdate: BufferUpdate.t, ~lines: array(string), state) => {
-  let highlightsMap =
-    IntMap.update(
-      bufferUpdate.id,
-      current =>
-        switch (current) {
-        | None =>
-          let getTextmateGrammar = scope =>
-            GrammarRepository.getGrammar(~scope, state.grammarRepository);
+let applyBufferUpdate = (~update: BufferUpdate.t, state) => {
+  let bufferInfo =
+    state.bufferInfo
+    |> IntMap.update(update.id, current =>
+         switch (current) {
+         | None =>
+           if (update.isFull) {
+             Some({lines: update.lines, version: update.version});
+           } else {
+             None;
+           }
+         | Some({lines, _}) =>
+           if (update.isFull) {
+             Some({lines: update.lines, version: update.version});
+           } else {
+             let newLines =
+               ArrayEx.replace(
+                 ~replacement=update.lines,
+                 ~start=update.startLine |> Index.toZeroBased,
+                 ~stop=update.endLine |> Index.toZeroBased,
+                 lines,
+               );
+             Some({lines: newLines, version: update.version});
+           }
+         }
+       );
+  {...state, bufferInfo};
+};
 
-          let getTreesitterScope = scope =>
-            TreesitterRepository.getScopeConverter(
-              ~scope,
-              state.treesitterRepository,
-            );
+let getBuffer = (~bufferId, state) => {
+  IntMap.find_opt(bufferId, state.bufferInfo);
+};
 
-          Some(
-            NativeSyntaxHighlights.create(
-              ~useTreeSitter=state.useTreeSitter,
-              ~bufferUpdate,
-              ~theme=state.theme,
-              ~scope,
-              ~getTreesitterScope,
-              ~getTextmateGrammar,
-              lines,
-            ),
-          );
-        | Some(v) =>
-          Some(NativeSyntaxHighlights.update(~bufferUpdate, ~lines, v))
-        },
-      state.highlightsMap,
-    );
-  {...state, highlightsMap};
+let bufferUpdate = (~scope, ~bufferUpdate: BufferUpdate.t, state) => {
+  let state = applyBufferUpdate(~update=bufferUpdate, state);
+
+  state
+  |> getBuffer(~bufferId=bufferUpdate.id)
+  |> Option.map(({lines, _}) => {
+       let highlightsMap =
+         IntMap.update(
+           bufferUpdate.id,
+           current =>
+             switch (current) {
+             | None =>
+               let getTextmateGrammar = scope =>
+                 GrammarRepository.getGrammar(
+                   ~scope,
+                   state.grammarRepository,
+                 );
+
+               let getTreesitterScope = scope =>
+                 TreesitterRepository.getScopeConverter(
+                   ~scope,
+                   state.treesitterRepository,
+                 );
+
+               Some(
+                 NativeSyntaxHighlights.create(
+                   ~useTreeSitter=state.useTreeSitter,
+                   ~bufferUpdate,
+                   ~theme=state.theme,
+                   ~scope,
+                   ~getTreesitterScope,
+                   ~getTextmateGrammar,
+                   lines,
+                 ),
+               );
+             | Some(v) =>
+               Some(NativeSyntaxHighlights.update(~bufferUpdate, ~lines, v))
+             },
+           state.highlightsMap,
+         );
+       {...state, highlightsMap};
+     })
+  |> Option.to_result(~none="Unable to apply update");
 };
 
 let updateVisibility = (visibility: list((int, list(Range.t))), state) => {

--- a/src/Syntax_Server/State.rei
+++ b/src/Syntax_Server/State.rei
@@ -25,8 +25,7 @@ let anyPendingWork: t => bool;
 
 let bufferEnter: (int, t) => t;
 let bufferUpdate:
-  (~scope: string, ~bufferUpdate: BufferUpdate.t, ~lines: array(string), t) =>
-  t;
+  (~scope: string, ~bufferUpdate: BufferUpdate.t, t) => result(t, string);
 
 let updateTheme: (TokenTheme.t, t) => t;
 let setUseTreeSitter: (bool, t) => t;


### PR DESCRIPTION
A perf issue we hit in #1621 (or, exposed, rather) - is the way we are sending and synchronizing buffer lines with our syntax highlight process.

We'd send the entire set of buffer lines to the syntax highlight process on every buffer update - even if just a single line changed. For small files, this isn't so bad - but for large files, it could cause a significantly delay - the event loop would send files in chunks of 8192 bytes, and so it could some time for the full set of lines to be pushed over to the syntax process.

The majority of the time, though, we don't need to send the full buffer - it's sufficient just send a small update. This implements tracking and applying delta updates.