### PR TITLE
Exthost v2 - API - Completion

### DIFF
--- a/src/Core/Utility/ResultEx.re
+++ b/src/Core/Utility/ResultEx.re
@@ -8,6 +8,14 @@ let flatMap = f =>
   | Ok(x) => f(x)
   | Error(_) as err => err;
 
+let map2 = (f, a, b) => {
+  switch (a, b) {
+  | (Ok(vA), Ok(vB)) => Ok(f(vA, vB))
+  | (Error(_) as errA, _) => errA
+  | (_, Error(_) as errB) => errB
+  };
+};
+
 let tapError = f =>
   fun
   | Ok(_) as ok => ok

--- a/src/Core/Utility/ResultEx.re
+++ b/src/Core/Utility/ResultEx.re
@@ -8,14 +8,6 @@ let flatMap = f =>
   | Ok(x) => f(x)
   | Error(_) as err => err;
 
-let map2 = (f, a, b) => {
-  switch (a, b) {
-  | (Ok(vA), Ok(vB)) => Ok(f(vA, vB))
-  | (Error(_) as errA, _) => errA
-  | (_, Error(_) as errB) => errB
-  };
-};
-
 let tapError = f =>
   fun
   | Ok(_) as ok => ok

--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -188,9 +188,14 @@ let request =
     try(
       {
         finalize();
-        let ret = Lwt.return(parser(json));
-        Log.tracef(m => m("Request %d succeeded.", newRequestId));
-        ret;
+        exception ParseFailedException(string);
+
+        switch (parser(json)) {
+        | Ok(v) =>
+          Log.tracef(m => m("Request %d succeeded.", newRequestId));
+          Lwt.return(v);
+        | Error(msg) => Lwt.fail(ParseFailedException(msg))
+        };
       }
     ) {
     | e =>

--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -106,7 +106,9 @@ let start =
 };
 
 let notify =
-    (~rpcName: string, ~method: string, ~args, {lastRequestId, client}: t) => {
+    (
+    ~usesCancellationToken=false,
+    ~rpcName: string, ~method: string, ~args, {lastRequestId, client}: t) => {
   open Protocol.Message;
   let maybeId = Handlers.stringToId(rpcName);
   maybeId
@@ -120,7 +122,7 @@ let notify =
              requestId,
              method,
              args,
-             usesCancellationToken: false,
+             usesCancellationToken,
            }),
          client,
        );
@@ -128,6 +130,7 @@ let notify =
 };
 
 let request = (
+  ~usesCancellationToken=false,
   ~rpcName: string,
   ~method: string,
   ~args,
@@ -162,7 +165,7 @@ let request = (
     }
   };
 
-  let () = notify(~rpcName, ~method, ~args, client);
+  let () = notify(~usesCancellationToken, ~rpcName, ~method, ~args, client);
 
   // TODO: Actually implement
   Lwt.wakeup_exn(resolver, Placeholder)

--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -133,7 +133,7 @@ let notify =
       ~rpcName: string,
       ~method: string,
       ~args,
