### PR TITLE
CI - Linux (CentOS): Remove cleanup prior to tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,8 +95,6 @@ jobs:
     displayName: 'docker: ls -a'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
     displayName: 'docker: build Onivim 2'
-  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-test.sh'
-    displayName: 'docker: unit tests'
   - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-linux.yml

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -7,3 +7,7 @@ node install-node-deps.js --production
 esy build
 esy x Oni2 -f --checkhealth
 esy create-release
+
+esy @test install
+esy @test build
+esy @test run

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,12 +1,6 @@
 source /opt/rh/llvm-toolset-7.0/enable
 clang -v
 
-echo "Deleting esy folder"
-rm -rf _esy
-
-esy cleanup test.json --dry-run
-esy cleanup test.json
-
 esy @test install
 esy @test build
 esy @test run

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,6 +1,0 @@
-source /opt/rh/llvm-toolset-7.0/enable
-clang -v
-
-esy @test install
-esy @test build
-esy @test run


### PR DESCRIPTION
The CentOS build is taking twice as long as it should, because it's rebuilding the entire toolchain for running unit tests. This was originally done to save space; but is no longer necessary since we saved space elsewhere (removing the Android SDK, etc)