### PR TITLE
refactor(layout): Remove imperative AddSplit action

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -129,7 +129,6 @@ type t =
       option([ | `Horizontal | `Vertical]),
       option(Location.t),
     )
-  | AddSplit([ | `Horizontal | `Vertical], int)
   | RemoveSplit(int)
   | OpenConfigFile(string)
   | QuitBuffer([@opaque] Vim.Buffer.t, bool)

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -28,10 +28,7 @@ let getEditorGroupById = (model, id) => IntMap.find_opt(id, model.idToGroup);
 let getFirstEditorGroup = ({idToGroup, _}) => {
   // TODO: Move 'remove' gesture inside EditorGroups, so that we can maintain
   // the invariant that there is _always_ at least one editor group.
-  idToGroup
-  |> IntMap.bindings
-  |> List.hd
-  |> snd;
+  idToGroup |> IntMap.bindings |> List.hd |> snd;
 };
 
 let getActiveEditorGroup = model => getEditorGroupById(model, model.activeId);

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -25,6 +25,15 @@ let activeGroupId = model => model.activeId;
 
 let getEditorGroupById = (model, id) => IntMap.find_opt(id, model.idToGroup);
 
+let getFirstEditorGroup = ({idToGroup, _}) => {
+  // TODO: Move 'remove' gesture inside EditorGroups, so that we can maintain
+  // the invariant that there is _always_ at least one editor group.
+  idToGroup
+  |> IntMap.bindings
+  |> List.hd
+  |> snd;
+};
+
 let getActiveEditorGroup = model => getEditorGroupById(model, model.activeId);
 
 let isActive = (model, group: EditorGroup.t) =>

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -6,6 +6,8 @@ let activeGroupId: t => int; // TODO: Should return an option, or be removed ent
 let getEditorGroupById: (t, int) => option(EditorGroup.t);
 let getActiveEditorGroup: t => option(EditorGroup.t);
 
+let getFirstEditorGroup: t => EditorGroup.t;
+
 let isActive: (t, EditorGroup.t) => bool;
 let isEmpty: (int, t) => bool;
 

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -74,7 +74,22 @@ type t = {
   textContentProviders: list((int, string)),
 };
 
+let initialLayout = (editorGroup: EditorGroup.t) => {
+    Feature_Layout.initial
+    |>
+          Feature_Layout.addWindow(
+            ~target=None,
+            ~position=`After,
+            `Vertical,
+            editorGroup.editorGroupId);
+};
+
 let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
