### PR TITLE
Fix #1686 - Sneak color unreadable in Monokai theme

### DIFF
--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -587,7 +587,8 @@ module Oni = {
 
   module Sneak = {
     let background =
-      define("oni.sneak.background", all(ref(Selection.background)));
+      define("oni.sneak.background", all(ref(Menu.selectionBackground)
+      ));
     let foreground =
       define("oni.sneak.foreground", all(ref(Menu.foreground)));
     let highlight =

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -587,8 +587,7 @@ module Oni = {
 
   module Sneak = {
     let background =
-      define("oni.sneak.background", all(ref(Menu.selectionBackground)
-      ));
+      define("oni.sneak.background", all(ref(Menu.selectionBackground)));
     let foreground =
       define("oni.sneak.foreground", all(ref(Menu.foreground)));
     let highlight =

--- a/src/UI/SneakView.re
+++ b/src/UI/SneakView.re
@@ -31,6 +31,13 @@ module Styles = {
   let item = (x, y, theme) => [
     backgroundColor(Colors.Oni.Sneak.background.from(theme)),
     position(`Absolute),
+      boxShadow(
+        ~xOffset=3.,
+        ~yOffset=3.,
+        ~blurRadius=5.,
+        ~spreadRadius=0.,
+        ~color=Revery.Color.rgba(0., 0., 0., 0.2),
+      ),
     top(y),
     left(x + Constants.size / 2),
     Style.height(Constants.size),

--- a/src/UI/SneakView.re
+++ b/src/UI/SneakView.re
@@ -31,13 +31,13 @@ module Styles = {
   let item = (x, y, theme) => [
     backgroundColor(Colors.Oni.Sneak.background.from(theme)),
     position(`Absolute),
-      boxShadow(
-        ~xOffset=3.,
-        ~yOffset=3.,
-        ~blurRadius=5.,
-        ~spreadRadius=0.,
-        ~color=Revery.Color.rgba(0., 0., 0., 0.2),
-      ),
+    boxShadow(
+      ~xOffset=3.,
+      ~yOffset=3.,
+      ~blurRadius=5.,
+      ~spreadRadius=0.,
+      ~color=Revery.Color.rgba(0., 0., 0., 0.2),
+    ),
     top(y),
     left(x + Constants.size / 2),
     Style.height(Constants.size),


### PR DESCRIPTION
__`master`__:
![2020-04-29 13 23 24](https://user-images.githubusercontent.com/13532591/80643596-3371c480-8a1d-11ea-9daa-e3affc7a3714.gif)
(Note several themes are unreadable, like `Monokai` - called out in #1686)

__PR__:
![2020-04-29 13 25 12](https://user-images.githubusercontent.com/13532591/80643622-3d93c300-8a1d-11ea-851a-3d453e31d40c.gif)
(Some themes do not have an ideal contrast, but better than being totally unreadable...)

Fixes #1686 