### PR TITLE
Bugfix: Fix broken save command

### DIFF
--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -363,7 +363,10 @@ module Workbench = {
 
     module Files = {
       let save =
-        register("workbench.action.files.save", Command("workbench.action.files.save"));
+        register(
+          "workbench.action.files.save",
+          Command("workbench.action.files.save"),
+        );
     };
   };
   module Actions = {

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -363,7 +363,7 @@ module Workbench = {
 
     module Files = {
       let save =
-        register("workbench.action.save", Command("workbench.action.save"));
+        register("workbench.action.files.save", Command("workbench.action.files.save"));
     };
   };
   module Actions = {


### PR DESCRIPTION
**Issue:** The save command had stopped working

**Defect:** In the command infrastructure refactor (#1595), the command id for the save command had been reproduced incorrectly as `workbench.action.save`

**Fix:** Change the command id back to `workbench.action.files.save`