### PR TITLE
Fix #660 - Clipboard: Specify Character mode when not multiple lines

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6ebdc8dc4641498496ab159e26f4433c",
+  "checksum": "4199a547768d8fe5434fe1cefcf6039a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,13 +422,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a0510e5",
+      "version": "github:onivim/reason-libvim#2493884",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a0510e5" ]
+        "source": [ "github:onivim/reason-libvim#2493884" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1187,7 +1187,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3023@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4d4b9b304c9cffd35546833e9092b51b",
+  "checksum": "b87ae45c586c2628ed0d75e58969a35c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,18 +422,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#ce6b248",
+      "version": "github:onivim/reason-libvim#a85c11f",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#ce6b248" ]
+        "source": [ "github:onivim/reason-libvim#a85c11f" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.41@d41d8cd9",
+        "libvim@8.10869.43@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658", "@esy-ocaml/reason@3.5.2@d41d8cd9"
@@ -625,14 +625,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.41@d41d8cd9": {
-      "id": "libvim@8.10869.41@d41d8cd9",
+    "libvim@8.10869.43@d41d8cd9": {
+      "id": "libvim@8.10869.43@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.41",
+      "version": "8.10869.43",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.41.tgz#sha1:b22bae4a0f9661e4f4e4ed9b8a540eefe5d3bb37"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.43.tgz#sha1:bea17634cc9bb797fe0abf90973ba7813efd055e"
         ]
       },
       "overrides": [],
@@ -1187,7 +1187,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3022@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -25,7 +25,7 @@ No additional requirements.
 
 ### macOS
 
-Requires `libtool`. Can be installed via homebrew: `brew install libtool`.
+Requires `libtool` and `gettext` from homebrew: `brew install libtool gettext`.
 
 ### Linux
 

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6ebdc8dc4641498496ab159e26f4433c",
+  "checksum": "4199a547768d8fe5434fe1cefcf6039a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -153,7 +153,7 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#2352b85@d41d8cd9",
-        "reason-sdl2@2.10.3022@d41d8cd9",
+        "reason-sdl2@2.10.3023@d41d8cd9",
         "reason-harfbuzz@1.91.8001@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -337,7 +337,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3022@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3023@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
@@ -347,14 +347,14 @@
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.1@a0c1e658" ]
     },
-    "reason-sdl2@2.10.3022@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3022@d41d8cd9",
+    "reason-sdl2@2.10.3023@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3023@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3022",
+      "version": "2.10.3023",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3022.tgz#sha1:9987104b0bad2627e66c4632e8525a177fdb8a2d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3023.tgz#sha1:ee3fea956160c9139ed588acf76c02bd80c4c962"
         ]
       },
       "overrides": [],
@@ -422,13 +422,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a0510e5",
+      "version": "github:onivim/reason-libvim#2493884",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a0510e5" ]
+        "source": [ "github:onivim/reason-libvim#2493884" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1184,9 +1184,9 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3022@d41d8cd9",
+        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3023@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4d4b9b304c9cffd35546833e9092b51b",
+  "checksum": "b87ae45c586c2628ed0d75e58969a35c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,18 +422,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#ce6b248",
+      "version": "github:onivim/reason-libvim#a85c11f",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#ce6b248" ]
+        "source": [ "github:onivim/reason-libvim#a85c11f" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.41@d41d8cd9",
+        "libvim@8.10869.43@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658", "@esy-ocaml/reason@3.5.2@d41d8cd9"
@@ -625,14 +625,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.41@d41d8cd9": {
-      "id": "libvim@8.10869.41@d41d8cd9",
+    "libvim@8.10869.43@d41d8cd9": {
+      "id": "libvim@8.10869.43@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.41",
+      "version": "8.10869.43",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.41.tgz#sha1:b22bae4a0f9661e4f4e4ed9b8a540eefe5d3bb37"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.43.tgz#sha1:bea17634cc9bb797fe0abf90973ba7813efd055e"
         ]
       },
       "overrides": [],
@@ -1186,7 +1186,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3022@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/integration_test/ClipboardNormalModePasteTest.re
+++ b/integration_test/ClipboardNormalModePasteTest.re
@@ -23,7 +23,7 @@ runTest(
   );
 
   // '*' test case
-  setClipboard(Some("abc"));
+  setClipboard(Some("abc\n"));
 
   dispatch(KeyboardInput("\""));
   dispatch(KeyboardInput("*"));
@@ -94,7 +94,7 @@ runTest(
     }
   );
   // '+' test case
