### PR TITLE
Fix #1671 - Buffer loses unsaved changes when switching

### DIFF
--- a/integration_test/Regression1671Test.re
+++ b/integration_test/Regression1671Test.re
@@ -1,0 +1,65 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// Validate that unsaved changes persist when switching buffers
+// Regression test for: https://github.com/onivim/oni2/issues/1671
+runTest(~name="Regression1671 - Opening new buffer loses changes in previous buffer", (_dispatch, wait, _runEffects) => {
+  wait(~name="Capture initial state", (state: State.t) =>
+    state.vimMode == Vim.Types.Normal
+  );
+
+  Vim.command("e a-test-file");
+  let _: list(Vim.Cursor.t) = Vim.input("iabc");
+
+  // Wait for lines to be available in buffer
+  let originalBufferId = ref(-1);
+  wait(~name="Buffer gets updated", (state: State.t) =>
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(buffer => {
+      let lines = Buffer.getLines(buffer);
+      originalBufferId := Buffer.getId(buffer);
+      prerr_endline (lines[0]);
+      lines[0] == "abc"
+    })
+    |> Option.value(~default=false)
+  );
+
+  
+  // Repro for 1671 - switch to a different file, and then back
+  let _: list(Vim.Cursor.t) = Vim.input("<ESC>");
+  Vim.command("e! another-test-file");
+  _runEffects();
+  wait(~name="Buffer switched", (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(buffer => {
+      Buffer.getId(buffer) != originalBufferId^
+      })
+    |> Option.value(~default=false);
+  });
+
+  Vim.command("e! a-test-file");
+  _runEffects();
+  wait(~name="Buffer switched back", (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(buffer => {
+      Buffer.getId(buffer) == originalBufferId^
+      })
+    |> Option.value(~default=false);
+  });
+  
+  // Buffer modifications should still be around!
+  wait(~name="Buffer updates are still around after switching back", (state: State.t) =>
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(buffer => {
+      let lines = Buffer.getLines(buffer);
+      prerr_endline (lines[0]);
+      lines[0] == "abc"
+    })
+    |> Option.value(~default=false)
+  );
+});

--- a/integration_test/Regression1671Test.re
+++ b/integration_test/Regression1671Test.re
@@ -4,62 +4,62 @@ open Oni_IntegrationTestLib;
 
 // Validate that unsaved changes persist when switching buffers
 // Regression test for: https://github.com/onivim/oni2/issues/1671
-runTest(~name="Regression1671 - Opening new buffer loses changes in previous buffer", (_dispatch, wait, _runEffects) => {
-  wait(~name="Capture initial state", (state: State.t) =>
-    state.vimMode == Vim.Types.Normal
-  );
+runTest(
+  ~name="Regression1671 - Opening new buffer loses changes in previous buffer",
+  (_dispatch, wait, runEffects) => {
+    wait(~name="Capture initial state", (state: State.t) =>
+      state.vimMode == Vim.Types.Normal
+    );
 
-  Vim.command("e a-test-file");
-  let _: list(Vim.Cursor.t) = Vim.input("iabc");
+    Vim.command("e a-test-file");
+    let _: list(Vim.Cursor.t) = Vim.input("iabc");
 
-  // Wait for lines to be available in buffer
-  let originalBufferId = ref(-1);
-  wait(~name="Buffer gets updated", (state: State.t) =>
-    state
-    |> Selectors.getActiveBuffer
-    |> Option.map(buffer => {
-      let lines = Buffer.getLines(buffer);
-      originalBufferId := Buffer.getId(buffer);
-      prerr_endline (lines[0]);
-      lines[0] == "abc"
-    })
-    |> Option.value(~default=false)
-  );
+    // Wait for lines to be available in buffer
+    let originalBufferId = ref(-1);
+    wait(~name="Buffer gets updated", (state: State.t) =>
+      state
+      |> Selectors.getActiveBuffer
+      |> Option.map(buffer => {
+           let lines = Buffer.getLines(buffer);
+           originalBufferId := Buffer.getId(buffer);
+           prerr_endline(lines[0]);
+           lines[0] == "abc";
+         })
+      |> Option.value(~default=false)
+    );
 
-  
-  // Repro for 1671 - switch to a different file, and then back
-  let _: list(Vim.Cursor.t) = Vim.input("<ESC>");
-  Vim.command("e! another-test-file");
-  _runEffects();
-  wait(~name="Buffer switched", (state: State.t) => {
-    state
-    |> Selectors.getActiveBuffer
-    |> Option.map(buffer => {
-      Buffer.getId(buffer) != originalBufferId^
-      })
-    |> Option.value(~default=false);
-  });
+    // Repro for 1671 - switch to a different file, and then back
+    let _: list(Vim.Cursor.t) = Vim.input("<ESC>");
+    Vim.command("e! another-test-file");
+    runEffects();
+    wait(~name="Buffer switched", (state: State.t) => {
+      state
+      |> Selectors.getActiveBuffer
+      |> Option.map(buffer => {Buffer.getId(buffer) != originalBufferId^})
+      |> Option.value(~default=false)
+    });
 
-  Vim.command("e! a-test-file");
-  _runEffects();
-  wait(~name="Buffer switched back", (state: State.t) => {
-    state
-    |> Selectors.getActiveBuffer
-    |> Option.map(buffer => {
-      Buffer.getId(buffer) == originalBufferId^
-      })
-    |> Option.value(~default=false);
-  });
-  
-  // Buffer modifications should still be around!
-  wait(~name="Buffer updates are still around after switching back", (state: State.t) =>
-    state
-    |> Selectors.getActiveBuffer
-    |> Option.map(buffer => {
-      let lines = Buffer.getLines(buffer);
-      prerr_endline (lines[0]);
-      lines[0] == "abc"
-    })
-    |> Option.value(~default=false)
-  );
-});
+    Vim.command("e! a-test-file");
+    runEffects();
+    wait(~name="Buffer switched back", (state: State.t) => {
+      state
+      |> Selectors.getActiveBuffer
+      |> Option.map(buffer => {Buffer.getId(buffer) == originalBufferId^})
+      |> Option.value(~default=false)
+    });
+
+    // Buffer modifications should still be around!
+    wait(
+      ~name="Buffer updates are still around after switching back",
+      (state: State.t) =>
+      state
+      |> Selectors.getActiveBuffer
+      |> Option.map(buffer => {
+           let lines = Buffer.getLines(buffer);
+           prerr_endline(lines[0]);
+           lines[0] == "abc";
+         })
+      |> Option.value(~default=false)
+    );
+  },
+);

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -32,6 +32,7 @@
            SyntaxServerParentPidTest
            SyntaxServerParentPidCorrectTest
            SyntaxServerReadExceptionTest
+           Regression1671Test
            RegressionCommandLineNoCompletionTest
            RegressionDeleteAllLinesTest
            RegressionFileModifiedIndicationTest
@@ -85,6 +86,7 @@
         LanguageTypeScriptTest.exe
         LineEndingsLFTest.exe
         QuickOpenEventuallyCompletesTest.exe
+        Regression1671Test.exe
         RegressionCommandLineNoCompletionTest.exe
         RegressionDeleteAllLinesTest.exe
         RegressionFileModifiedIndicationTest.exe


### PR DESCRIPTION
Fixes #1671 + adds a regression test.

The actual fix came in https://github.com/onivim/libvim/pull/199 and was picked up here: https://github.com/onivim/oni2/pull/1694