### PR TITLE
chore(CI): update Azure Pipelines to use stages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,284 +6,297 @@
 name: $(Build.SourceVersion)
 
 # Master build triggers
-trigger: 
+trigger:
 - master
 
 # PR Triggers
 pr:
   autoCancel: true
   branches:
-    include: 
+    include:
     - master
   paths:
-    exclude: 
+    exclude:
     - README.md
 
-jobs:
-- job: Kickoff
-  displayName: "Kickoff"
-  pool:
-    vmImage: 'ubuntu-latest'
+# Multistage pipeline, but no stage depends on another.
+# Split by Linux, Mac, Windows, Docker
+stages:
+- stage: LinuxStages
+  dependsOn: []
+  jobs:
+  - job: Kickoff
+    displayName: "Kickoff"
+    pool:
+      vmImage: 'ubuntu-latest'
 
-  steps:
-  - script: ./scripts/set-short-commit-variable.sh
-    name: shortCommitVariableStep
+    steps:
+    - script: ./scripts/set-short-commit-variable.sh
+      name: shortCommitVariableStep
 
-- job: Hygiene_Checks
-  displayName: 'Hygiene Checks'
-  timeoutInMinutes: 0
-  pool:
-    vmImage: 'macOS 10.14'
+  - job: Linux
+    displayName: 'Linux - Ubuntu 16.04'
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'ubuntu-16.04'
 
-  variables:
-    STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3__________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3__________________________________________________________________/b
-    ESY__CACHE_SOURCE_TARBALL_PATH: /Users/runner/.esy/source/i
-    MACOSX_DEPLOYMENT_TARGET: 10.12
-    # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
+    variables:
+      STAGING_DIRECTORY: $(Build.StagingDirectory)
+      ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+      ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
+      ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+      # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
 
-  steps:
-  - template: .ci/use-node.yml
-  - script: brew update
-  - script: brew install libtool libpng ragel
-  - template: .ci/restore-build-cache.yml
-  - template: .ci/swap-xcode.yml
-  - template: .ci/js-build-steps.yml
-  - template: .ci/esy-check-hygiene.yml
-  - template: .ci/publish-build-cache.yml
+    steps:
+    - template: .ci/clean-linux-deps.yml
+    - template: .ci/use-node.yml
+    - script: sudo apt-get update
+    - script: sudo apt-get install -y libncurses5-dev libacl1-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev nasm
+    - template: .ci/js-build-steps.yml
+    - template: .ci/run-integration-tests.yml
 
-- job: Linux
-  displayName: 'Linux - Ubuntu 16.04'
-  timeoutInMinutes: 60
-  pool:
-    vmImage: 'ubuntu-16.04'
+  - job: ValidateLinuxReleaseUbuntu16
+    displayName: "Linux: Validate Release (Ubuntu 16.04)"
+    dependsOn:
+    - Kickoff
+    - CentOS
+    pool:
+      vmImage: 'ubuntu-16.04'
+    variables:
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
-  variables:
-    STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
-    ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
-    # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
+    steps:
+    - script: echo $(ONI2_SHORT_COMMIT_ID)
+    - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
+      displayName: 'Echo artifact dir'
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'single'
+        artifactName: 'Release_Linux'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    - script: ./scripts/linux/validate-release.sh
+      env:
+        SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-  steps:
-  - template: .ci/clean-linux-deps.yml
-  - template: .ci/use-node.yml
-  - script: sudo apt-get update
-  - script: sudo apt-get install -y libncurses5-dev libacl1-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev nasm
-  - template: .ci/js-build-steps.yml
-  - template: .ci/run-integration-tests.yml
+  - job: ValidateLinuxReleaseUbuntu18
+    displayName: "Linux: Validate Release (Ubuntu 18.04)"
+    dependsOn:
+    - Kickoff
+    - CentOS
+    pool:
+      vmImage: 'ubuntu-18.04'
+    variables:
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
-- job: CentOS
-  displayName: 'Linux - CentOS - Docker Image'
-  timeoutInMinutes: 0
-  pool:
-    vmImage: 'Ubuntu 16.04'
+    steps:
+    - script: echo $(ONI2_SHORT_COMMIT_ID)
+    - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
+      displayName: 'Echo artifact dir'
+    - script: sudo apt-get install libegl1-mesa
+      displayName: 'Install dependencies'
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'single'
+        artifactName: 'Release_Linux'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    - script: ./scripts/linux/validate-release.sh
+      env:
+        SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-  variables:
-    STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
-    ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
-    # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
+- stage: MacStages
+  dependsOn: []
+  jobs:
+  - job: Hygiene_Checks
+    displayName: 'Hygiene Checks'
+    timeoutInMinutes: 0
+    pool:
+      vmImage: 'macOS 10.14'
 
