### PR TITLE
fix(exthost): marshalled URIs not revived correctly

### DIFF
--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -72,6 +72,7 @@ type t = {
 let encode = uri =>
   Json.Encode.(
     obj([
+      ("$mid", Json.Encode.int(1)), // Magic marshaling id for Uri
       ("scheme", uri.scheme |> Scheme.encode),
       ("path", uri.path |> string),
       ("query", uri.query |> nullable(string)),

--- a/test/Exthost/UriTest.re
+++ b/test/Exthost/UriTest.re
@@ -8,7 +8,7 @@ let waitForMessage = (~name, f, context) => {
   |> Test.waitForMessage(
        ~name,
        fun
-       | Msg.MessageService(ShowMessage({message, severity})) =>
+       | Msg.MessageService(ShowMessage({message, severity, _})) =>
          f(severity, message)
        | _ => false,
      );

--- a/test/Exthost/UriTest.re
+++ b/test/Exthost/UriTest.re
@@ -1,0 +1,37 @@
+open TestFramework;
+
+open Oni_Core;
+open Exthost;
+
+let waitForMessage = (~name, f, context) => {
+  context
+  |> Test.waitForMessage(
+       ~name,
+       fun
+       | Msg.MessageService(ShowMessage({message, severity})) =>
+         f(severity, message)
+       | _ => false,
+     );
+};
+
+describe("UriTest", ({test, _}) => {
+  test("revive uri", _ => {
+    Test.startWithExtensions(["oni-uri"])
+    |> Test.waitForExtensionActivation("oni-uri")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[Uri.encode(Uri.fromPath("/"))],
+           ~command="developer.oni.reviveUri",
+         ),
+       )
+    |> waitForMessage(~name="revive uri success", (severity, _message) =>
+         switch (severity) {
+         | Info => true
+         | Error => false
+         | _ => assert(false)
+         }
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+});

--- a/test/collateral/extensions/oni-uri/extension.js
+++ b/test/collateral/extensions/oni-uri/extension.js
@@ -1,0 +1,29 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	context.subscriptions.push(
+		vscode.commands.registerCommand('developer.oni.reviveUri', uri => {
+			if (uri instanceof vscode.Uri) {
+				vscode.window.showInformationMessage('success');
+			} else {
+				vscode.window.showErrorMessage('failed');
+			}
+		})
+	);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-uri/package.json
+++ b/test/collateral/extensions/oni-uri/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "oni-uri",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"publisher": "vscode-samples",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": ["*"],
+	"contributes": {
+		"commands": [
+			{
+				"command": "developer.oni.reviveUri",
+				"title": "Onivim - Developer: Test URI"
+			}
+		]
+	},
+	"main": "./extension.js",
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
This adds an `$mid` field to the encoded JSON of URIs, so that the exthost marshaller can properly detect it.