### PR TITLE
refactor(exthost/#1747): Upgrade exthost to 1.45.6

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onivim/vscode-exthost": "1.45.4",
+    "@onivim/vscode-exthost": "1.45.6",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
     "yauzl": "^2.5.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@onivim/vscode-exthost@1.45.4":
-  version "1.45.4"
-  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.45.4.tgz#b15105ba1517bc869f93907b2f636667a2b50c1e"
-  integrity sha512-VEvZzsCrQaZo5X3Zl3dwa76OjuervpromdtuNOT+hO7j14+NZmbTWQO8U9N0x5acL2N8Oz8p9CsNqbaLchnFtA==
+"@onivim/vscode-exthost@1.45.6":
+  version "1.45.6"
+  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.45.6.tgz#686a8200217615e457a96453276dafe72c38778d"
+  integrity sha512-9IKvY6lO9GVIlPNsXk+JxYDjbZB1sSuZzVmQFGSDuqmu+NopdoQhedpwPR9qOiqIgUEiDRAWRZwqjX3WuVld+g==
   dependencies:
     graceful-fs "4.2.3"
     iconv-lite "0.5.0"


### PR DESCRIPTION
Another round of fixes for #1747 - it turns out there were still additional paths I missed in https://github.com/onivim/vscode-exthost/pull/23 that are now addressed in https://github.com/onivim/vscode-exthost/pull/24

Validated locally that there no errors after codesigning... but I'll wait until the portal build is confirmed fix before I close #1747, this time!