### PR TITLE
feat(other): add changelog

### DIFF
--- a/assets/changelog.xml
+++ b/assets/changelog.xml
@@ -1,5 +1,62 @@
 <changelog>
-  <commit hash="5d4c99a9" pr=1623 time=588257227>
+  <commit type="feat" scope="other/#1631" hash="92bab00d" pr=1717 time=588630193>
+    correct double click behavior on macOS (maximize)
+  </commit>
+  <commit type="feat" scope="Extension Host" hash="4edce141" pr=1709 time=588627097>
+    Workspace APIs
+  </commit>
+  <commit type="refactor" scope="exthost" hash="89236cac" pr=1711 time=588617053>
+    v2 - API - provideTextDocumentContent
+  </commit>
+  <commit type="chore" scope="dependency" hash="ea560d1d" pr=1714 time=588519632>
+    add fs, fp, dir
+  </commit>
+  <commit type="fix" scope="search/#1693" hash="4b76ab42" pr=1713 time=588516594>
+    closing the search pane doesn't "defocus it"
+  </commit>
+  <commit type="chore" scope="dependency" hash="996f6b48" pr=1712 time=588503999>
+    revery -> 7853ddb
+  </commit>
+  <commit type="refactor" scope="exthost" hash="33790f4e" pr=1706 time=588448480>
+    v2 - API - completion
+  </commit>
+  <commit type="fix" scope="file-explorer/#873" hash="cf6af66d" pr=1705 time=588433491>
+    exit zen mode when toggling explorer
+  </commit>
+  <commit type="fix" scope="vim" hash="3890823d" pr=1704 time=588433444>
+    linewise clipboard paste (yyp)
+  </commit>
+  <commit type="refactor" scope="exthost" hash="b3be9160" pr=1702 time=588373057>
+    API - ExtHostDocuments: Document edit / update
+  </commit>
+  <commit type="refactor" scope="exthost" hash="ef4c6b33" pr=1701 time=588357323>
+    move handlers to Msg module
+  </commit>
+  <commit type="chore" scope="dependency" hash="670657c4" pr=1700 time=588345462>
+    esy-skia -> d60e5fe
+  </commit>
+  <commit type="fix" scope="workspace" hash="ccb322ff" pr=1699 time=588343021>
+    broken save command
+  </commit>
+  <commit type="refactor" scope="exthost" hash="9838721d" pr=1697 time=588341199>
+    DocumentContentProvider, Decorations, Diagnostics
+  </commit>
+  <commit type="fix" scope="vim/#1671" hash="7c6f4a78" pr=1685 time=588298351>
+    - buffer loses unsaved changes when switching
+  </commit>
+  <commit type="chore" scope="ci" hash="bc2ac4d2" pr=1698 time=588298337>
+    Linux (CentOS) - remove cleanup prior to tests
+  </commit>
+  <commit type="chore" scope="dependency" hash="25539c48" pr=1696 time=588294522>
+    revery -> 9f725e0
+  </commit>
+  <commit type="fix" scope="vim/#660" hash="ac39e58c" pr=1694 time=588287421>
+    clipboard - specify character mode when not multiple lines
+  </commit>
+  <commit type="chore" hash="a6506982" pr=1690 time=588262364>
+    Dependency: ocaml -> 4.9
+  </commit>
+  <commit type="fix" scope="configuration" hash="5d4c99a9" pr=1623 time=588257227>
     <breaking>
       On Windows, git-bash, powershell-core and perhaps others now correctly
       loads the config from %LOCALAPPDATA% instead of $HOME
@@ -7,5 +64,7 @@
         
     Always load Windows config from %LOCALAPPDATA% 
   </commit>
-  <commit hash="2e704922"/>
+  <commit hash="2e704922" pr=1676 time=588206100>
+    Fix #1578 - Terminal command + args configuration settings
+  </commit>
 </changelog>

--- a/assets/changelog.xml
+++ b/assets/changelog.xml
@@ -1,0 +1,11 @@
+<changelog>
+  <commit hash="5d4c99a9" pr=1623 time=588257227>
+    <breaking>
+      On Windows, git-bash, powershell-core and perhaps others now correctly
+      loads the config from %LOCALAPPDATA% instead of $HOME
+    </breaking>
+        
+    Always load Windows config from %LOCALAPPDATA% 
+  </commit>
+  <commit hash="2e704922"/>
+</changelog>

--- a/assets/changelog.xml
+++ b/assets/changelog.xml
@@ -1,62 +1,96 @@
 <changelog>