-  steps:
-  - template: .ci/clean-linux-deps.yml
-  - script: docker build -t centos scripts/docker/centos
-    displayName: 'docker: build Dockerfile'
-  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
-    displayName: 'docker: ls -a'
-  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
-    displayName: 'docker: build Onivim 2'
-  - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
-    displayName: 'Release: --checkhealth'
-  - template: .ci/publish-linux.yml
+    variables:
+      STAGING_DIRECTORY: $(Build.StagingDirectory)
+      ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3__________________________________________________________________/i
+      ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3__________________________________________________________________/b
+      ESY__CACHE_SOURCE_TARBALL_PATH: /Users/runner/.esy/source/i
+      MACOSX_DEPLOYMENT_TARGET: 10.12
+      # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
-- job: MacOS
-  displayName: "MacOS 10.14"
-  timeoutInMinutes: 0
-  pool:
-    vmImage: 'macOS 10.14'
+    steps:
+    - template: .ci/use-node.yml
+    - script: brew update
+    - script: brew install libtool libpng ragel
+    - template: .ci/restore-build-cache.yml
+    - template: .ci/swap-xcode.yml
+    - template: .ci/js-build-steps.yml
+    - template: .ci/esy-check-hygiene.yml
+    - template: .ci/publish-build-cache.yml
 
-  variables:
-    STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3__________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3__________________________________________________________________/b
-    ESY__CACHE_SOURCE_TARBALL_PATH: /Users/runner/.esy/source/i
-    MACOSX_DEPLOYMENT_TARGET: 10.12
-    # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
+  - job: MacOS
+    displayName: "MacOS 10.14"
+    timeoutInMinutes: 0
+    pool:
+      vmImage: 'macOS 10.14'
 
-  steps:
-  - template: .ci/use-node.yml
-  - script: brew update
-  - script: brew install libtool libpng ragel
-  - template: .ci/restore-build-cache.yml
-  - template: .ci/swap-xcode.yml
-  - template: .ci/js-build-steps.yml
-  - template: .ci/esy-build-steps.yml
-    parameters:
-      platform: darwin
-  - script: _release/Onivim2.App/Contents/MacOS/Oni2 -f --checkhealth
-    displayName: 'Release: --checkhealth'
-  - template: .ci/publish-osx.yml
-  - template: .ci/publish-build-cache.yml
+    variables:
+      STAGING_DIRECTORY: $(Build.StagingDirectory)
+      ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3__________________________________________________________________/i
+      ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3__________________________________________________________________/b
+      ESY__CACHE_SOURCE_TARBALL_PATH: /Users/runner/.esy/source/i
+      MACOSX_DEPLOYMENT_TARGET: 10.12
+      # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
-- job: Windows
-  timeoutInMinutes: 150
-  pool:
-    vmImage: 'vs2017-win2016'
+    steps:
+    - template: .ci/use-node.yml
+    - script: brew update
+    - script: brew install libtool libpng ragel
+    - template: .ci/restore-build-cache.yml
+    - template: .ci/swap-xcode.yml
+    - template: .ci/js-build-steps.yml
+    - template: .ci/esy-build-steps.yml
+      parameters:
+        platform: darwin
+    - script: _release/Onivim2.App/Contents/MacOS/Oni2 -f --checkhealth
+      displayName: 'Release: --checkhealth'
+    - template: .ci/publish-osx.yml
+    - template: .ci/publish-build-cache.yml
 