-  setClipboard(Some("def"));
+  setClipboard(Some("def\n"));
 
   dispatch(KeyboardInput("\""));
   dispatch(KeyboardInput("*"));
@@ -119,7 +119,7 @@ runTest(
   dispatch(KeyboardInput("y"));
   runEffects();
 
-  setClipboard(Some("ghi"));
+  setClipboard(Some("ghi\n"));
 
   dispatch(KeyboardInput("\""));
   dispatch(KeyboardInput("a"));
@@ -137,7 +137,7 @@ runTest(
   );
 
   // Test if the configuration is set - paste from unnamed register will pull from the keyboard
-  setClipboard(Some("jkl"));
+  setClipboard(Some("jkl\n"));
 
   wait(~name="Set configuration to pull clipboard on paste", (state: State.t) => {
     let configuration = state.configuration;
@@ -177,7 +177,7 @@ runTest(
   );
 
   // Set configuration back (paste=false), and it should not pull from clipboard
-  setClipboard(Some("mno"));
+  setClipboard(Some("mno\n"));
 
   wait(~name="Set configuration to pull clipboard on paste", (state: State.t) => {
     let configuration = state.configuration;
@@ -213,6 +213,26 @@ runTest(
       let line = Buffer.getLine(0, buf) |> BufferLine.raw;
       Log.info("Current line is: |" ++ line ++ "|");
       String.equal(line, "jkl");
+    }
+    );
+  
+  // Single line case - should paste in front of previous text
+  setClipboard(Some("mno"));
+  dispatch(KeyboardInput("\""));
+  dispatch(KeyboardInput("*"));
+  dispatch(KeyboardInput("P"));
+  runEffects();
+
+  wait(
+    ~name=
+      "paste with single line, from clipboard",
+    (state: State.t) =>
+    switch (Selectors.getActiveBuffer(state)) {
+    | None => false
+    | Some(buf) =>
+      let line = Buffer.getLine(0, buf) |> BufferLine.raw;
+      Log.info("Current line is: |" ++ line ++ "|");
+      String.equal(line, "mnojkl");
     }
   );
 });

--- a/integration_test/ClipboardNormalModePasteTest.re
+++ b/integration_test/ClipboardNormalModePasteTest.re
@@ -214,8 +214,8 @@ runTest(
       Log.info("Current line is: |" ++ line ++ "|");
       String.equal(line, "jkl");
     }
-    );
-  
+  );
+
   // Single line case - should paste in front of previous text
   setClipboard(Some("mno"));
   dispatch(KeyboardInput("\""));
