### PR TITLE
chore(ci): Remove integration test clean-up

### DIFF
--- a/.ci/run-integration-tests.yml
+++ b/.ci/run-integration-tests.yml
@@ -5,12 +5,6 @@ steps:
     displayName: 'Install Dependencies: esy install'
   - script: esy bootstrap
     displayName: 'Bootstrap Oni2 setup with system specific build variables'
-  - script: esy cleanup . --dry-run
-    displayName: 'esy cleanup . --dry-run'
-  - script: esy cleanup .
-    displayName: 'esy cleanup'
-  - bash: 'rm -rf _esy'
-    displayName: 'Integration Tests: rm -rf _esy'
   - script: esy @integrationtest install
     displayName: 'Integration Tests: install'
   - script: esy @integrationtest build


### PR DESCRIPTION
We run `esy cleanup` to try and save disk space on CI machines, but this no longer necessary (and doubles the build time...), since we delete several large SDKs from the linux machines