### PR TITLE
fix(persistence/#1766): Blank input data

### DIFF
--- a/src/Core/Persistence.rei
+++ b/src/Core/Persistence.rei
@@ -31,7 +31,9 @@ module Store: {
   type entry('state);
   let entry: Schema.item('state, _) => entry('state);
 
-  let instantiate: (string, unit => list(entry('state))) => t('state);
+  let instantiate:
+    (~storeFolder: string=?, string, unit => list(entry('state))) =>
+    t('state);
 
   let isDirty: ('state, t('state)) => bool;
   let update: ('state, t('state)) => unit;

--- a/test/Core/PersistenceTests.re
+++ b/test/Core/PersistenceTests.re
@@ -1,0 +1,45 @@
+open Oni_Core;
+open TestFramework;
+
+module Store = Persistence.Store;
+open Persistence.Schema;
+
+describe("Persistence", ({test, _}) => {
+  let setup = () => {
+    let storeFolder =
+      Filename.get_temp_dir_name()
+      ++ "store-testXXXXXX"
+      |> Luv.File.Sync.mkdtemp
+      |> Result.get_ok;
+
+    let instantiate = Store.instantiate(~storeFolder);
+
+    let testBool = define("testBool", bool, false, state => state);
+
+    let store = instantiate("global", () => [Store.entry(testBool)]);
+
+    (storeFolder, store, testBool);
+  };
+
+  test("get defaults", ({expect, _}) => {
+    let (storeFolder, store, testBool) = setup();
+    expect.bool(Store.get(testBool, store)).toBe(false);
+  });
+
+  test("empty file (regression test for #1766)", ({expect, _}) => {
+    let (storeFolder, _ignoreStore, testBool) = setup();
+
+    // We'll write out an empty file...
+    let oc = open_out(storeFolder ++ "/global/store.json");
+    Printf.fprintf(oc, "\n");
+    close_out(oc);
+
+    // ...and hydrate a new store to exercise #1766
+    let store =
+      Store.instantiate(~storeFolder, "global", () =>
+        [Store.entry(testBool)]
+      );
+
+    expect.bool(Store.get(testBool, store)).toBe(false);
+  });
+});

--- a/test/Core/PersistenceTests.re
+++ b/test/Core/PersistenceTests.re
@@ -28,12 +28,12 @@ describe("Persistence", ({test, _}) => {
   };
 
   test("get defaults", ({expect, _}) => {
-    let { store, testBool, _} = setup();
+    let {store, testBool, _} = setup();
     expect.bool(Store.get(testBool, store)).toBe(false);
   });
 
   test("empty file (regression test for #1766)", ({expect, _}) => {
-    let { storeFolder, testBool, _ } = setup();
+    let {storeFolder, testBool, _} = setup();
 
     // We'll write out an empty file...
     let oc = open_out(storeFolder ++ "/global/store.json");

--- a/test/Core/PersistenceTests.re
+++ b/test/Core/PersistenceTests.re
@@ -4,6 +4,12 @@ open TestFramework;
 module Store = Persistence.Store;
 open Persistence.Schema;
 
+type testContext = {
+  storeFolder: string,
+  store: Store.t(bool),
+  testBool: item(bool, bool),
+};
+
 describe("Persistence", ({test, _}) => {
   let setup = () => {
     let storeFolder =
@@ -18,16 +24,16 @@ describe("Persistence", ({test, _}) => {
 
     let store = instantiate("global", () => [Store.entry(testBool)]);
 
-    (storeFolder, store, testBool);
+    {storeFolder, store, testBool};
   };
 
   test("get defaults", ({expect, _}) => {
-    let (storeFolder, store, testBool) = setup();
+    let { store, testBool, _} = setup();
     expect.bool(Store.get(testBool, store)).toBe(false);
   });
 
   test("empty file (regression test for #1766)", ({expect, _}) => {
-    let (storeFolder, _ignoreStore, testBool) = setup();
+    let { storeFolder, testBool, _ } = setup();
 
     // We'll write out an empty file...
     let oc = open_out(storeFolder ++ "/global/store.json");

--- a/test/Core/dune
+++ b/test/Core/dune
@@ -7,5 +7,6 @@
         Oni_Core_Utility_Test
         Oni_Core_WhenExpr_Test
         rely.lib
+        luv
         editor-core-types
     ))


### PR DESCRIPTION
__Issue:__ If the `store.json` is corrupt, we crash on launch - described by #1766 

__Defect:__ There are some additional error cases - like a corrupted `store.json` file - that could cause us to crash.

__Fix:__ Log out errors, but revert to defaults if we can't load the persistence file.