### PR TITLE
Bugfix #1693: closing the search pane doesn't "defocus it"

### DIFF
--- a/src/Store/PaneStore.re
+++ b/src/Store/PaneStore.re
@@ -5,37 +5,25 @@
 open Oni_Model;
 open Actions;
 
-let showSearchPane = (state: State.t, isSearchFocused) => {
-  let newState = {
+let showSearchPane = (state: State.t) =>
+  {
     ...state,
     pane: {
       isOpen: true,
       selected: Search,
     },
-  };
+  }
+  |> FocusManager.push(Search);
 
-  if (isSearchFocused) {
-    newState;
-  } else {
-    newState |> FocusManager.push(Search);
-  };
-};
-
-let hideSearchPane = (state: State.t, isSearchFocused) => {
-  let newState = {
+let hideSearchPane = (state: State.t) =>
+  {
     ...state,
     pane: {
       ...state.pane,
       isOpen: false,
     },
-  };
-
-  if (isSearchFocused) {
-    newState |> FocusManager.pop(Search);
-  } else {
-    newState;
-  };
-};
+  }
+  |> FocusManager.pop(Search);
 
 let openDiagnosticsPane = (state: State.t) => {
   ...state,
@@ -53,27 +41,29 @@ let openNotificationsPane = (state: State.t) => {
   },
 };
 
-let closePane = (state: State.t) => {
-  ...state,
-  pane: {
-    ...state.pane,
-    isOpen: false,
-  },
-};
+let closePane = (state: State.t) =>
+  {
+    ...state,
+    pane: {
+      ...state.pane,
+      isOpen: false,
+    },
+  }
+  |> FocusManager.pop(Search);
 
 let update = (state: State.t, action: Actions.t) =>
   switch (action) {
   | SearchHotkey
   | ActivityBar(SearchClick) when Pane.isVisible(Search, state.pane) => (
       FocusManager.current(state) == Search
-        ? hideSearchPane(state, true) : showSearchPane(state, false),
+        ? hideSearchPane(state) : showSearchPane(state),
       Isolinear.Effect.none,
     )
 
   | SearchHotkey
   | PaneTabClicked(Search)
   | ActivityBar(SearchClick) => (
-      showSearchPane(state, FocusManager.current(state) == Search),
+      showSearchPane(state),
       Isolinear.Effect.none,
     )
 

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -30,6 +30,8 @@ let start = () => {
 
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
+    | EditorGroupSelected(_) => FocusManager.push(Editor, s)
+
     | AddSplit(direction, split) => {
         ...s,
         // Fix #686: If we're adding a split, we should turn off zen mode... unless it's the first split being added.


### PR DESCRIPTION
**Issue:** There is actually two separate but related issues. The first is that the search input field doesn't lose focus if the pane is closed by the close button. This has probably been around since the close button got added. The other is more recent, that the editor doesn't take focus when clicked, or when a tab or editor group is selected.

**Defect:** The first issue was caused by simply not popping he search input field focus when the close button is clicked. The second was caused by #1646, more specifically [here](https://github.com/onivim/oni2/pull/1646/files#diff-0ebd45c812a44e8684925f9d3ce599aaL32-L40), where `WindowSetActive` was replaced by `EditorGroupSelected´ and the active window id removed from the window tree, which also inadvertently removed a call to `FocusManager.push(Editor)``

**Fix:** For the first issue, pop `Search` focus also when the close button is clicked. For the second issue, push `Editor` focus on `EditorGroupSelected`.

Fixes #1693