### PR TITLE
test(windows): No unit test output on windows

### DIFF
--- a/test/Core/Helpers.re
+++ b/test/Core/Helpers.re
@@ -1,6 +1,15 @@
 open EditorCoreTypes;
 open Oni_Core;
 
+let allocateConsoleIfNecessary = () =>
+  // On Windows, because this is linked against the '-mwindows' flag (for a GUI app)
+  // there is no console allocated by default, so we need to manually allocate one.
+  if (Sys.win32) {
+    let _: int = Sdl2.Platform.win32AttachConsole();
+    // Unfortunately, colors aren't showing up correctly in the allocated console...
+    Pastel.setMode(Pastel.Disabled);
+  };
+
 exception OptionInvalidException(string);
 let getOrThrow: option('a) => 'a =
   v =>

--- a/test/OniUnitTestRunner.re
+++ b/test/OniUnitTestRunner.re
@@ -1,3 +1,5 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
+
 Oni_Core_Test.TestFramework.cli();
 Oni_Core_Utility_Test.TestFramework.cli();
 Oni_Core_WhenExpr_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerCore.re
+++ b/test/OniUnitTestRunnerCore.re
@@ -1,3 +1,5 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
+
 Oni_Core_Test.TestFramework.cli();
 Oni_Core_Utility_Test.TestFramework.cli();
 Oni_Core_WhenExpr_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerExtHost.re
+++ b/test/OniUnitTestRunnerExtHost.re
@@ -1,2 +1,4 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
+
 Exthost_Transport_Test.TestFramework.cli();
 Exthost_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerInput.re
+++ b/test/OniUnitTestRunnerInput.re
@@ -1,1 +1,3 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
+
 Oni_Input_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerModel.re
+++ b/test/OniUnitTestRunnerModel.re
@@ -1,1 +1,3 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
+
 Oni_Model_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerUI.re
+++ b/test/OniUnitTestRunnerUI.re
@@ -1,1 +1,2 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
 Oni_UI_Test.TestFramework.cli();

--- a/test/dune
+++ b/test/dune
@@ -56,7 +56,9 @@
     (public_name OniUnitTestRunnerUI)
     (modules OniUnitTestRunnerUI)
     (package OniUnitTestRunner)
-    (libraries Oni_UI_Test))
+    (libraries 
+        Oni_Core_Test
+        Oni_UI_Test))
 
 (executable
     (name OniUnitTestRunnerExtHost)
@@ -64,6 +66,7 @@
     (modules OniUnitTestRunnerExtHost)
     (package OniUnitTestRunner)
     (libraries 
+        Oni_Core_Test
         Exthost_Transport_Test
         Exthost_Test))
 


### PR DESCRIPTION
Same issue as https://github.com/revery-ui/revery/pull/845

__Issue:__ `esy @test run` stopped producing output on all the windows devices I tried.

__Defect:__ Linking in `reason-sdl2` brings in the `-mwindows` flag, which causes the application to not allocate or attach console.

__Fix:__ Explicitly attach a console for the test runner.