+
+  let editorGroups = EditorGroups.create();
+  let initialEditorGroup = editorGroups |> EditorGroups.getFirstEditorGroup;
+
+  {
   buffers: Buffers.empty,
   bufferHighlights: BufferHighlights.initial,
   bufferRenderers: BufferRenderers.initial,
@@ -109,7 +124,7 @@ let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
   uiFont: UiFont.default,
   sideBar: SideBar.initial,
   tokenTheme: TokenTheme.empty,
-  editorGroups: EditorGroups.create(),
+  editorGroups,
   iconTheme: IconTheme.create(),
   isQuitting: false,
   keyBindings: Keybindings.empty,
@@ -121,7 +136,7 @@ let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
   sneak: Sneak.initial,
   statusBar: StatusBarModel.create(),
   syntaxHighlights: Feature_Syntax.empty,
-  layout: Feature_Layout.initial,
+  layout: initialLayout(initialEditorGroup),
   windowTitle: "",
   windowIsFocused: true,
   windowIsMaximized: false,
@@ -134,6 +149,7 @@ let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
   modal: None,
   terminals: Feature_Terminal.initial,
   textContentProviders: [],
+  };
 };
 
 let commands = state =>

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -75,80 +75,79 @@ type t = {
 };
 
 let initialLayout = (editorGroup: EditorGroup.t) => {
-    Feature_Layout.initial
-    |>
-          Feature_Layout.addWindow(
-            ~target=None,
-            ~position=`After,
-            `Vertical,
-            editorGroup.editorGroupId);
+  Feature_Layout.initial
+  |> Feature_Layout.addWindow(
+       ~target=None,
+       ~position=`After,
+       `Vertical,
+       editorGroup.editorGroupId,
+     );
 };
 
 let initial = (~getUserSettings, ~contributedCommands, ~workingDirectory) => {
-
   let editorGroups = EditorGroups.create();
   let initialEditorGroup = editorGroups |> EditorGroups.getFirstEditorGroup;
 
   {
-  buffers: Buffers.empty,
-  bufferHighlights: BufferHighlights.initial,
-  bufferRenderers: BufferRenderers.initial,
-  colorTheme:
-    Feature_Theme.initial([
-      Feature_Terminal.Contributions.colors,
-      Feature_Notification.Contributions.colors,
-    ]),
-  commands: Feature_Commands.initial(contributedCommands),
-  contextMenu: ContextMenu.Nothing,
-  completions: Completions.initial,
-  config:
-    Feature_Configuration.initial(
-      ~getUserSettings,
-      [
-        Feature_Editor.Contributions.configuration,
-        Feature_Syntax.Contributions.configuration,
-        Feature_Terminal.Contributions.configuration,
-      ],
-    ),
-  configuration: Configuration.default,
-  decorationProviders: [],
-  definition: Definition.empty,
-  diagnostics: Diagnostics.create(),
-  vimMode: Normal,
-  quickmenu: None,
-  editorFont: Service_Font.default,
-  terminalFont: Service_Font.default,
-  extensions: Extensions.empty,
-  languageFeatures: LanguageFeatures.empty,
-  lifecycle: Lifecycle.create(),
-  uiFont: UiFont.default,
-  sideBar: SideBar.initial,
-  tokenTheme: TokenTheme.empty,
-  editorGroups,
-  iconTheme: IconTheme.create(),
-  isQuitting: false,
-  keyBindings: Keybindings.empty,
-  keyDisplayer: None,
-  languageInfo: Ext.LanguageInfo.initial,
-  notifications: Feature_Notification.initial,
-  references: References.initial,
-  scm: Feature_SCM.initial,
-  sneak: Sneak.initial,
-  statusBar: StatusBarModel.create(),
-  syntaxHighlights: Feature_Syntax.empty,
-  layout: initialLayout(initialEditorGroup),
-  windowTitle: "",
-  windowIsFocused: true,
-  windowIsMaximized: false,
-  workspace: Workspace.initial(workingDirectory),
-  fileExplorer: FileExplorer.initial,
-  zenMode: false,
-  pane: Pane.initial,
-  searchPane: Feature_Search.initial,
-  focus: Focus.initial,
-  modal: None,
-  terminals: Feature_Terminal.initial,
-  textContentProviders: [],
+    buffers: Buffers.empty,
+    bufferHighlights: BufferHighlights.initial,
+    bufferRenderers: BufferRenderers.initial,
+    colorTheme:
+      Feature_Theme.initial([
+        Feature_Terminal.Contributions.colors,
+        Feature_Notification.Contributions.colors,
+      ]),
+    commands: Feature_Commands.initial(contributedCommands),
+    contextMenu: ContextMenu.Nothing,
+    completions: Completions.initial,
+    config:
+      Feature_Configuration.initial(
+        ~getUserSettings,
+        [
+          Feature_Editor.Contributions.configuration,
+          Feature_Syntax.Contributions.configuration,
+          Feature_Terminal.Contributions.configuration,
+        ],
+      ),
+    configuration: Configuration.default,
+    decorationProviders: [],
+    definition: Definition.empty,
+    diagnostics: Diagnostics.create(),
+    vimMode: Normal,
+    quickmenu: None,
+    editorFont: Service_Font.default,
+    terminalFont: Service_Font.default,
+    extensions: Extensions.empty,
+    languageFeatures: LanguageFeatures.empty,
+    lifecycle: Lifecycle.create(),
+    uiFont: UiFont.default,
+    sideBar: SideBar.initial,
+    tokenTheme: TokenTheme.empty,
+    editorGroups,
+    iconTheme: IconTheme.create(),
+    isQuitting: false,
+    keyBindings: Keybindings.empty,
+    keyDisplayer: None,
+    languageInfo: Ext.LanguageInfo.initial,
+    notifications: Feature_Notification.initial,
+    references: References.initial,
+    scm: Feature_SCM.initial,
+    sneak: Sneak.initial,
+    statusBar: StatusBarModel.create(),
+    syntaxHighlights: Feature_Syntax.empty,
+    layout: initialLayout(initialEditorGroup),
+    windowTitle: "",
+    windowIsFocused: true,
+    windowIsMaximized: false,
+    workspace: Workspace.initial(workingDirectory),
+    fileExplorer: FileExplorer.initial,
+    zenMode: false,
+    pane: Pane.initial,
+    searchPane: Feature_Search.initial,
+    focus: Focus.initial,
+    modal: None,
+    terminals: Feature_Terminal.initial,
+    textContentProviders: [],
   };
 };
 

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Oni_Core.Utility;
 
 open Oni_Model;
 open Oni_Model.Actions;
