### PR TITLE
chore(dependency): ocaml-decoders -> 0.4.0

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b12dcb2545299645884955b7d7c2b635",
+  "checksum": "661df2a5391d91327d39711dc3178dc8",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -1188,7 +1188,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
-        "@opam/decoders-yojson@opam:0.3.0@b9081413",
+        "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
         "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@esy-ocaml/libffi@github:onivim/libffi#590b041@d41d8cd9"
@@ -2976,20 +2976,20 @@
         "@opam/dune@opam:2.5.1@a0c1e658"
       ]
     },
-    "@opam/decoders-yojson@opam:0.3.0@b9081413": {
-      "id": "@opam/decoders-yojson@opam:0.3.0@b9081413",
+    "@opam/decoders-yojson@opam:0.4.0@cb39dea6": {
+      "id": "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
       "name": "@opam/decoders-yojson",
-      "version": "opam:0.3.0",
+      "version": "opam:0.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/a5/a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d",
-          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+          "archive:https://opam.ocaml.org/cache/sha256/18/18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7",
+          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
         ],
         "opam": {
           "name": "decoders-yojson",
-          "version": "0.3.0",
-          "path": "bench.esy.lock/opam/decoders-yojson.0.3.0"
+          "version": "0.4.0",
+          "path": "bench.esy.lock/opam/decoders-yojson.0.4.0"
         }
       },
       "overrides": [],

--- a/bench.esy.lock/opam/decoders-yojson.0.4.0/opam
+++ b/bench.esy.lock/opam/decoders-yojson.0.4.0/opam
@@ -35,9 +35,9 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
   checksum: [
-    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
-    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
   ]
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b12dcb2545299645884955b7d7c2b635",
+  "checksum": "661df2a5391d91327d39711dc3178dc8",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -1187,7 +1187,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
-        "@opam/decoders-yojson@opam:0.3.0@b9081413",
+        "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
         "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@esy-ocaml/libffi@github:onivim/libffi#590b041@d41d8cd9"
@@ -2975,20 +2975,20 @@
         "@opam/dune@opam:2.5.1@a0c1e658"
       ]
     },
-    "@opam/decoders-yojson@opam:0.3.0@b9081413": {
-      "id": "@opam/decoders-yojson@opam:0.3.0@b9081413",
+    "@opam/decoders-yojson@opam:0.4.0@cb39dea6": {
+      "id": "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
       "name": "@opam/decoders-yojson",
-      "version": "opam:0.3.0",
+      "version": "opam:0.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/a5/a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d",
-          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+          "archive:https://opam.ocaml.org/cache/sha256/18/18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7",
+          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
         ],
         "opam": {
           "name": "decoders-yojson",
-          "version": "0.3.0",
-          "path": "esy.lock/opam/decoders-yojson.0.3.0"
+          "version": "0.4.0",
+          "path": "esy.lock/opam/decoders-yojson.0.4.0"
         }
       },
       "overrides": [],

--- a/esy.lock/opam/decoders-yojson.0.4.0/opam
+++ b/esy.lock/opam/decoders-yojson.0.4.0/opam
@@ -35,9 +35,9 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
   checksum: [
-    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
-    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
   ]
 }

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b12dcb2545299645884955b7d7c2b635",
+  "checksum": "661df2a5391d91327d39711dc3178dc8",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -1187,7 +1187,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
-        "@opam/decoders-yojson@opam:0.3.0@b9081413",
+        "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
         "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@esy-ocaml/libffi@github:onivim/libffi#590b041@d41d8cd9"
@@ -2976,20 +2976,20 @@
         "@opam/dune@opam:2.5.1@a0c1e658"
       ]
     },
-    "@opam/decoders-yojson@opam:0.3.0@b9081413": {
-      "id": "@opam/decoders-yojson@opam:0.3.0@b9081413",
+    "@opam/decoders-yojson@opam:0.4.0@cb39dea6": {
+      "id": "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
       "name": "@opam/decoders-yojson",
-      "version": "opam:0.3.0",
+      "version": "opam:0.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/a5/a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d",
-          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+          "archive:https://opam.ocaml.org/cache/sha256/18/18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7",
+          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
         ],
         "opam": {
           "name": "decoders-yojson",
-          "version": "0.3.0",
-          "path": "integrationtest.esy.lock/opam/decoders-yojson.0.3.0"
+          "version": "0.4.0",
+          "path": "integrationtest.esy.lock/opam/decoders-yojson.0.4.0"
         }
       },
       "overrides": [],

--- a/integrationtest.esy.lock/opam/decoders-yojson.0.4.0/opam
+++ b/integrationtest.esy.lock/opam/decoders-yojson.0.4.0/opam
@@ -35,9 +35,9 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
   checksum: [
-    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
-    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@glennsl/timber": "1.0.0",
     "refmterr": "*",
     "@esy-ocaml/libffi": "*",
-    "@opam/decoders-yojson": "^0.3.0",
+    "@opam/decoders-yojson": "^0.4.0",
     "@opam/uutf": "*",
     "@opam/uucp": "*",
     "@opam/luv": "~0.5.1",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cd984704befa5d5cca69a62246ff5018",
+  "checksum": "14a420eedadaf7eacbf19bbfddc2123b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -1187,7 +1187,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.1@a0c1e658",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
-        "@opam/decoders-yojson@opam:0.3.0@b9081413",
+        "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
         "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@esy-ocaml/libffi@github:onivim/libffi#590b041@d41d8cd9"
@@ -2975,20 +2975,20 @@
         "@opam/dune@opam:2.5.1@a0c1e658"
       ]
     },
-    "@opam/decoders-yojson@opam:0.3.0@b9081413": {
-      "id": "@opam/decoders-yojson@opam:0.3.0@b9081413",
+    "@opam/decoders-yojson@opam:0.4.0@cb39dea6": {
+      "id": "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
       "name": "@opam/decoders-yojson",
-      "version": "opam:0.3.0",
+      "version": "opam:0.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/a5/a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d",
-          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz#sha256:a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+          "archive:https://opam.ocaml.org/cache/sha256/18/18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7",
+          "archive:https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz#sha256:18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
         ],
         "opam": {
           "name": "decoders-yojson",
-          "version": "0.3.0",
-          "path": "test.esy.lock/opam/decoders-yojson.0.3.0"
+          "version": "0.4.0",
+          "path": "test.esy.lock/opam/decoders-yojson.0.4.0"
         }
       },
       "overrides": [],

--- a/test.esy.lock/opam/decoders-yojson.0.4.0/opam
+++ b/test.esy.lock/opam/decoders-yojson.0.4.0/opam
@@ -35,9 +35,9 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
   checksum: [
-    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
-    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
   ]
 }


### PR DESCRIPTION
I got a bunch of deprecation warnings in #1752 causing me to pin to an older version and follow up on it with this. But seems like I was on an outdated tree and the warnings were fixed already in #1708, so this is just to bump it back up to 0.4.0.