### PR TITLE
feat(workspace): window/split resizing, part 1 - basic functionality and commands

### DIFF
--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -336,3 +336,20 @@ let rotateBackward = (target, tree) => {
   Internal.rotate(target, f, tree);
 };
 
+let rec resizeWindow = (target, factor, tree) => {
+  switch (tree) {
+  | Split(dir, containers) =>
+    Split(dir, List.map(resizeContainer(target, factor), containers))
+  | node => node
+  };
+}
+and resizeContainer = (target, factor) =>
+  fun
+  | {content: Window(id), weight} as container when id == target => {
+      Console.log(weight *. factor);
+      {...container, weight: weight *. factor};
+    }
+  | {content, _} as container => {
+      ...container,
+      content: resizeWindow(target, factor, content),
+    };

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -229,6 +229,7 @@ let removeWindow = (target, tree) => {
     | Split(direction, size, children) =>
       switch (List.filter_map(traverse, children)) {
       | [] => None
+      | [child] => Some(child)
       | newChildren => Some(Split(direction, size, newChildren))
       }
     | Window(_, id) when id == target => None

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -231,7 +231,7 @@ let removeWindow = (target, tree) => {
     | Split(direction, size, children) =>
       switch (List.filter_map(traverse, children)) {
       | [] => None
-      // BUG: Simplification disabled because it doesn't preserve size.
+      // BUG: Collapsing disabled as it doesn't preserve size properly.
       // | [child] => Some(child)
       | newChildren => Some(Split(direction, size, newChildren))
       }
@@ -409,3 +409,9 @@ let resizeWindow = (direction, target, factor, node) => {
 
   traverse(node) |> snd;
 };
+
+let rec resetWeights =
+  fun
+  | Split(direction, Weight(_), children) =>
+    Split(direction, Weight(1.), List.map(resetWeights, children))
+  | Window(_, id) => Window(Weight(1.), id);

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -153,7 +153,7 @@ let addWindow = (~target=None, ~position, direction, id, tree) => {
   | Some(targetId) =>
     let rec traverse = node => {
       switch (node) {
-      | Split(d, size, []) => Split(d, size, [newWindow]) // HACK: to work around this being intially called with an idea that doesn't yet exist in the tree
+      | Split(d, size, []) => Window(size, id) // HACK: to work around this being intially called with an idea that doesn't yet exist in the tree
       | Split(thisDirection, size, children) when thisDirection == direction =>
         let onMatch = child =>
           switch (position) {
@@ -217,6 +217,7 @@ let addWindow = (~target=None, ~position, direction, id, tree) => {
 
   | None =>
     switch (tree) {
+    | Split(d, size, []) => Window(size, id)
     | Split(d, size, children) => Split(d, size, [newWindow, ...children])
     | _ => tree
     }
@@ -296,7 +297,7 @@ let rec layout = (x, y, width, height, tree) => {
     //   width,
     //   height,
     // );
-    [{id, x, y, width, height}];
+    [{id, x, y, width, height}]
   };
 };
 
@@ -372,7 +373,7 @@ let rec resizeWindow = (target, factor, node) => {
 
   | Window(Weight(weight), id) when id == target =>
     // Console.log(weight *. factor);
-    Window(Weight(weight *. factor), id);
+    Window(Weight(weight *. factor), id)
 
   | Window(_) => node
   };

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -242,9 +242,6 @@ let removeWindow = (target, tree) => {
 };
 
 let rec layout = (x, y, width, height, tree) => {
-  // Console.log(
-  //   show((fmt, id) => Format.pp_print_int(fmt, Obj.magic(id)), tree),
-  // );
   switch (tree) {
   | Split(direction, _, children) =>
     let totalWeight =
@@ -277,7 +274,6 @@ let rec layout = (x, y, width, height, tree) => {
             switch (nodeSize(child)) {
             | Weight(weight) =>
               let width = int_of_float(unitWidth *. weight);
-              // Printf.printf("%f *. %f = %n\n%!", unitWidth, weight, width);
               let windows = layout(x, y, width, height, child);
               (x + width, windows @ acc);
             }
@@ -290,16 +286,7 @@ let rec layout = (x, y, width, height, tree) => {
     |> snd
     |> List.rev;
 
-  | Window(_, id) =>
-    // Printf.printf(
-    //   "%n: %n, %n, %n, %n\n%!",
-    //   Obj.magic(id),
-    //   x,
-    //   y,
-    //   width,
-    //   height,
-    // );
-    [{id, x, y, width, height}]
+  | Window(_, id) => [{id, x, y, width, height}]
   };
 };
 
@@ -349,26 +336,6 @@ let rotateBackward = (target, tree) => {
 
   Internal.rotate(target, f, tree);
 };
-
-// let pathTo = (target, tree) => {
-//   let rec traverse = path =>
-//     fun
-//     | Split(_, _, children) as split =>
-//       traverseChildren([split, ...path], children)
-//     | Window(_, id) as window when id == target => Some([window, ...path])
-//     | Window(_) => None
-
-//   and traverseChildren = path =>
-//     fun
-//     | [] => None
-//     | [node, ...rest] =>
-//       switch (traverse(path, node)) {
-//       | None => traverseChildren(path, rest)
-//       | path => path
-//       };
-
-//   traverse(tree);
-// };
 
 let resizeWindow = (direction, target, factor, node) => {
   let rec traverse = (~parentDirection=?) =>

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -231,7 +231,8 @@ let removeWindow = (target, tree) => {
     | Split(direction, size, children) =>
       switch (List.filter_map(traverse, children)) {
       | [] => None
-      | [child] => Some(child)
+      // BUG: Simplification disabled because it doesn't preserve size.
+      // | [child] => Some(child)
       | newChildren => Some(Split(direction, size, newChildren))
       }
     | Window(_, id) when id == target => None

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -217,9 +217,10 @@ let addWindow = (~target=None, ~position, direction, id, tree) => {
 
   | None =>
     switch (tree) {
-    | Split(d, size, []) => Window(size, id)
+    | Split(_, size, []) => Window(size, id)
     | Split(d, size, children) => Split(d, size, [newWindow, ...children])
-    | _ => tree
+    | Window(size, id) =>
+      Split(direction, size, [newWindow, Window(Weight(1.), id)])
     }
   };
 };

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -5,17 +5,18 @@ type direction =
   | Right;
 
 // definition only used for tests
-type t('content) =
-  | Split([ | `Horizontal | `Vertical], list(t('content)))
-  | Window({
-      weight: float,
-      content: 'content,
-    })
-  | Empty;
+type t('id) =
+  | Split([ | `Horizontal | `Vertical], list(container('id)))
+  | Window('id)
+  | Empty
+and container('id) = {
+  weight: float,
+  content: t('id),
+};
 
 [@deriving show]
-type sizedWindow('content) = {
-  content: 'content,
+type sizedWindow('id) = {
+  id: 'id,
   x: int,
   y: int,
   width: int,
@@ -23,32 +24,33 @@ type sizedWindow('content) = {
 };
 
 module Internal: {
-  let move:
-    ('content, int, int, list(sizedWindow('content))) => option('content); // only used for tests
+  let move: ('id, int, int, list(sizedWindow('id))) => option('id); // only used for tests
 };
 
-let initial: t('content);
+let initial: t('id);
 
-let windows: t('content) => list('content);
+let windows: t('id) => list('id);
 let addWindow:
   (
-    ~target: option('content)=?,
+    ~target: option('id)=?,
     ~position: [ | `Before | `After],
     [ | `Horizontal | `Vertical],
-    'content,
-    t('content)
+    'id,
+    t('id)
   ) =>
-  t('content);
-let removeWindow: ('content, t('content)) => t('content);
+  t('id);
+let removeWindow: ('id, t('id)) => t('id);
 
-let layout:
-  (int, int, int, int, t('content)) => list(sizedWindow('content));
+let layout: (int, int, int, int, t('id)) => list(sizedWindow('id));
 
-let move: (direction, 'content, t('content)) => 'content;
-let moveLeft: ('content, t('content)) => 'content;
-let moveRight: ('content, t('content)) => 'content;
-let moveUp: ('content, t('content)) => 'content;
-let moveDown: ('content, t('content)) => 'content;
+let move: (direction, 'id, t('id)) => 'id;
+let moveLeft: ('id, t('id)) => 'id;
+let moveRight: ('id, t('id)) => 'id;
+let moveUp: ('id, t('id)) => 'id;
+let moveDown: ('id, t('id)) => 'id;
+
+let rotateForward: ('id, t('id)) => t('id);
+let rotateBackward: ('id, t('id)) => t('id);
 
 let rotateForward: ('content, t('content)) => t('content);
 let rotateBackward: ('content, t('content)) => t('content);

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -5,14 +5,15 @@ type direction =
   | Right;
 
 // definition only used for tests
+[@deriving show({with_path: false})]
+type size =
+  | Weight(float);
+
+// definition only used for tests
+[@deriving show({with_path: false})]
 type t('id) =
-  | Split([ | `Horizontal | `Vertical], list(container('id)))
-  | Window('id)
-  | Empty
-and container('id) = {
-  weight: float,
-  content: t('id),
-};
+  | Split([ | `Horizontal | `Vertical], size, list(t('id)))
+  | Window(size, 'id);
 
 [@deriving show]
 type sizedWindow('id) = {

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -55,3 +55,4 @@ let rotateBackward: ('id, t('id)) => t('id);
 
 let resizeWindow:
   ([ | `Horizontal | `Vertical], 'id, float, t('id)) => t('id);
+let resetWeights: t('id) => t('id);

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -53,4 +53,5 @@ let moveDown: ('id, t('id)) => 'id;
 let rotateForward: ('id, t('id)) => t('id);
 let rotateBackward: ('id, t('id)) => t('id);
 
-let resizeWindow: ('id, float, t('id)) => t('id);
+let resizeWindow:
+  ([ | `Horizontal | `Vertical], 'id, float, t('id)) => t('id);

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -52,5 +52,4 @@ let moveDown: ('id, t('id)) => 'id;
 let rotateForward: ('id, t('id)) => t('id);
 let rotateBackward: ('id, t('id)) => t('id);
 
-let rotateForward: ('content, t('content)) => t('content);
-let rotateBackward: ('content, t('content)) => t('content);
+let resizeWindow: ('id, float, t('id)) => t('id);

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -409,6 +409,14 @@ module Workbench = {
         Command("workbench.action.increaseViewSize"),
       );
 
+    let evenEditorWidths =
+      register(
+        ~category="View",
+        ~title="Reset Window Sizes",
+        "workbench.action.evenEditorWidths",
+        Command("workbench.action.evenEditorWidths"),
+      );
+
     module Files = {
       let save =
         register("workbench.action.save", Command("workbench.action.save"));

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -171,6 +171,38 @@ module Oni = {
         "vim.tutor",
         Command("vim.tutor"),
       );
+
+    let decreaseHorizontalWindowSize =
+      register(
+        ~category="View",
+        ~title="Decrease Horizontal Window Size",
+        "vim.decreaseHorizontalWindowSize",
+        Command("vim.decreaseHorizontalWindowSize"),
+      );
+
+    let increaseHorizontalWindowSize =
+      register(
+        ~category="View",
+        ~title="Increase Horizontal Window Size",
+        "vim.increaseHorizontalWindowSize",
+        Command("vim.increaseHorizontalWindowSize"),
+      );
+
+    let decreaseVerticalWindowSize =
+      register(
+        ~category="View",
+        ~title="Decrease Vertical Window Size",
+        "vim.decreaseVerticalWindowSize",
+        Command("vim.decreaseVerticalWindowSize"),
+      );
+
+    let increaseVerticalWindowSize =
+      register(
+        ~category="View",
+        ~title="Increase Vertical Window Size",
+        "vim.increaseVerticalWindowSize",
+        Command("vim.increaseVerticalWindowSize"),
+      );
   };
 
   module Workbench = {

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -361,6 +361,22 @@ module Workbench = {
         Command("workbench.action.zoomReset"),
       );
 
+    let decreaseViewSize =
+      register(
+        ~category="View",
+        ~title="Decrease Currrent Window/View Size",
+        "workbench.action.decreaseViewSize",
+        Command("workbench.action.decreaseViewSize"),
+      );
+
+    let increaseViewSize =
+      register(
+        ~category="View",
+        ~title="Increase Currrent Window/View Size",
+        "workbench.action.increaseViewSize",
+        Command("workbench.action.increaseViewSize"),
+      );
+
     module Files = {
       let save =
         register("workbench.action.save", Command("workbench.action.save"));

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -396,7 +396,7 @@ module Workbench = {
     let decreaseViewSize =
       register(
         ~category="View",
-        ~title="Decrease Currrent Window/View Size",
+        ~title="Decrease Current Window/View Size",
         "workbench.action.decreaseViewSize",
         Command("workbench.action.decreaseViewSize"),
       );
@@ -404,7 +404,7 @@ module Workbench = {
     let increaseViewSize =
       register(
         ~category="View",
-        ~title="Increase Currrent Window/View Size",
+        ~title="Increase Current Window/View Size",
         "workbench.action.increaseViewSize",
         Command("workbench.action.increaseViewSize"),
       );

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -28,6 +28,21 @@ let start = () => {
       )
     });
 
+  let resize = (axis, factor, state: State.t) =>
+    switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
+    | Some((editorGroup: EditorGroup.t)) => {
+        ...state,
+        layout:
+          Feature_Layout.resizeWindow(
+            axis,
+            editorGroup.editorGroupId,
+            factor,
+            state.layout,
+          ),
+      }
+    | None => state
+    };
+
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
     | AddSplit(direction, split) => {
@@ -97,44 +112,22 @@ let start = () => {
       }
 
     | Command("workbench.action.decreaseViewSize") =>
-      switch (EditorGroups.getActiveEditorGroup(s.editorGroups)) {
-      | Some((editorGroup: EditorGroup.t)) => {
-          ...s,
-          layout:
-            s.layout
-            |> Feature_Layout.resizeWindow(
-                 `Vertical,
-                 editorGroup.editorGroupId,
-                 0.95,
-               )
-            |> Feature_Layout.resizeWindow(
-                 `Horizontal,
-                 editorGroup.editorGroupId,
-                 0.95,
-               ),
-        }
-      | None => s
-      }
+      s |> resize(`Horizontal, 0.95) |> resize(`Vertical, 0.95)
 
     | Command("workbench.action.increaseViewSize") =>
-      switch (EditorGroups.getActiveEditorGroup(s.editorGroups)) {
-      | Some((editorGroup: EditorGroup.t)) => {
-          ...s,
-          layout:
-            s.layout
-            |> Feature_Layout.resizeWindow(
-                 `Horizontal,
-                 editorGroup.editorGroupId,
-                 1.05,
-               )
-            |> Feature_Layout.resizeWindow(
-                 `Vertical,
-                 editorGroup.editorGroupId,
-                 1.05,
-               ),
-        }
-      | None => s
-      }
+      s |> resize(`Horizontal, 1.05) |> resize(`Vertical, 1.05)
+
+    | Command("vim.decreaseHorizontalWindowSize") =>
+      s |> resize(`Horizontal, 0.95)
+
+    | Command("vim.increaseHorizontalWindowSize") =>
+      s |> resize(`Horizontal, 1.05)
+
+    | Command("vim.decreaseVerticalWindowSize") =>
+      s |> resize(`Vertical, 0.95)
+
+    | Command("vim.increaseVerticalWindowSize") =>
+      s |> resize(`Vertical, 1.05)
 
     | _ => s
     };

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -129,6 +129,11 @@ let start = () => {
     | Command("vim.increaseVerticalWindowSize") =>
       s |> resize(`Vertical, 1.05)
 
+    | Command("workbench.action.evenEditorWidths") => {
+        ...s,
+        layout: Feature_Layout.resetWeights(s.layout),
+      }
+
     | _ => s
     };
 

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -96,6 +96,46 @@ let start = () => {
       | None => s
       }
 
+    | Command("workbench.action.decreaseViewSize") =>
+      switch (EditorGroups.getActiveEditorGroup(s.editorGroups)) {
+      | Some((editorGroup: EditorGroup.t)) => {
+          ...s,
+          layout:
+            s.layout
+            |> Feature_Layout.resizeWindow(
+                 `Vertical,
+                 editorGroup.editorGroupId,
+                 0.95,
+               )
+            |> Feature_Layout.resizeWindow(
+                 `Horizontal,
+                 editorGroup.editorGroupId,
+                 0.95,
+               ),
+        }
+      | None => s
+      }
+
+    | Command("workbench.action.increaseViewSize") =>
+      switch (EditorGroups.getActiveEditorGroup(s.editorGroups)) {
+      | Some((editorGroup: EditorGroup.t)) => {
+          ...s,
+          layout:
+            s.layout
+            |> Feature_Layout.resizeWindow(
+                 `Horizontal,
+                 editorGroup.editorGroupId,
+                 1.05,
+               )
+            |> Feature_Layout.resizeWindow(
+                 `Vertical,
+                 editorGroup.editorGroupId,
+                 1.05,
+               ),
+        }
+      | None => s
+      }
+
     | _ => s
     };
 

--- a/src/UI/EditorLayoutView.re
+++ b/src/UI/EditorLayoutView.re
@@ -35,7 +35,7 @@ let renderTree = (~width, ~height, state: State.t, theme, tree) => {
            height(item.height),
          ]>
          {switch (
-            EditorGroups.getEditorGroupById(state.editorGroups, item.content)
+            EditorGroups.getEditorGroupById(state.editorGroups, item.id)
           ) {
           | Some(editorGroup) => <EditorGroupView state theme editorGroup />
           | None => React.empty

--- a/test/Model/WindowTreeLayoutTests.re
+++ b/test/Model/WindowTreeLayoutTests.re
@@ -29,9 +29,9 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       expect.equal(
         Layout.[
-          {content: 3, width: 300, height: 100, x: 0, y: 0},
-          {content: 2, width: 300, height: 100, x: 0, y: 100},
-          {content: 1, width: 300, height: 100, x: 0, y: 200},
+          {id: 3, width: 300, height: 100, x: 0, y: 0},
+          {id: 2, width: 300, height: 100, x: 0, y: 100},
+          {id: 1, width: 300, height: 100, x: 0, y: 200},
         ],
         layoutItems,
       );
@@ -61,8 +61,8 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       expect.equal(
         Layout.[
-          {content: 2, width: 100, height: 200, x: 0, y: 0},
-          {content: 1, width: 100, height: 200, x: 100, y: 0},
+          {id: 2, width: 100, height: 200, x: 0, y: 0},
+          {id: 1, width: 100, height: 200, x: 100, y: 0},
         ],
         layoutItems,
       );
@@ -83,8 +83,8 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       expect.equal(
         Layout.[
-          {content: 2, width: 200, height: 100, x: 0, y: 0},
-          {content: 1, width: 200, height: 100, x: 0, y: 100},
+          {id: 2, width: 200, height: 100, x: 0, y: 0},
+          {id: 1, width: 200, height: 100, x: 0, y: 100},
         ],
         layoutItems,
       );
@@ -106,9 +106,9 @@ describe("WindowTreeLayout", ({describe, _}) => {
 
       expect.equal(
         Layout.[
-          {content: 2, width: 200, height: 100, x: 0, y: 0},
-          {content: 3, width: 100, height: 100, x: 0, y: 100},
-          {content: 1, width: 100, height: 100, x: 100, y: 100},
+          {id: 2, width: 200, height: 100, x: 0, y: 0},
+          {id: 1, width: 100, height: 100, x: 100, y: 100},
+          {id: 3, width: 100, height: 100, x: 0, y: 100},
         ],
         layoutItems,
       );

--- a/test/Model/WindowTreeTests.re
+++ b/test/Model/WindowTreeTests.re
@@ -7,9 +7,11 @@ module Layout = Feature_Layout;
 module DSL = {
   open Layout;
 
-  let hsplit = children => Split(`Horizontal, Weight(1.), children);
-  let vsplit = children => Split(`Vertical, Weight(1.), children);
-  let window = id => Window(Weight(1.), id);
+  let hsplit = (~weight=1., children) =>
+    Split(`Horizontal, Weight(weight), children);
+  let vsplit = (~weight=1., children) =>
+    Split(`Vertical, Weight(weight), children);
+  let window = (~weight=1., id) => Window(Weight(weight), id);
 };
 
 include DSL;
@@ -198,6 +200,84 @@ describe("rotateBackward", ({test, _}) => {
 
     expect.equal(
       vsplit([window(4), hsplit([window(2), window(1), window(3)])]),
+      newTree,
+    );
+  });
+});
+
+describe("resizeWindow", ({test, _}) => {
+  test("vsplit  - vresize", ({expect, _}) => {
+    let tree = vsplit([window(1), window(2)]);
+
+    let newTree = Layout.resizeWindow(`Vertical, 2, 5., tree);
+
+    expect.equal(vsplit([window(1), window(2)]), newTree);
+  });
+
+  test("vsplit  - hresize", ({expect, _}) => {
+    let tree = vsplit([window(1), window(2)]);
+
+    let newTree = Layout.resizeWindow(`Horizontal, 2, 5., tree);
+
+    expect.equal(vsplit([window(1), window(~weight=5., 2)]), newTree);
+  });
+
+  test("hsplit  - hresize", ({expect, _}) => {
+    let tree = hsplit([window(1), window(2)]);
+
+    let newTree = Layout.resizeWindow(`Horizontal, 2, 5., tree);
+
+    expect.equal(hsplit([window(1), window(2)]), newTree);
+  });
+
+  test("hsplit  - vresize", ({expect, _}) => {
+    let tree = hsplit([window(1), window(2)]);
+
+    let newTree = Layout.resizeWindow(`Vertical, 2, 5., tree);
+
+    expect.equal(hsplit([window(1), window(~weight=5., 2)]), newTree);
+  });
+
+  test("vsplit+hsplit - hresize", ({expect, _}) => {
+    let tree = vsplit([window(1), hsplit([window(2), window(3)])]);
+
+    let newTree = Layout.resizeWindow(`Horizontal, 2, 5., tree);
+
+    expect.equal(
+      vsplit([window(1), hsplit(~weight=5., [window(2), window(3)])]),
+      newTree,
+    );
+  });
+
+  test("vsplit+hsplit - vresize", ({expect, _}) => {
+    let tree = vsplit([window(1), hsplit([window(2), window(3)])]);
+
+    let newTree = Layout.resizeWindow(`Vertical, 2, 5., tree);
+
+    expect.equal(
+      vsplit([window(1), hsplit([window(~weight=5., 2), window(3)])]),
+      newTree,
+    );
+  });
+
+  test("hsplit+vsplit - hresize", ({expect, _}) => {
+    let tree = hsplit([window(1), vsplit([window(2), window(3)])]);
+
+    let newTree = Layout.resizeWindow(`Horizontal, 2, 5., tree);
+
+    expect.equal(
+      hsplit([window(1), vsplit([window(~weight=5., 2), window(3)])]),
+      newTree,
+    );
+  });
+
+  test("hsplit+vsplit - vresize", ({expect, _}) => {
+    let tree = hsplit([window(1), vsplit([window(2), window(3)])]);
+
+    let newTree = Layout.resizeWindow(`Vertical, 2, 5., tree);
+
+    expect.equal(
+      hsplit([window(1), vsplit(~weight=5., [window(2), window(3)])]),
       newTree,
     );
   });

--- a/test/Model/WindowTreeTests.re
+++ b/test/Model/WindowTreeTests.re
@@ -4,6 +4,16 @@ open TestFramework;
 
 module Layout = Feature_Layout;
 
+module DSL = {
+  open Layout;
+
+  let hsplit = children => Split(`Horizontal, Weight(1.), children);
+  let vsplit = children => Split(`Vertical, Weight(1.), children);
+  let window = id => Window(Weight(1.), id);
+};
+
+include DSL;
+
 describe("WindowTreeTests", ({describe, _}) => {
   describe("removeWindow", ({test, _}) => {
     test("empty parent splits are removed", ({expect, _}) => {
@@ -37,13 +47,7 @@ describe("WindowTreeTests", ({describe, _}) => {
         |> Layout.removeWindow(3)
         |> Layout.removeWindow(2);
 
-      expect.equal(
-        newLayout,
-        Split(
-          `Vertical,
-          [Split(`Horizontal, [Window({weight: 1., content: 1})])],
-        ),
-      );
+      expect.equal(window(1), newLayout);
     })
   });
 
@@ -51,7 +55,7 @@ describe("WindowTreeTests", ({describe, _}) => {
     test("add vertical split", ({expect, _}) => {
       let layout = Layout.initial;
 
-      expect.equal(Layout.Split(`Vertical, [Empty]), layout);
+      expect.equal(vsplit([]), layout);
 
       let layout =
         Layout.addWindow(
@@ -62,10 +66,7 @@ describe("WindowTreeTests", ({describe, _}) => {
           layout,
         );
 
-      expect.equal(
-        Layout.Split(`Vertical, [Window({weight: 1., content: 1})]),
-        layout,
-      );
+      expect.equal(window(1), layout);
 
       let layout =
         Layout.addWindow(
@@ -75,22 +76,13 @@ describe("WindowTreeTests", ({describe, _}) => {
           2,
           layout,
         );
-      expect.equal(
-        Layout.Split(
-          `Vertical,
-          [
-            Window({weight: 1., content: 2}),
-            Window({weight: 1., content: 1}),
-          ],
-        ),
-        layout,
-      );
+      expect.equal(vsplit([window(2), window(1)]), layout);
     });
 
     test("add vertical split - after", ({expect, _}) => {
       let layout = Layout.initial;
 
-      expect.equal(Layout.Split(`Vertical, [Empty]), layout);
+      expect.equal(vsplit([]), layout);
 
       let layout =
         Layout.addWindow(
@@ -101,10 +93,7 @@ describe("WindowTreeTests", ({describe, _}) => {
           layout,
         );
 
-      expect.equal(
-        Layout.Split(`Vertical, [Window({weight: 1., content: 1})]),
-        layout,
-      );
+      expect.equal(window(1), layout);
 
       let layout =
         Layout.addWindow(
@@ -114,22 +103,13 @@ describe("WindowTreeTests", ({describe, _}) => {
           2,
           layout,
         );
-      expect.equal(
-        Layout.Split(
-          `Vertical,
-          [
-            Window({weight: 1., content: 1}),
-            Window({weight: 1., content: 2}),
-          ],
-        ),
-        layout,
-      );
+      expect.equal(vsplit([window(1), window(2)]), layout);
     });
 
     test("parent split changes direction if needed", ({expect, _}) => {
       let layout = Layout.initial;
 
-      expect.equal(Layout.Split(`Vertical, [Empty]), layout);
+      expect.equal(vsplit([]), layout);
 
       let layout =
         Layout.addWindow(
@@ -148,21 +128,7 @@ describe("WindowTreeTests", ({describe, _}) => {
           layout,
         );
 
-      expect.equal(
-        Layout.Split(
-          `Vertical,
-          [
-            Split(
-              `Horizontal,
-              [
-                Window({weight: 1., content: 2}),
-                Window({weight: 1., content: 1}),
-              ],
-            ),
-          ],
-        ),
-        layout,
-      );
+      expect.equal(hsplit([window(2), window(1)]), layout);
 
       let layout =
         Layout.addWindow(
@@ -174,24 +140,7 @@ describe("WindowTreeTests", ({describe, _}) => {
         );
 
       expect.equal(
-        Layout.Split(
-          `Vertical,
-          [
-            Split(
-              `Horizontal,
-              [
-                Window({weight: 1., content: 2}),
-                Split(
-                  `Vertical,
-                  [
-                    Window({weight: 1., content: 3}),
-                    Window({weight: 1., content: 1}),
-                  ],
-                ),
-              ],
-            ),
-          ],
-        ),
+        hsplit([window(2), vsplit([window(3), window(1)])]),
         layout,
       );
     });
@@ -206,86 +155,21 @@ describe("rotateForward", ({test, _}) => {
       |> Layout.addWindow(~position=`Before, `Vertical, 2)
       |> Layout.addWindow(~position=`Before, `Vertical, 3);
 
-    expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 3}),
-          Window({weight: 1., content: 2}),
-          Window({weight: 1., content: 1}),
-        ],
-      ),
-      tree,
-    );
+    expect.equal(vsplit([window(3), window(2), window(1)]), tree);
 
     let newTree = Layout.rotateForward(3, tree);
 
-    expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 1}),
-          Window({weight: 1., content: 3}),
-          Window({weight: 1., content: 2}),
-        ],
-      ),
-      newTree,
-    );
+    expect.equal(vsplit([window(1), window(3), window(2)]), newTree);
   });
 
   test("nested tree", ({expect, _}) => {
     let tree =
-      Layout.initial
-      |> Layout.addWindow(~position=`Before, `Vertical, 1)
-      |> Layout.addWindow(
-           ~position=`Before,
-           `Horizontal,
-           2,
-           ~target=Some(1),
-         )
-      |> Layout.addWindow(
-           ~position=`Before,
-           `Horizontal,
-           3,
-           ~target=Some(2),
-         )
-      |> Layout.addWindow(~position=`Before, `Vertical, 4);
-
-    expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 4}),
-          Split(
-            `Horizontal,
-            [
-              Window({weight: 1., content: 3}),
-              Window({weight: 1., content: 2}),
-              Window({weight: 1., content: 1}),
-            ],
-          ),
-        ],
-      ),
-      tree,
-    );
+      vsplit([window(4), hsplit([window(3), window(2), window(1)])]);
 
     let newTree = Layout.rotateForward(1, tree);
 
     expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 4}),
-          Split(
-            `Horizontal,
-            [
-              Window({weight: 1., content: 1}),
-              Window({weight: 1., content: 3}),
-              Window({weight: 1., content: 2}),
-            ],
-          ),
-        ],
-      ),
+      vsplit([window(4), hsplit([window(1), window(3), window(2)])]),
       newTree,
     );
   });
@@ -299,86 +183,21 @@ describe("rotateBackward", ({test, _}) => {
       |> Layout.addWindow(~position=`Before, `Vertical, 2)
       |> Layout.addWindow(~position=`Before, `Vertical, 3);
 
-    expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 3}),
-          Window({weight: 1., content: 2}),
-          Window({weight: 1., content: 1}),
-        ],
-      ),
-      tree,
-    );
+    expect.equal(vsplit([window(3), window(2), window(1)]), tree);
 
     let newTree = Layout.rotateBackward(3, tree);
 
-    expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 2}),
-          Window({weight: 1., content: 1}),
-          Window({weight: 1., content: 3}),
-        ],
-      ),
-      newTree,
-    );
+    expect.equal(vsplit([window(2), window(1), window(3)]), newTree);
   });
 
   test("nested tree", ({expect, _}) => {
     let tree =
-      Layout.initial
-      |> Layout.addWindow(~position=`Before, `Vertical, 1)
-      |> Layout.addWindow(
-           ~position=`Before,
-           `Horizontal,
-           2,
-           ~target=Some(1),
-         )
-      |> Layout.addWindow(
-           ~position=`Before,
-           `Horizontal,
-           3,
-           ~target=Some(2),
-         )
-      |> Layout.addWindow(~position=`Before, `Vertical, 4);
-
-    expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 4}),
-          Split(
-            `Horizontal,
-            [
-              Window({weight: 1., content: 3}),
-              Window({weight: 1., content: 2}),
-              Window({weight: 1., content: 1}),
-            ],
-          ),
-        ],
-      ),
-      tree,
-    );
+      vsplit([window(4), hsplit([window(3), window(2), window(1)])]);
 
     let newTree = Layout.rotateBackward(1, tree);
 
     expect.equal(
-      Layout.Split(
-        `Vertical,
-        [
-          Window({weight: 1., content: 4}),
-          Split(
-            `Horizontal,
-            [
-              Window({weight: 1., content: 2}),
-              Window({weight: 1., content: 1}),
-              Window({weight: 1., content: 3}),
-            ],
-          ),
-        ],
-      ),
+      vsplit([window(4), hsplit([window(2), window(1), window(3)])]),
       newTree,
     );
   });

--- a/test/Model/WindowTreeTests.re
+++ b/test/Model/WindowTreeTests.re
@@ -49,7 +49,7 @@ describe("WindowTreeTests", ({describe, _}) => {
         |> Layout.removeWindow(3)
         |> Layout.removeWindow(2);
 
-      expect.equal(window(1), newLayout);
+      expect.equal(vsplit([hsplit([window(1)])]), newLayout);
     })
   });
 


### PR DESCRIPTION
This refactors `Feature_Layout` to support window resizing and adds a number of commands to do so. Default keybindings are unfortunately blocked by multiple levels of bugs. It will still work with custom keybindings however, if carefully selected, and the PR should still be mergeable. It's just limited in functionality.
![Peek 2020-04-25 22-34](https://user-images.githubusercontent.com/5207036/80290387-fa97ce00-8744-11ea-951e-2315f1e324cb.gif)


TODO:
- [ ] Keybindings (blocked by several bugs)
- [ ] Mouse resizing
- [ ] implement `workbench.action.toggleEditorWidths`
- [ ] implement `<C-W>_` and `<C-W>|` (maximum height/width)
- [ ] add minimum window size constraint?
- [ ] wire up `:resize` and `:vertical resize`