### PR TITLE
fix(exthost) - Handle acknowledged message type

### DIFF
--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -104,8 +104,8 @@ let start =
                )
              }
            })
-      | Incoming.Acknowledged({ requestId }) =>
-        Log.tracef(m => m("Received ack: %d", requestId));
+      | Incoming.Acknowledged({requestId}) =>
+        Log.tracef(m => m("Received ack: %d", requestId))
       | _ =>
         Log.warn(
           "Unhandled message: " ++ Protocol.Message.Incoming.show(msg),

--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -104,6 +104,8 @@ let start =
                )
              }
            })
+      | Incoming.Acknowledged({ requestId }) =>
+        Log.tracef(m => m("Received ack: %d", requestId));
       | _ =>
         Log.warn(
           "Unhandled message: " ++ Protocol.Message.Incoming.show(msg),

--- a/src/Exthost/Protocol/Exthost_Protocol.re
+++ b/src/Exthost/Protocol/Exthost_Protocol.re
@@ -220,7 +220,7 @@ module Message = {
           } else if (messageType == replyOkEmpty) {
             Ok(ReplyOk({requestId, payload: Empty}));
           } else if (messageType == acknowledged) {
-            Ok(Acknowledged({ requestId: requestId }));
+            Ok(Acknowledged({requestId: requestId}));
           } else if (messageType == replyOkJSON) {
             let (msg, _bytes) = ByteParser.readLongString(bytes);
             let json = msg |> Yojson.Safe.from_string;

--- a/src/Exthost/Protocol/Exthost_Protocol.re
+++ b/src/Exthost/Protocol/Exthost_Protocol.re
@@ -157,7 +157,7 @@ module Message = {
   let requestJsonArgsWithCancellation = 2;
   let requestMixedArgs = 3;
   let requestMixedArgsWithCancellation = 4;
-  //  let acknowledged = 5;
+  let acknowledged = 5;
   //  let cancel = 6;
   let replyOkEmpty = 7;
   //  let replyOkBuffer = 8;
@@ -219,6 +219,8 @@ module Message = {
             );
           } else if (messageType == replyOkEmpty) {
             Ok(ReplyOk({requestId, payload: Empty}));
+          } else if (messageType == acknowledged) {
+            Ok(Acknowledged({ requestId: requestId }));
           } else if (messageType == replyOkJSON) {
             let (msg, _bytes) = ByteParser.readLongString(bytes);
             let json = msg |> Yojson.Safe.from_string;


### PR DESCRIPTION
For the v2 exthost, we would get warnings after every sent message, as we were not handling the acknowledged message we get back from the exthost.

This sets up a handler and logs it.