### PR TITLE
Perf - Syntax: Fix shift on delete

### DIFF
--- a/src/Core/Kernel/IntMap.re
+++ b/src/Core/Kernel/IntMap.re
@@ -27,34 +27,35 @@ let shift =
   if (endPos - startPos == delta) {
     map;
   } else {
+    let original: t('a) = map;
     // Shift all items based on delta
     let newMap =
       fold(
-        (key, v, prev) =>
+        (key, oldValue, prev) => {
           if (delta > 0) {
             if (key < startPos) {
-              update(key, _opt => Some(v), prev);
+              prev;
             } else {
-              update(key + delta, _opt => Some(v), prev);
+              update(key + delta, _ => Some(oldValue), prev);
             };
           } else if (key <= endPos) {
-            update(key, _opt => Some(v), prev);
+            prev;
           } else {
-            update(key + delta, _opt => Some(v), prev);
-          },
-        map,
-        empty,
+            let originalValue: option('a) = find_opt(key, original);
+            update(key + delta, _ => originalValue, prev);
+          };
+        },
+        map, /* map to fold over */
+        map /* seed defaults */
       );
 
     // Set 'new' items to be the default value
-    let start_ = ref(startPos);
     let current = find_opt(startPos, newMap);
-    let end_ = startPos + (endPos - startPos + delta);
+    let stop = startPos + (endPos - startPos + delta);
     let ret = ref(newMap);
 
-    while (start_^ < end_) {
-      ret := update(start_^, _ => default(current), ret^);
-      incr(start_);
+    for (idx in startPos to stop - 1) {
+      ret := update(idx, _ => default(current), ret^);
     };
 
     ret^;

--- a/src/Core/Kernel/IntMap.re
+++ b/src/Core/Kernel/IntMap.re
@@ -24,7 +24,7 @@ let shift =
       ~delta: int,
       map,
     ) =>
-  if (endPos - startPos == delta) {
+  if (delta == 0) {
     map;
   } else {
     let original: t('a) = map;

--- a/src/Core/Kernel/IntMap.re
+++ b/src/Core/Kernel/IntMap.re
@@ -31,7 +31,7 @@ let shift =
     // Shift all items based on delta
     let newMap =
       fold(
-        (key, oldValue, prev) => {
+        (key, oldValue, prev) =>
           if (delta > 0) {
             if (key < startPos) {
               prev;
@@ -43,8 +43,7 @@ let shift =
           } else {
             let originalValue: option('a) = find_opt(key, original);
             update(key + delta, _ => originalValue, prev);
-          };
-        },
+          },
         map, /* map to fold over */
         map /* seed defaults */
       );

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -127,7 +127,7 @@ let ignore = (~bufferId, bufferHighlights) => {
 };
 
 // When there is a buffer update, shift the lines to match
-let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) =>
+let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) => {
   if (BufferMap.mem(bufferUpdate.id, bufferHighlights.ignoredBuffers)) {
     bufferHighlights;
   } else {
@@ -153,6 +153,7 @@ let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) =>
       );
     {...bufferHighlights, highlights};
   };
+};
 
 let update = (highlights: t, msg) =>
   switch (msg) {

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -127,7 +127,7 @@ let ignore = (~bufferId, bufferHighlights) => {
 };
 
 // When there is a buffer update, shift the lines to match
-let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) => {
+let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) =>
   if (BufferMap.mem(bufferUpdate.id, bufferHighlights.ignoredBuffers)) {
     bufferHighlights;
   } else {
@@ -153,7 +153,6 @@ let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) => {
       );
     {...bufferHighlights, highlights};
   };
-};
 
 let update = (highlights: t, msg) =>
   switch (msg) {

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -136,16 +136,19 @@ let handleUpdate = (bufferUpdate: BufferUpdate.t, bufferHighlights) =>
         bufferUpdate.id,
         fun
         | None => None
-        | Some(lineMap) =>
-          Some(
-            LineMap.shift(
-              ~default=v => v,
-              ~startPos=bufferUpdate.startLine |> Index.toZeroBased,
-              ~endPos=bufferUpdate.endLine |> Index.toZeroBased,
-              ~delta=Array.length(bufferUpdate.lines),
-              lineMap,
-            ),
-          ),
+        | Some(lineMap) => {
+            let startPos = bufferUpdate.startLine |> Index.toZeroBased;
+            let endPos = bufferUpdate.endLine |> Index.toZeroBased;
+            Some(
+              LineMap.shift(
+                ~default=v => v,
+                ~startPos,
+                ~endPos,
+                ~delta=Array.length(bufferUpdate.lines) - (endPos - startPos),
+                lineMap,
+              ),
+            );
+          },
         bufferHighlights.highlights,
       );
     {...bufferHighlights, highlights};

--- a/src/Store/SyntaxHighlightingStoreConnector.re
+++ b/src/Store/SyntaxHighlightingStoreConnector.re
@@ -175,7 +175,6 @@ let start = (~enabled, languageInfo: Ext.LanguageInfo.t) => {
 
           (
             {...state, syntaxHighlights},
-            Isolinear.Effect.none
             Service_Syntax.Effect.bufferUpdate(
               state.syntaxClient,
               update,

--- a/src/Store/SyntaxHighlightingStoreConnector.re
+++ b/src/Store/SyntaxHighlightingStoreConnector.re
@@ -175,6 +175,7 @@ let start = (~enabled, languageInfo: Ext.LanguageInfo.t) => {
 
           (
             {...state, syntaxHighlights},
+            Isolinear.Effect.none
             Service_Syntax.Effect.bufferUpdate(
               state.syntaxClient,
               update,


### PR DESCRIPTION
I've noticed a jarring experience when deleting lines:

There'd be a temporary flash of unhighlighted or shifted lines.

We should be able to immediately accomodate this, by shifting the highlights to correspond with the buffer update - if lines were added, we shift the highlights down to map to the new lines, and vice versa for deletion. There was a bug in the way were handling deletions, though, that caused this shifting logic to not be correctly applied.