### PR TITLE
refactor(editor) - Remove imperative Recalculate actions

### DIFF
--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -38,15 +38,19 @@ let simpleState =
     Actions.EditorFont(Service_Font.FontLoaded(defaultFont)),
   );
 
+let thousandLines =
+  Array.make(1000, "This is a buffer with a thousand lines!");
+
+let defaultBuffer = Oni_Core.Buffer.ofLines(~id=0, thousandLines);
+let defaultEditorBuffer =
+  defaultBuffer |> Feature_Editor.EditorBuffer.ofBuffer;
+
 let simpleEditor =
-  Editor.create(~font=defaultFont, ())
+  Editor.create(~font=defaultFont, ~buffer=defaultEditorBuffer, ())
   |> Editor.setSize(~pixelWidth=3440, ~pixelHeight=1440);
 let editorGroup =
   EditorGroups.getActiveEditorGroup(simpleState.editorGroups)
   |> Option.value(~default=EditorGroup.create());
-
-let thousandLines =
-  Array.make(1000, "This is a buffer with a thousand lines!");
 
 let createUpdateAction = (oldBuffer: Buffer.t, update: BufferUpdate.t) => {
   let newBuffer = Buffer.update(oldBuffer, update);

--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -2,7 +2,6 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 
 runTest(~name="AddRemoveSplitTest", (dispatch, wait, _runEffects) => {
-
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
     splitCount == 1;
@@ -11,29 +10,32 @@ runTest(~name="AddRemoveSplitTest", (dispatch, wait, _runEffects) => {
   let initialEditorId: ref(option(int)) = ref(None);
 
   wait(~name="Wait for initial editor", (state: State.t) => {
-    let maybeEditor = state
-    |> Selectors.getActiveEditorGroup
-    |> Selectors.getActiveEditor;
+    let maybeEditor =
+      state |> Selectors.getActiveEditorGroup |> Selectors.getActiveEditor;
 
     maybeEditor
     |> Option.map(Feature_Editor.Editor.getId)
     |> Option.iter(id => initialEditorId := Some(id));
 
-    maybeEditor != None
+    maybeEditor != None;
   });
-  
 
   dispatch(Command("view.splitVertical"));
 
-  wait(~name="Wait for split to be created, and editor to be focused", (state: State.t) => {
+  wait(
+    ~name="Wait for split to be created, and editor to be focused",
+    (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
 
-    let maybeEditorId = state
-    |> Selectors.getActiveEditorGroup
-    |> Selectors.getActiveEditor
-    |> Option.map(Feature_Editor.Editor.getId);
+    let maybeEditorId =
+      state
+      |> Selectors.getActiveEditorGroup
+      |> Selectors.getActiveEditor
+      |> Option.map(Feature_Editor.Editor.getId);
 
-    splitCount == 2 && maybeEditorId != None && maybeEditorId != initialEditorId^;
+    splitCount == 2
+    && maybeEditorId != None
+    && maybeEditorId != initialEditorId^;
   });
 
   dispatch(QuitBuffer(Vim.Buffer.getCurrent(), false));
@@ -41,7 +43,7 @@ runTest(~name="AddRemoveSplitTest", (dispatch, wait, _runEffects) => {
   wait(~name="Wait for split to be closed", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
 
-    prerr_endline ("Split count: " ++ string_of_int(splitCount));
+    prerr_endline("Split count: " ++ string_of_int(splitCount));
 
     splitCount == 1;
   });

--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="AddRemoveSplitTest", (dispatch, wait, _) => {
+runTest(~name="AddRemoveSplitTest", (dispatch, wait, _runEffects) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
     splitCount == 1;

--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -2,23 +2,46 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 
 runTest(~name="AddRemoveSplitTest", (dispatch, wait, _runEffects) => {
+
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
     splitCount == 1;
   });
 
+  let initialEditorId: ref(option(int)) = ref(None);
+
+  wait(~name="Wait for initial editor", (state: State.t) => {
+    let maybeEditor = state
+    |> Selectors.getActiveEditorGroup
+    |> Selectors.getActiveEditor;
+
+    maybeEditor
+    |> Option.map(Feature_Editor.Editor.getId)
+    |> Option.iter(id => initialEditorId := Some(id));
+
+    maybeEditor != None
+  });
+  
+
   dispatch(Command("view.splitVertical"));
 
-  wait(~name="Wait for split to be created", (state: State.t) => {
+  wait(~name="Wait for split to be created, and editor to be focused", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
 
-    splitCount == 2;
+    let maybeEditorId = state
+    |> Selectors.getActiveEditorGroup
+    |> Selectors.getActiveEditor
+    |> Option.map(Feature_Editor.Editor.getId);
+
+    splitCount == 2 && maybeEditorId != None && maybeEditorId != initialEditorId^;
   });
 
   dispatch(QuitBuffer(Vim.Buffer.getCurrent(), false));
 
   wait(~name="Wait for split to be closed", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
+
+    prerr_endline ("Split count: " ++ string_of_int(splitCount));
 
     splitCount == 1;
   });

--- a/integration_test/RegressionFileModifiedIndicationTest.re
+++ b/integration_test/RegressionFileModifiedIndicationTest.re
@@ -7,12 +7,32 @@ open Oni_IntegrationTestLib;
 //
 // Verify some simple cases around the file modified flag
 runTestWithInput(
-  ~name="RegressionFileModifiedIndication", (input, _, wait, _) => {
+  ~name="RegressionFileModifiedIndication",
+  (input, dispatch, wait, runEffects) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     state.vimMode == Vim.Types.Normal
   );
 
-  Vim.command("e regression-file-modified-indication.txt");
+  let initialBuffer = Vim.Buffer.getCurrent();
+
+  dispatch(
+    Actions.OpenFileByPath(
+      "regression-file-modified-indication.txt",
+      None,
+      None,
+    ),
+  );
+  runEffects();
+
+  wait(~name="Wait for new buffer", (state: State.t) => {
+    let activeBufferId =
+      state
+      |> Selectors.getActiveBuffer
+      |> Option.map(Buffer.getId)
+      |> Option.value(~default=-1);
+
+    activeBufferId != Vim.Buffer.getId(initialBuffer);
+  });
 
   let id = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
 

--- a/integration_test/RegressionNonExistentDirectory.re
+++ b/integration_test/RegressionNonExistentDirectory.re
@@ -1,5 +1,6 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
+module Editor = Feature_Editor.Editor;
 
 runTest(~name="RegressionVspEmpty", (_, wait, _) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
@@ -35,9 +36,11 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
 
     switch (firstActiveEditor, secondActiveEditor) {
     | (Some(e1), Some(e2)) =>
-      print_endline("e1 buffer id: " ++ string_of_int(e1.bufferId));
-      print_endline("e2 buffer id: " ++ string_of_int(e2.bufferId));
-      e1.bufferId == e2.bufferId;
+      let bufferId1 = Editor.getBufferId(e1);
+      let bufferId2 = Editor.getBufferId(e2);
+      print_endline("e1 buffer id: " ++ string_of_int(bufferId1));
+      print_endline("e2 buffer id: " ++ string_of_int(bufferId2));
+      bufferId1 == bufferId2;
     | _ => false
     };
   });

--- a/integration_test/RegressionVspEmptyExistingBufferTest.re
+++ b/integration_test/RegressionVspEmptyExistingBufferTest.re
@@ -1,5 +1,6 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
+module Editor = Feature_Editor.Editor;
 
 runTest(~name="RegressionVspEmpty", (_, wait, _) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
@@ -35,9 +36,11 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
 
     switch (firstActiveEditor, secondActiveEditor) {
     | (Some(e1), Some(e2)) =>
-      print_endline("e1 buffer id: " ++ string_of_int(e1.bufferId));
-      print_endline("e2 buffer id: " ++ string_of_int(e2.bufferId));
-      e1.bufferId == e2.bufferId;
+      let bufferId1 = Editor.getBufferId(e1);
+      let bufferId2 = Editor.getBufferId(e2);
+      print_endline("e1 buffer id: " ++ string_of_int(bufferId1));
+      print_endline("e2 buffer id: " ++ string_of_int(bufferId2));
+      bufferId1 == bufferId2;
     | _ => false
     };
   });

--- a/integration_test/RegressionVspEmptyInitialBufferTest.re
+++ b/integration_test/RegressionVspEmptyInitialBufferTest.re
@@ -6,6 +6,7 @@
 // buffer - so by testing that we aren't opening a new buffer at all,
 // we can avoid that particular issue.
 
+open Oni_Core;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
@@ -14,6 +15,14 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount = state.layout |> Feature_Layout.windows |> List.length;
     splitCount == 1;
+  });
+
+  // Wait for initial buffer
+  wait(~name="Initial buffer", state => {
+    let maybeFilePath =
+      state |> Selectors.getActiveBuffer |> Option.map(Buffer.getFilePath);
+
+    maybeFilePath != None;
   });
 
   /* :vsp with no arguments should create a second split w/ same buffer */

--- a/integration_test/RegressionVspEmptyInitialBufferTest.re
+++ b/integration_test/RegressionVspEmptyInitialBufferTest.re
@@ -8,6 +8,7 @@
 
 open Oni_Model;
 open Oni_IntegrationTestLib;
+module Editor = Feature_Editor.Editor;
 
 runTest(~name="RegressionVspEmpty", (_, wait, _) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
@@ -41,9 +42,11 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
 
     switch (firstActiveEditor, secondActiveEditor) {
     | (Some(e1), Some(e2)) =>
-      print_endline("e1 buffer id: " ++ string_of_int(e1.bufferId));
-      print_endline("e2 buffer id: " ++ string_of_int(e2.bufferId));
-      e1.bufferId == e2.bufferId;
+      let bufferId1 = Editor.getBufferId(e1);
+      let bufferId2 = Editor.getBufferId(e2);
+      print_endline("e1 buffer id: " ++ string_of_int(bufferId1));
+      print_endline("e2 buffer id: " ++ string_of_int(bufferId2));
+      bufferId1 == bufferId2;
     | _ => false
     };
   });

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -38,6 +38,7 @@ let getMediumFriendlyName =
        | Version => "Version"
        | Terminal({cmd, _}) => "Terminal - " ++ cmd
        | UpdateChangelog => "Updates"
+       | Changelog => "Changelog"
        | FilePath(fp) =>
          switch (workingDirectory) {
          | Some(base) => Path.toRelative(~base, fp)
@@ -60,6 +61,7 @@ let getLongFriendlyName = ({filePath: maybeFilePath, _}) => {
        | Welcome => "Welcome"
        | Version => "Version"
        | UpdateChangelog => "Updates"
+       | Changelog => "Changelog"
        | Terminal({cmd, _}) => "Terminal - " ++ cmd
        | FilePath(fp) => fp
        }

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -91,12 +91,12 @@ let ofLines = (~id=0, rawLines: array(string)) => {
 
 let initial = ofLines([||]);
 
-let ofMetadata = (metadata: Vim.BufferMetadata.t) => {
-  id: metadata.id,
-  version: metadata.version,
-  filePath: metadata.filePath,
+let ofMetadata = (~id, ~version, ~filePath, ~modified) => {
+  id,
+  version,
+  filePath,
   lineEndings: None,
-  modified: metadata.modified,
+  modified,
   fileType: None,
   lines: [||],
   originalUri: None,

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -37,6 +37,7 @@ let getMediumFriendlyName =
        | Welcome => "Welcome"
        | Version => "Version"
        | Terminal({cmd, _}) => "Terminal - " ++ cmd
+       | UpdateChangelog => "Updates"
        | FilePath(fp) =>
          switch (workingDirectory) {
          | Some(base) => Path.toRelative(~base, fp)
@@ -58,6 +59,7 @@ let getLongFriendlyName = ({filePath: maybeFilePath, _}) => {
        switch (BufferPath.parse(filePath)) {
        | Welcome => "Welcome"
        | Version => "Version"
+       | UpdateChangelog => "Updates"
        | Terminal({cmd, _}) => "Terminal - " ++ cmd
        | FilePath(fp) => fp
        }

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -156,25 +156,21 @@ let getUri = (buffer: t) => {
 
 let getNumberOfLines = (buffer: t) => Array.length(buffer.lines);
 
-
 // TODO: This method needs a lot of improvements:
 // - It's only estimated, as the byte length is quicker to calculate
 // - It always traverses the entire buffer - we could be much smarter
 //   by using buffer updates and only recalculating subsets.
-let getEstimatedMaxLineLength = (buffer) => {
+let getEstimatedMaxLineLength = buffer => {
   let totalLines = getNumberOfLines(buffer);
 
   let currentMax = ref(0);
   for (idx in 0 to totalLines - 1) {
-  
-    let lengthInBytes = buffer
-    |> getLine(idx)
-    |> BufferLine.lengthInBytes;
+    let lengthInBytes = buffer |> getLine(idx) |> BufferLine.lengthInBytes;
 
     if (lengthInBytes > currentMax^) {
       currentMax := lengthInBytes;
-    }
-  }
+    };
+  };
 
   currentMax^;
 };

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -156,6 +156,29 @@ let getUri = (buffer: t) => {
 
 let getNumberOfLines = (buffer: t) => Array.length(buffer.lines);
 
+
+// TODO: This method needs a lot of improvements:
+// - It's only estimated, as the byte length is quicker to calculate
+// - It always traverses the entire buffer - we could be much smarter
+//   by using buffer updates and only recalculating subsets.
+let getEstimatedMaxLineLength = (buffer) => {
+  let totalLines = getNumberOfLines(buffer);
+
+  let currentMax = ref(0);
+  for (idx in 0 to totalLines - 1) {
+  
+    let lengthInBytes = buffer
+    |> getLine(idx)
+    |> BufferLine.lengthInBytes;
+
+    if (lengthInBytes > currentMax^) {
+      currentMax := lengthInBytes;
+    }
+  }
+
+  currentMax^;
+};
+
 let applyUpdate =
     (~indentation, lines: array(BufferLine.t), update: BufferUpdate.t) => {
   let updateLines = update.lines |> Array.map(BufferLine.make(~indentation));

--- a/src/Core/Buffer.rei
+++ b/src/Core/Buffer.rei
@@ -11,7 +11,8 @@ let initial: t;
 let show: t => string;
 
 let ofLines: (~id: int=?, array(string)) => t;
-let ofMetadata: Vim.BufferMetadata.t => t;
+let ofMetadata:
+  (~id: int, ~version: int, ~filePath: option(string), ~modified: bool) => t;
 
 let getId: t => int;
 let getUri: t => Uri.t;

--- a/src/Core/Buffer.rei
+++ b/src/Core/Buffer.rei
@@ -18,6 +18,8 @@ let getUri: t => Uri.t;
 let getFilePath: t => option(string);
 let setFilePath: (option(string), t) => t;
 
+let getEstimatedMaxLineLength: t => int;
+
 let getLineEndings: t => option(Vim.lineEnding);
 let setLineEndings: (Vim.lineEnding, t) => t;
 

--- a/src/Core/BufferPath.re
+++ b/src/Core/BufferPath.re
@@ -7,6 +7,7 @@ open Oniguruma;
 module OptionEx = Utility.OptionEx;
 
 type t =
+  | Changelog
   | FilePath(string)
   | Terminal({
       bufferId: int,
@@ -16,16 +17,19 @@ type t =
   | Welcome
   | Version;
 
+let changelog = "oni://Changelog";
 let updateChangelog = "oni://UpdateChangelog";
 let welcome = "oni://Welcome";
 let version = "oni://Version";
 let terminalRegex = OnigRegExp.create("oni://terminal/([0-9]*)/(.*)");
 
-let parse = bufferPath =>
+let parse = bufferPath => 
   if (String.equal(bufferPath, welcome)) {
     Welcome;
   } else if (String.equal(bufferPath, version)) {
     Version;
+  } else if (String.equal(bufferPath, changelog)) {
+    Changelog;
   } else if (String.equal(bufferPath, updateChangelog)) {
     UpdateChangelog;
   } else {

--- a/src/Core/BufferPath.re
+++ b/src/Core/BufferPath.re
@@ -12,9 +12,11 @@ type t =
       bufferId: int,
       cmd: string,
     })
+  | UpdateChangelog
   | Welcome
   | Version;
 
+let updateChangelog = "oni://UpdateChangelog";
 let welcome = "oni://Welcome";
 let version = "oni://Version";
 let terminalRegex = OnigRegExp.create("oni://terminal/([0-9]*)/(.*)");
@@ -24,6 +26,8 @@ let parse = bufferPath =>
     Welcome;
   } else if (String.equal(bufferPath, version)) {
     Version;
+  } else if (String.equal(bufferPath, updateChangelog)) {
+    UpdateChangelog;
   } else {
     terminalRegex
     |> Result.to_option

--- a/src/Core/BufferPath.re
+++ b/src/Core/BufferPath.re
@@ -23,7 +23,7 @@ let welcome = "oni://Welcome";
 let version = "oni://Version";
 let terminalRegex = OnigRegExp.create("oni://terminal/([0-9]*)/(.*)");
 
-let parse = bufferPath => 
+let parse = bufferPath =>
   if (String.equal(bufferPath, welcome)) {
     Welcome;
   } else if (String.equal(bufferPath, version)) {

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -5,7 +5,7 @@ let lastId = ref(0);
 
 [@deriving show]
 type t = {
-  bufferId: int,
+  buffer: [@opaque] EditorBuffer.t,
   editorId: EditorId.t,
   scrollX: float,
   scrollY: float,
@@ -24,13 +24,13 @@ type t = {
   pixelHeight: int,
 };
 
-let create = (~font, ~bufferId=0, ()) => {
+let create = (~font, ~buffer, ()) => {
   let id = lastId^;
   incr(lastId);
 
   {
     editorId: id,
-    bufferId,
+    buffer,
     scrollX: 0.,
     scrollY: 0.,
     minimapMaxColumnWidth: Constants.minimapMaxColumn,
@@ -270,4 +270,16 @@ let scrollToColumn = (~column, view) => {
 let scrollDeltaPixelY = (~pixelY, view) => {
   let pixelY = view.scrollY +. pixelY;
   scrollToPixelY(~pixelY, view);
+};
+
+let getBufferId = ({buffer, _}) => EditorBuffer.id(buffer);
+
+let updateBuffer = (~buffer, editor) => {
+  {
+    ...editor,
+    buffer,
+    // TODO: These will both change with word wrap
+    viewLines: EditorBuffer.numberOfLines(buffer),
+    maxLineLength: EditorBuffer.getEstimatedMaxLineLength(buffer)
+  }
 };

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -35,8 +35,8 @@ let create = (~font, ~buffer, ()) => {
     scrollY: 0.,
     minimapMaxColumnWidth: Constants.minimapMaxColumn,
     minimapScrollY: 0.,
-    maxLineLength: 0,
-    viewLines: 0,
+    viewLines: EditorBuffer.numberOfLines(buffer),
+    maxLineLength: EditorBuffer.getEstimatedMaxLineLength(buffer),
     /*
      * We need an initial editor size, otherwise we'll immediately scroll the view
      * if a buffer loads prior to our first render.

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -280,6 +280,6 @@ let updateBuffer = (~buffer, editor) => {
     buffer,
     // TODO: These will both change with word wrap
     viewLines: EditorBuffer.numberOfLines(buffer),
-    maxLineLength: EditorBuffer.getEstimatedMaxLineLength(buffer)
-  }
+    maxLineLength: EditorBuffer.getEstimatedMaxLineLength(buffer),
+  };
 };

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -4,6 +4,7 @@ open Oni_Core;
 let lastId = ref(0);
 
 [@deriving show]
+// TODO: This type needs to be private, so we can maintain invariants with the `EditorBuffer.t` and computed properties
 type t = {
   buffer: [@opaque] EditorBuffer.t,
   editorId: EditorId.t,

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -28,9 +28,10 @@ type scrollbarMetrics = {
   thumbOffset: int,
 };
 
-let create: (~font: Service_Font.font, ~bufferId: int=?, unit) => t;
+let create: (~font: Service_Font.font, ~buffer: EditorBuffer.t, unit) => t;
 
 let getId: t => int;
+let getBufferId: t => int;
 let getTopVisibleLine: t => int;
 let getBottomVisibleLine: t => int;
 let getLeftVisibleColumn: t => int;
@@ -57,3 +58,5 @@ let getLineHeight: t => float;
 
 let setFont: (~font: Service_Font.font, t) => t;
 let setSize: (~pixelWidth: int, ~pixelHeight: int, t) => t;
+
+let updateBuffer: (~buffer: EditorBuffer.t, t) => t;

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -3,7 +3,7 @@ open Oni_Core;
 
 [@deriving show]
 type t = {
-  bufferId: int,
+  buffer: EditorBuffer.t,
   editorId: EditorId.t,
   scrollX: float,
   scrollY: float,

--- a/src/Feature/Editor/EditorBuffer.re
+++ b/src/Feature/Editor/EditorBuffer.re
@@ -1,5 +1,6 @@
 type t = Oni_Core.Buffer.t;
 
+let ofBuffer = buffer => buffer;
 let id = Oni_Core.Buffer.getId;
 let getEstimatedMaxLineLength = Oni_Core.Buffer.getEstimatedMaxLineLength;
 let numberOfLines = Oni_Core.Buffer.getNumberOfLines;

--- a/src/Feature/Editor/EditorBuffer.re
+++ b/src/Feature/Editor/EditorBuffer.re
@@ -1,0 +1,4 @@
+type t = Oni_Core.Buffer.t;
+
+let id = Oni_Core.Buffer.getId;
+let getEstimatedMaxLineLength = Oni_Core.Buffer.getEstimatedMaxLineLength;

--- a/src/Feature/Editor/EditorBuffer.re
+++ b/src/Feature/Editor/EditorBuffer.re
@@ -2,3 +2,4 @@ type t = Oni_Core.Buffer.t;
 
 let id = Oni_Core.Buffer.getId;
 let getEstimatedMaxLineLength = Oni_Core.Buffer.getEstimatedMaxLineLength;
+let numberOfLines = Oni_Core.Buffer.getNumberOfLines;

--- a/src/Feature/Editor/EditorBuffer.rei
+++ b/src/Feature/Editor/EditorBuffer.rei
@@ -4,6 +4,7 @@
 
 type t;
 
+let ofBuffer: Oni_Core.Buffer.t => t;
 let id: t => int;
 let getEstimatedMaxLineLength: t => int;
 let numberOfLines: t => int;

--- a/src/Feature/Editor/EditorBuffer.rei
+++ b/src/Feature/Editor/EditorBuffer.rei
@@ -6,3 +6,4 @@ type t;
 
 let id: t => int;
 let getEstimatedMaxLineLength: t => int;
+let numberOfLines: t => int;

--- a/src/Feature/Editor/EditorBuffer.rei
+++ b/src/Feature/Editor/EditorBuffer.rei
@@ -1,0 +1,8 @@
+// EditorBuffer is a subset of the buffer model,
+// specifically containing the functions and data
+// needed by the editor surface.
+
+type t;
+
+let id: t => int;
+let getEstimatedMaxLineLength: t => int;

--- a/src/Feature/Editor/EditorVerticalScrollbar.re
+++ b/src/Feature/Editor/EditorVerticalScrollbar.re
@@ -97,7 +97,7 @@ let make =
     ];
 
   let matchingPairElements =
-    BufferHighlights.getMatchingPair(editor.bufferId, bufferHighlights)
+    BufferHighlights.getMatchingPair(Editor.getBufferId(editor), bufferHighlights)
     |> Option.map(mp => {
          let (startPos, endPos) = mp;
          let topLine =
@@ -163,7 +163,7 @@ let make =
 
   let searchMatchElements =
     BufferHighlights.getHighlights(
-      ~bufferId=editor.bufferId,
+      ~bufferId=Editor.getBufferId(editor),
       bufferHighlights,
     )
     |> List.map(searchHighlightToElement)

--- a/src/Feature/Editor/EditorVerticalScrollbar.re
+++ b/src/Feature/Editor/EditorVerticalScrollbar.re
@@ -97,7 +97,10 @@ let make =
     ];
 
   let matchingPairElements =
-    BufferHighlights.getMatchingPair(Editor.getBufferId(editor), bufferHighlights)
+    BufferHighlights.getMatchingPair(
+      Editor.getBufferId(editor),
+      bufferHighlights,
+    )
     |> Option.map(mp => {
          let (startPos, endPos) = mp;
          let topLine =

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -3,6 +3,7 @@ module BufferViewTokenizer = BufferViewTokenizer;
 module Selection = Selection;
 
 module Editor = Editor;
+module EditorBuffer = EditorBuffer;
 module EditorId = EditorId;
 module EditorLayout = EditorLayout;
 module EditorSurface = EditorSurface;

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -273,7 +273,7 @@ let%component make =
 
               let highlightRanges =
                 BufferHighlights.getHighlightsByLine(
-                  ~bufferId=editor.bufferId,
+                  ~bufferId=Editor.getBufferId(editor),
                   ~line=index,
                   bufferHighlights,
                 );

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -24,9 +24,14 @@ type t =
   | BufferHighlights(BufferHighlights.action)
   | BufferDisableSyntaxHighlighting(int)
   | BufferEnter({
-      metadata: [@opaque] Vim.BufferMetadata.t,
+      id: int,
       fileType: option(string),
       lineEndings: [@opaque] option(Vim.lineEnding),
+      filePath: option(string),
+      modified: bool,
+      version: int,
+      // TODO: This duplication-of-truth is really awkward,
+      // but I want to remove it shortly
       buffer: [@opaque] Buffer.t,
     })
   | BufferFilenameChanged({

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -27,6 +27,14 @@ type t =
       metadata: [@opaque] Vim.BufferMetadata.t,
       fileType: option(string),
       lineEndings: [@opaque] option(Vim.lineEnding),
+      buffer: [@opaque] Buffer.t,
+    })
+  | BufferFilenameChanged({
+      id: int,
+      newFilePath: option(string),
+      newFileType: option(string),
+      version: int,
+      modified: bool,
     })
   | BufferUpdate({
       update: [@opaque] BufferUpdate.t,

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -28,7 +28,7 @@ type t =
       fileType: option(string),
       lineEndings: [@opaque] option(Vim.lineEnding),
       filePath: option(string),
-      modified: bool,
+      isModified: bool,
       version: int,
       // TODO: This duplication-of-truth is really awkward,
       // but I want to remove it shortly
@@ -39,7 +39,7 @@ type t =
       newFilePath: option(string),
       newFileType: option(string),
       version: int,
-      modified: bool,
+      isModified: bool,
     })
   | BufferUpdate({
       update: [@opaque] BufferUpdate.t,

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -81,7 +81,6 @@ type t =
   | DiagnosticsSet(Uri.t, string, [@opaque] list(Diagnostic.t))
   | DiagnosticsClear(string)
   | SelectionChanged([@opaque] VisualRange.t)
-  | RecalculateEditorView([@opaque] option(Buffer.t))
   | DisableKeyDisplayer
   | EnableKeyDisplayer
   | KeyboardInput(string)

--- a/src/Model/Buffers.re
+++ b/src/Model/Buffers.re
@@ -60,7 +60,7 @@ let reduce = (state: t, action: Actions.t) => {
   | BufferDisableSyntaxHighlighting(id) =>
     IntMap.update(id, disableSyntaxHighlighting, state)
 
-  | BufferEnter({fileType, lineEndings, modified, filePath, version, buffer}) =>
+  | BufferEnter({fileType, lineEndings, isModified, filePath, version, buffer}) =>
     let maybeSetLineEndings = (maybeLineEndings, buf) => {
       switch (maybeLineEndings) {
       | Some(le) => Buffer.setLineEndings(le, buf)
@@ -74,14 +74,14 @@ let reduce = (state: t, action: Actions.t) => {
       fun
       | Some(buffer) =>
         buffer
-        |> Buffer.setModified(modified)
+        |> Buffer.setModified(isModified)
         |> Buffer.setFilePath(filePath)
         |> Buffer.setVersion(version)
         |> Buffer.stampLastUsed
         |> maybeSetLineEndings(lineEndings)
         |> Option.some
       | None =>
-        Buffer.ofMetadata(~id=bufferId, ~version, ~filePath, ~modified)
+        Buffer.ofMetadata(~id=bufferId, ~version, ~filePath, ~modified=isModified)
         |> Buffer.setFileType(fileType)
         |> Buffer.stampLastUsed
         |> maybeSetLineEndings(lineEndings)
@@ -89,12 +89,12 @@ let reduce = (state: t, action: Actions.t) => {
     );
     IntMap.update(bufferId, updater, state);
 
-  | BufferFilenameChanged({id, newFileType, newFilePath, version, modified}) =>
+  | BufferFilenameChanged({id, newFileType, newFilePath, version, isModified}) =>
     let updater = (
       fun
       | Some(buffer) =>
         buffer
-        |> Buffer.setModified(modified)
+        |> Buffer.setModified(isModified)
         |> Buffer.setFilePath(newFilePath)
         |> Buffer.setFileType(newFileType)
         |> Buffer.setVersion(version)
@@ -104,8 +104,8 @@ let reduce = (state: t, action: Actions.t) => {
     );
     IntMap.update(id, updater, state);
   /* | BufferDelete(bd) => IntMap.remove(bd, state) */
-  | BufferSetModified(id, modified) =>
-    IntMap.update(id, setModified(modified), state)
+  | BufferSetModified(id, isModified) =>
+    IntMap.update(id, setModified(isModified), state)
 
   | BufferSetIndentation(id, indent) =>
     IntMap.update(id, setIndentation(indent), state)

--- a/src/Model/Buffers.re
+++ b/src/Model/Buffers.re
@@ -60,7 +60,7 @@ let reduce = (state: t, action: Actions.t) => {
   | BufferDisableSyntaxHighlighting(id) =>
     IntMap.update(id, disableSyntaxHighlighting, state)
 
-  | BufferEnter({metadata, fileType, lineEndings}) =>
+  | BufferEnter({metadata, fileType, lineEndings, _}) =>
     let maybeSetLineEndings = (maybeLineEndings, buf) => {
       switch (maybeLineEndings) {
       | Some(le) => Buffer.setLineEndings(le, buf)
@@ -87,6 +87,20 @@ let reduce = (state: t, action: Actions.t) => {
     );
     IntMap.update(metadata.id, updater, state);
 
+  | BufferFilenameChanged({id, newFileType, newFilePath, version, modified}) =>
+    let updater = (
+      fun
+      | Some(buffer) =>
+        buffer
+        |> Buffer.setModified(modified)
+        |> Buffer.setFilePath(newFilePath)
+        |> Buffer.setFileType(newFileType)
+        |> Buffer.setVersion(version)
+        |> Buffer.stampLastUsed
+        |> Option.some
+      | None => None
+    );
+    IntMap.update(id, updater, state);
   /* | BufferDelete(bd) => IntMap.remove(bd, state) */
   | BufferSetModified(id, modified) =>
     IntMap.update(id, setModified(modified), state)

--- a/src/Model/Buffers.re
+++ b/src/Model/Buffers.re
@@ -60,15 +60,13 @@ let reduce = (state: t, action: Actions.t) => {
   | BufferDisableSyntaxHighlighting(id) =>
     IntMap.update(id, disableSyntaxHighlighting, state)
 
-  | BufferEnter({fileType, lineEndings, isModified, filePath, version, buffer}) =>
+  | BufferEnter({id, fileType, lineEndings, isModified, filePath, version,  _}) =>
     let maybeSetLineEndings = (maybeLineEndings, buf) => {
       switch (maybeLineEndings) {
       | Some(le) => Buffer.setLineEndings(le, buf)
       | None => buf
       };
     };
-
-    let bufferId = Buffer.getId(buffer);
 
     let updater = (
       fun
@@ -81,13 +79,13 @@ let reduce = (state: t, action: Actions.t) => {
         |> maybeSetLineEndings(lineEndings)
         |> Option.some
       | None =>
-        Buffer.ofMetadata(~id=bufferId, ~version, ~filePath, ~modified=isModified)
+        Buffer.ofMetadata(~id, ~version, ~filePath, ~modified=isModified)
         |> Buffer.setFileType(fileType)
         |> Buffer.stampLastUsed
         |> maybeSetLineEndings(lineEndings)
         |> Option.some
     );
-    IntMap.update(bufferId, updater, state);
+    IntMap.update(id, updater, state);
 
   | BufferFilenameChanged({id, newFileType, newFilePath, version, isModified}) =>
     let updater = (

--- a/src/Model/Buffers.re
+++ b/src/Model/Buffers.re
@@ -60,7 +60,7 @@ let reduce = (state: t, action: Actions.t) => {
   | BufferDisableSyntaxHighlighting(id) =>
     IntMap.update(id, disableSyntaxHighlighting, state)
 
-  | BufferEnter({id, fileType, lineEndings, isModified, filePath, version,  _}) =>
+  | BufferEnter({id, fileType, lineEndings, isModified, filePath, version, _}) =>
     let maybeSetLineEndings = (maybeLineEndings, buf) => {
       switch (maybeLineEndings) {
       | Some(le) => Buffer.setLineEndings(le, buf)

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -45,7 +45,7 @@ let setBufferFont = (~bufferId, ~font, group) => {
   let editors =
     group.editors
     |> IntMap.map((editor: Feature_Editor.Editor.t) =>
-         if (editor.bufferId == bufferId) {
+         if (Editor.getBufferId(editor) == bufferId) {
            Editor.setFont(~font, editor);
          } else {
            editor;

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -55,6 +55,8 @@ let setBufferFont = (~bufferId, ~font, group) => {
   {...group, editors};
 };
 
+let count = ({editors, _}) => IntMap.bindings(editors) |> List.length;
+
 let getOrCreateEditorForBuffer = (~font, ~buffer, state) => {
   let bufferId = Feature_Editor.EditorBuffer.id(buffer);
   switch (IntMap.find_opt(bufferId, state.bufferIdToEditorId)) {

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -55,11 +55,12 @@ let setBufferFont = (~bufferId, ~font, group) => {
   {...group, editors};
 };
 
-let getOrCreateEditorForBuffer = (~font, ~bufferId, state) => {
+let getOrCreateEditorForBuffer = (~font, ~buffer, state) => {
+  let bufferId = Feature_Editor.EditorBuffer.id(buffer);
   switch (IntMap.find_opt(bufferId, state.bufferIdToEditorId)) {
   | Some(editor) => (state, editor)
   | None =>
-    let newEditor = Editor.create(~font, ~bufferId, ());
+    let newEditor = Editor.create(~font, ~buffer, ());
     let newState = {
       ...state,
       editors: IntMap.add(newEditor.editorId, newEditor, state.editors),
@@ -147,7 +148,7 @@ let removeEditorById = (state, editorId) => {
   switch (IntMap.find_opt(editorId, state.editors)) {
   | None => state
   | Some(editor) =>
-    let bufferId = editor.bufferId;
+    let bufferId = Feature_Editor.Editor.getBufferId(editor);
     let filteredTabList =
       List.filter(t => editorId != t, state.reverseTabOrder);
     let bufferIdToEditorId =

--- a/src/Model/EditorGroup.rei
+++ b/src/Model/EditorGroup.rei
@@ -11,6 +11,9 @@ type t = {
 
 let create: unit => t;
 
+// [count] gets the number of editors in the group
+let count: t => int;
+
 let getActiveEditor: t => option(Feature_Editor.Editor.t);
 let setActiveEditor: (t, int) => t;
 let getEditorById: (int, t) => option(Feature_Editor.Editor.t);

--- a/src/Model/EditorGroup.rei
+++ b/src/Model/EditorGroup.rei
@@ -15,7 +15,7 @@ let getActiveEditor: t => option(Feature_Editor.Editor.t);
 let setActiveEditor: (t, int) => t;
 let getEditorById: (int, t) => option(Feature_Editor.Editor.t);
 let getOrCreateEditorForBuffer:
-  (~font: Service_Font.font, ~bufferId: int, t) =>
+  (~font: Service_Font.font, ~buffer: Feature_Editor.EditorBuffer.t, t) =>
   (t, Feature_Editor.EditorId.t);
 let nextEditor: t => t;
 let previousEditor: t => t;

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -37,11 +37,13 @@ let reduce = (~defaultFont, v: EditorGroup.t, action: Actions.t) => {
           editors,
         ),
     }
-  | BufferEnter({metadata: {id, _}, _}) =>
+  // TEMPORARY: Needs https://github.com/onivim/oni2/pull/1627 to remove
+  | BufferEnter({buffer, _}) =>
+    let editorBuffer = buffer |> Feature_Editor.EditorBuffer.ofBuffer;
     let (newState, activeEditorId) =
       EditorGroup.getOrCreateEditorForBuffer(
         ~font=defaultFont,
-        ~bufferId=id,
+        ~buffer=editorBuffer,
         v,
       );
 

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -2,44 +2,44 @@ open Oni_Core;
 open Feature_Editor;
 open Editor;
 
-module Internal = {
-  let getMaxLineLength = (buffer: Buffer.t) => {
-    let i = ref(0);
-    let lines = Buffer.getNumberOfLines(buffer);
+//module Internal = {
+//  let getMaxLineLength = (buffer: Buffer.t) => {
+//    let i = ref(0);
+//    let lines = Buffer.getNumberOfLines(buffer);
+//
+//    let max = ref(0);
+//
+//    while (i^ < lines) {
+//      let line = i^;
+//      // TODO: This is approximate, beacuse the length in bytes isn't actually
+//      // the max length. But the length in bytes is quicker to calculate.
+//      let length = buffer |> Buffer.getLine(line) |> BufferLine.lengthInBytes;
+//
+//      if (length > max^) {
+//        max := length;
+//      };
+//
+//      incr(i);
+//    };
+//
+//    max^;
+//  };
+//};
 
-    let max = ref(0);
-
-    while (i^ < lines) {
-      let line = i^;
-      // TODO: This is approximate, beacuse the length in bytes isn't actually
-      // the max length. But the length in bytes is quicker to calculate.
-      let length = buffer |> Buffer.getLine(line) |> BufferLine.lengthInBytes;
-
-      if (length > max^) {
-        max := length;
-      };
-
-      incr(i);
-    };
-
-    max^;
-  };
-};
-
-let recalculate = (view, maybeBuffer) =>
-  switch (maybeBuffer) {
-  | Some(buffer) => {
-      ...view,
-      viewLines: Buffer.getNumberOfLines(buffer),
-      maxLineLength: Internal.getMaxLineLength(buffer),
-    }
-  | None => view
-  };
+//let recalculate = (view, maybeBuffer) =>
+//  switch (maybeBuffer) {
+//  | Some(buffer) => {
+//      ...view,
+//      viewLines: Buffer.getNumberOfLines(buffer),
+//      maxLineLength: Internal.getMaxLineLength(buffer),
+//    }
+//  | None => view
+//  };
 
 let reduce = (view, action) =>
   switch ((action: Actions.t)) {
   | SelectionChanged(selection) => {...view, selection}
-  | RecalculateEditorView(buffer) => recalculate(view, buffer)
+  //| RecalculateEditorView(buffer) => recalculate(view, buffer)
   | EditorCursorMove(id, cursors) when EditorId.equals(view.editorId, id) => {
       ...view,
       cursors,

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -1,45 +1,13 @@
-open Oni_Core;
 open Feature_Editor;
 open Editor;
-
-//module Internal = {
-//  let getMaxLineLength = (buffer: Buffer.t) => {
-//    let i = ref(0);
-//    let lines = Buffer.getNumberOfLines(buffer);
-//
-//    let max = ref(0);
-//
-//    while (i^ < lines) {
-//      let line = i^;
-//      // TODO: This is approximate, beacuse the length in bytes isn't actually
-//      // the max length. But the length in bytes is quicker to calculate.
-//      let length = buffer |> Buffer.getLine(line) |> BufferLine.lengthInBytes;
-//
-//      if (length > max^) {
-//        max := length;
-//      };
-//
-//      incr(i);
-//    };
-//
-//    max^;
-//  };
-//};
-
-//let recalculate = (view, maybeBuffer) =>
-//  switch (maybeBuffer) {
-//  | Some(buffer) => {
-//      ...view,
-//      viewLines: Buffer.getNumberOfLines(buffer),
-//      maxLineLength: Internal.getMaxLineLength(buffer),
-//    }
-//  | None => view
-//  };
 
 let reduce = (view, action) =>
   switch ((action: Actions.t)) {
   | SelectionChanged(selection) => {...view, selection}
-  //| RecalculateEditorView(buffer) => recalculate(view, buffer)
+  | BufferUpdate({newBuffer, _})
+      when Oni_Core.Buffer.getId(newBuffer) == Editor.getBufferId(view) =>
+    let buffer = EditorBuffer.ofBuffer(newBuffer);
+    Editor.updateBuffer(~buffer, view);
   | EditorCursorMove(id, cursors) when EditorId.equals(view.editorId, id) => {
       ...view,
       cursors,

--- a/src/Model/EditorVisibleRanges.re
+++ b/src/Model/EditorVisibleRanges.re
@@ -81,7 +81,7 @@ let getVisibleBuffers = (state: State.t) => {
   Feature_Layout.windows(state.layout)
   |> List.filter_map(EditorGroups.getEditorGroupById(state.editorGroups))
   |> List.filter_map(EditorGroup.getActiveEditor)
-  |> List.map(e => e.Editor.bufferId);
+  |> List.map(editor => Editor.getBufferId(editor));
 };
 
 type t = list((int, list(Range.t)));
@@ -91,7 +91,7 @@ let getVisibleRangesForBuffer = (bufferId: int, state: State.t) => {
     Feature_Layout.windows(state.layout)
     |> List.filter_map(EditorGroups.getEditorGroupById(state.editorGroups))
     |> List.filter_map(EditorGroup.getActiveEditor)
-    |> List.filter(editor => editor.Editor.bufferId == bufferId);
+    |> List.filter(editor => Editor.getBufferId(editor) == bufferId);
 
   let flatten = (prev: list(list(Range.t)), curr: individualRange) => {
     [curr.editorRanges, curr.minimapRanges, ...prev];

--- a/src/Model/Selectors.re
+++ b/src/Model/Selectors.re
@@ -30,7 +30,7 @@ let getBufferById = (state: State.t, id: int) => {
 };
 
 let getBufferForEditor = (state: State.t, editor: Editor.t) => {
-  Buffers.getBuffer(editor.bufferId, state.buffers);
+  Buffers.getBuffer(Editor.getBufferId(editor), state.buffers);
 };
 
 let getConfigurationValue = (state: State.t, buffer: Buffer.t, f) => {

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -106,18 +106,7 @@ let start = () => {
 
   let openChangelogEffect = _ =>
     Isolinear.Effect.createWithDispatch(~name="oni.changelog", dispatch => {
-      Vim.init();
-      let _: unit = Vim.command("e oni://Changelog");
-
-      let bufferId = Vim.Buffer.getCurrent() |> Vim.Buffer.getId;
-      dispatch(
-        Actions.BufferRenderer(
-          BufferRenderer.RendererAvailable(
-            bufferId,
-            BufferRenderer.FullChangelog,
-          ),
-        ),
-      );
+     dispatch(OpenFileByPath(BufferPath.changelog, None, None));
     });
 
   let commands = [

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -29,7 +29,6 @@ let start = () => {
       let getBufferAndLocation = () => {
         open Base.Option.Let_syntax;
         let%bind buffer = state |> Selectors.getActiveBuffer;
-
         let%bind path = buffer |> Buffer.getFilePath;
 
         let%bind cursorLocation =

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -106,7 +106,7 @@ let start = () => {
 
   let openChangelogEffect = _ =>
     Isolinear.Effect.createWithDispatch(~name="oni.changelog", dispatch => {
-     dispatch(OpenFileByPath(BufferPath.changelog, None, None));
+      dispatch(OpenFileByPath(BufferPath.changelog, None, None))
     });
 
   let commands = [

--- a/src/Store/CompletionStoreConnector.re
+++ b/src/Store/CompletionStoreConnector.re
@@ -76,7 +76,10 @@ module Actions = {
       state |> Selectors.getActiveEditorGroup |> Selectors.getActiveEditor;
     let maybeBuffer =
       Option.bind(maybeEditor, editor =>
-        Buffers.getBuffer(editor.bufferId, state.buffers)
+        Buffers.getBuffer(
+          Feature_Editor.Editor.getBufferId(editor),
+          state.buffers,
+        )
       );
     let maybeCursor =
       OptionEx.map2(

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -16,16 +16,16 @@ module CompletionItem = Feature_LanguageSupport.CompletionItem;
 module Diagnostic = Feature_LanguageSupport.Diagnostic;
 module LanguageFeatures = Feature_LanguageSupport.LanguageFeatures;
 
-let start = (extensions, extHostClient: Exthost.Client.t) => {
-  let _bufferMetadataToModelAddedDelta =
-      (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
-    switch (bm.filePath, fileType) {
+module Internal = {
+  let bufferMetadataToModelAddedDelta =
+      (~version, ~filePath, ~fileType: option(string)) =>
+    switch (filePath, fileType) {
     | (Some(fp), Some(ft)) =>
       Log.trace("Creating model for filetype: " ++ ft);
 
       Some(
         Exthost.ModelAddedDelta.create(
-          ~versionId=bm.version,
+          ~versionId=version,
           ~lines=[""],
           ~modeId=ft,
           ~isDirty=true,
@@ -34,7 +34,9 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
       );
     | _ => None
     };
+};
 
+let start = (extensions, extHostClient: Exthost.Client.t) => {
   let activatedFileTypes: Hashtbl.t(string, bool) = Hashtbl.create(16);
 
   let activateFileType = (fileType: option(string)) =>
@@ -50,10 +52,15 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
          }
        );
 
-  let sendBufferEnterEffect =
-      (bm: Vim.BufferMetadata.t, fileType: option(string)) =>
+  let sendBufferEnterEffect = (~version, ~filePath, ~fileType) =>
     Isolinear.Effect.create(~name="exthost.bufferEnter", () =>
-      switch (_bufferMetadataToModelAddedDelta(bm, fileType)) {
+      switch (
+        Internal.bufferMetadataToModelAddedDelta(
+          ~version,
+          ~filePath,
+          ~fileType,
+        )
+      ) {
       | None => ()
       | Some((v: Exthost.ModelAddedDelta.t)) =>
         activateFileType(fileType);
@@ -238,19 +245,19 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
 
     | VimDirectoryChanged(path) => (state, changeWorkspaceEffect(path))
 
-    | BufferEnter({metadata, fileType, _}) =>
+    | BufferEnter({id, version, filePath, fileType, _}) =>
       let eff =
-        switch (metadata.filePath) {
+        switch (filePath) {
         | Some(path) =>
           Isolinear.Effect.batch([
             Feature_SCM.Effects.getOriginalUri(
               extHostClient, state.scm, path, uri =>
-              Actions.GotOriginalUri({bufferId: metadata.id, uri})
+              Actions.GotOriginalUri({bufferId: id, uri})
             ),
-            sendBufferEnterEffect(metadata, fileType),
+            sendBufferEnterEffect(~version, ~filePath, ~fileType),
           ])
 
-        | None => sendBufferEnterEffect(metadata, fileType)
+        | None => sendBufferEnterEffect(~version, ~filePath, ~fileType)
         };
       (state, eff);
 

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -205,7 +205,7 @@ let start = () => {
         ]),
       )
 
-    | BufferEnter({metadata: {filePath, _}, _}) =>
+    | BufferEnter({filePath, _}) =>
       switch (state.fileExplorer) {
       | {active, _} when active != filePath =>
         let state = setActive(filePath, state);

--- a/src/Store/IndentationStoreConnector.re
+++ b/src/Store/IndentationStoreConnector.re
@@ -79,14 +79,15 @@ let start = () => {
 
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
-    | Actions.BufferEnter({metadata, _}) =>
-      switch (Buffers.getBuffer(metadata.id, state.buffers)) {
+    | Actions.BufferEnter({buffer, _}) =>
+      let id = Oni_Core.Buffer.getId(buffer);
+      switch (Buffers.getBuffer(id, state.buffers)) {
       | Some(buffer) when !Buffer.isIndentationSet(buffer) => (
           state,
           checkIndentationEffect(state, buffer),
         )
       | _ => (state, Isolinear.Effect.none)
-      }
+      };
 
     | Actions.BufferUpdate({oldBuffer, newBuffer, _})
         when

--- a/src/Store/LifecycleStoreConnector.re
+++ b/src/Store/LifecycleStoreConnector.re
@@ -30,7 +30,7 @@ let start = quit => {
       | None => ()
       | Some(editor) =>
         let bufferMeta = Vim.BufferMetadata.ofBuffer(buffer);
-        if (editor.bufferId == bufferMeta.id) {
+        if (Feature_Editor.Editor.getBufferId(editor) == bufferMeta.id) {
           if (force || !bufferMeta.modified) {
             dispatch(Actions.ViewCloseEditor(editor.editorId));
           };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -59,7 +59,7 @@ let start =
       setClipboardText,
     ) => {
   let (stream, dispatch) = Isolinear.Stream.create();
-  let hasInitialized = ref(false);
+  let libvimHasInitialized = ref(false);
 
   let languageConfigLoader =
     Ext.LanguageConfigurationLoader.create(languageInfo);
@@ -371,7 +371,7 @@ let start =
     Vim.Buffer.onEnter(buf => {
       let metadata = Vim.BufferMetadata.ofBuffer(buf);
 
-      if (metadata.id == 1 && ! hasInitialized^) {
+      if (metadata.id == 1 && ! libvimHasInitialized^) {
         Log.info("Ignoring initial buffer");
       } else {
         let fileType =
@@ -561,7 +561,7 @@ let start =
           Actions.OpenFileByPath(Core.BufferPath.updateChangelog, None, None),
         );
       };
-      hasInitialized := true;
+      libvimHasInitialized := true;
     });
 
   let currentBufferId: ref(option(int)) = ref(None);
@@ -853,7 +853,7 @@ let start =
   // TODO: Remove remaining 'synchronization'
   let synchronizeEditorEffect = state =>
     Isolinear.Effect.create(~name="vim.synchronizeEditor", () =>
-      switch (hasInitialized^) {
+      switch (libvimHasInitialized^) {
       | false => ()
       | true =>
         let editorGroup = Selectors.getActiveEditorGroup(state);

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -222,16 +222,16 @@ let start =
           id: meta.id,
           newFileType: fileType,
           newFilePath: meta.filePath,
-          modified: meta.modified,
+          isModified: meta.modified,
           version: meta.version,
         }),
       );
     });
 
   let _: unit => unit =
-    Vim.Buffer.onModifiedChanged((id, modified) => {
-      Log.debugf(m => m("Buffer metadata changed: %n | %b", id, modified));
-      dispatch(Actions.BufferSetModified(id, modified));
+    Vim.Buffer.onModifiedChanged((id, isModified) => {
+      Log.debugf(m => m("Buffer metadata changed: %n | %b", id, isModified));
+      dispatch(Actions.BufferSetModified(id, isModified));
     });
 
   let _: unit => unit =
@@ -409,7 +409,7 @@ let start =
             lineEndings,
             // Version must be 0 so that a buffer update will be processed
             version: 0,
-            modified: metadata.modified,
+            isModified: metadata.modified,
             filePath: metadata.filePath,
           }),
         );
@@ -688,7 +688,7 @@ let start =
         // TODO: Will this be necessary with https://github.com/onivim/oni2/pull/1627?
         let fileType = Core.Buffer.getFileType(buffer);
         let lineEndings = Core.Buffer.getLineEndings(buffer);
-        let modified = Core.Buffer.isModified(buffer);
+        let isModified = Core.Buffer.isModified(buffer);
         let filePath = Core.Buffer.getFilePath(buffer);
         let version = Core.Buffer.getVersion(buffer);
         dispatch(
@@ -698,7 +698,7 @@ let start =
             fileType,
             lineEndings,
             filePath,
-            modified,
+            isModified,
             version,
           }),
         );
@@ -751,7 +751,7 @@ let start =
           fileType,
           lineEndings,
           filePath: metadata.filePath,
-          modified: metadata.modified,
+          isModified: metadata.modified,
           version: metadata.version,
         }),
       );

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -30,11 +30,13 @@ let toUiTabs =
     switch (Model.EditorGroup.getEditorById(id, editorGroup)) {
     | None => None
     | Some(editor) =>
+      open Feature_Editor;
       let (modified, title, filePath) =
-        Model.Buffers.getBuffer(editor.bufferId, buffers) |> getBufferMetadata;
+        Model.Buffers.getBuffer(Editor.getBufferId(editor), buffers)
+        |> getBufferMetadata;
 
       let renderer =
-        Model.BufferRenderers.getById(editor.bufferId, renderers);
+        Model.BufferRenderers.getById(Editor.getBufferId(editor), renderers);
 
       Some(
         Tabs.{editorId: editor.editorId, filePath, title, modified, renderer},
@@ -113,7 +115,10 @@ module Parts = {
       let State.{uiFont, editorFont, _} = state;
 
       let renderer =
-        BufferRenderers.getById(editor.bufferId, state.bufferRenderers);
+        BufferRenderers.getById(
+          Feature_Editor.Editor.getBufferId(editor),
+          state.bufferRenderers,
+        );
 
       switch (renderer) {
       | Terminal({insertMode, _}) when !insertMode =>

--- a/test/Model/BuffersTests.re
+++ b/test/Model/BuffersTests.re
@@ -1,7 +1,5 @@
 open TestFramework;
 
-open Vim;
-
 module Buffers = Oni_Model.Buffers;
 module Buffer = Oni_Core.Buffer;
 
@@ -45,7 +43,7 @@ describe("Buffer List Tests", ({test, _}) => {
           lineEndings: None,
           isModified: false,
           version: 0,
-          filePath: Some("/test1.re")
+          filePath: Some("/test1.re"),
         }),
       );
 

--- a/test/Model/BuffersTests.re
+++ b/test/Model/BuffersTests.re
@@ -39,11 +39,13 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          id: 0,
           buffer: emptyBuffer,
-          metadata:
-            BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
           fileType: None,
           lineEndings: None,
+          isModified: false,
+          version: 0,
+          filePath: Some("/test1.re")
         }),
       );
 
@@ -66,9 +68,11 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          id: 0,
           buffer: emptyBuffer,
-          metadata:
-            BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
+          filePath: Some("/test1.re"),
+          isModified: false,
+          version: 0,
           fileType: None,
           lineEndings: None,
         }),
@@ -77,9 +81,11 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         added,
         BufferEnter({
+          id: 0,
           buffer: emptyBuffer,
-          metadata:
-            BufferMetadata.create(~id=0, ~filePath=Some("/test2.re"), ()),
+          filePath: Some("/test2.re"),
+          isModified: false,
+          version: 0,
           fileType: None,
           lineEndings: None,
         }),
@@ -97,9 +103,11 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          id: 4,
           buffer: emptyBuffer,
-          metadata:
-            BufferMetadata.create(~filePath=Some("/myfile.js"), ~id=4, ()),
+          filePath: Some("/myfile.js"),
+          isModified: false,
+          version: 0,
           fileType: None,
           lineEndings: None,
         }),
@@ -115,9 +123,11 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          id: 4,
           buffer: emptyBuffer,
-          metadata:
-            BufferMetadata.create(~filePath=Some("/myfile.js"), ~id=4, ()),
+          filePath: Some("/myfile.js"),
+          isModified: false,
+          version: 0,
           fileType: Some("reason"),
           lineEndings: None,
         }),

--- a/test/Model/BuffersTests.re
+++ b/test/Model/BuffersTests.re
@@ -29,6 +29,9 @@ let getFileTypeOrFail = (v: option(Buffer.t)) => {
   };
 };
 
+
+let emptyBuffer = Oni_Core.Buffer.ofLines([||]);
+
 describe("Buffer List Tests", ({test, _}) => {
   test("Buffer enter should create metadata", ({expect, _}) => {
     let bufferList = Buffers.empty;
@@ -37,6 +40,7 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          buffer: emptyBuffer,
           metadata:
             BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
           fileType: None,
@@ -63,6 +67,7 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          buffer: emptyBuffer,
           metadata:
             BufferMetadata.create(~id=0, ~filePath=Some("/test1.re"), ()),
           fileType: None,
@@ -73,6 +78,7 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         added,
         BufferEnter({
+          buffer: emptyBuffer,
           metadata:
             BufferMetadata.create(~id=0, ~filePath=Some("/test2.re"), ()),
           fileType: None,
@@ -92,6 +98,7 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          buffer: emptyBuffer,
           metadata:
             BufferMetadata.create(~filePath=Some("/myfile.js"), ~id=4, ()),
           fileType: None,
@@ -109,6 +116,7 @@ describe("Buffer List Tests", ({test, _}) => {
       Buffers.reduce(
         bufferList,
         BufferEnter({
+          buffer: emptyBuffer,
           metadata:
             BufferMetadata.create(~filePath=Some("/myfile.js"), ~id=4, ()),
           fileType: Some("reason"),

--- a/test/Model/BuffersTests.re
+++ b/test/Model/BuffersTests.re
@@ -29,7 +29,6 @@ let getFileTypeOrFail = (v: option(Buffer.t)) => {
   };
 };
 
-
 let emptyBuffer = Oni_Core.Buffer.ofLines([||]);
 
 describe("Buffer List Tests", ({test, _}) => {


### PR DESCRIPTION
We have an awkward set of `Recalculate` actions, dispatched here: https://github.com/onivim/oni2/blob/4d413cfaa48d5c9b2692f9625677a24fc53e5771/src/Store/StoreThread.re#L341 - between this and the `synchronization` effects addressed in https://github.com/onivim/oni2/pull/1627, there are a lot of tricky timing dependencies that occur along the editor pipeline.

This is an incremental refactor, to help remove that timing dependency - with the observation that we will need the `Editor` to know more about the buffer contents (for features like word wrap, etc). This replaces the 'recalculation' (which really was just calculating some metrics like max line length and number of lines for the view) with the actual event that requires it (ie, `BufferUpdate`).

To model the buffer-stuff-that-the-editor cares about, I added an `EditorBuffer.t` - this is just a subset of `Oni_Core.Buffer.t` that exposes the properties we sync (there's extra information on the core buffer, like metadata or filetype, that we don't synchronize right now - so we don't expose that.

In addition, there is a `BufferEnter` event that is overloaded (we also dispatch it for changes to the filename) - I'd really like to get rid of this event in general, as it also involves a timing dependency, but requires some further work. In the meantime, I split it out so that there is a separate action to model the filename-changed occurrence.

There's still further refactoring needed, but this is chipping away at the timing dependencies that are still blocking #1627 

__TODO:__ 
- [x] Fix splitting via a command when there is no 'path' associated with the buffer (blocking `AddRemoveSplitTest.exe`
- [x] Stability test

__Test cases:__
- [x] Initial welcome buffer shows up
- [x] Changelog can be opened via command palette
- [x] `:vsp`
- [x] `:sp` with file
- [ ] startup with single file (ie, `oni2 package.json`)
- [x] rename file with `:sav`
- [x] use `enew` to create a buffer without path, and split
- [x] use `gd` to navigate in a buffer


