### PR TITLE
bugfix(configuration) - Fix 'no default' errors for syntax/terminal configuration

### DIFF
--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -89,7 +89,10 @@ let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
   config:
     Feature_Configuration.initial(
       ~getUserSettings,
-      [Feature_Editor.Contributions.configuration],
+      [
+        Feature_Editor.Contributions.configuration,
+        Feature_Syntax.Contributions.configuration,
+      ],
     ),
   configuration: Configuration.default,
   decorationProviders: [],

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -92,6 +92,7 @@ let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
       [
         Feature_Editor.Contributions.configuration,
         Feature_Syntax.Contributions.configuration,
+        Feature_Terminal.Contributions.configuration,
       ],
     ),
   configuration: Configuration.default,


### PR DESCRIPTION
__Issue:__ There were warnings showing up in the log for both syntax and terminal settings that no default value as available.

__Fix:__ Add configuration contributions to initial configuration creation.