### PR TITLE
bugfix(osx/#1755) - fix hang on maximize

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "661df2a5391d91327d39711dc3178dc8",
+  "checksum": "983ea962b61cbdb6081f83fb2b35e9f2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -153,7 +153,7 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#6b459c7@d41d8cd9",
-        "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-harfbuzz@1.91.8001@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -337,7 +337,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
@@ -347,14 +347,14 @@
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.1@a0c1e658" ]
     },
-    "reason-sdl2@2.10.3030@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3030@d41d8cd9",
+    "reason-sdl2@2.10.3031@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3031@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3030",
+      "version": "2.10.3031",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3030.tgz#sha1:a268fca497228667d89bfcc85929b9ec255c478d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3031.tgz#sha1:18f5212f834f0182b7cb43b126da12b920d3758b"
         ]
       },
       "overrides": [],
@@ -1163,7 +1163,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "ocaml@4.9.1000@d41d8cd9",
@@ -3057,7 +3057,7 @@
       "dependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/integers@opam:0.4.0@f7acfaeb",
-        "@opam/conf-pkg-config@opam:1.2@5cd99130",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3093,8 +3093,8 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-pkg-config@opam:1.2@5cd99130": {
-      "id": "@opam/conf-pkg-config@opam:1.2@5cd99130",
+    "@opam/conf-pkg-config@opam:1.2@d86c8f53": {
+      "id": "@opam/conf-pkg-config@opam:1.2@d86c8f53",
       "name": "@opam/conf-pkg-config",
       "version": "opam:1.2",
       "source": {

--- a/bench.esy.lock/opam/conf-pkg-config.1.2/opam
+++ b/bench.esy.lock/opam/conf-pkg-config.1.2/opam
@@ -18,7 +18,7 @@ post-messages: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "661df2a5391d91327d39711dc3178dc8",
+  "checksum": "983ea962b61cbdb6081f83fb2b35e9f2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -153,7 +153,7 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#6b459c7@d41d8cd9",
-        "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-harfbuzz@1.91.8001@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -337,7 +337,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
@@ -347,14 +347,14 @@
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.1@a0c1e658" ]
     },
-    "reason-sdl2@2.10.3030@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3030@d41d8cd9",
+    "reason-sdl2@2.10.3031@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3031@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3030",
+      "version": "2.10.3031",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3030.tgz#sha1:a268fca497228667d89bfcc85929b9ec255c478d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3031.tgz#sha1:18f5212f834f0182b7cb43b126da12b920d3758b"
         ]
       },
       "overrides": [],
@@ -1162,7 +1162,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "ocaml@4.9.1000@d41d8cd9",
@@ -3056,7 +3056,7 @@
       "dependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/integers@opam:0.4.0@f7acfaeb",
-        "@opam/conf-pkg-config@opam:1.2@5cd99130",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3092,8 +3092,8 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-pkg-config@opam:1.2@5cd99130": {
-      "id": "@opam/conf-pkg-config@opam:1.2@5cd99130",
+    "@opam/conf-pkg-config@opam:1.2@d86c8f53": {
+      "id": "@opam/conf-pkg-config@opam:1.2@d86c8f53",
       "name": "@opam/conf-pkg-config",
       "version": "opam:1.2",
       "source": {

--- a/esy.lock/opam/conf-pkg-config.1.2/opam
+++ b/esy.lock/opam/conf-pkg-config.1.2/opam
@@ -18,7 +18,7 @@ post-messages: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "661df2a5391d91327d39711dc3178dc8",
+  "checksum": "983ea962b61cbdb6081f83fb2b35e9f2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -153,7 +153,7 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#6b459c7@d41d8cd9",
-        "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-harfbuzz@1.91.8001@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -337,7 +337,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
@@ -347,14 +347,14 @@
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.1@a0c1e658" ]
     },
-    "reason-sdl2@2.10.3030@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3030@d41d8cd9",
+    "reason-sdl2@2.10.3031@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3031@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3030",
+      "version": "2.10.3031",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3030.tgz#sha1:a268fca497228667d89bfcc85929b9ec255c478d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3031.tgz#sha1:18f5212f834f0182b7cb43b126da12b920d3758b"
         ]
       },
       "overrides": [],
