### PR TITLE
fix(persistence/#1749): window growing on each launch in scaled display

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b168de2e5b40f61b7c4e3e4429262f63",
+  "checksum": "9e3c5dc16aa20b848172bef488246cf5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+    "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3911d3c",
+      "version": "github:revery-ui/revery#f9fedcbe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3911d3c" ]
+        "source": [ "github:revery-ui/revery#f9fedcbe" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "983ea962b61cbdb6081f83fb2b35e9f2",
+  "checksum": "b168de2e5b40f61b7c4e3e4429262f63",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#cf290df@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#cf290df",
+      "version": "github:revery-ui/revery#3911d3c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#cf290df" ]
+        "source": [ "github:revery-ui/revery#3911d3c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "983ea962b61cbdb6081f83fb2b35e9f2",
+  "checksum": "b168de2e5b40f61b7c4e3e4429262f63",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#cf290df@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#cf290df",
+      "version": "github:revery-ui/revery#3911d3c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#cf290df" ]
+        "source": [ "github:revery-ui/revery#3911d3c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b168de2e5b40f61b7c4e3e4429262f63",
+  "checksum": "9e3c5dc16aa20b848172bef488246cf5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+    "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3911d3c",
+      "version": "github:revery-ui/revery#f9fedcbe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3911d3c" ]
+        "source": [ "github:revery-ui/revery#f9fedcbe" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "983ea962b61cbdb6081f83fb2b35e9f2",
+  "checksum": "b168de2e5b40f61b7c4e3e4429262f63",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#cf290df@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#cf290df",
+      "version": "github:revery-ui/revery#3911d3c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#cf290df" ]
+        "source": [ "github:revery-ui/revery#3911d3c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b168de2e5b40f61b7c4e3e4429262f63",
+  "checksum": "9e3c5dc16aa20b848172bef488246cf5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+    "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3911d3c",
+      "version": "github:revery-ui/revery#f9fedcbe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3911d3c" ]
+        "source": [ "github:revery-ui/revery#f9fedcbe" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
   "resolutions": {
     "@esy-ocaml/libffi": "onivim/libffi#590b041",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "revery": "revery-ui/revery#3911d3c",
+    "revery": "revery-ui/revery#f9fedcbe",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-skia": "revery-ui/esy-skia#d60e5fe",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
   "resolutions": {
     "@esy-ocaml/libffi": "onivim/libffi#590b041",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "revery": "revery-ui/revery#cf290df",
+    "revery": "revery-ui/revery#3911d3c",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-skia": "revery-ui/esy-skia#d60e5fe",

--- a/src/Components/LocationList.re
+++ b/src/Components/LocationList.re
@@ -194,7 +194,7 @@ let%component make =
          ~default=
            Revery.UI.getActiveWindow()
            |> Option.map((window: Window.t) =>
-                Revery.Window.getRawSize(window).width
+                Revery.Window.getSize(window).width
               )
            |> Option.value(~default=4000),
        );

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "15b3f3d6afe26a1c257c6ef90c9c1979",
+  "checksum": "7ecd968cd69cbafb837e94dcacfd0fea",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#cf290df@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#cf290df",
+      "version": "github:revery-ui/revery#3911d3c",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#cf290df" ]
+        "source": [ "github:revery-ui/revery#3911d3c" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#cf290df@d41d8cd9",
+        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7ecd968cd69cbafb837e94dcacfd0fea",
+  "checksum": "a9c7641efd60a43510148af58717d46d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3911d3c@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+    "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3911d3c",
+      "version": "github:revery-ui/revery#f9fedcbe",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3911d3c" ]
+        "source": [ "github:revery-ui/revery#f9fedcbe" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1157,7 +1157,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#3911d3c@d41d8cd9",
+        "revery@github:revery-ui/revery#f9fedcbe@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",


### PR DESCRIPTION
__Issue:__ On a scaled display - ie, setting `GDK_SCALE` in Linux, or scaled display settings in Windows, every launch of the app would cause the window to grow.

__Defect:__ More fully described here: https://github.com/revery-ui/revery/pull/840 - but the gist is, the initial window creation expected window sizes that were _scaled_, whereas we were reading _unscaled ones_ due to an inconsistency in Revery's API. This meant that every time persistence saved a window size, it would grow by the scale factor.

__Fix:__ Clean up the revery API to use a consistent coordinate space for window creation, setting the size, getting the size, and listening to size changed events. 

Related to #1749, but we should also be more robust in the case window creation fails: https://github.com/revery-ui/reason-sdl2/pulls/73