### PR TITLE
Release - Windows: Fix release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -78,9 +78,16 @@ const getRlsPath = () => {
 const updateIcon = (rcedit, exe, iconFile) => {
     console.log(`Updating ${exe} icon`)
 
+    // HACK: `rcedit` crashes with an assertion failure on windows:
+    // Assertion failed: len < MAX_ENV_VAR_LENGTH, file c:\ws\deps\uv\src\win\util.c, line 1476
+    let oldEnv = process.env;
+    process.env = {
+        "PATH": process.env.PATH,
+    };
     rcedit(exe, {
         icon: iconFile
     })
+    process.env = oldEnv;
 
     console.log(`Successfully updated icon.`)
 }


### PR DESCRIPTION
Seeing failures on CI like:
```
Updating D:\a\1\s\_release\win32\Oni2.exe icon
Assertion failed: len < MAX_ENV_VAR_LENGTH, file c:\ws\deps\uv\src\win\util.c, line 1476
```
https://dev.azure.com/onivim/oni2/_build/results?buildId=11046&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=bb49dc73-3f54-5b89-b75a-67151df6b89d&l=22

This adds a hack to un-set the environment variables for the `rcedit` command.