-  variables:
-    STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/b
-    ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
-    # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
+  - job: ValidateMacOSRelease14
+    displayName: "MacOS: Validate Release (10.14)"
+    dependsOn:
+    - MacOS
+    pool:
+      vmImage: 'macOS-10.14'
+    variables:
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
-  steps:
-  - template: .ci/use-node.yml
-  - powershell: ./scripts/windows/verify-signtool.ps1
-    displayName: 'Validate signtool path'
-  - template: .ci/restore-build-cache.yml
-  - template: .ci/js-build-steps.yml
-  - template: .ci/esy-build-steps.yml
-    parameters:
-      platform: windows
-  - script: dir
-    workingDirectory: _release/win32
-    displayName: 'check directory contents'
-  - script: Oni2.exe -f --no-log-colors --checkhealth
-    workingDirectory: _release/win32
-    displayName: 'Release: --checkhealth'
-  - template: .ci/publish-win.yml
-  - template: .ci/publish-build-cache.yml
+    steps:
+    - script: echo $(ONI2_SHORT_COMMIT_ID)
+    - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
+      displayName: 'Echo artifact dir'
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'single'
+        artifactName: 'Release_Darwin'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    - script: ./scripts/osx/validate-release.sh
+      env:
+        SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-- job: ValidateLinuxReleaseUbuntu16
-  displayName: "Linux: Validate Release (Ubuntu 16.04)"
-  dependsOn: 
-  - Kickoff
-  - CentOS
-  pool:
-    vmImage: 'ubuntu-16.04'
-  variables:
-    ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+  - job: ValidateMacOSRelease15
+    displayName: "MacOS: Validate Release (10.15)"
+    dependsOn:
+    - MacOS
+    pool:
+      vmImage: 'macOS-10.15'
+    variables:
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
-  steps:
-  - script: echo $(ONI2_SHORT_COMMIT_ID)
-  - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
-    displayName: 'Echo artifact dir'
-  - task: DownloadBuildArtifacts@0
-    inputs: 
-      buildType: 'current'
-      downloadType: 'single'
-      artifactName: 'Release_Linux'
-      downloadPath: '$(System.ArtifactsDirectory)'
-  - script: ./scripts/linux/validate-release.sh
-    env:
-      SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+    steps:
+    - script: echo $(ONI2_SHORT_COMMIT_ID)
+    - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
+      displayName: 'Echo artifact dir'
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'single'
+        artifactName: 'Release_Darwin'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    - script: ./scripts/osx/validate-release.sh
+      env:
+        SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-- job: ValidateLinuxReleaseUbuntu18
-  displayName: "Linux: Validate Release (Ubuntu 18.04)"
-  dependsOn: 
-  - Kickoff
-  - CentOS
-  pool:
-    vmImage: 'ubuntu-18.04'
-  variables:
-    ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+- stage: WindowsStages
+  dependsOn: []
+  jobs:
+  - job: Windows
+    timeoutInMinutes: 150
+    pool:
+      vmImage: 'vs2017-win2016'
 
-  steps:
-  - script: echo $(ONI2_SHORT_COMMIT_ID)
-  - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
-    displayName: 'Echo artifact dir'
-  - script: sudo apt-get install libegl1-mesa
-    displayName: 'Install dependencies'
-  - task: DownloadBuildArtifacts@0
-    inputs: 
-      buildType: 'current'
-      downloadType: 'single'
-      artifactName: 'Release_Linux'
-      downloadPath: '$(System.ArtifactsDirectory)'
-  - script: ./scripts/linux/validate-release.sh
-    env:
-      SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+    variables:
+      STAGING_DIRECTORY: $(Build.StagingDirectory)
+      ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/i
+      ESY__CACHE_BUILD_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/b
+      ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
+      # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
-- job: ValidateMacOSRelease14
-  displayName: "MacOS: Validate Release (10.14)"
-  dependsOn: 
-  - Kickoff
-  - MacOS
-  pool:
-    vmImage: 'macOS-10.14'
-  variables:
-    ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+    steps:
+    - template: .ci/use-node.yml
+    - powershell: ./scripts/windows/verify-signtool.ps1
+      displayName: 'Validate signtool path'
+    - template: .ci/restore-build-cache.yml
+    - template: .ci/js-build-steps.yml
+    - template: .ci/esy-build-steps.yml
+      parameters:
+        platform: windows
+    - script: dir
+      workingDirectory: _release/win32
+      displayName: 'check directory contents'
+    - script: Oni2.exe -f --no-log-colors --checkhealth
+      workingDirectory: _release/win32
+      displayName: 'Release: --checkhealth'
+    - template: .ci/publish-win.yml
+    - template: .ci/publish-build-cache.yml
 
