### PR TITLE
fix(extensions/#1729): some gitlens regex patterns failed to parse

### DIFF
--- a/src/Core/WhenExpr/WhenExpr.rei
+++ b/src/Core/WhenExpr/WhenExpr.rei
@@ -42,7 +42,7 @@ type t =
   | Defined(string)
   | Eq(string, Value.t)
   | Neq(string, Value.t)
-  | Regex(string, option(Re.re))
+  | Regex(string, option([@opaque] Oniguruma.OnigRegExp.t))
   | And(list(t))
   | Or(list(t))
   | Not(t)

--- a/src/Core/WhenExpr/dune
+++ b/src/Core/WhenExpr/dune
@@ -2,4 +2,4 @@
     (name WhenExpr)
     (public_name Oni2.core.whenExpr)
     (preprocess (pps ppx_deriving.show))
-    (libraries Oni2.core.kernel re timber))
+    (libraries Oni2.core.kernel re timber oniguruma))

--- a/test/Core/WhenExpr/WhenExprTests.re
+++ b/test/Core/WhenExpr/WhenExprTests.re
@@ -5,23 +5,32 @@ let re = (pattern, str) => {
   Re.execp(re, str);
 };
 
+let createContext = pairs => {
+  let context = Hashtbl.create(List.length(pairs));
+  List.iter(((k, v)) => Hashtbl.add(context, k, v), pairs);
+
+  name =>
+    switch (Hashtbl.find_opt(context, name)) {
+    | Some(value) => value
+    | None => WhenExpr.Value.False
+    };
+};
+
 describe("WhenExpr", ({describe, _}) => {
   describe("vscode tests", ({describe, _}) => {
     // Translkated from https://github.com/microsoft/vscode/blob/7fc5d9150569247b3494eb3715a078bf7f8e9272/src/vs/platform/contextkey/test/common/contextkey.test.ts
     // TODO: equals
     // TODO: normalize
     describe("evaluate", ({test, _}) => {
-      let context = Hashtbl.create(4);
-      Hashtbl.add(context, "a", WhenExpr.Value.True);
-      Hashtbl.add(context, "b", WhenExpr.Value.False);
-      Hashtbl.add(context, "c", WhenExpr.Value.String("5"));
-      Hashtbl.add(context, "d", WhenExpr.Value.String("d"));
-
-      let getValue = name =>
-        switch (Hashtbl.find_opt(context, name)) {
-        | Some(value) => value
-        | None => WhenExpr.Value.False
-        };
+      let getValue =
+        createContext(
+          WhenExpr.Value.[
+            ("a", True),
+            ("b", False),
+            ("c", String("5")),
+            ("d", String("d")),
+          ],
+        );
 
       let testExpression = (expr, expected) =>
         test(
@@ -65,23 +74,17 @@ describe("WhenExpr", ({describe, _}) => {
 
   describe("regex", ({test, _}) => {
     test("1729-gitlens-regression", ({expect, _}) => {
-      let context = Hashtbl.create(2);
-      Hashtbl.add(
-        context,
-        "gitlens:activeFileStatus",
-        WhenExpr.Value.String("some revision or other"),
-      );
-      Hashtbl.add(context, "resourceScheme", WhenExpr.Value.String("file$"));
-
-      let getValue = name =>
-        switch (Hashtbl.find_opt(context, name)) {
-        | Some(value) => value
-        | None => WhenExpr.Value.False
-        };
+      let getValue =
+        createContext(
+          WhenExpr.Value.[
+            ("gitlens:activeFileStatus", String("some revision or other")),
+            ("resourceScheme", String("file$")),
+          ],
+        );
 
       let expr = "gitlens:activeFileStatus =~ /revision/ && resourceScheme =~ /^(?!(file|git)$).*$/";
       let rules = WhenExpr.parse(expr);
-      Console.log(WhenExpr.show(rules));
+      //Console.log(WhenExpr.show(rules));
       expect.bool(WhenExpr.evaluate(rules, getValue)).toBe(true);
     })
   });

--- a/test/Core/WhenExpr/WhenExprTests.re
+++ b/test/Core/WhenExpr/WhenExprTests.re
@@ -61,5 +61,28 @@ describe("WhenExpr", ({describe, _}) => {
       testExpression("a && b", true && false);
       testExpression("a && !b && c == 5", true && !false && "5" == "5");
     })
-  })
+  });
+
+  describe("regex", ({test, _}) => {
+    test("1729-gitlens-regression", ({expect, _}) => {
+      let context = Hashtbl.create(2);
+      Hashtbl.add(
+        context,
+        "gitlens:activeFileStatus",
+        WhenExpr.Value.String("some revision or other"),
+      );
+      Hashtbl.add(context, "resourceScheme", WhenExpr.Value.String("file$"));
+
+      let getValue = name =>
+        switch (Hashtbl.find_opt(context, name)) {
+        | Some(value) => value
+        | None => WhenExpr.Value.False
+        };
+
+      let expr = "gitlens:activeFileStatus =~ /revision/ && resourceScheme =~ /^(?!(file|git)$).*$/";
+      let rules = WhenExpr.parse(expr);
+      Console.log(WhenExpr.show(rules));
+      expect.bool(WhenExpr.evaluate(rules, getValue)).toBe(true);
+    })
+  });
 });


### PR DESCRIPTION
**Issue:** Some regexes in the GitLens extension failed to parse

**Defect:** It seems to have been caused by the use of negative lookahead assertion (`(?!...)`), which doesn't seem to be valid Perl regex syntax.

**Fix:** Switch to using Oniguruma instead.

Should fix #1729 (though I haven't tried all the regexes) 

```changelog
some gitlens regex patterns failed to parse

<breaking>As this switches to a different regex engine, there's a chance that it might break other extension regexes.</breaking>
```