### PR TITLE
refactor(editor): Remove imperative EditorGroupAdd action

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -87,7 +87,6 @@ type t =
   | KeyboardInput(string)
   | WindowTitleSet(string)
   | EditorGroupSelected(int)
-  | EditorGroupAdd(EditorGroup.t)
   | EditorGroupSizeChanged({
       id: int,
       width: int,

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -23,6 +23,26 @@ let create = () => {
 
 let activeGroupId = model => model.activeId;
 
+let add = (~defaultFont, editorGroup, model) => {
+  let editorGroup =
+    switch (model.lastEditorFont) {
+    | Some(font) =>
+      EditorGroupReducer.reduce(
+        ~defaultFont,
+        editorGroup,
+        EditorFont(Service_Font.FontLoaded(font)),
+      )
+    | None => editorGroup
+    };
+
+  {
+    ...model,
+    activeId: editorGroup.editorGroupId,
+    idToGroup:
+      IntMap.add(editorGroup.editorGroupId, editorGroup, model.idToGroup),
+  };
+};
+
 let getEditorGroupById = (model, id) => IntMap.find_opt(id, model.idToGroup);
 
 let getFirstEditorGroup = ({idToGroup, _}) => {
@@ -96,25 +116,6 @@ let reduce = (~defaultFont, model, action: Actions.t) => {
     }
 
   | EditorGroupSelected(editorGroupId) => {...model, activeId: editorGroupId}
-
-  | EditorGroupAdd(editorGroup) =>
-    let editorGroup =
-      switch (model.lastEditorFont) {
-      | Some(font) =>
-        EditorGroupReducer.reduce(
-          ~defaultFont,
-          editorGroup,
-          EditorFont(Service_Font.FontLoaded(font)),
-        )
-      | None => editorGroup
-      };
-
-    {
-      ...model,
-      activeId: editorGroup.editorGroupId,
-      idToGroup:
-        IntMap.add(editorGroup.editorGroupId, editorGroup, model.idToGroup),
-    };
 
   | action =>
     let newModel =

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -8,6 +8,8 @@ let getActiveEditorGroup: t => option(EditorGroup.t);
 
 let getFirstEditorGroup: t => EditorGroup.t;
 
+let add: (~defaultFont: Service_Font.font, EditorGroup.t, t) => t;
+
 let isActive: (t, EditorGroup.t) => bool;
 let isEmpty: (int, t) => bool;
 


### PR DESCRIPTION
Another round of streamlining the `dispatch`s that happen in the `openFileByPath` effect - this removes the `EditorGroupAdd` imperative action with a function call, to help reduce timing dependencies and streamline the open code path.