-  steps:
-  - script: echo $(ONI2_SHORT_COMMIT_ID)
-  - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
-    displayName: 'Echo artifact dir'
-  - task: DownloadBuildArtifacts@0
-    inputs: 
-      buildType: 'current'
-      downloadType: 'single'
-      artifactName: 'Release_Darwin'
-      downloadPath: '$(System.ArtifactsDirectory)'
-  - script: ./scripts/osx/validate-release.sh
-    env:
-      SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+  - job: ValidateWindowsRelease
+    timeoutInMinutes: 10
+    displayName: "Windows: Validate Release"
+    dependsOn:
+    - Kickoff
+    - Windows
+    pool:
+      vmImage: 'vs2017-win2016'
+    variables:
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
-- job: ValidateMacOSRelease15
-  displayName: "MacOS: Validate Release (10.15)"
-  dependsOn: 
-  - Kickoff
-  - MacOS
-  pool:
-    vmImage: 'macOS-10.15'
-  variables:
-    ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+    steps:
+    - script: echo $(ONI2_SHORT_COMMIT_ID)
+    - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
+      displayName: 'Echo artifact dir'
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'single'
+        artifactName: 'Release_Windows'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    - powershell: ./scripts/windows/validate-release.ps1
+      env:
+        SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+    - script: echo %PATH%
+    # The validate-release.ps1 installs Onivim 2 and checks it,
+    # but we need to check from the command prompt, too via %PATH% - for #872
+    - script: |
+        set PATH=%PATH%;D:/a/1/s/Onivim2
+        Oni2.exe -f --no-log-colors --checkhealth
+      displayName: "Oni2.exe -f --no-log-colors --checkhealth (run installed)"
 
-  steps:
-  - script: echo $(ONI2_SHORT_COMMIT_ID)
-  - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
-    displayName: 'Echo artifact dir'
-  - task: DownloadBuildArtifacts@0
-    inputs: 
-      buildType: 'current'
-      downloadType: 'single'
-      artifactName: 'Release_Darwin'
-      downloadPath: '$(System.ArtifactsDirectory)'
-  - script: ./scripts/osx/validate-release.sh
-    env:
-      SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
+- stage: DockerStages
+  dependsOn: []
+  jobs:
+  - job: CentOS
+    displayName: 'Linux - CentOS - Docker Image'
+    timeoutInMinutes: 0
+    pool:
+      vmImage: 'Ubuntu 16.04'
 
-- job: ValidateWindowsRelease
-  timeoutInMinutes: 10
-  displayName: "Windows: Validate Release"
-  dependsOn: 
-  - Kickoff
-  - Windows
-  pool:
-    vmImage: 'vs2017-win2016'
-  variables:
-    ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+    variables:
+      STAGING_DIRECTORY: $(Build.StagingDirectory)
+      ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+      ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
+      ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+      # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
 
