### PR TITLE
Fix #873: Exit zen mode when toggling explorer

### DIFF
--- a/src/Store/Reducer.re
+++ b/src/Store/Reducer.re
@@ -27,7 +27,7 @@ let reduce: (State.t, Actions.t) => State.t =
         languageFeatures:
           LanguageFeaturesReducer.reduce(a, s.languageFeatures),
         lifecycle: Lifecycle.reduce(s.lifecycle, a),
-        sideBar: SideBarReducer.reduce(s.sideBar, a),
+        sideBar: SideBarReducer.reduce(~zenMode=s.zenMode, s.sideBar, a),
         statusBar: StatusBarReducer.reduce(s.statusBar, a),
       };
 
@@ -44,6 +44,9 @@ let reduce: (State.t, Actions.t) => State.t =
       | SetLanguageInfo(languageInfo) => {...s, languageInfo}
       | SetIconTheme(iconTheme) => {...s, iconTheme}
       | TokenThemeLoaded(tokenTheme) => {...s, tokenTheme}
+      | ActivityBar(ActivityBar.FileExplorerClick) => {...s, zenMode: false}
+      | ActivityBar(ActivityBar.SCMClick) => {...s, zenMode: false}
+      | ActivityBar(ActivityBar.ExtensionsClick) => {...s, zenMode: false}
       | EnableZenMode => {...s, zenMode: true}
       | DisableZenMode => {...s, zenMode: false}
       | ReallyQuitting => {...s, isQuitting: true}

--- a/src/Store/SideBarReducer.re
+++ b/src/Store/SideBarReducer.re
@@ -6,12 +6,14 @@ open Oni_Core;
 open Oni_Model;
 open Actions;
 
-let reduce = (state: SideBar.t, action: Actions.t) => {
+let reduce = (~zenMode, state: SideBar.t, action: Actions.t) => {
   switch (action) {
-  | ActivityBar(ActivityBar.FileExplorerClick) =>
+  // When we're in Zen mode, we ignore toggling, and exit zen mode
+  | ActivityBar(ActivityBar.FileExplorerClick) when !zenMode =>
     SideBar.toggle(SideBar.FileExplorer, state)
-  | ActivityBar(ActivityBar.SCMClick) => SideBar.toggle(SideBar.SCM, state)
-  | ActivityBar(ActivityBar.ExtensionsClick) =>
+  | ActivityBar(ActivityBar.SCMClick) when !zenMode =>
+    SideBar.toggle(SideBar.SCM, state)
+  | ActivityBar(ActivityBar.ExtensionsClick) when !zenMode =>
     SideBar.toggle(SideBar.Extensions, state)
   | ConfigurationSet(newConfig) =>
     let sideBarSetting =


### PR DESCRIPTION
__Issue:__ When toggling the file explorer via a key-binding, like `Control+Shift+B` - when you're in Zen mode, the file explorer toggles behind the scenes, but nothing happens from the users perspective.

__Defect:__ Even though the toggling occurs in the 'background', we never show the explorer in zen mode.

__Fix:__ When any of the activity-bar-actions are triggered, if zen mode is enabled, we exit zen mode.

Fixes #873 