### PR TITLE
test(exthost): Add test case to exercise SCM API

### DIFF
--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -563,7 +563,15 @@ module SCM = {
       | `List([`Int(handle), `String(id), `String(label), rootUri]) =>
         let rootUri = Uri.of_yojson(rootUri) |> Stdlib.Result.to_option;
         Ok(RegisterSourceControl({handle, id, label, rootUri}));
-
+      | `List([`String(handleStr), `String(id), `String(label), rootUri]) =>
+        let rootUri = Uri.of_yojson(rootUri) |> Stdlib.Result.to_option;
+        let maybeHandle = int_of_string_opt(handleStr);
+        switch (maybeHandle) {
+        | Some(handle) =>
+          Ok(RegisterSourceControl({handle, id, label, rootUri}))
+        | None =>
+          Error("Expected number for handle, but received: " ++ handleStr)
+        };
       | _ => Error("Unexpected arguments for $registerSourceControl")
       }
 

--- a/test/Exthost/SCMTest.re
+++ b/test/Exthost/SCMTest.re
@@ -75,20 +75,13 @@ describe("SCM", ({test, _}) => {
     |> Test.terminate
     |> Test.waitForProcessClosed
   });
-  test("provideOriginalResource returns URI", ({expect, _}) => {
+  test("provideOriginalResource returns URI", _ => {
     let testUri = Uri.fromPath("a-test-file.txt");
     Test.startWithExtensions(["oni-scm"])
     |> Test.waitForExtensionActivation("oni-scm")
     |> Test.withClientRequest(
          ~name="provideOriginalResource",
-         ~validate=
-           maybeUri => {
-             switch (maybeUri) {
-             | Some(uri) => prerr_endline("URI: " ++ Uri.toString(uri))
-             | None => prerr_endline(" NO URI")
-             };
-             maybeUri == Some(testUri);
-           },
+         ~validate=maybeUri => maybeUri == Some(testUri),
          Exthost.Request.SCM.provideOriginalResource(~handle=0, ~uri=testUri),
        )
     |> Test.terminate

--- a/test/Exthost/SCMTest.re
+++ b/test/Exthost/SCMTest.re
@@ -1,0 +1,77 @@
+open TestFramework;
+
+open Exthost;
+
+describe("SCM", ({test, _}) => {
+  test("oni-scm extension activates", _ => {
+    Test.startWithExtensions(["oni-scm"])
+    |> Test.waitForExtensionActivation("oni-scm")
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  });
+
+  test("gets RegisterSourceControl message", _ => {
+    Test.startWithExtensions(["oni-scm"])
+    |> Test.waitForExtensionActivation("oni-scm")
+    |> Test.waitForMessage(
+         ~name="RegisterSourceControl",
+         fun
+         | Msg.SCM(RegisterSourceControl({id, label, _})) =>
+           id == "\"test\"" && label == "\"Test\""
+         | _ => false,
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  });
+
+  test("gets RegisterSCMResourceGroup message", _ => {
+    Test.startWithExtensions(["oni-scm"])
+    |> Test.waitForExtensionActivation("oni-scm")
+    |> Test.waitForMessage(
+         ~name="RegisterSCMResourceGroup",
+         fun
+         | Msg.SCM(RegisterSCMResourceGroup({id, label, _})) =>
+           id == "resourceGroup" && label == "resourceGroup"
+         | _ => false,
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  });
+
+  test("gets UnregisterSourceControl message after disposing", _ => {
+    Test.startWithExtensions(["oni-scm"])
+    |> Test.waitForExtensionActivation("oni-scm")
+    |> Test.withClient(
+         Exthost.Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="testSCM.dispose",
+         ),
+       )
+    |> Test.waitForMessage(
+         ~name="UnregisterSourceControl",
+         fun
+         | Msg.SCM(UnregisterSourceControl(_)) => true
+         | _ => false,
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  });
+  test("gets UnregisterSCMResourceGroup message after disposing", _ => {
+    Test.startWithExtensions(["oni-scm"])
+    |> Test.waitForExtensionActivation("oni-scm")
+    |> Test.withClient(
+         Exthost.Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="testSCM.dispose",
+         ),
+       )
+    |> Test.waitForMessage(
+         ~name="UnregisterSCMResourceGroup",
+         fun
+         | Msg.SCM(UnregisterSCMResourceGroup(_)) => true
+         | _ => false,
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  });
+});

--- a/test/Exthost/SCMTest.re
+++ b/test/Exthost/SCMTest.re
@@ -1,3 +1,4 @@
+open Oni_Core;
 open TestFramework;
 
 open Exthost;
@@ -73,5 +74,24 @@ describe("SCM", ({test, _}) => {
        )
     |> Test.terminate
     |> Test.waitForProcessClosed
+  });
+  test("provideOriginalResource returns URI", ({expect, _}) => {
+    let testUri = Uri.fromPath("a-test-file.txt");
+    Test.startWithExtensions(["oni-scm"])
+    |> Test.waitForExtensionActivation("oni-scm")
+    |> Test.withClientRequest(
+         ~name="provideOriginalResource",
+         ~validate=
+           maybeUri => {
+             switch (maybeUri) {
+             | Some(uri) => prerr_endline("URI: " ++ Uri.toString(uri))
+             | None => prerr_endline(" NO URI")
+             };
+             maybeUri == Some(testUri);
+           },
+         Exthost.Request.SCM.provideOriginalResource(~handle=0, ~uri=testUri),
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed;
   });
 });

--- a/test/collateral/extensions/oni-scm/extension.js
+++ b/test/collateral/extensions/oni-scm/extension.js
@@ -1,0 +1,38 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+
+    const testSCM = vscode.scm.createSourceControl('test', 'Test');
+
+	const resourceGroup = testSCM.createResourceGroup('resourceGroup', 'resourceGroup');
+	resourceGroup.resourceStates = [];
+
+	testSCM.quickDiffProvider = {
+		provideOriginalResource: (uri, _token) => {
+			// Test round-trip
+			return uri;
+		}
+	};
+	
+	const disposable0 = vscode.commands.registerCommand("testSCM.dispose", (_args) => {
+		testSCM.dispose();
+	});
+
+	context.subscriptions.push(disposable0);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-scm/package.json
+++ b/test/collateral/extensions/oni-scm/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "oni-scm",
+	"description": "SCM extension for Onivim tests",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": ["*"],
+	"main": "./extension.js",
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
This adds test cases to cover the register/unregister methods of the extension host SCM API, and also fixes a bug that was hit while editing the cases - the `$registerSourceControl` API method, although documenting the handle as a `number`, was sending us a `string` - so we'll handle that case as well.