@@ -1162,7 +1162,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "ocaml@4.9.1000@d41d8cd9",
@@ -3057,7 +3057,7 @@
       "dependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/integers@opam:0.4.0@f7acfaeb",
-        "@opam/conf-pkg-config@opam:1.2@5cd99130",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3093,8 +3093,8 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-pkg-config@opam:1.2@5cd99130": {
-      "id": "@opam/conf-pkg-config@opam:1.2@5cd99130",
+    "@opam/conf-pkg-config@opam:1.2@d86c8f53": {
+      "id": "@opam/conf-pkg-config@opam:1.2@d86c8f53",
       "name": "@opam/conf-pkg-config",
       "version": "opam:1.2",
       "source": {

--- a/integrationtest.esy.lock/opam/conf-pkg-config.1.2/opam
+++ b/integrationtest.esy.lock/opam/conf-pkg-config.1.2/opam
@@ -18,7 +18,7 @@ post-messages: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "revery-terminal": "revery-ui/revery-terminal#4e8ca1c",
     "@opam/fs": "bryphe/reason-native:fs.opam#fd0225c",
     "@opam/fp": "bryphe/reason-native:fp.opam#fd0225c",
-    "@opam/dir": "bryphe/reason-native:dir.opam#fd0225"
+    "@opam/dir": "bryphe/reason-native:dir.opam#fd0225",
+    "reason-sdl2": "2.10.3031"
   },
   "devDependencies": {
     "ocaml": "~4.9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "14a420eedadaf7eacbf19bbfddc2123b",
+  "checksum": "15b3f3d6afe26a1c257c6ef90c9c1979",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -153,7 +153,7 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#6b459c7@d41d8cd9",
-        "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-harfbuzz@1.91.8001@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -337,7 +337,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10006@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
@@ -347,14 +347,14 @@
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.1@a0c1e658" ]
     },
-    "reason-sdl2@2.10.3030@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3030@d41d8cd9",
+    "reason-sdl2@2.10.3031@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3031@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3030",
+      "version": "2.10.3031",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3030.tgz#sha1:a268fca497228667d89bfcc85929b9ec255c478d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3031.tgz#sha1:18f5212f834f0182b7cb43b126da12b920d3758b"
         ]
       },
       "overrides": [],
@@ -1162,7 +1162,7 @@
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
-        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3030@d41d8cd9",
+        "reason-textmate@3.1.2@d41d8cd9", "reason-sdl2@2.10.3031@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#ae1fd34@d41d8cd9",
         "reason-libvim@github:onivim/reason-libvim#2493884@d41d8cd9",
         "ocaml@4.9.1000@d41d8cd9",
@@ -3056,7 +3056,7 @@
       "dependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/integers@opam:0.4.0@f7acfaeb",
-        "@opam/conf-pkg-config@opam:1.2@5cd99130",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3092,8 +3092,8 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-pkg-config@opam:1.2@5cd99130": {
-      "id": "@opam/conf-pkg-config@opam:1.2@5cd99130",
+    "@opam/conf-pkg-config@opam:1.2@d86c8f53": {
+      "id": "@opam/conf-pkg-config@opam:1.2@d86c8f53",
       "name": "@opam/conf-pkg-config",
       "version": "opam:1.2",
       "source": {

--- a/test.esy.lock/opam/conf-pkg-config.1.2/opam
+++ b/test.esy.lock/opam/conf-pkg-config.1.2/opam
@@ -18,7 +18,7 @@ post-messages: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}


### PR DESCRIPTION
This picks up a fix for #1755 from reason-sdl2 - https://github.com/revery-ui/reason-sdl2/commit/4b79da99a9905dae9d36e43f3bcf753482cb59b4

The issue is that, depending on where the added `resizeListener` is hit - we may not be certain of whether the OCaml runtime system is acquired or released. We'd need to check the entry points for that function, and make sure we're releasing prior to a codepath that could hit it.

In the case of #1755, we could add `caml_release_runtime_system` and `caml_acquire_runtime_system` around the `SDL_MaximizeWindow` call - but we need to inventory & investigate and see what other code paths from the OCaml side could hit this (ie, `SDL_MinimizeWindow`, etc), so we can be confident in our fix.

Fixes #1755 