### PR TITLE
bugfix(osx/#1747): Gatekeeper reporting application bundle as damaged

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onivim/vscode-exthost": "1.45.3",
+    "@onivim/vscode-exthost": "1.45.4",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
     "yauzl": "^2.5.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@onivim/vscode-exthost@1.45.3":
-  version "1.45.3"
-  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.45.3.tgz#aea0f35c2803be94fd1b74c5207280eda871eacf"
-  integrity sha512-LQTcM9wnVzyJiuilHn03xeTDUzWUSzRfkMQMdN3CPOvi+WndvSDjrC+iE2JPEj+QPgofGHvTo6vyVVy3byJjvw==
+"@onivim/vscode-exthost@1.45.4":
+  version "1.45.4"
+  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.45.4.tgz#b15105ba1517bc869f93907b2f636667a2b50c1e"
+  integrity sha512-VEvZzsCrQaZo5X3Zl3dwa76OjuervpromdtuNOT+hO7j14+NZmbTWQO8U9N0x5acL2N8Oz8p9CsNqbaLchnFtA==
   dependencies:
     graceful-fs "4.2.3"
     iconv-lite "0.5.0"


### PR DESCRIPTION
__Issue:__ Even after fixing the code-signing notarization issues in #1742 , there was still a Gatekeeper dialog reporting that the app bundle is damaged.

__Defect:__ When we upgraded the `vscode-exthost` dependency, our script that removed extraneous files (like test cases) didn't make it to the new dependency. At best, these extraneous files take up extra space... worst case, they break gatekeeper validation:
![image](https://user-images.githubusercontent.com/13532591/81625046-aaf40c00-93ac-11ea-91f7-127382ed0dc4.png)

__Fix:__ Remove these extraneous files (test folders, css, .js.map files) for the `vscode-exthost` NPM package we use.

Fixes #1747 