-  steps:
-  - script: echo $(ONI2_SHORT_COMMIT_ID)
-  - script: 'echo ArtifactDir: $(System.ArtifactsDirectory)'
-    displayName: 'Echo artifact dir'
-  - task: DownloadBuildArtifacts@0
-    inputs: 
-      buildType: 'current'
-      downloadType: 'single'
-      artifactName: 'Release_Windows'
-      downloadPath: '$(System.ArtifactsDirectory)'
-  - powershell: ./scripts/windows/validate-release.ps1
-    env:
-      SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
-  - script: echo %PATH%
-  # The validate-release.ps1 installs Onivim 2 and checks it,
-  # but we need to check from the command prompt, too via %PATH% - for #872
-  - script: |
-      set PATH=%PATH%;D:/a/1/s/Onivim2
-      Oni2.exe -f --no-log-colors --checkhealth
-    displayName: "Oni2.exe -f --no-log-colors --checkhealth (run installed)"
+    steps:
+    - template: .ci/clean-linux-deps.yml
+    - script: docker build -t centos scripts/docker/centos
+      displayName: 'docker: build Dockerfile'
+    - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
+      displayName: 'docker: ls -a'
+    - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
+      displayName: 'docker: build Onivim 2'
+    - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
+      displayName: 'Release: --checkhealth'
+    - template: .ci/publish-linux.yml
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,10 @@ stages:
       ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
       ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
       # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
+    - script: echo $(ONI2_SHORT_COMMIT_ID)
     - template: .ci/clean-linux-deps.yml
     - template: .ci/use-node.yml
     - script: sudo apt-get update
@@ -89,7 +91,7 @@ stages:
     pool:
       vmImage: 'ubuntu-16.04'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -112,7 +114,7 @@ stages:
     pool:
       vmImage: 'ubuntu-18.04'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -193,7 +195,7 @@ stages:
     pool:
       vmImage: 'macOS-10.14'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -216,7 +218,7 @@ stages:
     pool:
       vmImage: 'macOS-10.15'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -273,7 +275,7 @@ stages:
     pool:
       vmImage: 'vs2017-win2016'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,9 +22,7 @@ pr:
 # Multistage pipeline, but no stage depends on another.
 # Split by Linux, Mac, Windows
 stages:
-- stage: Linux
-  dependsOn: []
-  jobs:
+- stage: Setup
   - job: Kickoff
     displayName: "Kickoff"
     pool:
@@ -34,6 +32,9 @@ stages:
     - script: ./scripts/set-short-commit-variable.sh
       name: shortCommitVariableStep
 
+- stage: LinuxBuild
+  dependsOn: [Setup]
+  jobs:
   - job: Linux
     displayName: 'Linux - Ubuntu 16.04'
     timeoutInMinutes: 60
@@ -80,15 +81,17 @@ stages:
       displayName: 'Release: --checkhealth'
     - template: .ci/publish-linux.yml
 
+- stage: LinuxTest
+  dependsOn: [Setup, LinuxBuild]
+  jobs:
   - job: ValidateLinuxReleaseUbuntu16
     displayName: "Linux: Validate Release (Ubuntu 16.04)"
     dependsOn:
