### PR TITLE
Bugfix: Linewise clipboard paste (yyp)

### DIFF
--- a/integration_test/ClipboardYankTest.re
+++ b/integration_test/ClipboardYankTest.re
@@ -59,7 +59,7 @@ runTest(~name="ClipboardYankTest", (dispatch, wait, runEffects) => {
 
   wait(~name="Yank 1 is sent to clipboard", _ => {
     print_endline("CLIPBOARD: " ++ printOpt(getClipboard()));
-    optEqual(getClipboard(), "abc");
+    optEqual(getClipboard(), "abc\n");
   });
 
   setClipboard(None);
@@ -72,7 +72,7 @@ runTest(~name="ClipboardYankTest", (dispatch, wait, runEffects) => {
 
   wait(~name="Yank 2 is sent to clipboard", _ => {
     print_endline("CLIPBOARD: " ++ printOpt(getClipboard()));
-    optEqual(getClipboard(), "abc");
+    optEqual(getClipboard(), "abc\n");
   });
 
   wait(
@@ -129,6 +129,6 @@ runTest(~name="ClipboardYankTest", (dispatch, wait, runEffects) => {
 
   wait(~name="Yank 4 w/ register '+' is still sent to clipboard", _ => {
     print_endline("CLIPBOARD: " ++ printOpt(getClipboard()));
-    optEqual(getClipboard(), "abc");
+    optEqual(getClipboard(), "abc\n");
   });
 });

--- a/integration_test/ClipboardxpTest.re
+++ b/integration_test/ClipboardxpTest.re
@@ -1,0 +1,53 @@
+open Oni_Core;
+open Oni_Core.Utility;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(~name="ClipboardyypTest", (dispatch, wait, runEffects) => {
+  wait(
+    ~name="Set configuration to always yank to clipboard", (state: State.t) => {
+    let configuration = state.configuration;
+    dispatch(
+      ConfigurationSet({
+        ...configuration,
+        default: {
+          ...configuration.default,
+          vimUseSystemClipboard: {
+            yank: true,
+            paste: true,
+            delete: true,
+          },
+        },
+      }),
+    );
+    runEffects();
+    true;
+  });
+
+  let testFile = getAssetPath("some-test-file.txt");
+  dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+  wait(~name="Verify buffer is loaded", (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> OptionEx.flatMap(Buffer.getShortFriendlyName)
+    |> Option.map(name => String.equal(name, "some-test-file.txt"))
+    |> Option.value(~default=false)
+  });
+
+  dispatch(KeyboardInput("x"));
+  dispatch(KeyboardInput("p"));
+
+  runEffects();
+
+  wait(~name="Verify characters get swapped", ~timeout=10.0, (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(buffer => {
+         let firstLine = Buffer.getLine(0, buffer) |> BufferLine.raw;
+
+         String.equal(firstLine, "bac");
+       })
+    |> Option.value(~default=false)
+  });
+});

--- a/integration_test/ClipboardyypTest.re
+++ b/integration_test/ClipboardyypTest.re
@@ -1,0 +1,56 @@
+open Oni_Core;
+open Oni_Core.Utility;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(~name="ClipboardyypTest", (dispatch, wait, runEffects) => {
+  wait(
+    ~name="Set configuration to always yank to clipboard", (state: State.t) => {
+    let configuration = state.configuration;
+    dispatch(
+      ConfigurationSet({
+        ...configuration,
+        default: {
+          ...configuration.default,
+          vimUseSystemClipboard: {
+            yank: true,
+            paste: true,
+            delete: true,
+          },
+        },
+      }),
+    );
+    runEffects();
+    true;
+  });
+
+  let testFile = getAssetPath("some-test-file.txt");
+  dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+  wait(~name="Verify buffer is loaded", (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> OptionEx.flatMap(Buffer.getShortFriendlyName)
+    |> Option.map(name => String.equal(name, "some-test-file.txt"))
+    |> Option.value(~default=false)
+  });
+
+  dispatch(KeyboardInput("y"));
+  dispatch(KeyboardInput("y"));
+  dispatch(KeyboardInput("p"));
+
+  runEffects();
+
+  wait(
+    ~name="Verify first line gets duplicated", ~timeout=10.0, (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(buffer => {
+         let firstLine = Buffer.getLine(0, buffer) |> BufferLine.raw;
+         let secondLine = Buffer.getLine(1, buffer) |> BufferLine.raw;
+
+         String.equal(firstLine, "abc") && String.equal(secondLine, "abc");
+       })
+    |> Option.value(~default=false)
+  });
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -5,6 +5,8 @@
            ClipboardInsertModePasteEmptyTest
            ClipboardNormalModePasteTest
            ClipboardYankTest
+           ClipboardxpTest
+           ClipboardyypTest
            CopyActiveFilepathToClipboardTest
            EchoNotificationTest
            EditorFontFromPathTest
@@ -67,6 +69,8 @@
         ClipboardInsertModePasteEmptyTest.exe
         ClipboardNormalModePasteTest.exe
         ClipboardYankTest.exe
+        ClipboardxpTest.exe
+        ClipboardyypTest.exe
         CopyActiveFilepathToClipboardTest.exe
         EchoNotificationTest.exe
         EditorFontFromPathTest.exe

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -93,11 +93,6 @@ let start =
       |> String.split_on_char('\n')
       |> Array.of_list;
 
-    let getClipboardValue = () => {
-      getClipboardText()
-      |> Option.map(text => text |> removeWindowsNewLines |> splitNewLines);
-    };
-
     let starReg = Char.code('*');
     let plusReg = Char.code('+');
     let unnamedReg = 0;


### PR DESCRIPTION
This fixes a regression from https://github.com/onivim/oni2/pull/1694 (and adds test to cover the case in the future).

__Issue:__ When running `yyp`, which should yank a line and then paste it underneath, the line would actually get pasted on the same line as the line that was yanked from - this was because, in the case where we don't see a yank as multiple-lines, we'd use the `Character` paste mode. There wasn't any context when we 'yanked' to the clipboard that it should be multiple lines.

__Fix:__ When yanking a single-line, and the yank mode is `Line`, we tag it with a newline. Then, we look for the newlines to decide if we should paste linewise or characterwise.