### PR TITLE
refactor(exthost) - V2 - use decoder for parsing

### DIFF
--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -172,11 +172,10 @@ let request =
     Log.tracef(m => m("Request finalized: %d", newRequestId));
   };
 
-  let parser = json => Oni_Core.Json.Decode.(
-        json
-        |> decode_value(decoder)
-        |> Result.map_error(string_of_error)
-  );
+  let parser = json =>
+    Oni_Core.Json.Decode.(
+      json |> decode_value(decoder) |> Result.map_error(string_of_error)
+    );
 
   let onError = e => {
     finalize();

--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -1,5 +1,4 @@
 type reply = unit;
-
 module Protocol = Exthost_Protocol;
 module Extension = Exthost_Extension;
 
@@ -161,7 +160,7 @@ let request =
       ~rpcName: string,
       ~method: string,
       ~args,
-      ~parser,
+      ~decoder,
       client,
     ) => {
   let newRequestId = client.lastRequestId^ + 1;
@@ -172,6 +171,12 @@ let request =
     Hashtbl.remove(client.requestIdToReply, newRequestId);
     Log.tracef(m => m("Request finalized: %d", newRequestId));
   };
+
+  let parser = json => Oni_Core.Json.Decode.(
+        json
+        |> decode_value(decoder)
+        |> Result.map_error(string_of_error)
+  );
 
   let onError = e => {
     finalize();

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -12,16 +12,8 @@ module Commands = {
 
 module DocumentContentProvider = {
   let provideTextDocumentContent = (~handle, ~uri, client) => {
-    let parser = json => {
-      Json.Decode.(
-        json
-        |> decode_value(maybe(string))
-        |> Result.map_error(string_of_error)
-      );
-    };
-
     Client.request(
-      ~parser,
+      ~decoder=Json.Decode.(maybe(string)),
       ~usesCancellationToken=false,
       ~rpcName="ExtHostDocumentContentProviders",
       ~method="$provideTextDocumentContent",
@@ -110,14 +102,8 @@ module LanguageFeatures = {
         ~context: CompletionContext.t,
         client,
       ) => {
-    let parser = json => {
-      json
-      |> Json.Decode.decode_value(SuggestResult.decode)
-      |> Result.map_error(Json.Decode.string_of_error);
-    };
-
     Client.request(
-      ~parser,
+      ~decoder=SuggestResult.decode,
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$provideCompletionItems",
@@ -135,16 +121,8 @@ module LanguageFeatures = {
   module Internal = {
     let provideDefinitionLink =
         (~handle, ~resource, ~position, method, client) => {
-      let parser = json => {
-        Json.Decode.(
-          json
-          |> decode_value(list(Location.decode))
-          |> Result.map_error(string_of_error)
-        );
-      };
-
       Client.request(
-        ~parser,
+        ~decoder=Json.Decode.(list(Location.decode)),
         ~usesCancellationToken=true,
         ~rpcName="ExtHostLanguageFeatures",
         ~method,
@@ -159,16 +137,8 @@ module LanguageFeatures = {
     };
   };
   let provideDocumentHighlights = (~handle, ~resource, ~position, client) => {
-    let parser = json => {
-      Json.Decode.(
-        json
-        |> decode_value(list(DocumentHighlight.decode))
-        |> Result.map_error(string_of_error)
-      );
-    };
-
     Client.request(
-      ~parser,
+      ~decoder=Json.Decode.(list(DocumentHighlight.decode)),
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$provideDocumentHighlights",
@@ -183,16 +153,8 @@ module LanguageFeatures = {
   };
 
   let provideDocumentSymbols = (~handle, ~resource, client) => {
-    let parser = json => {
-      Json.Decode.(
-        json
-        |> decode_value(list(DocumentSymbol.decode))
-        |> Result.map_error(string_of_error)
-      );
-    };
-
     Client.request(
-      ~parser,
+      ~decoder=Json.Decode.(list(DocumentSymbol.decode)),
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$provideDocumentSymbols",
@@ -235,16 +197,8 @@ module LanguageFeatures = {
     );
 
   let provideReferences = (~handle, ~resource, ~position, ~context, client) => {
-    let parser = json => {
-      Json.Decode.(
-        json
-        |> decode_value(list(Location.decode))
-        |> Result.map_error(string_of_error)
-      );
-    };
-
     Client.request(
-      ~parser,
+      ~decoder=Json.Decode.(list(Location.decode)),
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$provideReferences",


### PR DESCRIPTION
This removes some duplication in the parse code for handling responses to requests, and standardizes it to use json decoders