### PR TITLE
Dependency: esy-skia -> d60e5fe

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f678cce578f36760177e85cc8b4c121b",
+  "checksum": "0eac3c2b07bd666d6d941296b8e0dfac",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -339,7 +339,7 @@
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3025@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
@@ -831,17 +831,17 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#07c13a9",
+      "version": "github:revery-ui/esy-skia#d60e5fe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#07c13a9" ]
+        "source": [ "github:revery-ui/esy-skia#d60e5fe" ]
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -932,19 +932,19 @@
       ],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9": {
+    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:revery-ui/libjpeg-turbo#61e031f",
+      "version": "github:revery-ui/libjpeg-turbo#dbb3dd5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/libjpeg-turbo#61e031f" ]
+        "source": [ "github:revery-ui/libjpeg-turbo#dbb3dd5" ]
       },
       "overrides": [],
       "dependencies": [
         "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9",
-        "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
+        "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -1189,7 +1189,7 @@
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
@@ -1217,6 +1217,20 @@
         "innosetup-compiler@5.5.9@d41d8cd9", "fs-extra@7.0.1@d41d8cd9",
         "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#04733ed@d41d8cd9"
       ]
+    },
+    "@revery/esy-cmake@0.3.5001@d41d8cd9": {
+      "id": "@revery/esy-cmake@0.3.5001@d41d8cd9",
+      "name": "@revery/esy-cmake",
+      "version": "0.3.5001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@revery/esy-cmake/-/esy-cmake-0.3.5001.tgz#sha1:19d35421b8ec11c545a16071fc23c5ceb03a2bcb"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
     },
     "@reason-native/rely@3.2.1@d41d8cd9": {
       "id": "@reason-native/rely@3.2.1@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f678cce578f36760177e85cc8b4c121b",
+  "checksum": "0eac3c2b07bd666d6d941296b8e0dfac",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -339,7 +339,7 @@
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3025@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
@@ -831,17 +831,17 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#07c13a9",
+      "version": "github:revery-ui/esy-skia#d60e5fe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#07c13a9" ]
+        "source": [ "github:revery-ui/esy-skia#d60e5fe" ]
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -932,19 +932,19 @@
       ],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9": {
+    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:revery-ui/libjpeg-turbo#61e031f",
+      "version": "github:revery-ui/libjpeg-turbo#dbb3dd5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/libjpeg-turbo#61e031f" ]
+        "source": [ "github:revery-ui/libjpeg-turbo#dbb3dd5" ]
       },
       "overrides": [],
       "dependencies": [
         "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9",
-        "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
+        "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -1188,7 +1188,7 @@
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
@@ -1216,6 +1216,20 @@
         "innosetup-compiler@5.5.9@d41d8cd9", "fs-extra@7.0.1@d41d8cd9",
         "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#04733ed@d41d8cd9"
       ]
+    },
+    "@revery/esy-cmake@0.3.5001@d41d8cd9": {
+      "id": "@revery/esy-cmake@0.3.5001@d41d8cd9",
+      "name": "@revery/esy-cmake",
+      "version": "0.3.5001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@revery/esy-cmake/-/esy-cmake-0.3.5001.tgz#sha1:19d35421b8ec11c545a16071fc23c5ceb03a2bcb"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
     },
     "@reason-native/rely@3.2.1@d41d8cd9": {
       "id": "@reason-native/rely@3.2.1@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f678cce578f36760177e85cc8b4c121b",
+  "checksum": "0eac3c2b07bd666d6d941296b8e0dfac",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -339,7 +339,7 @@
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3025@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
@@ -831,17 +831,17 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#07c13a9",
+      "version": "github:revery-ui/esy-skia#d60e5fe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#07c13a9" ]
+        "source": [ "github:revery-ui/esy-skia#d60e5fe" ]
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -932,19 +932,19 @@
       ],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9": {
+    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:revery-ui/libjpeg-turbo#61e031f",
+      "version": "github:revery-ui/libjpeg-turbo#dbb3dd5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/libjpeg-turbo#61e031f" ]
+        "source": [ "github:revery-ui/libjpeg-turbo#dbb3dd5" ]
       },
       "overrides": [],
       "dependencies": [
         "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9",
-        "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
+        "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -1188,7 +1188,7 @@
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
@@ -1216,6 +1216,20 @@
         "innosetup-compiler@5.5.9@d41d8cd9", "fs-extra@7.0.1@d41d8cd9",
         "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#04733ed@d41d8cd9"
       ]
+    },
+    "@revery/esy-cmake@0.3.5001@d41d8cd9": {
+      "id": "@revery/esy-cmake@0.3.5001@d41d8cd9",
+      "name": "@revery/esy-cmake",
+      "version": "0.3.5001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@revery/esy-cmake/-/esy-cmake-0.3.5001.tgz#sha1:19d35421b8ec11c545a16071fc23c5ceb03a2bcb"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
     },
     "@reason-native/rely@3.2.1@d41d8cd9": {
       "id": "@reason-native/rely@3.2.1@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "revery": "revery-ui/revery#9f725e0",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
-    "esy-skia": "revery-ui/esy-skia#07c13a9",
+    "esy-skia": "revery-ui/esy-skia#d60e5fe",
     "rench": "bryphe/rench#a976fe5",
     "reasonFuzz": "CrossR/reasonFuzz#1ad6f5d",
     "esy-oniguruma": "onivim/esy-oniguruma#4698ce4",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "48a109e19ff0920d060662f98aa3ca2a",
+  "checksum": "56ccafa323e92d853b5f565629b90115",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -339,7 +339,7 @@
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3025@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
@@ -831,17 +831,17 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#07c13a9",
+      "version": "github:revery-ui/esy-skia#d60e5fe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#07c13a9" ]
+        "source": [ "github:revery-ui/esy-skia#d60e5fe" ]
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -932,19 +932,19 @@
       ],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9": {
+    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:revery-ui/libjpeg-turbo#61e031f",
+      "version": "github:revery-ui/libjpeg-turbo#dbb3dd5",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/libjpeg-turbo#61e031f" ]
+        "source": [ "github:revery-ui/libjpeg-turbo#dbb3dd5" ]
       },
       "overrides": [],
       "dependencies": [
         "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9",
-        "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
+        "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -1188,7 +1188,7 @@
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "reason-jsonrpc@1.5.0@d41d8cd9", "ocaml@4.9.0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#07c13a9@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
         "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#6a8afaf@d41d8cd9",
@@ -1216,6 +1216,20 @@
         "innosetup-compiler@5.5.9@d41d8cd9", "fs-extra@7.0.1@d41d8cd9",
         "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#04733ed@d41d8cd9"
       ]
+    },
+    "@revery/esy-cmake@0.3.5001@d41d8cd9": {
+      "id": "@revery/esy-cmake@0.3.5001@d41d8cd9",
+      "name": "@revery/esy-cmake",
+      "version": "0.3.5001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@revery/esy-cmake/-/esy-cmake-0.3.5001.tgz#sha1:19d35421b8ec11c545a16071fc23c5ceb03a2bcb"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
     },
     "@reason-native/rely@3.2.1@d41d8cd9": {
       "id": "@reason-native/rely@3.2.1@d41d8cd9",


### PR DESCRIPTION
Actually pick up the clang 10 build fixes. Not sure why the revery update PR worked with the stale resolution. And not sure why this resolution is needed now, but without it it falls back to 0.6.0. So there you go.