-    - Kickoff
     - CentOS
     pool:
       vmImage: 'ubuntu-16.04'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[stageDependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -107,12 +110,11 @@ stages:
   - job: ValidateLinuxReleaseUbuntu18
     displayName: "Linux: Validate Release (Ubuntu 18.04)"
     dependsOn:
-    - Kickoff
     - CentOS
     pool:
       vmImage: 'ubuntu-18.04'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[stageDependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -130,18 +132,9 @@ stages:
       env:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-- stage: Mac
-  dependsOn: []
+- stage: MacBuild
+  dependsOn: [Setup]
   jobs:
-  - job: Kickoff
-    displayName: "Kickoff"
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    steps:
-    - script: ./scripts/set-short-commit-variable.sh
-      name: shortCommitVariableStep
-
   - job: Hygiene_Checks
     displayName: 'Hygiene Checks'
     timeoutInMinutes: 0
@@ -195,15 +188,17 @@ stages:
     - template: .ci/publish-osx.yml
     - template: .ci/publish-build-cache.yml
 
+- stage: MacTest
+  dependsOn: [Setup, MacBuild]
+  jobs:
   - job: ValidateMacOSRelease14
     displayName: "MacOS: Validate Release (10.14)"
     dependsOn:
-    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.14'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[stageDependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -222,12 +217,11 @@ stages:
   - job: ValidateMacOSRelease15
     displayName: "MacOS: Validate Release (10.15)"
     dependsOn:
-    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.15'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[stageDependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -243,18 +237,9 @@ stages:
       env:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-- stage: Windows
-  dependsOn: []
+- stage: WindowsBuild
+  dependsOn: [Setup]
   jobs:
-  - job: Kickoff
-    displayName: "Kickoff"
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    steps:
-    - script: ./scripts/set-short-commit-variable.sh
-      name: shortCommitVariableStep
-
   - job: Windows
     timeoutInMinutes: 150
     pool:
@@ -285,16 +270,18 @@ stages:
     - template: .ci/publish-win.yml
     - template: .ci/publish-build-cache.yml
 
+- stage: WindowsTest
+  dependsOn: [Setup, WindowsBuild]
+  jobs:
   - job: ValidateWindowsRelease
     timeoutInMinutes: 10
     displayName: "Windows: Validate Release"
     dependsOn:
-    - Kickoff
     - Windows
     pool:
       vmImage: 'vs2017-win2016'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[stageDependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,6 @@ stages:
   - job: ValidateLinuxReleaseUbuntu16
     displayName: "Linux: Validate Release (Ubuntu 16.04)"
     dependsOn:
-    - Kickoff
     - CentOS
     pool:
       vmImage: 'ubuntu-16.04'
@@ -109,7 +108,6 @@ stages:
   - job: ValidateLinuxReleaseUbuntu18
     displayName: "Linux: Validate Release (Ubuntu 18.04)"
     dependsOn:
-    - Kickoff
     - CentOS
     pool:
       vmImage: 'ubuntu-18.04'
@@ -191,7 +189,6 @@ stages:
   - job: ValidateMacOSRelease14
     displayName: "MacOS: Validate Release (10.14)"
     dependsOn:
-    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.14'
@@ -215,7 +212,6 @@ stages:
   - job: ValidateMacOSRelease15
     displayName: "MacOS: Validate Release (10.15)"
     dependsOn:
-    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.15'
@@ -273,7 +269,6 @@ stages:
     timeoutInMinutes: 10
     displayName: "Windows: Validate Release"
     dependsOn:
-    - Kickoff
     - Windows
     pool:
       vmImage: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ pr:
 # Split by Linux, Mac, Windows
 stages:
 - stage: Setup
+  dependsOn: []
+  jobs:
   - job: Kickoff
     displayName: "Kickoff"
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,8 +88,6 @@ stages:
   jobs:
   - job: ValidateLinuxReleaseUbuntu16
     displayName: "Linux: Validate Release (Ubuntu 16.04)"
-    dependsOn:
-    - CentOS
     pool:
       vmImage: 'ubuntu-16.04'
     variables:
@@ -111,8 +109,6 @@ stages:
 
   - job: ValidateLinuxReleaseUbuntu18
     displayName: "Linux: Validate Release (Ubuntu 18.04)"
-    dependsOn:
-    - CentOS
     pool:
       vmImage: 'ubuntu-18.04'
     variables:
@@ -195,8 +191,6 @@ stages:
   jobs:
   - job: ValidateMacOSRelease14
     displayName: "MacOS: Validate Release (10.14)"
-    dependsOn:
-    - MacOS
     pool:
       vmImage: 'macOS-10.14'
     variables:
@@ -218,8 +212,6 @@ stages:
 
   - job: ValidateMacOSRelease15
     displayName: "MacOS: Validate Release (10.15)"
-    dependsOn:
-    - MacOS
     pool:
       vmImage: 'macOS-10.15'
     variables:
@@ -278,8 +270,6 @@ stages:
   - job: ValidateWindowsRelease
     timeoutInMinutes: 10
     displayName: "Windows: Validate Release"
-    dependsOn:
-    - Windows
     pool:
       vmImage: 'vs2017-win2016'
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,8 @@ pr:
 # Multistage pipeline, but no stage depends on another.
 # Split by Linux, Mac, Windows
 stages:
-- stage: Setup
+- stage: LinuxStages
+  dependsOn: []
   jobs:
   - job: Kickoff
     displayName: "Kickoff"
@@ -33,9 +34,6 @@ stages:
     - script: ./scripts/set-short-commit-variable.sh
       name: shortCommitVariableStep
 
-- stage: LinuxStages
-  dependsOn: [Setup]
-  jobs:
   - job: Linux
     displayName: 'Linux - Ubuntu 16.04'
     timeoutInMinutes: 60
@@ -48,10 +46,8 @@ stages:
       ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
       ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
       # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
-    - script: echo $(ONI2_SHORT_COMMIT_ID)
     - template: .ci/clean-linux-deps.yml
     - template: .ci/use-node.yml
     - script: sudo apt-get update
@@ -91,7 +87,7 @@ stages:
     pool:
       vmImage: 'ubuntu-16.04'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -114,7 +110,7 @@ stages:
     pool:
       vmImage: 'ubuntu-18.04'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -133,8 +129,17 @@ stages:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
 - stage: MacStages
-  dependsOn: [Setup]
+  dependsOn: []
   jobs:
+  - job: Kickoff
+    displayName: "Kickoff"
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+    - script: ./scripts/set-short-commit-variable.sh
+      name: shortCommitVariableStep
+
   - job: Hygiene_Checks
     displayName: 'Hygiene Checks'
     timeoutInMinutes: 0
@@ -195,7 +200,7 @@ stages:
     pool:
       vmImage: 'macOS-10.14'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -218,7 +223,7 @@ stages:
     pool:
       vmImage: 'macOS-10.15'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)
@@ -235,8 +240,17 @@ stages:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
 - stage: WindowsStages
-  dependsOn: [Setup]
+  dependsOn: []
   jobs:
+  - job: Kickoff
+    displayName: "Kickoff"
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+    - script: ./scripts/set-short-commit-variable.sh
+      name: shortCommitVariableStep
+
   - job: Windows
     timeoutInMinutes: 150
     pool:
@@ -275,7 +289,7 @@ stages:
     pool:
       vmImage: 'vs2017-win2016'
     variables:
-      ONI2_SHORT_COMMIT_ID: $[dependencies.Setup.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
+      ONI2_SHORT_COMMIT_ID: $[dependencies.Kickoff.outputs['shortCommitVariableStep.ONI2_SHORT_COMMIT_ID'] ]
 
     steps:
     - script: echo $(ONI2_SHORT_COMMIT_ID)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ pr:
 # Multistage pipeline, but no stage depends on another.
 # Split by Linux, Mac, Windows
 stages:
-- stage: LinuxStages
+- stage: Linux
   dependsOn: []
   jobs:
   - job: Kickoff
@@ -83,6 +83,7 @@ stages:
   - job: ValidateLinuxReleaseUbuntu16
     displayName: "Linux: Validate Release (Ubuntu 16.04)"
     dependsOn:
+    - Kickoff
     - CentOS
     pool:
       vmImage: 'ubuntu-16.04'
@@ -106,6 +107,7 @@ stages:
   - job: ValidateLinuxReleaseUbuntu18
     displayName: "Linux: Validate Release (Ubuntu 18.04)"
     dependsOn:
+    - Kickoff
     - CentOS
     pool:
       vmImage: 'ubuntu-18.04'
@@ -128,7 +130,7 @@ stages:
       env:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-- stage: MacStages
+- stage: Mac
   dependsOn: []
   jobs:
   - job: Kickoff
@@ -196,6 +198,7 @@ stages:
   - job: ValidateMacOSRelease14
     displayName: "MacOS: Validate Release (10.14)"
     dependsOn:
+    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.14'
@@ -219,6 +222,7 @@ stages:
   - job: ValidateMacOSRelease15
     displayName: "MacOS: Validate Release (10.15)"
     dependsOn:
+    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.15'
@@ -239,7 +243,7 @@ stages:
       env:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
-- stage: WindowsStages
+- stage: Windows
   dependsOn: []
   jobs:
   - job: Kickoff
@@ -285,6 +289,7 @@ stages:
     timeoutInMinutes: 10
     displayName: "Windows: Validate Release"
     dependsOn:
+    - Kickoff
     - Windows
     pool:
       vmImage: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,9 @@ pr:
     - README.md
 
 # Multistage pipeline, but no stage depends on another.
-# Split by Linux, Mac, Windows, Docker
+# Split by Linux, Mac, Windows
 stages:
-- stage: LinuxStages
-  dependsOn: []
+- stage: Setup
   jobs:
   - job: Kickoff
     displayName: "Kickoff"
@@ -34,6 +33,9 @@ stages:
     - script: ./scripts/set-short-commit-variable.sh
       name: shortCommitVariableStep
 
+- stage: LinuxStages
+  dependsOn: [Setup]
+  jobs:
   - job: Linux
     displayName: 'Linux - Ubuntu 16.04'
     timeoutInMinutes: 60
@@ -54,6 +56,31 @@ stages:
     - script: sudo apt-get install -y libncurses5-dev libacl1-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev nasm
     - template: .ci/js-build-steps.yml
     - template: .ci/run-integration-tests.yml
+
+  - job: CentOS
+    displayName: 'Linux - CentOS - Docker Image'
+    timeoutInMinutes: 0
+    pool:
+      vmImage: 'Ubuntu 16.04'
+
+    variables:
+      STAGING_DIRECTORY: $(Build.StagingDirectory)
+      ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+      ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
+      ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+      # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
+
+    steps:
+    - template: .ci/clean-linux-deps.yml
+    - script: docker build -t centos scripts/docker/centos
+      displayName: 'docker: build Dockerfile'
+    - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
+      displayName: 'docker: ls -a'
+    - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
+      displayName: 'docker: build Onivim 2'
+    - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
+      displayName: 'Release: --checkhealth'
+    - template: .ci/publish-linux.yml
 
   - job: ValidateLinuxReleaseUbuntu16
     displayName: "Linux: Validate Release (Ubuntu 16.04)"
@@ -106,7 +133,7 @@ stages:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
 - stage: MacStages
-  dependsOn: []
+  dependsOn: [Setup]
   jobs:
   - job: Hygiene_Checks
     displayName: 'Hygiene Checks'
@@ -164,6 +191,7 @@ stages:
   - job: ValidateMacOSRelease14
     displayName: "MacOS: Validate Release (10.14)"
     dependsOn:
+    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.14'
@@ -187,6 +215,7 @@ stages:
   - job: ValidateMacOSRelease15
     displayName: "MacOS: Validate Release (10.15)"
     dependsOn:
+    - Kickoff
     - MacOS
     pool:
       vmImage: 'macOS-10.15'
@@ -208,7 +237,7 @@ stages:
         SYSTEM_ARTIFACTSDIRECTORY: $(System.ArtifactsDirectory)
 
 - stage: WindowsStages
-  dependsOn: []
+  dependsOn: [Setup]
   jobs:
   - job: Windows
     timeoutInMinutes: 150
@@ -271,32 +300,4 @@ stages:
         set PATH=%PATH%;D:/a/1/s/Onivim2
         Oni2.exe -f --no-log-colors --checkhealth
       displayName: "Oni2.exe -f --no-log-colors --checkhealth (run installed)"
-
-- stage: DockerStages
-  dependsOn: []
-  jobs:
-  - job: CentOS
-    displayName: 'Linux - CentOS - Docker Image'
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'Ubuntu 16.04'
-
-    variables:
-      STAGING_DIRECTORY: $(Build.StagingDirectory)
-      ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
-      ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
-      ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
-      # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
-
-    steps:
-    - template: .ci/clean-linux-deps.yml
-    - script: docker build -t centos scripts/docker/centos
-      displayName: 'docker: build Dockerfile'
-    - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
-      displayName: 'docker: ls -a'
-    - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
-      displayName: 'docker: build Onivim 2'
-    - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
-      displayName: 'Release: --checkhealth'
-    - template: .ci/publish-linux.yml
 


### PR DESCRIPTION
Split up CI steps into stages, to aid re-running.
This should mean that we can more easily run individual stages of the CI, rather than the whole thing on a failure.