### PR TITLE
fix(syntax): regression in first-load syntax highlighting

### DIFF
--- a/integration_test/dune
+++ b/integration_test/dune
@@ -43,8 +43,7 @@
            RegressionVspEmptyExistingBufferTest
            SCMGitTest
            SyntaxHighlightTextMateTest
-           ; TODO: Troubleshoot and bring back!
-           ; SyntaxHighlightTreesitterTest
+           SyntaxHighlightTreesitterTest
            AddRemoveSplitTest
            TerminalSetPidTitleTest
            TerminalConfigurationTest
@@ -101,7 +100,7 @@
         SCMGitTest.exe
         SearchShowClearHighlightsTest.exe
         SyntaxHighlightTextMateTest.exe
-        ; SyntaxHighlightTreesitterTest.exe
+        SyntaxHighlightTreesitterTest.exe
         SyntaxServer.exe
         SyntaxServerCloseTest.exe
         SyntaxServerMessageExceptionTest.exe

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -74,7 +74,6 @@ let runTest =
   Core.Log.enableDebug();
   Timber.App.enable();
   Timber.App.setLevel(Timber.Level.trace);
-  Timber.App.setNamespaceFilter("Syntax");
 
   switch (Sys.getenv_opt("ONI2_LOG_FILE")) {
   | None => ()


### PR DESCRIPTION
__Issue:__ When opening a file from Onivim 2 (ie, `oni2 some-file.json`), syntax highlighting wouldn't be triggered until reloading the file or changing something. This was the same issue causing the `SyntaxHighlightTreesitterTest.exe` to fail.

__Defect:__ Regression from https://github.com/onivim/oni2/pull/1745 - when the syntax server gets `BufferStartSyntaxHighlighting` message in the new subscription model, it should start doing the work of highlighting. However, it wasn't - it would only start once a `BufferUpdate` came through.

__Fix:__ Create the syntax highlighter (which does the work of highlighting) on that `BufferStartSyntaxHighlighting` message, which will queue work and cause token updates to be sent to the client.