@@ -28,31 +27,27 @@ let start = () => {
   let splitEditorEffect = (state, direction, _) =>
     Isolinear.Effect.createWithDispatch(~name="splitEditorEffect", dispatch => {
       let getBufferAndLocation = () => {
-      open Base.Option.Let_syntax;
-      let%bind buffer = state
-      |> Selectors.getActiveBuffer
+        open Base.Option.Let_syntax;
+        let%bind buffer = state |> Selectors.getActiveBuffer;
 
-      let%bind path = buffer |> Buffer.getFilePath;
+        let%bind path = buffer |> Buffer.getFilePath;
 
-      let%bind cursorLocation = state
-      |> Selectors.getActiveEditorGroup
-      |> Selectors.getActiveEditor
-      |> Option.map(Feature_Editor.Editor.getPrimaryCursor(~buffer));
+        let%bind cursorLocation =
+          state
+          |> Selectors.getActiveEditorGroup
+          |> Selectors.getActiveEditor
+          |> Option.map(Feature_Editor.Editor.getPrimaryCursor(~buffer));
 
-      Some((path, cursorLocation))
+        Some((path, cursorLocation));
       };
 
       getBufferAndLocation()
       |> Option.iter(((path, cursorLocation)) => {
-        dispatch(OpenFileByPath(
-          path,
-          Some(direction),
-          Some(cursorLocation),
-        ));
-      })
-      
-
-      });
+           dispatch(
+             OpenFileByPath(path, Some(direction), Some(cursorLocation)),
+           )
+         });
+    });
 
   let windowMoveEffect = (state: State.t, direction, _) => {
     Isolinear.Effect.createWithDispatch(~name="window.move", dispatch => {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -678,7 +678,7 @@ let start =
       | Some(editorGroup) =>
         // This needs to be dispatched after the split, since this will set the
         // active editor group, which is then used as the target for the split.
-        dispatch(Actions.EditorGroupAdd(editorGroup));
+        dispatch(Actions.EditorGroupAdd(editorGroup))
       | None => ()
       };
 
@@ -1024,21 +1024,21 @@ let start =
   };
 
   let addSplit = (direction, state: State.t, editorGroup) => {
-        ...state,
-        // Fix #686: If we're adding a split, we should turn off zen mode... unless it's the first split being added.
-        zenMode: state.zenMode && Feature_Layout.windows(state.layout) == [],
-        layout:
-          Feature_Layout.addWindow(
-            ~target={
-              EditorGroups.getActiveEditorGroup(state.editorGroups)
-              |> Option.map((group: EditorGroup.t) => group.editorGroupId);
-            },
-            ~position=`After,
-            direction,
-            editorGroup,
-            state.layout,
-          ),
-      };
+    ...state,
+    // Fix #686: If we're adding a split, we should turn off zen mode... unless it's the first split being added.
+    zenMode: state.zenMode && Feature_Layout.windows(state.layout) == [],
+    layout:
+      Feature_Layout.addWindow(
+        ~target={
+          EditorGroups.getActiveEditorGroup(state.editorGroups)
+          |> Option.map((group: EditorGroup.t) => group.editorGroupId);
+        },
+        ~position=`After,
+        direction,
+        editorGroup,
+        state.layout,
+      ),
+  };
 
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
@@ -1075,21 +1075,17 @@ let start =
 
     | Init => (state, initEffect)
     | ModeChanged(vimMode) => ({...state, vimMode}, Isolinear.Effect.none)
-    | OpenFileByPath(path, maybeDirection, location) => {
-
+    | OpenFileByPath(path, maybeDirection, location) =>
       /* If a split was requested, create that first! */
-      let (state, maybeEditorGroup) = switch(maybeDirection) {
-      | None => (state, None)
-      | Some(direction) => 
-        let editorGroup = EditorGroup.create();
-        let state' = addSplit(direction, state, editorGroup.editorGroupId);
-        (state', Some(editorGroup));
-      };
-      (
-        state,
-        openFileByPathEffect(path, maybeEditorGroup, location),
-      );
-    }
+      let (state, maybeEditorGroup) =
+        switch (maybeDirection) {
+        | None => (state, None)
+        | Some(direction) =>
+          let editorGroup = EditorGroup.create();
+          let state' = addSplit(direction, state, editorGroup.editorGroupId);
+          (state', Some(editorGroup));
+        };
+      (state, openFileByPathEffect(path, maybeEditorGroup, location));
     | BufferEnter(_)
     | EditorFont(Service_Font.FontLoaded(_))
     | EditorGroupSelected(_)

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -672,18 +672,13 @@ let start =
       }
     );
 
-  let openFileByPathEffect = (filePath, dir, location) =>
+  let openFileByPathEffect = (filePath, maybeEditorGroup, location) =>
     Isolinear.Effect.create(~name="vim.openFileByPath", () => {
-      /* If a split was requested, create that first! */
-      switch (dir) {
-      | Some(direction) =>
-        let eg = EditorGroup.create();
-
-        dispatch(Actions.AddSplit(direction, eg.editorGroupId));
-
+      switch (maybeEditorGroup) {
+      | Some(editorGroup) =>
         // This needs to be dispatched after the split, since this will set the
         // active editor group, which is then used as the target for the split.
-        dispatch(Actions.EditorGroupAdd(eg));
+        dispatch(Actions.EditorGroupAdd(editorGroup));
       | None => ()
       };
 
@@ -721,7 +716,7 @@ let start =
        * If we're splitting, make sure a BufferEnter event gets dispatched.
        * (This wouldn't happen if we're splitting the same buffer we're already at)
        */
-      switch (dir) {
+      switch (maybeEditorGroup) {
       | Some(_) =>
         dispatch(Actions.BufferEnter({metadata, fileType, lineEndings}))
       | None => ()
@@ -1028,6 +1023,23 @@ let start =
     });
   };
 
+  let addSplit = (direction, state: State.t, editorGroup) => {
+        ...state,
+        // Fix #686: If we're adding a split, we should turn off zen mode... unless it's the first split being added.
+        zenMode: state.zenMode && Feature_Layout.windows(state.layout) == [],
+        layout:
+          Feature_Layout.addWindow(
+            ~target={
+              EditorGroups.getActiveEditorGroup(state.editorGroups)
+              |> Option.map((group: EditorGroup.t) => group.editorGroupId);
+            },
+            ~position=`After,
+            direction,
+            editorGroup,
+            state.layout,
+          ),
+      };
+
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
     | ConfigurationSet(configuration) => (
@@ -1063,10 +1075,21 @@ let start =
 
     | Init => (state, initEffect)
     | ModeChanged(vimMode) => ({...state, vimMode}, Isolinear.Effect.none)
-    | OpenFileByPath(path, direction, location) => (
+    | OpenFileByPath(path, maybeDirection, location) => {
+
+      /* If a split was requested, create that first! */
+      let (state, maybeEditorGroup) = switch(maybeDirection) {
+      | None => (state, None)
+      | Some(direction) => 
+        let editorGroup = EditorGroup.create();
+        let state' = addSplit(direction, state, editorGroup.editorGroupId);
+        (state', Some(editorGroup));
+      };
+      (
         state,
-        openFileByPathEffect(path, direction, location),
-      )
+        openFileByPathEffect(path, maybeEditorGroup, location),
+      );
+    }
     | BufferEnter(_)
     | EditorFont(Service_Font.FontLoaded(_))
     | EditorGroupSelected(_)

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1025,8 +1025,8 @@ let start =
 
   let addSplit = (direction, state: State.t, editorGroup) => {
     ...state,
-    // Fix #686: If we're adding a split, we should turn off zen mode... unless it's the first split being added.
-    zenMode: state.zenMode && Feature_Layout.windows(state.layout) == [],
+    // Fix #686: If we're adding a split, we should turn off Zen mode.
+    zenMode: false,
     layout:
       Feature_Layout.addWindow(
         ~target={

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -18,16 +18,6 @@ let start = () => {
       dispatch(Model.Actions.Quit(false))
     );
 
-  let initializeDefaultViewEffect = (state: State.t) =>
-    Isolinear.Effect.createWithDispatch(~name="windows.init", dispatch => {
-      dispatch(
-        Actions.AddSplit(
-          `Vertical,
-          EditorGroups.activeGroupId(state.editorGroups),
-        ),
-      )
-    });
-
   let resize = (axis, factor, state: State.t) =>
     switch (EditorGroups.getActiveEditorGroup(state.editorGroups)) {
     | Some((editorGroup: EditorGroup.t)) => {
@@ -46,23 +36,6 @@ let start = () => {
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
     | EditorGroupSelected(_) => FocusManager.push(Editor, s)
-
-    | AddSplit(direction, split) => {
-        ...s,
-        // Fix #686: If we're adding a split, we should turn off zen mode... unless it's the first split being added.
-        zenMode: s.zenMode && Feature_Layout.windows(s.layout) == [],
-        layout:
-          Feature_Layout.addWindow(
-            ~target={
-              EditorGroups.getActiveEditorGroup(s.editorGroups)
-              |> Option.map((group: EditorGroup.t) => group.editorGroupId);
-            },
-            ~position=`After,
-            direction,
-            split,
-            s.layout,
-          ),
-      }
 
     | RemoveSplit(id) => {
         ...s,
@@ -144,7 +117,6 @@ let start = () => {
 
     let effect =
       switch (action) {
-      | Init => initializeDefaultViewEffect(state)
       // When opening a file, ensure that the active editor is getting focus
       | ViewCloseEditor(_) =>
         if (Feature_Layout.windows(state.layout) == []) {

--- a/src/Store/dune
+++ b/src/Store/dune
@@ -32,4 +32,4 @@
         textmate
         treesitter
     )
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show)))
+    (preprocess (pps ppx_let brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show)))


### PR DESCRIPTION
This removes the imperative `AddSplit` action, to help streamline the path we take when we open a file.

This moves the `addSplit` to just a function call - and removes the need for a special initialization effect to create the initial window split, as it just gets baked into the actual model.