### PR TITLE
bugfix(windows/#1744): Many console windows open on startup

### DIFF
--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -407,7 +407,6 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
     Luv.Process.spawn(
       ~environment,
       ~on_exit,
-      ~detached=true,
       ~windows_hide=true,
       ~windows_hide_console=true,
       ~windows_hide_gui=true,


### PR DESCRIPTION
__Issue:__ On Windows, when launching the app, the user would be spammed by console windows.

__Defect:__ We sent the wrong flags for spinning up libuv process - we want the extension host to be 'invisible', which the `windows_hide*` flags handle... However, we were also sending the `detached` flag, which is problematic, because, being detached from the parent, means the console windows would become visible whenever the extension host decides to spawn shell commands (which happens frequently with the git extension!)

__Fix:__ Don't use `detached` - the reason we'd consider it is to ensure the extension host process dies when Onivim 2 dies, but that is already baked into the extension host logic (and covered by this test: https://github.com/onivim/oni2/blob/3f50e8d54971a75f11faf617c5a84f4069530cf8/test/Exthost/LifecycleTest.re#L16)

Fixes #1744 