-      {lastRequestId, client}: t,
+      {lastRequestId, client, _}: t,
     ) => {
   open Protocol.Message;
   let maybeId = Handlers.stringToId(rpcName);

--- a/src/Exthost/CompletionContext.re
+++ b/src/Exthost/CompletionContext.re
@@ -1,29 +1,27 @@
-
-type triggerKind = 
-| Invoke
-| TriggerCharacter
-| TriggerForIncompleteCompletions;
+type triggerKind =
+  | Invoke
+  | TriggerCharacter
+  | TriggerForIncompleteCompletions;
 
 type t = {
-	triggerKind: triggerKind,
-	triggerCharacter: option(string)
+  triggerKind,
+  triggerCharacter: option(string),
 };
 
-let kindToInt = fun 
-| Invoke => 0
-| TriggerCharacter => 1
-| TriggerForIncompleteCompletions => 2;
+let kindToInt =
+  fun
+  | Invoke => 0
+  | TriggerCharacter => 1
+  | TriggerForIncompleteCompletions => 2;
 
 let kindToJson = kind => `Int(kindToInt(kind));
 
 let to_yojson = ({triggerKind, triggerCharacter}) => {
-	let kindJson = kindToJson(triggerKind);
-	let characterJson = switch(triggerCharacter) {
-	| None => `Null
-	| Some(v) => `String(v);
-	};
-	`Assoc([
-		("triggerKind", kindJson),
-		("triggerCharacter", characterJson)
-	])
+  let kindJson = kindToJson(triggerKind);
+  let characterJson =
+    switch (triggerCharacter) {
+    | None => `Null
+    | Some(v) => `String(v)
+    };
+  `Assoc([("triggerKind", kindJson), ("triggerCharacter", characterJson)]);
 };

--- a/src/Exthost/CompletionContext.re
+++ b/src/Exthost/CompletionContext.re
@@ -1,0 +1,29 @@
+
+type triggerKind = 
+| Invoke
+| TriggerCharacter
+| TriggerForIncompleteCompletions;
+
+type t = {
+	triggerKind: triggerKind,
+	triggerCharacter: option(string)
+};
+
+let kindToInt = fun 
+| Invoke => 0
+| TriggerCharacter => 1
+| TriggerForIncompleteCompletions => 2;
+
+let kindToJson = kind => `Int(kindToInt(kind));
+
+let to_yojson = ({triggerKind, triggerCharacter}) => {
+	let kindJson = kindToJson(triggerKind);
+	let characterJson = switch(triggerCharacter) {
+	| None => `Null
+	| Some(v) => `String(v);
+	};
+	`Assoc([
+		("triggerKind", kindJson),
+		("triggerCharacter", characterJson)
+	])
+};

--- a/src/Exthost/CompletionKind.re
+++ b/src/Exthost/CompletionKind.re
@@ -1,60 +1,61 @@
-type t = 
-| Method
-| Function
-| Constructor
-| Field
-| Variable
-| Class
-| Struct
-| Interface
-| Module
-| Property
-| Event
-| Operator
-| Unit
-| Value
-| Constant
-| Enum
-| EnumMember
-| Keyword
-| Text
-| Color
-| File
-| Reference
-| Customcolor
-| Folder
-| TypeParameter
-| User
-| Issue
-| Snippet;
+type t =
+  | Method
+  | Function
+  | Constructor
+  | Field
+  | Variable
+  | Class
+  | Struct
+  | Interface
+  | Module
+  | Property
+  | Event
+  | Operator
+  | Unit
+  | Value
+  | Constant
+  | Enum
+  | EnumMember
+  | Keyword
+  | Text
+  | Color
+  | File
+  | Reference
+  | Customcolor
+  | Folder
+  | TypeParameter
+  | User
+  | Issue
+  | Snippet;
 
-let ofInt = fun
-| 0 => Some(Method)
-| 1 => Some(Function)
-| 2 => Some(Constructor)
-| 3 => Some(Field)
-| 4 => Some(Variable)
-| 5 => Some(Class)
-| 6 => Some(Struct)
-| 7 => Some(Interface)
-| 8 => Some(Module)
-| 9 => Some(Property)
-| 10 => Some(Event)
-| 11 => Some(Operator)
-| 12 => Some(Unit)
-| 13 => Some(Value)
-| 14 => Some(Constant)
-| 15 => Some(Enum)
-| 16 => Some(EnumMember)
-| 17 => Some(Keyword)
-| 18 => Some(Text)
-| 19 => Some(Color)
-| 20 => Some(File)
-| 21 => Some(Reference)
-| 22 => Some(Customcolor)
-| 23 => Some(Folder)
-| 24 => Some(TypeParameter)
-| 25 => Some(User)
-| 26 => Some(Issue)
-| 27 => Some(Snippet)
-| _ => None;
+let ofInt =
+  fun
+  | 0 => Some(Method)
+  | 1 => Some(Function)
+  | 2 => Some(Constructor)
+  | 3 => Some(Field)
+  | 4 => Some(Variable)
+  | 5 => Some(Class)
+  | 6 => Some(Struct)
+  | 7 => Some(Interface)
+  | 8 => Some(Module)
+  | 9 => Some(Property)
+  | 10 => Some(Event)
+  | 11 => Some(Operator)
+  | 12 => Some(Unit)
+  | 13 => Some(Value)
+  | 14 => Some(Constant)
+  | 15 => Some(Enum)
+  | 16 => Some(EnumMember)
+  | 17 => Some(Keyword)
+  | 18 => Some(Text)
+  | 19 => Some(Color)
+  | 20 => Some(File)
+  | 21 => Some(Reference)
+  | 22 => Some(Customcolor)
+  | 23 => Some(Folder)
+  | 24 => Some(TypeParameter)
+  | 25 => Some(User)
+  | 26 => Some(Issue)
+  | 27 => Some(Snippet)
+  | _ => None;

--- a/src/Exthost/CompletionKind.re
+++ b/src/Exthost/CompletionKind.re
@@ -1,0 +1,60 @@
+type t = 
+| Method
+| Function
+| Constructor
+| Field
+| Variable
+| Class
+| Struct
+| Interface
+| Module
+| Property
+| Event
+| Operator
+| Unit
+| Value
+| Constant
+| Enum
+| EnumMember
+| Keyword
+| Text
+| Color
+| File
+| Reference
+| Customcolor
+| Folder
+| TypeParameter
+| User
+| Issue
+| Snippet;
+
+let ofInt = fun
+| 0 => Some(Method)
+| 1 => Some(Function)
+| 2 => Some(Constructor)
+| 3 => Some(Field)
+| 4 => Some(Variable)
+| 5 => Some(Class)
+| 6 => Some(Struct)
+| 7 => Some(Interface)
+| 8 => Some(Module)
+| 9 => Some(Property)
+| 10 => Some(Event)
+| 11 => Some(Operator)
+| 12 => Some(Unit)
+| 13 => Some(Value)
+| 14 => Some(Constant)
+| 15 => Some(Enum)
+| 16 => Some(EnumMember)
+| 17 => Some(Keyword)
+| 18 => Some(Text)
+| 19 => Some(Color)
+| 20 => Some(File)
+| 21 => Some(Reference)
+| 22 => Some(Customcolor)
+| 23 => Some(Folder)
+| 24 => Some(TypeParameter)
+| 25 => Some(User)
+| 26 => Some(Issue)
+| 27 => Some(Snippet)
+| _ => None;

--- a/src/Exthost/DocumentFilter.re
+++ b/src/Exthost/DocumentFilter.re
@@ -1,0 +1,20 @@
+open Oni_Core;
+
+[@deriving show]
+type t = {
+  language: option(string),
+  scheme: option(string),
+  exclusive: bool,
+};
+
+let decode = {
+  Json.Decode.(
+    obj(({field, _}) =>
+      {
+        language: field.optional("language", string),
+        scheme: field.optional("scheme", string),
+        exclusive: field.withDefault("exclusive", true, bool),
+      }
+    )
+  );
+};

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -4,11 +4,13 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module CompletionContext = CompletionContext;
 module DocumentsAndEditorsDelta = DocumentsAndEditorsDelta;
 module Eol = Eol;
 module ModelAddedDelta = ModelAddedDelta;
 module ModelChangedEvent = ModelChangedEvent;
 module ModelContentChange = ModelContentChange;
+module OneBasedPosition = OneBasedPosition;
 module OneBasedRange = OneBasedRange;
 
 module Client = Client;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -5,6 +5,7 @@ module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
 module CompletionContext = CompletionContext;
+module CompletionKind = CompletionKind;
 module DocumentsAndEditorsDelta = DocumentsAndEditorsDelta;
 module Eol = Eol;
 module ModelAddedDelta = ModelAddedDelta;
@@ -12,6 +13,7 @@ module ModelChangedEvent = ModelChangedEvent;
 module ModelContentChange = ModelContentChange;
 module OneBasedPosition = OneBasedPosition;
 module OneBasedRange = OneBasedRange;
+module SuggestItem = SuggestItem;
 
 module Client = Client;
 module Request = Request;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -14,6 +14,7 @@ module ModelContentChange = ModelContentChange;
 module OneBasedPosition = OneBasedPosition;
 module OneBasedRange = OneBasedRange;
 module SuggestItem = SuggestItem;
+module SuggestResult = SuggestResult;
 
 module Client = Client;
 module Request = Request;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -7,6 +7,7 @@ module Transport = Exthost_Transport;
 module CompletionContext = CompletionContext;
 module CompletionKind = CompletionKind;
 module DocumentsAndEditorsDelta = DocumentsAndEditorsDelta;
+module DocumentFilter = DocumentFilter;
 module Eol = Eol;
 module ModelAddedDelta = ModelAddedDelta;
 module ModelChangedEvent = ModelChangedEvent;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -18,38 +18,37 @@ module CompletionContext: {
 };
 
 module CompletionKind: {
-  
-type t = 
-| Method
-| Function
-| Constructor
-| Field
-| Variable
-| Class
-| Struct
-| Interface
-| Module
-| Property
-| Event
-| Operator
-| Unit
-| Value
-| Constant
-| Enum
-| EnumMember
-| Keyword
-| Text
-| Color
-| File
-| Reference
-| Customcolor
-| Folder
-| TypeParameter
-| User
-| Issue
-| Snippet;
+  type t =
+    | Method
+    | Function
+    | Constructor
+    | Field
+    | Variable
+    | Class
+    | Struct
+    | Interface
+    | Module
+    | Property
+    | Event
+    | Operator
+    | Unit
+    | Value
+    | Constant
+    | Enum
+    | EnumMember
+    | Keyword
+    | Text
+    | Color
+    | File
+    | Reference
+    | Customcolor
+    | Folder
+    | TypeParameter
+    | User
+    | Issue
+    | Snippet;
 
-let ofInt: int => option(t);
+  let ofInt: int => option(t);
 };
 
 module SuggestItem: {
@@ -61,6 +60,15 @@ module SuggestItem: {
     sortText: option(string),
     filterText: option(string),
     insertText: option(string),
+  };
+
+  let decode: Json.decoder(t);
+};
+
+module SuggestResult: {
+  type t = {
+    completions: list(SuggestItem.t),
+    isIncomplete: bool,
   };
 
   let decode: Json.decoder(t);
@@ -444,7 +452,7 @@ module Request: {
         ~context: CompletionContext.t,
         Client.t
       ) =>
-      Lwt.t(list(int));
+      Lwt.t(SuggestResult.t);
   };
 
   module TerminalService: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -51,6 +51,17 @@ module CompletionKind: {
   let ofInt: int => option(t);
 };
 
+module DocumentFilter: {
+  [@deriving show]
+  type t = {
+    language: option(string),
+    scheme: option(string),
+    exclusive: bool,
+  };
+
+  let decode: Json.decoder(t);
+};
+
 module SuggestItem: {
   type t = {
     label: string,
@@ -286,6 +297,19 @@ module Msg: {
           errorMessage: string,
         })
       | ExtensionRuntimeError({extensionId: string});
+  };
+
+  module LanguageFeatures: {
+    [@deriving show]
+    type msg =
+      | RegisterSuggestSupport({
+          handle: int,
+          selector: list(DocumentFilter.t),
+          triggerCharacters: list(string),
+          supportsResolveDetails: bool,
+          extensionId: string,
+        })
+      | Unregister({handle: int});
   };
 
   module MessageService: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -6,15 +6,15 @@ module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
 module CompletionContext: {
-  type triggerKind = 
-  | Invoke
-  | TriggerCharacter
-  | TriggerForIncompleteCompletions;
+  type triggerKind =
+    | Invoke
+    | TriggerCharacter
+    | TriggerForIncompleteCompletions;
 
   type t = {
-    triggerKind: triggerKind,
+    triggerKind,
     triggerCharacter: option(string),
-  }
+  };
 };
 
 module Configuration: {
@@ -138,7 +138,7 @@ module ShellLaunchConfig: {
   let to_yojson: t => Yojson.Safe.t;
 };
 
-module OneBasedPosition = {
+module OneBasedPosition: {
   type t = {
     lineNumber: int,
     column: int,
@@ -146,7 +146,7 @@ module OneBasedPosition = {
 
   let ofPosition: Location.t => t;
   let to_yojson: t => Yojson.Safe.t;
-}
+};
 
 module Msg: {
   module Commands: {
@@ -348,6 +348,8 @@ module Client: {
   let close: t => unit;
 
   let terminate: t => unit;
+
+  module Testing: {let getPendingRequestCount: t => int;};
 };
 
 module Request: {
@@ -382,6 +384,18 @@ module Request: {
 
   module ExtensionService: {
     let activateByEvent: (~event: string, Client.t) => unit;
+  };
+
+  module LanguageFeatures: {
+    let provideCompletionItems:
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~position: OneBasedPosition.t,
+        ~context: CompletionContext.t,
+        Client.t
+      ) =>
+      Lwt.t(list(int));
   };
 
   module TerminalService: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -17,6 +17,55 @@ module CompletionContext: {
   };
 };
 
+module CompletionKind: {
+  
+type t = 
+| Method
+| Function
+| Constructor
+| Field
+| Variable
+| Class
+| Struct
+| Interface
+| Module
+| Property
+| Event
+| Operator
+| Unit
+| Value
+| Constant
+| Enum
+| EnumMember
+| Keyword
+| Text
+| Color
+| File
+| Reference
+| Customcolor
+| Folder
+| TypeParameter
+| User
+| Issue
+| Snippet;
+
+let ofInt: int => option(t);
+};
+
+module SuggestItem: {
+  type t = {
+    label: string,
+    kind: CompletionKind.t,
+    detail: option(string),
+    documentation: option(string),
+    sortText: option(string),
+    filterText: option(string),
+    insertText: option(string),
+  };
+
+  let decode: Json.decoder(t);
+};
+
 module Configuration: {
   // Type relating to 'ConfigurationModel' in VSCode
   // This is an 'instance' of configuration - modelling user, workspace, or default configuration.

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -4,6 +4,18 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module CompletionContext: {
+  type triggerKind = 
+  | Invoke
+  | TriggerCharacter
+  | TriggerForIncompleteCompletions;
+
+  type t = {
+    triggerKind: triggerKind,
+    triggerCharacter: option(string),
+  }
+};
+
 module Configuration: {
   // Type relating to 'ConfigurationModel' in VSCode
   // This is an 'instance' of configuration - modelling user, workspace, or default configuration.
@@ -37,6 +49,16 @@ module ShellLaunchConfig: {
 
   let to_yojson: t => Yojson.Safe.t;
 };
+
+module OneBasedPosition = {
+  type t = {
+    lineNumber: int,
+    column: int,
+  };
+
+  let ofPosition: Location.t => t;
+  let to_yojson: t => Yojson.Safe.t;
+}
 
 module Msg: {
   module Commands: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -389,6 +389,7 @@ module Msg: {
     | Diagnostics(Diagnostics.msg)
     | DocumentContentProvider(DocumentContentProvider.msg)
     | ExtensionService(ExtensionService.msg)
+    | LanguageFeatures(LanguageFeatures.msg)
     | MessageService(MessageService.msg)
     | StatusBar(StatusBar.msg)
     | Telemetry(Telemetry.msg)

--- a/src/Exthost/Handlers.re
+++ b/src/Exthost/Handlers.re
@@ -101,7 +101,11 @@ let handlers =
     mainNotImplemented("MainThreadTreeViews"),
     mainNotImplemented("MainThreadDownloadService"),
     mainNotImplemented("MainThreadKeytar"),
-    mainNotImplemented("MainThreadLanguageFeatures"),
+    main(
+      ~handler=Msg.LanguageFeatures.handle,
+      ~mapper=msg => Msg.LanguageFeatures(msg),
+      "MainThreadLanguageFeatures",
+    ),
     mainNotImplemented("MainThreadLanguages"),
     mainNotImplemented("MainThreadLog"),
     main(

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -255,27 +255,29 @@ module LanguageFeatures = {
         ]),
       ) =>
       open Json.Decode;
-      let selectorResult =
+
+      let ret = {
+
+      open Base.Result.Let_syntax;
+      let%bind selector =
         selectorJson |> Json.Decode.decode_value(list(DocumentFilter.decode));
 
-      let triggerCharactersResult =
+      let%bind triggerCharacters =
         triggerCharactersJson
         |> Json.Decode.decode_value(list(list(string)))
         |> Result.map(List.flatten);
 
-      ResultEx.map2(
-        (selector, triggerCharacters) => {
-          RegisterSuggestSupport({
+       Ok(RegisterSuggestSupport({
             handle,
             selector,
             triggerCharacters,
             supportsResolveDetails,
             extensionId,
-          })
-        },
-        selectorResult,
-        triggerCharactersResult,
-      )
+          }));
+
+      };
+      
+      ret
       |> Result.map_error(Json.Decode.string_of_error);
 
     | _ => Error("Unhandled method: " ++ method)

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -257,28 +257,28 @@ module LanguageFeatures = {
       open Json.Decode;
 
       let ret = {
+        open Base.Result.Let_syntax;
+        let%bind selector =
+          selectorJson
+          |> Json.Decode.decode_value(list(DocumentFilter.decode));
 
-      open Base.Result.Let_syntax;
-      let%bind selector =
-        selectorJson |> Json.Decode.decode_value(list(DocumentFilter.decode));
+        let%bind triggerCharacters =
+          triggerCharactersJson
+          |> Json.Decode.decode_value(list(list(string)))
+          |> Result.map(List.flatten);
 
-      let%bind triggerCharacters =
-        triggerCharactersJson
-        |> Json.Decode.decode_value(list(list(string)))
-        |> Result.map(List.flatten);
-
-       Ok(RegisterSuggestSupport({
+        Ok(
+          RegisterSuggestSupport({
             handle,
             selector,
             triggerCharacters,
             supportsResolveDetails,
             extensionId,
-          }));
-
+          }),
+        );
       };
-      
-      ret
-      |> Result.map_error(Json.Decode.string_of_error);
+
+      ret |> Result.map_error(Json.Decode.string_of_error);
 
     | _ => Error("Unhandled method: " ++ method)
     };

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -259,7 +259,9 @@ module LanguageFeatures = {
         selectorJson |> Json.Decode.decode_value(list(DocumentFilter.decode));
 
       let triggerCharactersResult =
-        triggerCharactersJson |> Json.Decode.decode_value(list(string));
+        triggerCharactersJson
+        |> Json.Decode.decode_value(list(list(string)))
+        |> Result.map(List.flatten);
 
       ResultEx.map2(
         (selector, triggerCharacters) => {
@@ -482,6 +484,7 @@ type t =
   | Diagnostics(Diagnostics.msg)
   | DocumentContentProvider(DocumentContentProvider.msg)
   | ExtensionService(ExtensionService.msg)
+  | LanguageFeatures(LanguageFeatures.msg)
   | MessageService(MessageService.msg)
   | StatusBar(StatusBar.msg)
   | Telemetry(Telemetry.msg)

--- a/src/Exthost/OneBasedPosition.re
+++ b/src/Exthost/OneBasedPosition.re
@@ -1,0 +1,12 @@
+  open EditorCoreTypes;
+
+  [@deriving (show({with_path: false}), yojson({strict: false}))]
+  type t = {
+    lineNumber: int,
+    column: int,
+  };
+
+  let ofPosition = (p: Location.t) => {
+    lineNumber: p.line |> Index.toOneBased,
+    column: p.column |> Index.toOneBased,
+  };

--- a/src/Exthost/OneBasedPosition.re
+++ b/src/Exthost/OneBasedPosition.re
@@ -1,12 +1,12 @@
-  open EditorCoreTypes;
+open EditorCoreTypes;
 
-  [@deriving (show({with_path: false}), yojson({strict: false}))]
-  type t = {
-    lineNumber: int,
-    column: int,
-  };
+[@deriving (show({with_path: false}), yojson({strict: false}))]
+type t = {
+  lineNumber: int,
+  column: int,
+};
 
-  let ofPosition = (p: Location.t) => {
-    lineNumber: p.line |> Index.toOneBased,
-    column: p.column |> Index.toOneBased,
-  };
+let ofPosition = (p: Location.t) => {
+  lineNumber: p.line |> Index.toOneBased,
+  column: p.column |> Index.toOneBased,
+};

--- a/src/Exthost/Protocol/Exthost_Protocol.re
+++ b/src/Exthost/Protocol/Exthost_Protocol.re
@@ -188,7 +188,6 @@ module Message = {
       } else {
         try({
           let (messageType, bytes) = ByteParser.readUInt8(body);
-          prerr_endline("GOT MESSAGE: " ++ string_of_int(messageType));
           let (requestId, bytes) = ByteParser.readUInt32(bytes);
           if (messageType == requestJsonArgs
               || messageType == requestJsonArgsWithCancellation) {
@@ -333,7 +332,6 @@ let start =
 
       message
       |> Result.iter_error(err => {
-           prerr_endline("ERR: " ++ err);
            onError(err);
          });
     };

--- a/src/Exthost/Protocol/Exthost_Protocol.re
+++ b/src/Exthost/Protocol/Exthost_Protocol.re
@@ -330,10 +330,7 @@ let start =
 
       message |> Result.iter(dispatch);
 
-      message
-      |> Result.iter_error(err => {
-           onError(err);
-         });
+      message |> Result.iter_error(err => {onError(err)});
     };
 
   let transportHandler = msg =>

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -22,31 +22,31 @@ module ExtensionService = {
 };
 
 module LanguageFeatures = {
-  let provideCompletionItems = (
-    ~handle: int,
-    ~resource: Uri.t,
-    ~position: OneBasedPosition.t,
-    ~context: CompletionContext.t,
-    client,
-  ) =>  {
-
-    let parser = (_) => [];
+  let provideCompletionItems =
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~position: OneBasedPosition.t,
+        ~context: CompletionContext.t,
+        client,
+      ) => {
+    let parser = _ => [];
 
     Client.request(
       ~parser,
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~methodName="$provideCompletionItems",
-      ~args=`List([
-        `Int(handle),
-        Uri.to_yojson(resource),
-        OneBasedRange.to_yojson(position),
-        CompletionContext.to_yojson(context),
-      ]),
+      ~args=
+        `List([
+          `Int(handle),
+          Uri.to_yojson(resource),
+          OneBasedRange.to_yojson(position),
+          CompletionContext.to_yojson(context),
+        ]),
       client,
     );
-  }
-  
+  };
 };
 
 module TerminalService = {

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -21,6 +21,34 @@ module ExtensionService = {
   };
 };
 
+module LanguageFeatures = {
+  let provideCompletionItems = (
+    ~handle: int,
+    ~resource: Uri.t,
+    ~position: OneBasedPosition.t,
+    ~context: CompletionContext.t,
+    client,
+  ) =>  {
+
+    let parser = (_) => [];
+
+    Client.request(
+      ~parser,
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~methodName="$provideCompletionItems",
+      ~args=`List([
+        `Int(handle),
+        Uri.to_yojson(resource),
+        OneBasedRange.to_yojson(position),
+        CompletionContext.to_yojson(context),
+      ]),
+      client,
+    );
+  }
+  
+};
+
 module TerminalService = {
   let spawnExtHostProcess =
       (

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -89,18 +89,21 @@ module LanguageFeatures = {
         ~context: CompletionContext.t,
         client,
       ) => {
-    let parser = _ => [];
+    let parser = _ => {
+      prerr_endline("Parser called");
+      [];
+    };
 
     Client.request(
       ~parser,
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
-      ~methodName="$provideCompletionItems",
+      ~method="$provideCompletionItems",
       ~args=
         `List([
           `Int(handle),
           Uri.to_yojson(resource),
-          OneBasedRange.to_yojson(position),
+          OneBasedPosition.to_yojson(position),
           CompletionContext.to_yojson(context),
         ]),
       client,

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -90,8 +90,9 @@ module LanguageFeatures = {
         client,
       ) => {
     let parser = json => {
-      prerr_endline("Parser called: " ++ Yojson.Safe.to_string(json));
-      [];
+      json
+      |> Json.Decode.decode_value(SuggestResult.decode)
+      |> Result.map_error(Json.Decode.string_of_error);
     };
 
     Client.request(

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -89,8 +89,8 @@ module LanguageFeatures = {
         ~context: CompletionContext.t,
         client,
       ) => {
-    let parser = _ => {
-      prerr_endline("Parser called");
+    let parser = json => {
+      prerr_endline("Parser called: " ++ Yojson.Safe.to_string(json));
       [];
     };
 

--- a/src/Exthost/SuggestItem.re
+++ b/src/Exthost/SuggestItem.re
@@ -1,0 +1,46 @@
+open Oni_Core;
+type t = {
+	label: string,
+	kind: CompletionKind.t,
+	detail: option(string),
+	documentation: option(string),
+	sortText: option(string),
+	filterText: option(string),
+	insertText: option(string),
+	// TODO:
+	// insertTextRules
+	// range
+	// commitCharacters
+	// additionalTextEdits
+	// command
+	// kindModifer
+	// chainedCacheId?
+};
+
+let decode = {
+	open Json.Decode;
+
+	obj(({
+	field,
+	_
+		
+	}) => {
+
+		// These fields come from the `ISuggestDataDtoField` definition:
+		// https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L1089
+		let label = field.required("a", string);
+		
+		let kind = field.required("b", int)
+		|> CompletionKind.ofInt
+		|> Option.value(~default=CompletionKind.Method);
+		
+		let detail = field.optional("c", string);
+		let documentation = field.optional("d", string);
+		let sortText = field.optional("e", string);
+		let filterText = field.optional("f", string);
+		let insertText = field.optional("h", string);
+		{
+			label, kind, detail, documentation, sortText, filterText, insertText
+		}
+	});
+}

--- a/src/Exthost/SuggestItem.re
+++ b/src/Exthost/SuggestItem.re
@@ -1,46 +1,40 @@
 open Oni_Core;
 type t = {
-	label: string,
-	kind: CompletionKind.t,
-	detail: option(string),
-	documentation: option(string),
-	sortText: option(string),
-	filterText: option(string),
-	insertText: option(string),
-	// TODO:
-	// insertTextRules
-	// range
-	// commitCharacters
-	// additionalTextEdits
-	// command
-	// kindModifer
-	// chainedCacheId?
+  label: string,
+  kind: CompletionKind.t,
+  detail: option(string),
+  documentation: option(string),
+  sortText: option(string),
+  filterText: option(string),
+  insertText: option(string),
+  // TODO:
+  // insertTextRules
+  // range
+  // commitCharacters
+  // additionalTextEdits
+  // command
+  // kindModifer
+  // chainedCacheId?
 };
 
 let decode = {
-	open Json.Decode;
+  Json.Decode.(
+    obj(({field, _}) => {
+      // These fields come from the `ISuggestDataDtoField` definition:
+      // https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L1089
+      let label = field.required("a", string);
 
-	obj(({
-	field,
-	_
-		
-	}) => {
+      let kind =
+        field.required("b", int)
+        |> CompletionKind.ofInt
+        |> Option.value(~default=CompletionKind.Method);
 
-		// These fields come from the `ISuggestDataDtoField` definition:
-		// https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L1089
-		let label = field.required("a", string);
-		
-		let kind = field.required("b", int)
-		|> CompletionKind.ofInt
-		|> Option.value(~default=CompletionKind.Method);
-		
-		let detail = field.optional("c", string);
-		let documentation = field.optional("d", string);
-		let sortText = field.optional("e", string);
-		let filterText = field.optional("f", string);
-		let insertText = field.optional("h", string);
-		{
-			label, kind, detail, documentation, sortText, filterText, insertText
-		}
-	});
-}
+      let detail = field.optional("c", string);
+      let documentation = field.optional("d", string);
+      let sortText = field.optional("e", string);
+      let filterText = field.optional("f", string);
+      let insertText = field.optional("h", string);
+      {label, kind, detail, documentation, sortText, filterText, insertText};
+    })
+  );
+};

--- a/src/Exthost/SuggestResult.re
+++ b/src/Exthost/SuggestResult.re
@@ -1,0 +1,19 @@
+open Oni_Core;
+
+type t = {
+  completions: list(SuggestItem.t),
+  isIncomplete: bool,
+};
+
+let decode = {
+  Json.Decode.(
+    obj(({field, _}) =>
+      {
+        // These values come from `ISuggestResultDto`:
+        // https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L1129
+        completions: field.required("b", list(SuggestItem.decode)),
+        isIncomplete: field.withDefault("c", false, bool),
+      }
+    )
+  );
+};

--- a/src/Exthost/dune
+++ b/src/Exthost/dune
@@ -1,5 +1,5 @@
 (library
     (name Exthost)
     (libraries timber base Oni2.exthost.extension Oni2.exthost.protocol Oni2.exthost.transport luv yojson decoders-yojson)
-    (preprocess (pps ppx_deriving.show ppx_deriving_yojson))
+    (preprocess (pps ppx_let ppx_deriving.show ppx_deriving_yojson))
     (public_name Oni2.exthost))

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -63,9 +63,6 @@ module Sub = {
             arguments: params.arguments,
           };
 
-        let launchStr =
-          launchConfig |> ExtHostClient.Terminal.ShellLaunchConfig.show;
-
         let isResizing = ref(false);
 
         let makeDebouncedDispatch = () => {

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -66,7 +66,6 @@ module Sub = {
         let launchStr =
           launchConfig |> ExtHostClient.Terminal.ShellLaunchConfig.show;
 
-        prerr_endline("USING LAUNCHCONFIG: " ++ launchStr);
         let isResizing = ref(false);
 
         let makeDebouncedDispatch = () => {

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -17,7 +17,7 @@ let model = (~lines) =>
 
 describe("LanguageFeaturesTest", ({describe, _}) => {
   describe("completion", ({test, _}) => {
-    test("gets completion items", _ => {
+    test("gets completion items", ({expect, _}) => {
       let addedDelta =
         DocumentsAndEditorsDelta.create(
           ~removedDocuments=[],
@@ -43,7 +43,21 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
          )
       |> Test.withClientRequest(
            ~name="Get completion items",
-           ~validate=_ => true,
+           ~validate=
+             (suggestResult: Exthost.SuggestResult.t) => {
+               let {completions, isIncomplete}: Exthost.SuggestResult.t = suggestResult;
+               expect.int(List.length(completions)).toBe(2);
+               expect.bool(isIncomplete).toBe(false);
+
+               let firstResult: Exthost.SuggestItem.t =
+                 List.nth(completions, 0);
+               let secondResult: Exthost.SuggestItem.t =
+                 List.nth(completions, 1);
+
+               expect.string(firstResult.label).toEqual("item1");
+               expect.string(secondResult.label).toEqual("item2");
+               true;
+             },
            getCompletionItems,
          )
       |> Test.validateNoPendingRequests

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -13,7 +13,7 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
 
       Test.startWithExtensions(["oni-language-features"])
       |> Test.waitForReady
-      |> Test.waitForMessage(~name="Activation",waitForActivation)
+      |> Test.waitForMessage(~name="Activation", waitForActivation)
       |> Test.terminate
       |> Test.waitForProcessClosed;
     })

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -1,0 +1,21 @@
+open TestFramework;
+
+open Exthost;
+
+describe("LanguageFeaturesTest", ({describe, _}) => {
+  describe("completion", ({test, _}) => {
+    test("gets completion items", _ => {
+      let waitForActivation =
+        fun
+        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
+          extensionId == "oni-language-features"
+        | _ => false;
+
+      Test.startWithExtensions(["oni-language-features"])
+      |> Test.waitForReady
+      |> Test.waitForMessage(~name="Activation",waitForActivation)
+      |> Test.terminate
+      |> Test.waitForProcessClosed;
+    })
+  })
+});

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -1,19 +1,52 @@
 open TestFramework;
 
+open Oni_Core;
 open Exthost;
+
+let testUri = Uri.fromPath("/test/path");
+
+let model = (~lines) =>
+  Exthost.ModelAddedDelta.create(
+    ~versionId=0,
+    ~lines,
+    ~eol=Eol.LF,
+    ~modeId="plaintext",
+    ~isDirty=false,
+    testUri,
+  );
 
 describe("LanguageFeaturesTest", ({describe, _}) => {
   describe("completion", ({test, _}) => {
     test("gets completion items", _ => {
-      let waitForActivation =
-        fun
-        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
-          extensionId == "oni-language-features"
-        | _ => false;
+      let addedDelta =
+        DocumentsAndEditorsDelta.create(
+          ~removedDocuments=[],
+          ~addedDocuments=[model(~lines=["Hello", "World"])],
+        );
+
+      let getCompletionItems =
+        Request.LanguageFeatures.provideCompletionItems(
+          ~handle=0,
+          ~resource=testUri,
+          ~position=OneBasedPosition.{lineNumber: 1, column: 1},
+          ~context=
+            CompletionContext.{triggerKind: Invoke, triggerCharacter: None},
+        );
 
       Test.startWithExtensions(["oni-language-features"])
       |> Test.waitForReady
-      |> Test.waitForMessage(~name="Activation", waitForActivation)
+      |> Test.waitForExtensionActivation("oni-language-features")
+      |> Test.withClient(
+           Request.DocumentsAndEditors.acceptDocumentsAndEditorsDelta(
+             ~delta=addedDelta,
+           ),
+         )
+      |> Test.withClientRequest(
+           ~name="Get completion items",
+           ~validate=_ => true,
+           getCompletionItems,
+         )
+      |> Test.validateNoPendingRequests
       |> Test.terminate
       |> Test.waitForProcessClosed;
     })

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -1,0 +1,34 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+
+	const completionProvider = {
+		provideCompletionItems: (document, position, token, context) => {
+			return [{
+				label: "item1",
+			}, {
+				label: "item2"
+			}]
+		}
+	};
+
+	const disposable0 = vscode.languages.registerCompletionItemProvider("plaintext", completionProvider, ["."])
+
+	context.subscriptions.push(disposable0);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -12,6 +12,7 @@ function activate(context) {
 
 	const completionProvider = {
 		provideCompletionItems: (document, position, token, context) => {
+	vscode.window.showInformationMessage('Activated!');
 			return [{
 				label: "item1",
 			}, {

--- a/test/collateral/extensions/oni-language-features/package.json
+++ b/test/collateral/extensions/oni-language-features/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "oni-language-features",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": ["*"],
+	"main": "./extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.helloWorld",
+				"title": "Hello World"
+			}
+		]
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
This is the initial work to wire up language features to the 'v2' extension host, adding a test case for completion.

This adds a `request` API to the client which returns an `Lwt.t` promise with the response payload, and like the previous API, allows specifying a parser/transformer to convert the raw JSON to a strongly typed domain object.