@@ -223,10 +223,7 @@ runTest(
   dispatch(KeyboardInput("P"));
   runEffects();
 
-  wait(
-    ~name=
-      "paste with single line, from clipboard",
-    (state: State.t) =>
+  wait(~name="paste with single line, from clipboard", (state: State.t) =>
     switch (Selectors.getActiveBuffer(state)) {
     | None => false
     | Some(buf) =>

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6ebdc8dc4641498496ab159e26f4433c",
+  "checksum": "4199a547768d8fe5434fe1cefcf6039a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,13 +422,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a0510e5",
+      "version": "github:onivim/reason-libvim#2493884",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a0510e5" ]
+        "source": [ "github:onivim/reason-libvim#2493884" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1186,7 +1186,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3023@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4d4b9b304c9cffd35546833e9092b51b",
+  "checksum": "b87ae45c586c2628ed0d75e58969a35c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,18 +422,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#ce6b248",
+      "version": "github:onivim/reason-libvim#a85c11f",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#ce6b248" ]
+        "source": [ "github:onivim/reason-libvim#a85c11f" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.41@d41d8cd9",
+        "libvim@8.10869.43@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658", "@esy-ocaml/reason@3.5.2@d41d8cd9"
@@ -625,14 +625,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.41@d41d8cd9": {
-      "id": "libvim@8.10869.41@d41d8cd9",
+    "libvim@8.10869.43@d41d8cd9": {
+      "id": "libvim@8.10869.43@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.41",
+      "version": "8.10869.43",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.41.tgz#sha1:b22bae4a0f9661e4f4e4ed9b8a540eefe5d3bb37"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.43.tgz#sha1:bea17634cc9bb797fe0abf90973ba7813efd055e"
         ]
       },
       "overrides": [],
@@ -1186,7 +1186,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3022@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "ocaml": "~4.7.0",
     "reason-sdl2": "^2.10.2020",
     "reason-jsonrpc": "1.5.0",
-    "reason-libvim": "onivim/reason-libvim#a0510e5",
+    "reason-libvim": "onivim/reason-libvim#2493884",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#ae1fd34",
     "reasonFuzz": "*",
     "rench": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "ocaml": "~4.7.0",
     "reason-sdl2": "^2.10.2020",
     "reason-jsonrpc": "1.5.0",
-    "reason-libvim": "onivim/reason-libvim#ce6b248",
+    "reason-libvim": "onivim/reason-libvim#a85c11f",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#ae1fd34",
     "reasonFuzz": "*",
     "rench": "1.7.1",

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -79,7 +79,7 @@ let start =
     let isMultipleLines =
       fun
       | [s] => String.contains(s, '\n')
-      | [..._] => true
+      | [_, ..._] => true
       | [] => false;
 
     let splitNewLines = s => String.split_on_char('\n', s) |> Array.of_list;

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -79,7 +79,7 @@ let start =
     let isMultipleLines =
       fun
       | [s] => String.contains(s, '\n')
-      | [s, ..._tail] => true
+      | [..._] => true
       | [] => false;
 
     let splitNewLines = s => String.split_on_char('\n', s) |> Array.of_list;

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -76,6 +76,12 @@ let start =
       |> List.map(c => String.make(1, c))
       |> String.concat("");
 
+    let isMultipleLines =
+      fun
+      | [s] => String.contains(s, '\n')
+      | [s, ..._tail] => true
+      | [] => false;
+
     let splitNewLines = s => String.split_on_char('\n', s) |> Array.of_list;
 
     let getClipboardValue = () => {
@@ -93,7 +99,14 @@ let start =
       && yankConfig.paste; // or if 'paste' set, but unnamed
 
     if (shouldPullFromClipboard) {
-      getClipboardValue();
+      getClipboardValue()
+      |> Option.map(lines =>
+           Vim.Types.{
+             lines,
+             blockType:
+               isMultipleLines(lines |> Array.to_list) ? Line : Character,
+           }
+         );
     } else {
       None;
     };

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9dce6fb8ab72f2f7126f68c3d84b9849",
+  "checksum": "d57f4b8529f4edc92099175748fb061c",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,13 +422,13 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#a0510e5",
+      "version": "github:onivim/reason-libvim#2493884",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#a0510e5" ]
+        "source": [ "github:onivim/reason-libvim#2493884" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1186,7 +1186,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3023@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#a0510e5@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "718d4b9d7916567d98b83a5c95cbbba6",
+  "checksum": "8a094287f449023568aa7a2d6bb7c851",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -422,18 +422,18 @@
       ],
       "devDependencies": []
     },
-    "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9": {
-      "id": "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+    "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9": {
+      "id": "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
       "name": "reason-libvim",
-      "version": "github:onivim/reason-libvim#ce6b248",
+      "version": "github:onivim/reason-libvim#a85c11f",
       "source": {
         "type": "install",
-        "source": [ "github:onivim/reason-libvim#ce6b248" ]
+        "source": [ "github:onivim/reason-libvim#a85c11f" ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "libvim@8.10869.41@d41d8cd9",
+        "libvim@8.10869.43@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658", "@esy-ocaml/reason@3.5.2@d41d8cd9"
@@ -625,14 +625,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.41@d41d8cd9": {
-      "id": "libvim@8.10869.41@d41d8cd9",
+    "libvim@8.10869.43@d41d8cd9": {
+      "id": "libvim@8.10869.43@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.41",
+      "version": "8.10869.43",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.41.tgz#sha1:b22bae4a0f9661e4f4e4ed9b8a540eefe5d3bb37"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.43.tgz#sha1:bea17634cc9bb797fe0abf90973ba7813efd055e"
         ]
       },
       "overrides": [],
@@ -1186,7 +1186,7 @@
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3022@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "reason-libvim@github:onivim/reason-libvim#ce6b248@d41d8cd9",
+        "reason-libvim@github:onivim/reason-libvim#a85c11f@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",


### PR DESCRIPTION
Pull in https://github.com/onivim/reason-libvim/pull/116 , modify clipboard provider to specify `character` mode when not multiple lines

Fixes #660 (and also `xp` behavior, when use-clipboard-on-paste is enabled)