-  <commit type="feat" scope="other/#1631" hash="92bab00d" pr=1717 time=588630193>
+  <commit type="feat" scope="workspace" hash="3ce31076" pr=1668 time=1588790811>
+    window/split resizing, part 1 - basic functionality and commands
+  </commit>
+  <commit type="chore" hash="8556a5db" pr=1726 time=1588783526>
+    remove pkg-config workaround (#1726)
+  </commit>
+  <commit hash="ea1e82b4" pr=1725 time=1588775668>
+    refactor(exthost) - V2 - API - provideDocumentSymbols
+  </commit>
+  <commit hash="12952612" pr=1724 time=1588729527>
+    refactor(exthost) - v2 - API - reference provider
+  </commit>
+  <commit hash="c609e7c2" pr=1723 time=1588723287>
+    refactor(exhost) - v2 - API - provideDocumentHighlights
+  </commit>
+  <commit type="refactor" scope="exthost" hash="68a54e99" pr=1710 time=1588711111>
+    port definition provider to v2
+  </commit>
+  <commit type="feat" scope="workspace/#640" hash="9aac90b2" pr=1703 time=1588705176>
+    <breaking>
+      Oni2 will no longer open the working directory if no argument is passed. Instead you need to supply `.` 
+    </breaking>
+    
+    persistence infrastructure + persist workspace and window state
+    
+    Persists the last used version, the last opened workspace path and the window position and size for
+    each workspace.
+    
+    If no file or folder argument is given, the last workspace path will be opened. Or, if this is the first time
+    Oni2 is launched, open the Documents folder if possible, or fall back to the home folder if not.
+  </commit>
+  <commit type="perf" scope="terminal" hash="5c7d1971" pr=1689 time=1588694990>
+    input regression
+  </commit>
+  <commit type="feat" scope="other/#1631" hash="92bab00d" pr=1717 time=1588630193>
     correct double click behavior on macOS (maximize)
   </commit>
-  <commit type="feat" scope="Extension Host" hash="4edce141" pr=1709 time=588627097>
+  <commit type="feat" scope="Extension Host" hash="4edce141" pr=1709 time=1588627097>
     Workspace APIs
   </commit>
-  <commit type="refactor" scope="exthost" hash="89236cac" pr=1711 time=588617053>
+  <commit type="refactor" scope="exthost" hash="89236cac" pr=1711 time=1588617053>
     v2 - API - provideTextDocumentContent
   </commit>
-  <commit type="chore" scope="dependency" hash="ea560d1d" pr=1714 time=588519632>
+  <commit type="chore" scope="dependency" hash="ea560d1d" pr=1714 time=1588519632>
     add fs, fp, dir
   </commit>
-  <commit type="fix" scope="search/#1693" hash="4b76ab42" pr=1713 time=588516594>
+  <commit type="fix" scope="search/#1693" hash="4b76ab42" pr=1713 time=1588516594>
     closing the search pane doesn't "defocus it"
   </commit>
-  <commit type="chore" scope="dependency" hash="996f6b48" pr=1712 time=588503999>
+  <commit type="chore" scope="dependency" hash="996f6b48" pr=1712 time=1588503999>
     revery -> 7853ddb
   </commit>
-  <commit type="refactor" scope="exthost" hash="33790f4e" pr=1706 time=588448480>
+  <commit type="refactor" scope="exthost" hash="33790f4e" pr=1706 time=1588448480>
     v2 - API - completion
   </commit>
-  <commit type="fix" scope="file-explorer/#873" hash="cf6af66d" pr=1705 time=588433491>
+  <commit type="fix" scope="file-explorer/#873" hash="cf6af66d" pr=1705 time=1588433491>
     exit zen mode when toggling explorer
   </commit>
-  <commit type="fix" scope="vim" hash="3890823d" pr=1704 time=588433444>
+  <commit type="fix" scope="vim" hash="3890823d" pr=1704 time=1588433444>
     linewise clipboard paste (yyp)
   </commit>
-  <commit type="refactor" scope="exthost" hash="b3be9160" pr=1702 time=588373057>
+  <commit type="refactor" scope="exthost" hash="b3be9160" pr=1702 time=1588373057>
     API - ExtHostDocuments: Document edit / update
   </commit>
-  <commit type="refactor" scope="exthost" hash="ef4c6b33" pr=1701 time=588357323>
+  <commit type="refactor" scope="exthost" hash="ef4c6b33" pr=1701 time=1588357323>
     move handlers to Msg module
   </commit>
-  <commit type="chore" scope="dependency" hash="670657c4" pr=1700 time=588345462>
+  <commit type="chore" scope="dependency" hash="670657c4" pr=1700 time=1588345462>
     esy-skia -> d60e5fe
   </commit>
-  <commit type="fix" scope="workspace" hash="ccb322ff" pr=1699 time=588343021>
+  <commit type="fix" scope="workspace" hash="ccb322ff" pr=1699 time=1588343021>
     broken save command
   </commit>
-  <commit type="refactor" scope="exthost" hash="9838721d" pr=1697 time=588341199>
+  <commit type="refactor" scope="exthost" hash="9838721d" pr=1697 time=1588341199>
     DocumentContentProvider, Decorations, Diagnostics
   </commit>
-  <commit type="fix" scope="vim/#1671" hash="7c6f4a78" pr=1685 time=588298351>
-    - buffer loses unsaved changes when switching
+  <commit type="fix" scope="vim/#1671" hash="7c6f4a78" pr=1685 time=1588298351>
+    buffer loses unsaved changes when switching
   </commit>
-  <commit type="chore" scope="ci" hash="bc2ac4d2" pr=1698 time=588298337>
+  <commit type="chore" scope="ci" hash="bc2ac4d2" pr=1698 time=1588298337>
     Linux (CentOS) - remove cleanup prior to tests
   </commit>
-  <commit type="chore" scope="dependency" hash="25539c48" pr=1696 time=588294522>
+  <commit type="chore" scope="dependency" hash="25539c48" pr=1696 time=1588294522>
     revery -> 9f725e0
   </commit>
-  <commit type="fix" scope="vim/#660" hash="ac39e58c" pr=1694 time=588287421>
+  <commit type="fix" scope="vim/#660" hash="ac39e58c" pr=1694 time=1588287421>
     clipboard - specify character mode when not multiple lines
   </commit>
-  <commit type="chore" hash="a6506982" pr=1690 time=588262364>
+  <commit type="chore" hash="a6506982" pr=1690 time=1588262364>
     Dependency: ocaml -> 4.9
   </commit>
-  <commit type="fix" scope="configuration" hash="5d4c99a9" pr=1623 time=588257227>
+  <commit type="fix" scope="configuration" hash="5d4c99a9" pr=1623 time=1588257227>
     <breaking>
       On Windows, git-bash, powershell-core and perhaps others now correctly
       loads the config from %LOCALAPPDATA% instead of $HOME

--- a/assets/changelog.xml
+++ b/assets/changelog.xml
@@ -1,4 +1,36 @@
 <changelog>
+  <commit type="refactor" scope="exthost" hash="6ebe03ca" pr=1736 time=1588875205>
+    V2 - SCM - Port over SCM types / messages / requests
+  </commit>
+  <commit type="chore" scope="ci" hash="36eb8e81" pr=1738 time=1588873083>
+    Remove integration test clean-up (#1738)
+  </commit>
+  <commit hash="4b1479e0" pr=1734 time=1588865086>
+    refactor(exthost) - V2 - Decorations API
+  </commit>
+  <commit type="fix" scope="extensions" issue="1729" hash="b3e7fbbf" pr=1737 time=1588861553>
+    some gitlens regex patterns failed to parse
+    
+    <breaking>As this switches to a different regex engine, there's a chance that it might break other extension regexes.</breaking>
+  </commit>
+  <commit type="docs" hash="5822aaea" pr=1718 time=1588861510>
+    add changelog conventions to contribution guidelines (#1718)
+  </commit>
+  <commit type="fix" scope="extensions" issue="1729" hash="209ee404" pr=null time=1588837785>
+    don't crash if unable to parse regex
+  </commit>
+  <commit hash="6be50cf6" pr=1735 time=1588817417>
+    fix(exthost) - Handle acknowledged message type
+  </commit>
+  <commit hash="e4c56568" pr=1732 time=1588814866>
+    refactor(exthost) - V2 - SCM - Remove unused SCMRawResource properties
+  </commit>
+  <commit hash="c8fa1db0" pr=1727 time=1588809875>
+    refactor(exthost) - V2 - API - acceptConfiguration
+  </commit>
+  <commit hash="a0facccc" pr=1731 time=1588802210>
+    refactor(exthost) - V2 - use decoder for parsing
+  </commit>
   <commit type="feat" scope="workspace" hash="3ce31076" pr=1668 time=1588790811>
     window/split resizing, part 1 - basic functionality and commands
   </commit>
@@ -17,7 +49,7 @@
   <commit type="refactor" scope="exthost" hash="68a54e99" pr=1710 time=1588711111>
     port definition provider to v2
   </commit>
-  <commit type="feat" scope="workspace/#640" hash="9aac90b2" pr=1703 time=1588705176>
+  <commit type="feat" scope="workspace" issue="640" hash="9aac90b2" pr=1703 time=1588705176>
     <breaking>
       Oni2 will no longer open the working directory if no argument is passed. Instead you need to supply `.` 
     </breaking>
@@ -33,7 +65,7 @@
   <commit type="perf" scope="terminal" hash="5c7d1971" pr=1689 time=1588694990>
     input regression
   </commit>
-  <commit type="feat" scope="other/#1631" hash="92bab00d" pr=1717 time=1588630193>
+  <commit type="feat" scope="other" issue="1631" hash="92bab00d" pr=1717 time=1588630193>
     correct double click behavior on macOS (maximize)
   </commit>
   <commit type="feat" scope="Extension Host" hash="4edce141" pr=1709 time=1588627097>
@@ -45,7 +77,7 @@
   <commit type="chore" scope="dependency" hash="ea560d1d" pr=1714 time=1588519632>
     add fs, fp, dir
   </commit>
-  <commit type="fix" scope="search/#1693" hash="4b76ab42" pr=1713 time=1588516594>
+  <commit type="fix" scope="search" issue="1693" hash="4b76ab42" pr=1713 time=1588516594>
     closing the search pane doesn't "defocus it"
   </commit>
   <commit type="chore" scope="dependency" hash="996f6b48" pr=1712 time=1588503999>
@@ -54,7 +86,7 @@
   <commit type="refactor" scope="exthost" hash="33790f4e" pr=1706 time=1588448480>
     v2 - API - completion
   </commit>
-  <commit type="fix" scope="file-explorer/#873" hash="cf6af66d" pr=1705 time=1588433491>
+  <commit type="fix" scope="file-explorer" issue="873" hash="cf6af66d" pr=1705 time=1588433491>
     exit zen mode when toggling explorer
   </commit>
   <commit type="fix" scope="vim" hash="3890823d" pr=1704 time=1588433444>
@@ -75,7 +107,7 @@
   <commit type="refactor" scope="exthost" hash="9838721d" pr=1697 time=1588341199>
     DocumentContentProvider, Decorations, Diagnostics
   </commit>
-  <commit type="fix" scope="vim/#1671" hash="7c6f4a78" pr=1685 time=1588298351>
+  <commit type="fix" scope="vim" issue="1671" hash="7c6f4a78" pr=1685 time=1588298351>
     buffer loses unsaved changes when switching
   </commit>
   <commit type="chore" scope="ci" hash="bc2ac4d2" pr=1698 time=1588298337>
@@ -84,7 +116,7 @@
   <commit type="chore" scope="dependency" hash="25539c48" pr=1696 time=1588294522>
     revery -> 9f725e0
   </commit>
-  <commit type="fix" scope="vim/#660" hash="ac39e58c" pr=1694 time=1588287421>
+  <commit type="fix" scope="vim" issue="660" hash="ac39e58c" pr=1694 time=1588287421>
     clipboard - specify character mode when not multiple lines
   </commit>
   <commit type="chore" hash="a6506982" pr=1690 time=1588262364>

--- a/assets/dune
+++ b/assets/dune
@@ -1,0 +1,4 @@
+(install
+    (section bin)
+    (package Oni2)
+    (files changelog.xml))

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9f209ddeda9ab6b93d0490621ff5be17",
+  "checksum": "2ad1cc7d0353231d4a9a85483cadfa63",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -213,7 +213,7 @@
         "refmterr@3.3.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:3.0.0@50f5dee6",
+        "@opam/lambda-term@opam:3.0.1@161f34f6",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.1@a0c1e658",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -1201,8 +1201,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/luv@opam:0.5.2@bfb5a32a",
-        "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/luv@opam:0.5.2@bfb5a32a", "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/fmt@opam:0.8.8@01c3a23c",
@@ -2692,20 +2692,20 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
-    "@opam/lambda-term@opam:3.0.0@50f5dee6": {
-      "id": "@opam/lambda-term@opam:3.0.0@50f5dee6",
+    "@opam/lambda-term@opam:3.0.1@161f34f6": {
+      "id": "@opam/lambda-term@opam:3.0.1@161f34f6",
       "name": "@opam/lambda-term",
-      "version": "opam:3.0.0",
+      "version": "opam:3.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/3e/3ee0d8b6cb31f20a07fcbf34990f8a4b#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b",
-          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a5537057f8830783e9b17a7d40f4e644#md5:a5537057f8830783e9b17a7d40f4e644",
+          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz#md5:a5537057f8830783e9b17a7d40f4e644"
         ],
         "opam": {
           "name": "lambda-term",
-          "version": "3.0.0",
-          "path": "bench.esy.lock/opam/lambda-term.3.0.0"
+          "version": "3.0.1",
+          "path": "bench.esy.lock/opam/lambda-term.3.0.1"
         }
       },
       "overrides": [],

--- a/bench.esy.lock/opam/lambda-term.3.0.1/opam
+++ b/bench.esy.lock/opam/lambda-term.3.0.1/opam
@@ -30,6 +30,6 @@ for example, ncurses, by providing a native OCaml interface instead of bindings
 to a C library. Lambda-term integrates with zed to provide text edition
 facilities in console applications."""
 url {
-  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz"
-  checksum: "md5=3ee0d8b6cb31f20a07fcbf34990f8a4b"
+  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz"
+  checksum: "md5=a5537057f8830783e9b17a7d40f4e644"
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9f209ddeda9ab6b93d0490621ff5be17",
+  "checksum": "2ad1cc7d0353231d4a9a85483cadfa63",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -213,7 +213,7 @@
         "refmterr@3.3.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:3.0.0@50f5dee6",
+        "@opam/lambda-term@opam:3.0.1@161f34f6",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.1@a0c1e658",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -1200,8 +1200,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/luv@opam:0.5.2@bfb5a32a",
-        "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/luv@opam:0.5.2@bfb5a32a", "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/fmt@opam:0.8.8@01c3a23c",
@@ -2691,20 +2691,20 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
-    "@opam/lambda-term@opam:3.0.0@50f5dee6": {
-      "id": "@opam/lambda-term@opam:3.0.0@50f5dee6",
+    "@opam/lambda-term@opam:3.0.1@161f34f6": {
+      "id": "@opam/lambda-term@opam:3.0.1@161f34f6",
       "name": "@opam/lambda-term",
-      "version": "opam:3.0.0",
+      "version": "opam:3.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/3e/3ee0d8b6cb31f20a07fcbf34990f8a4b#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b",
-          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a5537057f8830783e9b17a7d40f4e644#md5:a5537057f8830783e9b17a7d40f4e644",
+          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz#md5:a5537057f8830783e9b17a7d40f4e644"
         ],
         "opam": {
           "name": "lambda-term",
-          "version": "3.0.0",
-          "path": "esy.lock/opam/lambda-term.3.0.0"
+          "version": "3.0.1",
+          "path": "esy.lock/opam/lambda-term.3.0.1"
         }
       },
       "overrides": [],

--- a/esy.lock/opam/lambda-term.3.0.1/opam
+++ b/esy.lock/opam/lambda-term.3.0.1/opam
@@ -30,6 +30,6 @@ for example, ncurses, by providing a native OCaml interface instead of bindings
 to a C library. Lambda-term integrates with zed to provide text edition
 facilities in console applications."""
 url {
-  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz"
-  checksum: "md5=3ee0d8b6cb31f20a07fcbf34990f8a4b"
+  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz"
+  checksum: "md5=a5537057f8830783e9b17a7d40f4e644"
 }

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9f209ddeda9ab6b93d0490621ff5be17",
+  "checksum": "2ad1cc7d0353231d4a9a85483cadfa63",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -213,7 +213,7 @@
         "refmterr@3.3.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:3.0.0@50f5dee6",
+        "@opam/lambda-term@opam:3.0.1@161f34f6",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.1@a0c1e658",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -1200,8 +1200,8 @@
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/luv@opam:0.5.2@bfb5a32a",
-        "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/luv@opam:0.5.2@bfb5a32a", "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/fmt@opam:0.8.8@01c3a23c",
@@ -2692,20 +2692,20 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
-    "@opam/lambda-term@opam:3.0.0@50f5dee6": {
-      "id": "@opam/lambda-term@opam:3.0.0@50f5dee6",
+    "@opam/lambda-term@opam:3.0.1@161f34f6": {
+      "id": "@opam/lambda-term@opam:3.0.1@161f34f6",
       "name": "@opam/lambda-term",
-      "version": "opam:3.0.0",
+      "version": "opam:3.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/3e/3ee0d8b6cb31f20a07fcbf34990f8a4b#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b",
-          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a5537057f8830783e9b17a7d40f4e644#md5:a5537057f8830783e9b17a7d40f4e644",
+          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz#md5:a5537057f8830783e9b17a7d40f4e644"
         ],
         "opam": {
           "name": "lambda-term",
-          "version": "3.0.0",
-          "path": "integrationtest.esy.lock/opam/lambda-term.3.0.0"
+          "version": "3.0.1",
+          "path": "integrationtest.esy.lock/opam/lambda-term.3.0.1"
         }
       },
       "overrides": [],

--- a/integrationtest.esy.lock/opam/lambda-term.3.0.1/opam
+++ b/integrationtest.esy.lock/opam/lambda-term.3.0.1/opam
@@ -30,6 +30,6 @@ for example, ncurses, by providing a native OCaml interface instead of bindings
 to a C library. Lambda-term integrates with zed to provide text edition
 facilities in console applications."""
 url {
-  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz"
-  checksum: "md5=3ee0d8b6cb31f20a07fcbf34990f8a4b"
+  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz"
+  checksum: "md5=a5537057f8830783e9b17a7d40f4e644"
 }

--- a/package.json
+++ b/package.json
@@ -233,7 +233,8 @@
     "@opam/luv": "~0.5.1",
     "@opam/fs": "*",
     "@opam/fp": "*",
-    "@opam/dir": "*"
+    "@opam/dir": "*",
+    "@opam/markup": "^0.8.2"
   },
   "resolutions": {
     "@esy-ocaml/libffi": "onivim/libffi#590b041",

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -41,7 +41,7 @@ function extractPRNumber(str) {
 function parseLogLine(line) {
     return Object.assign(parseSubject(line.substr(20)), {
         hash: line.substr(0, 8),
-        time: line.substr(10, 9),
+        time: line.substr(9, 10),
         pr: extractPRNumber(line),
     })
 }

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -34,16 +34,20 @@ function getLastCommit(xml) {
 // PARSING
 
 function parseSubject(str) {
-    let result = str.match(/^([a-z]+)(?:\(([^\)]+)\))?:\s*(.*)$/)
-    return result
-        ? {
-              type: result[1],
-              scope: result[2],
-              subject: result[3],
-          }
-        : {
-              subject: str,
-          }
+    let result = str.match(/^([a-z]+)(?:\(([^\)^\/]+)(?:\/([^\)]+))?\))?:\s*(.*)$$/)
+
+    if (result) {
+        return {
+            type: result[1],
+            scope: result[2],
+            issue: (result[3] || "").replace(/^#/, ""),
+            subject: result[4],
+        }
+    } else {
+        return {
+            subject: str,
+        }
+    }
 }
 
 function extractPRNumber(str) {
@@ -102,11 +106,12 @@ function extractLogEntry(body) {
 
 // GENERATE XML
 
-function createCommitXml({ type, scope, hash, pr, time, content, subject }) {
+function createCommitXml({ type, scope, issue, hash, pr, time, content, subject }) {
     const typeAttr = type ? `type="${type}" ` : ""
     const scopeAttr = scope ? `scope="${scope}" ` : ""
+    const issueAttr = issue ? `issue="${issue}" ` : ""
 
-    return `  <commit ${typeAttr}${scopeAttr}hash="${hash}" pr=${pr} time=${time}>
+    return `  <commit ${typeAttr}${scopeAttr}${issueAttr}hash="${hash}" pr=${pr} time=${time}>
     ${content ? content.replace(/\n/g, "\n    ") : subject}
   </commit>\n`
 }

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,146 +1,147 @@
-const childProcess = require("child_process");
+const childProcess = require("child_process")
 
-const initialLog = "<changelog>\n<changelog>";
+const initialLog = "<changelog>\n<changelog>"
 
 // READ XML
 
 function read(path) {
-  const fs = require("fs");
-  try {
-    return fs.readFileSync(path).toString();
-  } catch {
-    return null;
-  }
+    const fs = require("fs")
+    try {
+        return fs.readFileSync(path).toString()
+    } catch {
+        return null
+    }
 }
 
 function getLastCommit(xml) {
-  let result = xml.match(/<commit[^>]+hash="(.*?)"/);
-  return result && result[1];
+    let result = xml.match(/<commit[^>]+hash="(.*?)"/)
+    return result && result[1]
 }
 
 // GENERATE NEW ENTRIES
 
 function extractPRNumber(str) {
-  let result = str.match(/\(#(\d+)\)$/);
-  return result && result[1];
+    let result = str.match(/\(#(\d+)\)$/)
+    return result && result[1]
 }
 
 function parseLogLine(line) {
-  return {
-    hash: line.substr(0, 8),
-    time: line.substr(10, 9),
-    summary: line.substr(20),
-    pr: extractPRNumber(line),
-  };
+    return {
+        hash: line.substr(0, 8),
+        time: line.substr(10, 9),
+        summary: line.substr(20),
+        pr: extractPRNumber(line),
+    }
 }
 
 function getLog(fromCommit) {
-  const range = (fromCommit ? fromCommit + ".." : "");
-  const command = "git --no-pager log --format='%h %at %s' " + range;
+    const range = fromCommit ? fromCommit + ".." : ""
+    const command = "git --no-pager log --format='%h %at %s' " + range
 
-  return childProcess.execSync(command)
-    .toString()
-    .split("\n")
-    .filter(s => s)
-    .map(parseLogLine);
+    return childProcess
+        .execSync(command)
+        .toString()
+        .split("\n")
+        .filter((s) => s)
+        .map(parseLogLine)
 }
 
 function getPullRequest(token, number) {
-  const https = require('https');
+    const https = require("https")
 
-  const url = "https://api.github.com/repos/onivim/oni2/pulls/" + number;
-  const headers = {
-    "User-Agent": "oni-fetch",
-    "Authorization": token && `token ${token}`
-  };
-
-  return new Promise((resolve, reject) => https.get(url, {headers}, response => {
-    if (response.statusCode == 200) {
-      const body = [];
-      response.on('data', (chunk) => body.push(chunk));
-      response.on('end', () => resolve(JSON.parse(body.join(""))));
-    } else {
-       reject(response.statusCode + ": " + response.statusMessage);
+    const url = "https://api.github.com/repos/onivim/oni2/pulls/" + number
+    const headers = {
+        "User-Agent": "oni-fetch",
+        Authorization: token && `token ${token}`,
     }
-  }));
+
+    return new Promise((resolve, reject) =>
+        https.get(url, { headers }, (response) => {
+            if (response.statusCode == 200) {
+                const body = []
+                response.on("data", (chunk) => body.push(chunk))
+                response.on("end", () => resolve(JSON.parse(body.join(""))))
+            } else {
+                reject(response.statusCode + ": " + response.statusMessage)
+            }
+        }),
+    )
 }
 
 function extractLogEntry(pr) {
-  let result = pr.body.match(/```changelog\r?\n((.|[\s\S])*)\r?\n```/);
-  return result && result[1];
+    let result = pr.body.match(/```changelog\r?\n((.|[\s\S])*)\r?\n```/)
+    return result && result[1]
 }
 
 // GENERATE XML
 
 function createCommitXml(commit) {
-  return (
-`  <commit hash="${commit.hash}" pr=${commit.pr} time=${commit.time}>
+    return `  <commit hash="${commit.hash}" pr=${commit.pr} time=${commit.time}>
     ${commit.content.replace(/\n/g, "\n    ")}
-  </commit>\n`);
+  </commit>\n`
 }
 
 function addXmlCommits(xml, commits) {
-  const [before, after] = xml.split(/<changelog>\r?\n/, 2);
+    const [before, after] = xml.split(/<changelog>\r?\n/, 2)
 
-  return before + "<changelog>\n" + commits.join("") + after;
+    return before + "<changelog>\n" + commits.join("") + after
 }
 
 function write(path, content) {
-  const fs = require("fs");
-  fs.writeFileSync(path, content);
+    const fs = require("fs")
+    fs.writeFileSync(path, content)
 }
 
 // MAIN
 
-let path;
-let token;
+let path
+let token
 
-process.argv.slice(2).forEach(arg => {
-  if (arg.startsWith("--token=")) {
-    token = arg.slice("--token=".length);
-  } else if (!arg.startsWith("--")) {
-    path = arg;
-  } else {
-    throw new Error("invalid argument: " + arg);
-  };
-});
+process.argv.slice(2).forEach((arg) => {
+    if (arg.startsWith("--token=")) {
+        token = arg.slice("--token=".length)
+    } else if (!arg.startsWith("--")) {
+        path = arg
+    } else {
+        throw new Error("invalid argument: " + arg)
+    }
+})
 
-const xml = read(path) || initialLog;
-const lastCommitHash = getLastCommit(xml);
+const xml = read(path) || initialLog
+const lastCommitHash = getLastCommit(xml)
 
-console.log("Retrieving commits since " + lastCommitHash);
+console.log("Retrieving commits since " + lastCommitHash)
 
-const commits = getLog(lastCommitHash);
+const commits = getLog(lastCommitHash)
 
 Promise.all(
-  commits
-    .filter(commit => commit.pr)
-    .map(commit => {
-      console.log(`Checking ${commit.hash} / #${commit.pr}`);
-      return getPullRequest(token, commit.pr)
-        .then(pr => {
-          let logEntry = extractLogEntry(pr);
-          return Object.assign({}, commit, {content: logEntry});
-        })
-        .catch(error => {
-          console.error(`Error retrieving PR #${commit.pr} for ${commit.hash}: ${error}`);
-          return Promise.reject(error)
-        })
-    })
+    commits
+        .filter((commit) => commit.pr)
+        .map((commit) => {
+            console.log(`Checking ${commit.hash} / #${commit.pr}`)
+            return getPullRequest(token, commit.pr)
+                .then((pr) => {
+                    let logEntry = extractLogEntry(pr)
+                    return Object.assign({}, commit, { content: logEntry })
+                })
+                .catch((error) => {
+                    console.error(`Error retrieving PR #${commit.pr} for ${commit.hash}: ${error}`)
+                    return Promise.reject(error)
+                })
+        }),
 )
-  .then(commits => {
-    const validCommits = commits.filter(commit => commit && commit.content);
-    
-    console.log("New commits:", validCommits);
+    .then((commits) => {
+        const validCommits = commits.filter((commit) => commit && commit.content)
 
-    const xmlCommits = validCommits.map(createCommitXml);
-    const newXml = addXmlCommits(xml, xmlCommits);
-    
-    console.log("Writing to: " + path);
+        console.log("New commits:", validCommits)
 
-    write(path, newXml);
-    
-    console.log("Done.");
-  })
-  .catch(error => console.error("Failed:", error));
+        const xmlCommits = validCommits.map(createCommitXml)
+        const newXml = addXmlCommits(xml, xmlCommits)
 
+        console.log("Writing to: " + path)
+
+        write(path, newXml)
+
+        console.log("Done.")
+    })
+    .catch((error) => console.error("Failed:", error))

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,3 +1,16 @@
+/**
+ *  Usage:
+ *
+ *      node scripts/generate-changelog.js [--token <token>] <path>
+ *
+ *      where <token> is a GitHub authentication token and <path> is the path to
+ *      the changelog file. Typically assets/changelog.xml.
+ *
+ *      If the changelog file already exists, only commits after the last commit
+ *      in the file will be retrieved and added. Existing commits will not be
+ *      updated.
+ */
+
 const childProcess = require("child_process")
 
 const initialLog = "<changelog>\n<changelog>"

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,0 +1,146 @@
+const childProcess = require("child_process");
+
+const initialLog = "<changelog>\n<changelog>";
+
+// READ XML
+
+function read(path) {
+  const fs = require("fs");
+  try {
+    return fs.readFileSync(path).toString();
+  } catch {
+    return null;
+  }
+}
+
+function getLastCommit(xml) {
+  let result = xml.match(/<commit[^>]+hash="(.*?)"/);
+  return result && result[1];
+}
+
+// GENERATE NEW ENTRIES
+
+function extractPRNumber(str) {
+  let result = str.match(/\(#(\d+)\)$/);
+  return result && result[1];
+}
+
+function parseLogLine(line) {
+  return {
+    hash: line.substr(0, 8),
+    time: line.substr(10, 9),
+    summary: line.substr(20),
+    pr: extractPRNumber(line),
+  };
+}
+
+function getLog(fromCommit) {
+  const range = (fromCommit ? fromCommit + ".." : "");
+  const command = "git --no-pager log --format='%h %at %s' " + range;
+
+  return childProcess.execSync(command)
+    .toString()
+    .split("\n")
+    .filter(s => s)
+    .map(parseLogLine);
+}
+
+function getPullRequest(token, number) {
+  const https = require('https');
+
+  const url = "https://api.github.com/repos/onivim/oni2/pulls/" + number;
+  const headers = {
+    "User-Agent": "oni-fetch",
+    "Authorization": token && `token ${token}`
+  };
+
+  return new Promise((resolve, reject) => https.get(url, {headers}, response => {
+    if (response.statusCode == 200) {
+      const body = [];
+      response.on('data', (chunk) => body.push(chunk));
+      response.on('end', () => resolve(JSON.parse(body.join(""))));
+    } else {
+       reject(response.statusCode + ": " + response.statusMessage);
+    }
+  }));
+}
+
+function extractLogEntry(pr) {
+  let result = pr.body.match(/```changelog\r?\n((.|[\s\S])*)\r?\n```/);
+  return result && result[1];
+}
+
+// GENERATE XML
+
+function createCommitXml(commit) {
+  return (
+`  <commit hash="${commit.hash}" pr=${commit.pr} time=${commit.time}>
+    ${commit.content.replace(/\n/g, "\n    ")}
+  </commit>\n`);
+}
+
+function addXmlCommits(xml, commits) {
+  const [before, after] = xml.split(/<changelog>\r?\n/, 2);
+
+  return before + "<changelog>\n" + commits.join("") + after;
+}
+
+function write(path, content) {
+  const fs = require("fs");
+  fs.writeFileSync(path, content);
+}
+
+// MAIN
+
+let path;
+let token;
+
+process.argv.slice(2).forEach(arg => {
+  if (arg.startsWith("--token=")) {
+    token = arg.slice("--token=".length);
+  } else if (!arg.startsWith("--")) {
+    path = arg;
+  } else {
+    throw new Error("invalid argument: " + arg);
+  };
+});
+
+const xml = read(path) || initialLog;
+const lastCommitHash = getLastCommit(xml);
+
+console.log("Retrieving commits since " + lastCommitHash);
+
+const commits = getLog(lastCommitHash);
+
+Promise.all(
+  commits
+    .filter(commit => commit.pr)
+    .map(commit => {
+      console.log(`Checking ${commit.hash} / #${commit.pr}`);
+      return getPullRequest(token, commit.pr)
+        .then(pr => {
+          let logEntry = extractLogEntry(pr);
+          return Object.assign({}, commit, {content: logEntry});
+        })
+        .catch(error => {
+          console.error(`Error retrieving PR #${commit.pr} for ${commit.hash}: ${error}`);
+          return Promise.reject(error)
+        })
+    })
+)
+  .then(commits => {
+    const validCommits = commits.filter(commit => commit && commit.content);
+    
+    console.log("New commits:", validCommits);
+
+    const xmlCommits = validCommits.map(createCommitXml);
+    const newXml = addXmlCommits(xml, xmlCommits);
+    
+    console.log("Writing to: " + path);
+
+    write(path, newXml);
+    
+    console.log("Done.");
+  })
+  .catch(error => console.error("Failed:", error));
+

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -91,26 +91,151 @@ let read = () => {
   };
 };
 
+let isSameDate = (a, b) => {
+  let a = Unix.localtime(a);
+  let b = Unix.localtime(b);
+
+  a.tm_year == b.tm_year && a.tm_yday == b.tm_yday;
+};
+
 module View = {
   open Revery.UI;
+  open Revery.UI.Components;
+
+  module Colors = Feature_Theme.Colors;
 
   module Styles = {
     open Style;
 
-    let text = (font: UiFont.t) => [fontFamily(font.fontFile)];
+    let container = [
+      position(`Absolute),
+      top(0),
+      left(0),
+      bottom(0),
+      right(0),
+      padding(10),
+    ];
+
+    let commit = [flexDirection(`Row)];
+
+    let groupHeader = (font: UiFont.t) => [
+      fontFamily(font.fontFile),
+      fontSize(16.),
+      marginTop(4),
+    ];
+
+    let groupBody = [paddingLeft(10)];
+
+    let typ = (font: UiFont.t, ~color) => [
+      fontFamily(font.fontFile),
+      fontSize(12.),
+      Style.color(color),
+      width(80),
+    ];
+
+    let scope = (font: UiFont.t, ~theme) => [
+      fontFamily(font.fontFile),
+      fontSize(12.),
+      color(Revery.Colors.grey),
+      width(130),
+      color(
+        Colors.foreground.from(theme) |> Revery.Color.multiplyAlpha(0.75),
+      ),
+    ];
+
+    let summary = (font: UiFont.t, ~theme) => [
+      fontFamily(font.fontFile),
+      fontSize(12.),
+      color(Colors.foreground.from(theme)),
+    ];
+
+    let error = (font: UiFont.t) => [fontFamily(font.fontFile)];
+  };
+
+  let date = (~commit, ~style, ()) => {
+    let time = Unix.localtime(commit.time);
+    let text =
+      Printf.sprintf(
+        "%u-%02u-%02u",
+        time.tm_year + 1900,
+        time.tm_mon + 1,
+        time.tm_mday,
+      );
+    <Text style text />;
+  };
+
+  let typ = (~commit, ~uiFont, ~theme, ()) => {
+    let text =
+      switch (commit.typ) {
+      | Some("feat") => "feature"
+      | Some("fix") => "bugfix"
+      | Some("perf") => "performance"
+      | Some(other) => other
+      | None => "unknown"
+      };
+
+    let color =
+      switch (commit.typ) {
+      | Some("feat") => Colors.Oni.visualModeBackground.from(theme)
+      | Some("fix") => Colors.Oni.operatorModeBackground.from(theme)
+      | Some("perf") => Colors.Oni.normalModeBackground.from(theme)
+      | _ => Colors.foreground.from(theme)
+      };
+
+    <Text style={Styles.typ(uiFont, ~color)} text />;
+  };
+
+  let scope = (~commit, ~uiFont, ~theme, ()) => {
+    let text =
+      switch (commit.scope) {
+      | Some(scope) => scope
+      | None => "other"
+      };
+
+    <Text style={Styles.scope(uiFont, ~theme)} text />;
+  };
+
+  let summary = (~commit, ~uiFont, ~theme, ()) => {
+    <Text style={Styles.summary(uiFont, ~theme)} text={commit.summary} />;
   };
 
   module Full = {
-    let make = (~font, ()) => {
+    let line = (~commit, ~uiFont, ~theme, ()) => {
+      <View style=Styles.commit>
+        <typ commit uiFont theme />
+        <scope commit uiFont theme />
+        <summary commit uiFont theme />
+      </View>;
+    };
+
+    let group = (~commits, ~uiFont, ~theme, ()) => {
+      <View>
+        <date commit={List.hd(commits)} style={Styles.groupHeader(uiFont)} />
+        <View style=Styles.groupBody>
+          {commits
+           |> List.map(commit => <line commit uiFont theme />)
+           |> React.listToElement}
+        </View>
+      </View>;
+    };
+
+    let make = (~theme, ~uiFont, ~editorFont as _, ()) => {
+      let isSignificantCommit = commit =>
+        switch (commit.typ) {
+        | Some("feat" | "fix" | "perf") => true
+        | _ => false
+        };
+
       switch (read()) {
       | Ok(commits) =>
-        commits
-        |> List.map(commit => {
-             let text = Printf.sprintf("%s: %s", commit.hash, commit.summary);
-             <Text style={Styles.text(font)} text />;
-           })
-        |> React.listToElement
-      | Error(message) => <Text style={Styles.text(font)} text=message />
+        <ScrollView style=Styles.container>
+          {commits
+           |> List.filter(isSignificantCommit)
+           |> Base.List.group(~break=(a, b) => !isSameDate(a.time, b.time))
+           |> List.map(commits => <group commits uiFont theme />)
+           |> React.listToElement}
+        </ScrollView>
+      | Error(message) => <Text style={Styles.error(uiFont)} text=message />
       };
     };
   };

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -127,7 +127,7 @@ module View = {
       overflow(`Hidden),
     ];
 
-    let commit = [flexDirection(`Row), marginTop(6)];
+    let commit = [flexDirection(`Row), marginTop(10)];
 
     let groupHeader = (font: UiFont.t, ~theme) => [
       fontFamily(font.fontFile),

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -160,6 +160,8 @@ module View = {
       color(Colors.foreground.from(theme)),
     ];
 
+    let breakingCommit = [marginTop(10), marginBottom(6)];
+
     let breaking = [flexDirection(`Row), marginTop(4)];
 
     let breakingText = (font: UiFont.t, ~theme) => [
@@ -295,7 +297,7 @@ module View = {
         };
 
         let commit = (~item, ~uiFont, ~theme, ()) => {
-          <View>
+          <View style=Styles.breakingCommit>
             <Text
               text={item.summary |> Base.String.split(~on='\n') |> List.hd}
               style={Styles.summary(uiFont, ~theme)}

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -1,0 +1,117 @@
+open Oni_Core;
+
+module Log = (val Log.withNamespace("Oni2.Feature.Changelog"));
+
+type commit = {
+  hash: string,
+  time: float,
+  pr: option(int),
+  typ: option(string),
+  scope: option(string),
+  summary: string,
+  breaking: list(string),
+};
+
+type model =
+  | NotLoaded
+  | Loaded(list(commit))
+  | Error(string);
+
+type simpleXml =
+  | Element(string, list((string, string)), list(simpleXml))
+  | Text(string);
+
+let read = () => {
+  let simplify = stream =>
+    stream
+    |> Markup.trim
+    |> Markup.tree(
+         ~text=strings => Text(strings |> String.concat("")),
+         ~element=
+           ((_ns, name), attrs, children) => {
+             let attrs =
+               List.map((((_ns, name), value)) => (name, value), attrs);
+             Element(name, attrs, children);
+           },
+       )
+    |> Option.get;
+
+  let parseCommit =
+    fun
+    | Element("commit", attrs, children) => {
+        let hash =
+          try(List.assoc("hash", attrs)) {
+          | Not_found => failwith("hash is required")
+          };
+        let time =
+          try(List.assoc("time", attrs) |> float_of_string) {
+          | Not_found => failwith("time is required")
+          };
+        let pr = List.assoc_opt("pr", attrs) |> Option.map(int_of_string);
+        let typ = List.assoc_opt("type", attrs);
+        let scope = List.assoc_opt("scope", attrs);
+
+        let commit = {hash, time, pr, typ, scope, summary: "", breaking: []};
+
+        List.fold_left(
+          commit =>
+            fun
+            | Text(summary) => {
+                ...commit,
+                summary: commit.summary ++ summary,
+              }
+            | Element("breaking", _, [Text(text)]) => {
+                ...commit,
+                breaking: [text, ...commit.breaking],
+              }
+            | Element(name, _, _) => {
+                Log.warnf(m => m("Unexpected element %s in summary", name));
+                commit;
+              },
+          commit,
+          children,
+        );
+      }
+    | Element(_) => failwith("Unexpected element")
+    | Text(_) => failwith("Unexpected text node");
+
+  let parse =
+    fun
+    | Element("changelog", _, children) => List.map(parseCommit, children)
+    | Element(_) => failwith("Unexpected element")
+    | Text(_) => failwith("Unexpected text node");
+
+  let path = Revery.Environment.getAssetPath("changelog.xml");
+  let simpleXml =
+    Markup.file(path) |> fst |> Markup.parse_xml |> Markup.signals |> simplify;
+
+  switch (parse(simpleXml)) {
+  | commits => Ok(commits)
+  | exception (Failure(message)) => Error(message)
+  };
+};
+
+module View = {
+  open Revery.UI;
+
+  module Styles = {
+    open Style;
+
+    let text = (font: UiFont.t) => [fontFamily(font.fontFile)];
+  };
+
+  module Full = {
+    let make = (~font, ()) => {
+      switch (read()) {
+      | Ok(commits) =>
+        commits
+        |> List.map(commit => {
+             let text = Printf.sprintf("%s: %s", commit.hash, commit.summary);
+             <Text style={Styles.text(font)} text />;
+           })
+        |> React.listToElement
+      | Error(message) => <Text style={Styles.text(font)} text=message />
+      };
+    };
+  };
+};

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -117,14 +117,13 @@ module View = {
       overflow(`Hidden),
     ];
 
-    let commit = [flexDirection(`Row)];
+    let commit = [flexDirection(`Row), marginTop(6)];
 
     let groupHeader = (font: UiFont.t, ~theme) => [
       fontFamily(font.fontFile),
       fontSize(16.),
       color(Colors.foreground.from(theme)),
-      marginTop(12),
-      marginBottom(4),
+      marginTop(16),
     ];
 
     let groupBody = [paddingLeft(10)];

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -122,6 +122,13 @@ module View = {
       overflow(`Hidden),
     ];
 
+    let header = (font: UiFont.t, ~theme) => [
+      fontFamily(font.fontFile),
+      fontSize(20.),
+      color(Colors.foreground.from(theme)),
+      marginTop(16),
+    ];
+
     let commit = [flexDirection(`Row), marginTop(10)];
 
     let groupHeader = (font: UiFont.t, ~theme) => [
@@ -251,6 +258,7 @@ module View = {
       | Ok(commits) =>
         <ScrollView style=Styles.scrollContainer>
           <View style=Styles.content>
+            <Text text="Changelog" style={Styles.header(uiFont, ~theme)} />
             {commits
              |> List.filter(isSignificantCommit)
              |> Base.List.group(~break=(a, b) =>
@@ -384,6 +392,10 @@ module View = {
 
         <ScrollView style=Styles.scrollContainer>
           <View style=Styles.content>
+            <Text
+              text={"Changes since " ++ since}
+              style={Styles.header(uiFont, ~theme)}
+            />
             <Parts.Breaking items=breaking uiFont theme />
             <Parts.Features items=features uiFont theme />
             <Parts.Fixes items=fixes uiFont theme />

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -297,7 +297,7 @@ module View = {
         let commit = (~item, ~uiFont, ~theme, ()) => {
           <View>
             <Text
-              text={item.summary}
+              text={item.summary |> Base.String.split(~on='\n') |> List.hd}
               style={Styles.summary(uiFont, ~theme)}
             />
             {item.breaking

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -1,4 +1,5 @@
 open Oni_Core;
+open Utility;
 
 module Log = (val Log.withNamespace("Oni2.Feature.Changelog"));
 
@@ -10,6 +11,7 @@ type commit = {
   pr: option(int),
   typ: option(string),
   scope: option(string),
+  issue: option(int),
   summary: string,
   breaking: list(string),
 };
@@ -53,11 +55,24 @@ let read = () => {
           try(List.assoc("time", attrs) |> float_of_string) {
           | Not_found => failwith("time is required")
           };
-        let pr = List.assoc_opt("pr", attrs) |> Option.map(int_of_string);
+        let pr =
+          List.assoc_opt("pr", attrs) |> OptionEx.flatMap(int_of_string_opt);
         let typ = List.assoc_opt("type", attrs);
         let scope = List.assoc_opt("scope", attrs);
+        let issue =
+          List.assoc_opt("issue", attrs)
+          |> OptionEx.flatMap(int_of_string_opt);
 
-        let commit = {hash, time, pr, typ, scope, summary: "", breaking: []};
+        let commit = {
+          hash,
+          time,
+          pr,
+          typ,
+          scope,
+          issue,
+          summary: "",
+          breaking: [],
+        };
 
         List.fold_left(
           commit =>

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -396,9 +396,20 @@ module View = {
               text={"Changes since " ++ since}
               style={Styles.header(uiFont, ~theme)}
             />
-            <Parts.Breaking items=breaking uiFont theme />
-            <Parts.Features items=features uiFont theme />
-            <Parts.Fixes items=fixes uiFont theme />
+            {if (breaking == [] && features == [] && fixes == []) {
+               <Text text="Nothing" style={Styles.summary(uiFont, ~theme)} />;
+             } else {
+               React.listToElement([
+                 breaking == []
+                   ? React.empty
+                   : <Parts.Breaking items=breaking uiFont theme />,
+                 features == []
+                   ? React.empty
+                   : <Parts.Features items=features uiFont theme />,
+                 fixes == []
+                   ? React.empty : <Parts.Fixes items=fixes uiFont theme />,
+               ]);
+             }}
           </View>
         </ScrollView>;
 

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -362,9 +362,20 @@ module View = {
 
     // Update.make
 
-    let make = (~theme, ~uiFont, ()) => {
+    let make = (~since, ~theme, ~uiFont, ()) => {
       switch (Lazy.force(model)) {
       | Ok(commits) =>
+        let commits =
+          List.fold_right(
+            commit =>
+              fun
+              | None when since == commit.hash => Some([])
+              | None => None
+              | Some(commits) => Some([commit, ...commits]),
+            commits,
+            None,
+          )
+          |> Option.value(~default=commits);
         let breaking = commits |> List.filter(commit => commit.breaking != []);
         let features =
           commits |> List.filter(({typ, _}) => typ == Some("feat"));

--- a/src/Feature/Changelog/Feature_Changelog.re
+++ b/src/Feature/Changelog/Feature_Changelog.re
@@ -14,11 +14,6 @@ type commit = {
   breaking: list(string),
 };
 
-type model =
-  | NotLoaded
-  | Loaded(list(commit))
-  | Error(string);
-
 type simpleXml =
   | Element(string, list((string, string)), list(simpleXml))
   | Text(string);

--- a/src/Feature/Changelog/Feature_Changelog.rei
+++ b/src/Feature/Changelog/Feature_Changelog.rei
@@ -1,0 +1,15 @@
+open Oni_Core;
+open Revery.UI;
+
+module View: {
+  module Full: {
+    let make:
+      (~theme: ColorTheme.Colors.t, ~uiFont: UiFont.t, unit) => element;
+  };
+
+  module Update: {
+    let make:
+      (~since: string, ~theme: ColorTheme.Colors.t, ~uiFont: UiFont.t, unit) =>
+      element;
+  };
+};

--- a/src/Feature/Changelog/dune
+++ b/src/Feature/Changelog/dune
@@ -1,0 +1,10 @@
+(library
+    (name Feature_Changelog)
+    (public_name Oni2.feature.changelog)
+    (libraries 
+      Oni2.core
+      Oni2.feature.theme
+      Revery
+      isolinear
+    )
+    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Changelog/dune
+++ b/src/Feature/Changelog/dune
@@ -3,6 +3,7 @@
     (public_name Oni2.feature.changelog)
     (libraries 
       Oni2.core
+      Oni2.components
       Oni2.feature.theme
       Revery
       isolinear

--- a/src/Model/BufferRenderer.re
+++ b/src/Model/BufferRenderer.re
@@ -15,7 +15,8 @@ type t =
   | Editor
   | Welcome
   | Version
-  | Changelog
+  | FullChangelog
+  | UpdateChangelog
   | Terminal(Feature_Terminal.rendererState);
 
 [@deriving show({with_path: false})]

--- a/src/Model/BufferRenderer.re
+++ b/src/Model/BufferRenderer.re
@@ -16,7 +16,7 @@ type t =
   | Welcome
   | Version
   | FullChangelog
-  | UpdateChangelog
+  | UpdateChangelog({since: string})
   | Terminal(Feature_Terminal.rendererState);
 
 [@deriving show({with_path: false})]

--- a/src/Model/BufferRenderer.re
+++ b/src/Model/BufferRenderer.re
@@ -15,6 +15,7 @@ type t =
   | Editor
   | Welcome
   | Version
+  | Changelog
   | Terminal(Feature_Terminal.rendererState);
 
 [@deriving show({with_path: false})]

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -76,6 +76,14 @@ module List = {
 };
 
 module Oni = {
+  let changelog =
+    register(
+      ~category="Help",
+      ~title="Open changelog",
+      "oni.changelog",
+      Command("oni.changelog"),
+    );
+
   module Explorer = {
     let toggle =
       register(

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -106,6 +106,22 @@ let start = () => {
       };
     });
 
+  let openChangelogEffect = _ =>
+    Isolinear.Effect.createWithDispatch(~name="oni.changelog", dispatch => {
+      Vim.init();
+      let _: unit = Vim.command("e oni://Changelog");
+
+      let bufferId = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
+      dispatch(
+        Actions.BufferRenderer(
+          BufferRenderer.RendererAvailable(
+            bufferId,
+            BufferRenderer.FullChangelog,
+          ),
+        ),
+      );
+    });
+
   let commands = [
     ("system.addToPath", _ => togglePathEffect),
     ("system.removeFromPath", _ => togglePathEffect),
@@ -128,6 +144,7 @@ let start = () => {
       "workbench.action.zoomReset",
       state => zoomEffect(state, _zoom => Constants.defaultZoomValue),
     ),
+    ("oni.changelog", _ => openChangelogEffect),
   ];
 
   let commandMap =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -525,15 +525,36 @@ let start =
   let initEffect =
     Isolinear.Effect.create(~name="vim.init", () => {
       Vim.init();
-      let _ = Vim.command("e oni://Welcome");
-      hasInitialized := true;
 
-      let bufferId = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
-      dispatch(
-        Actions.BufferRenderer(
-          BufferRenderer.RendererAvailable(bufferId, BufferRenderer.Welcome),
-        ),
-      );
+      if (Core.BuildInfo.commitId == Persistence.Global.version()) {
+        let _ = Vim.command("e oni://Welcome");
+        hasInitialized := true;
+
+        let bufferId = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
+        dispatch(
+          Actions.BufferRenderer(
+            BufferRenderer.RendererAvailable(
+              bufferId,
+              BufferRenderer.Welcome,
+            ),
+          ),
+        );
+      } else {
+        let _ = Vim.command("e oni://UpdateChangelog");
+        hasInitialized := true;
+
+        let bufferId = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
+        dispatch(
+          Actions.BufferRenderer(
+            BufferRenderer.RendererAvailable(
+              bufferId,
+              BufferRenderer.UpdateChangelog({
+                since: Persistence.Global.version(),
+              }),
+            ),
+          ),
+        );
+      };
     });
 
   let currentBufferId: ref(option(int)) = ref(None);

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -144,7 +144,9 @@ module Parts = {
 
       | Version => <VersionView theme uiFont editorFont />
 
-      | Changelog => <Feature_Changelog.View.Full theme uiFont />
+      | FullChangelog => <Feature_Changelog.View.Full theme uiFont />
+
+      | UpdateChangelog => <Feature_Changelog.View.Update theme uiFont />
       };
     };
   };

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -132,8 +132,9 @@ let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
           );
         let renderer =
           BufferRenderers.getById(editor.bufferId, state.bufferRenderers);
+
         switch (renderer) {
-        | BufferRenderer.Terminal({insertMode, _}) when !insertMode =>
+        | Terminal({insertMode, _}) when !insertMode =>
           let buffer =
             Selectors.getBufferForEditor(state, editor)
             |> Option.value(~default=Buffer.initial);
@@ -164,7 +165,7 @@ let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
             windowIsFocused={state.windowIsFocused}
             config={Feature_Configuration.resolver(state.config)}
           />;
-        | BufferRenderer.Editor =>
+        | Editor =>
           let buffer =
             Selectors.getBufferForEditor(state, editor)
             |> Option.value(~default=Buffer.initial);
@@ -187,9 +188,10 @@ let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
             windowIsFocused={state.windowIsFocused}
             config={Feature_Configuration.resolver(state.config)}
           />;
-        | BufferRenderer.Welcome => <WelcomeView theme uiFont editorFont />
-        | BufferRenderer.Version => <VersionView theme uiFont editorFont />
-        | BufferRenderer.Terminal({id, _}) =>
+        | Welcome => <WelcomeView theme uiFont editorFont />
+        | Version => <VersionView theme uiFont editorFont />
+        | Changelog => <Feature_Changelog.View.Full theme uiFont editorFont />
+        | Terminal({id, _}) =>
           state.terminals
           |> Feature_Terminal.getTerminalOpt(id)
           |> Option.map(terminal => {
@@ -197,6 +199,7 @@ let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
              })
           |> Option.value(~default=React.empty)
         };
+
       | None => React.empty
       };
 

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -146,7 +146,8 @@ module Parts = {
 
       | FullChangelog => <Feature_Changelog.View.Full theme uiFont />
 
-      | UpdateChangelog => <Feature_Changelog.View.Update theme uiFont />
+      | UpdateChangelog({since}) =>
+        <Feature_Changelog.View.Update since theme uiFont />
       };
     };
   };

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -1,40 +1,19 @@
-/*
- * Editor.re
- *
- * Editor component - an 'Editor' encapsulates the following:
- * - a 'tabbar'
- * - an editor surface - usually a textual buffer view
- */
-
 open Revery.UI;
 open Oni_Core;
 open Oni_Model;
+open Actions;
 module Model = Oni_Model;
 
 module Colors = Feature_Theme.Colors;
 module EditorSurface = Feature_Editor.EditorSurface;
 
-let noop = () => ();
-
-let editorViewStyle = (background, foreground) =>
-  Style.[
-    backgroundColor(background),
-    color(foreground),
-    position(`Absolute),
-    top(0),
-    left(0),
-    right(0),
-    bottom(0),
-    flexDirection(`Column),
-  ];
-
 let getBufferMetadata = (buffer: option(Buffer.t)) => {
   switch (buffer) {
   | None => (false, "untitled", "untitled")
-  | Some(v) =>
+  | Some(buffer) =>
     let filePath =
-      Buffer.getFilePath(v) |> Option.value(~default="untitled");
-    let modified = Buffer.isModified(v);
+      Buffer.getFilePath(buffer) |> Option.value(~default="untitled");
+    let modified = Buffer.isModified(buffer);
 
     let title = filePath |> Filename.basename;
     (modified, title, filePath);
@@ -50,50 +29,147 @@ let toUiTabs =
   let f = (id: int) => {
     switch (Model.EditorGroup.getEditorById(id, editorGroup)) {
     | None => None
-    | Some(v) =>
+    | Some(editor) =>
       let (modified, title, filePath) =
-        Model.Buffers.getBuffer(v.bufferId, buffers) |> getBufferMetadata;
+        Model.Buffers.getBuffer(editor.bufferId, buffers) |> getBufferMetadata;
 
-      let renderer = Model.BufferRenderers.getById(v.bufferId, renderers);
+      let renderer =
+        Model.BufferRenderers.getById(editor.bufferId, renderers);
 
-      let ret: Tabs.tabInfo = {
-        editorId: v.editorId,
-        filePath,
-        title,
-        modified,
-        renderer,
-      };
-      Some(ret);
+      Some(
+        Tabs.{editorId: editor.editorId, filePath, title, modified, renderer},
+      );
     };
   };
 
   List.filter_map(f, editorGroup.reverseTabOrder) |> List.rev;
 };
 
-let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
-  let State.{vimMode: mode, uiFont, editorFont, _} = state;
+module Parts = {
+  module Editor = {
+    let make =
+        (
+          ~editor,
+          ~state: State.t,
+          ~theme,
+          ~isActive,
+          ~backgroundColor=?,
+          ~foregroundColor=?,
+          ~showDiffMarkers=true,
+          (),
+        ) => {
+      let buffer =
+        Selectors.getBufferForEditor(state, editor)
+        |> Option.value(~default=Buffer.initial);
 
-  let style =
-    editorViewStyle(
-      Colors.Editor.background.from(theme),
-      Colors.foreground.from(theme),
-    );
+      let onEditorSizeChanged = (editorId, pixelWidth, pixelHeight) =>
+        GlobalContext.current().dispatch(
+          EditorSizeChanged({id: editorId, pixelWidth, pixelHeight}),
+        );
+      let onScroll = deltaY =>
+        GlobalContext.current().editorScrollDelta(
+          ~editorId=editor.editorId,
+          ~deltaY,
+          (),
+        );
+      let onCursorChange = cursor =>
+        GlobalContext.current().dispatch(
+          EditorCursorMove(editor.editorId, [cursor]),
+        );
+
+      <EditorSurface
+        ?backgroundColor
+        ?foregroundColor
+        showDiffMarkers
+        isActiveSplit=isActive
+        editor
+        buffer
+        onCursorChange
+        onEditorSizeChanged
+        onScroll
+        theme
+        mode={state.vimMode}
+        bufferHighlights={state.bufferHighlights}
+        bufferSyntaxHighlights={state.syntaxHighlights}
+        diagnostics={state.diagnostics}
+        completions={state.completions}
+        tokenTheme={state.tokenTheme}
+        definition={state.definition}
+        windowIsFocused={state.windowIsFocused}
+        config={Feature_Configuration.resolver(state.config)}
+      />;
+    };
+  };
+
+  module EditorContainer = {
+    let make =
+        (
+          ~editor: Feature_Editor.Editor.t,
+          ~state: State.t,
+          ~theme,
+          ~isActive,
+          (),
+        ) => {
+      let State.{uiFont, editorFont, _} = state;
+
+      let renderer =
+        BufferRenderers.getById(editor.bufferId, state.bufferRenderers);
+
+      switch (renderer) {
+      | Terminal({insertMode, _}) when !insertMode =>
+        let backgroundColor = Feature_Terminal.defaultBackground(theme);
+        let foregroundColor = Feature_Terminal.defaultForeground(theme);
+
+        <Editor
+          editor
+          state
+          theme
+          isActive
+          backgroundColor
+          foregroundColor
+          showDiffMarkers=false
+        />;
+
+      | Terminal({id, _}) =>
+        state.terminals
+        |> Feature_Terminal.getTerminalOpt(id)
+        |> Option.map(terminal => {
+             <TerminalView theme font={state.terminalFont} terminal />
+           })
+        |> Option.value(~default=React.empty)
+
+      | Editor => <Editor editor state theme isActive />
+
+      | Welcome => <WelcomeView theme uiFont editorFont />
+
+      | Version => <VersionView theme uiFont editorFont />
+
+      | Changelog => <Feature_Changelog.View.Full theme uiFont />
+      };
+    };
+  };
+};
+
+module Styles = {
+  open Style;
+
+  let container = theme => [
+    backgroundColor(Colors.Editor.background.from(theme)),
+    color(Colors.foreground.from(theme)),
+    position(`Absolute),
+    top(0),
+    left(0),
+    right(0),
+    bottom(0),
+  ];
+
+  let editorContainer = [flexGrow(1), flexDirection(`Column)];
+};
+
+let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
+  let State.{vimMode: mode, uiFont, _} = state;
 
   let isActive = EditorGroups.isActive(state.editorGroups, editorGroup);
-
-  let overlayStyle =
-    Style.[
-      position(`Absolute),
-      top(0),
-      left(0),
-      right(0),
-      bottom(0),
-      pointerEvents(`Ignore),
-      backgroundColor(Revery.Color.rgba(0., 0., 0., isActive ? 0. : 0.1)),
-    ];
-
-  let absoluteStyle =
-    Style.[position(`Absolute), top(0), left(0), right(0), bottom(0)];
 
   let showTabs =
     if (state.zenMode) {
@@ -106,130 +182,35 @@ let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
     };
 
   let children = {
-    let maybeEditor = EditorGroup.getActiveEditor(editorGroup);
-    let tabs = toUiTabs(editorGroup, state.buffers, state.bufferRenderers);
-
-    let onEditorSizeChanged = (editorId, pixelWidth, pixelHeight) =>
-      GlobalContext.current().dispatch(
-        Actions.EditorSizeChanged({id: editorId, pixelWidth, pixelHeight}),
-      );
-
-    let editorView =
-      switch (maybeEditor) {
-      | Some(editor) =>
-        let onScroll = deltaY => {
-          let () =
-            GlobalContext.current().editorScrollDelta(
-              ~editorId=editor.editorId,
-              ~deltaY,
-              (),
-            );
-          ();
-        };
-        let onCursorChange = cursor =>
-          GlobalContext.current().dispatch(
-            Actions.EditorCursorMove(editor.editorId, [cursor]),
-          );
-        let renderer =
-          BufferRenderers.getById(editor.bufferId, state.bufferRenderers);
-
-        switch (renderer) {
-        | Terminal({insertMode, _}) when !insertMode =>
-          let buffer =
-            Selectors.getBufferForEditor(state, editor)
-            |> Option.value(~default=Buffer.initial);
-
-          let defaultTerminalBackground =
-            Feature_Terminal.defaultBackground(theme);
-          let defaultTerminalForeground =
-            Feature_Terminal.defaultForeground(theme);
-
-          <EditorSurface
-            backgroundColor=defaultTerminalBackground
-            foregroundColor=defaultTerminalForeground
-            showDiffMarkers=false
-            isActiveSplit=isActive
-            editor
-            buffer
-            onCursorChange
-            onEditorSizeChanged
-            onScroll
-            theme
-            mode
-            bufferHighlights={state.bufferHighlights}
-            bufferSyntaxHighlights={state.syntaxHighlights}
-            diagnostics={state.diagnostics}
-            completions={state.completions}
-            tokenTheme={state.tokenTheme}
-            definition={state.definition}
-            windowIsFocused={state.windowIsFocused}
-            config={Feature_Configuration.resolver(state.config)}
-          />;
-        | Editor =>
-          let buffer =
-            Selectors.getBufferForEditor(state, editor)
-            |> Option.value(~default=Buffer.initial);
-
-          <EditorSurface
-            isActiveSplit=isActive
-            editor
-            buffer
-            onCursorChange
-            onEditorSizeChanged
-            onScroll
-            theme
-            mode
-            bufferHighlights={state.bufferHighlights}
-            bufferSyntaxHighlights={state.syntaxHighlights}
-            diagnostics={state.diagnostics}
-            completions={state.completions}
-            tokenTheme={state.tokenTheme}
-            definition={state.definition}
-            windowIsFocused={state.windowIsFocused}
-            config={Feature_Configuration.resolver(state.config)}
-          />;
-        | Welcome => <WelcomeView theme uiFont editorFont />
-        | Version => <VersionView theme uiFont editorFont />
-        | Changelog => <Feature_Changelog.View.Full theme uiFont editorFont />
-        | Terminal({id, _}) =>
-          state.terminals
-          |> Feature_Terminal.getTerminalOpt(id)
-          |> Option.map(terminal => {
-               <TerminalView theme font={state.terminalFont} terminal />
-             })
-          |> Option.value(~default=React.empty)
-        };
-
+    let editorContainer =
+      switch (EditorGroup.getActiveEditor(editorGroup)) {
+      | Some(editor) => <Parts.EditorContainer editor state theme isActive />
       | None => React.empty
       };
 
-    switch (showTabs) {
-    | false => editorView
-    | true =>
-      React.listToElement([
+    if (showTabs) {
+      let tabs =
         <Tabs
           active=isActive
           activeEditorId={editorGroup.activeEditorId}
           theme
-          tabs
+          tabs={toUiTabs(editorGroup, state.buffers, state.bufferRenderers)}
           mode
           uiFont
           languageInfo={state.languageInfo}
           iconTheme={state.iconTheme}
-        />,
-        editorView,
-      ])
+        />;
+
+      <View style=Styles.editorContainer> tabs editorContainer </View>;
+    } else {
+      editorContainer;
     };
   };
 
-  let onMouseDown = _ => {
+  let onMouseDown = _ =>
     GlobalContext.current().dispatch(
       EditorGroupSelected(editorGroup.editorGroupId),
     );
-  };
 
-  <View onMouseDown style>
-    <View style=absoluteStyle> children </View>
-    <View style=overlayStyle />
-  </View>;
+  <View onMouseDown style={Styles.container(theme)}> children </View>;
 };

--- a/src/UI/dune
+++ b/src/UI/dune
@@ -19,6 +19,7 @@
         Oni2.feature.scm
         Oni2.feature.modals
         Oni2.feature.layout
+        Oni2.feature.changelog
         Rench
         Revery
         revery-terminal.lib

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,9 +1,5 @@
 {
-<<<<<<< HEAD
-  "checksum": "a211032fb68a10e94406ce3c9465b157",
-=======
-  "checksum": "a90109aacd9ccf2c1726b91f4c5a9c7d",
->>>>>>> 3739194e... Dependency: add markup
+  "checksum": "3e65c499389f296243bda186e15855b6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -217,7 +213,7 @@
         "refmterr@3.3.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:3.0.0@50f5dee6",
+        "@opam/lambda-term@opam:3.0.1@161f34f6",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.1@a0c1e658",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -1204,17 +1200,10 @@
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-<<<<<<< HEAD
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/luv@opam:0.5.2@bfb5a32a",
-        "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
-        "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
-=======
         "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/luv@opam:0.5.2@bfb5a32a", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fs@github:facebookexperimental/reason-native:fs.opam#bb80cbc@d41d8cd9",
-        "@opam/fp@github:facebookexperimental/reason-native:fp.opam#bb80cbc@d41d8cd9",
->>>>>>> 3739194e... Dependency: add markup
+        "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
+        "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658",
@@ -2702,20 +2691,20 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
-    "@opam/lambda-term@opam:3.0.0@50f5dee6": {
-      "id": "@opam/lambda-term@opam:3.0.0@50f5dee6",
+    "@opam/lambda-term@opam:3.0.1@161f34f6": {
+      "id": "@opam/lambda-term@opam:3.0.1@161f34f6",
       "name": "@opam/lambda-term",
-      "version": "opam:3.0.0",
+      "version": "opam:3.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/3e/3ee0d8b6cb31f20a07fcbf34990f8a4b#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b",
-          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz#md5:3ee0d8b6cb31f20a07fcbf34990f8a4b"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a5537057f8830783e9b17a7d40f4e644#md5:a5537057f8830783e9b17a7d40f4e644",
+          "archive:https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz#md5:a5537057f8830783e9b17a7d40f4e644"
         ],
         "opam": {
           "name": "lambda-term",
-          "version": "3.0.0",
-          "path": "test.esy.lock/opam/lambda-term.3.0.0"
+          "version": "3.0.1",
+          "path": "test.esy.lock/opam/lambda-term.3.0.1"
         }
       },
       "overrides": [],

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,9 @@
 {
+<<<<<<< HEAD
   "checksum": "a211032fb68a10e94406ce3c9465b157",
+=======
+  "checksum": "a90109aacd9ccf2c1726b91f4c5a9c7d",
+>>>>>>> 3739194e... Dependency: add markup
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -1200,10 +1204,17 @@
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+<<<<<<< HEAD
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/luv@opam:0.5.2@bfb5a32a",
         "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
+=======
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/luv@opam:0.5.2@bfb5a32a", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fs@github:facebookexperimental/reason-native:fs.opam#bb80cbc@d41d8cd9",
+        "@opam/fp@github:facebookexperimental/reason-native:fp.opam#bb80cbc@d41d8cd9",
+>>>>>>> 3739194e... Dependency: add markup
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658",

--- a/test.esy.lock/opam/lambda-term.3.0.1/opam
+++ b/test.esy.lock/opam/lambda-term.3.0.1/opam
@@ -30,6 +30,6 @@ for example, ncurses, by providing a native OCaml interface instead of bindings
 to a C library. Lambda-term integrates with zed to provide text edition
 facilities in console applications."""
 url {
-  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz"
-  checksum: "md5=3ee0d8b6cb31f20a07fcbf34990f8a4b"
+  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.1.tar.gz"
+  checksum: "md5=a5537057f8830783e9b17a7d40f4e644"
 }


### PR DESCRIPTION
This adds a nifty changelog, as well as an "update" screen that opens after updating, showing all changes since the last version used and, more importantly, any breaking changes users should be aware of.

The changelog is based on the conventions outlined in #1718, and is automatically generated from the commit log and PRs by a script intended to be run during the nightly build, to be packaged together with the releases. The script takes two arguments, the path to the changelog file and an optional authentication token for the GitHub API to increase the rate limit.

### Update screen
![2020-05-06-223720_811x694_scrot](https://user-images.githubusercontent.com/5207036/81225951-5df9e980-8fea-11ea-9dd2-bb88c1ff25c8.png)

### Full changelog
![2020-05-06-223737_823x697_scrot](https://user-images.githubusercontent.com/5207036/81225953-5fc3ad00-8fea-11ea-9629-89978028d27b.png)

