### PR TITLE
refactor(exthost) - V2 - SCM - Remove unused SCMRawResource properties

### DIFF
--- a/src/Extensions/ExtHostClient.rei
+++ b/src/Extensions/ExtHostClient.rei
@@ -27,9 +27,6 @@ module SCM: {
       tooltip: string,
       strikeThrough: bool,
       faded: bool,
-      source: option(string),
-      letter: option(string),
-      color: option(string),
     };
   };
 

--- a/src/Extensions/ExtHostClient_SCM.re
+++ b/src/Extensions/ExtHostClient_SCM.re
@@ -62,7 +62,7 @@ module Decode = {
         `String(tooltip),
         `Bool(strikeThrough),
         `Bool(faded),
-        ..._additionalArgs
+        ..._additionalArgs,
       ]) =>
       Resource.{
         handle,

--- a/src/Extensions/ExtHostClient_SCM.re
+++ b/src/Extensions/ExtHostClient_SCM.re
@@ -21,9 +21,6 @@ module Resource = {
     tooltip: string,
     strikeThrough: bool,
     faded: bool,
-    source: option(string),
-    letter: option(string),
-    color: option(string),
   };
 };
 
@@ -65,9 +62,7 @@ module Decode = {
         `String(tooltip),
         `Bool(strikeThrough),
         `Bool(faded),
-        source,
-        letter,
-        color,
+        ..._additionalArgs
       ]) =>
       Resource.{
         handle,
@@ -82,9 +77,6 @@ module Decode = {
         tooltip,
         strikeThrough,
         faded,
-        source: source |> to_string_option,
-        letter: letter |> to_string_option,
-        color: color |> member("id") |> to_string_option,
       }
 
     | _ => failwith("Unexpected json for scm resource");

--- a/src/Feature/SCM/Feature_SCM.rei
+++ b/src/Feature/SCM/Feature_SCM.rei
@@ -15,9 +15,6 @@ module Resource: {
     tooltip: string,
     strikeThrough: bool,
     faded: bool,
-    source: option(string),
-    letter: option(string),
-    color: option(string),
   };
 };
 


### PR DESCRIPTION
The protocol for the `SCMRawResource` object has changed. In the previous extension host, the `SCMRawResource` type looked like this:
```
export type SCMRawResource = [
	number /*handle*/,
	UriComponents /*resourceUri*/,
	string[] /*icons: light, dark*/,
	string /*tooltip*/,
	boolean /*strike through*/,
	boolean /*faded*/,

	string | undefined /*source*/,
	string | undefined /*letter*/,
	ThemeColor | null /*color*/
];
```
https://github.com/onivim/vscode-exthost/blob/8ebec0403c19a038932368df8c89e4676e923dd2/src/vs/workbench/api/node/extHost.protocol.ts#L621

In the new extension host, the `SCMRawResource` type is now:
```
export type SCMRawResource = [
	number /*handle*/,
	UriComponents /*resourceUri*/,
	UriComponents[] /*icons: light, dark*/,
	string /*tooltip*/,
	boolean /*strike through*/,
	boolean /*faded*/
];
```
https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L794

Luckily - it doesn't seem like we are actually these extra properties anywhere (as far as I can tell - @glennsl , you might want to check me on that!)

Otherwise - the SCM API looks pretty much the same, so it should be straightforward to bring to the v2 exthost, aside from this one protocol change.
