### PR TITLE
fix(editor/#733): Closing last window can result in no buffers being able to opened

### DIFF
--- a/integration_test/Regression733Test.re
+++ b/integration_test/Regression733Test.re
@@ -1,14 +1,10 @@
-open Oni_Core;
 open Oni_Model;
 open Oni_IntegrationTestLib;
-
-open Feature_Editor;
 
 // Regression test case covering #733:
 // Closing all active splits causes no other splits to be opened
 runTestWithInput(
-  ~name="Regression733Test",
-  (input, dispatch, wait, runEffects) => {
+  ~name="Regression733Test", (input, dispatch, wait, _runEffects) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     state.vimMode == Vim.Types.Normal
   );
@@ -16,19 +12,16 @@ runTestWithInput(
   let activeEditorRef = ref(None);
 
   wait(~name="Verify there is an editor open...", (state: State.t) => {
-      state
-      |> Selectors.getActiveEditorGroup
-      |> Option.map(EditorGroup.count)
-      |> Option.map(count => count == 1)
-      |> Option.value(~default=false);
+    state
+    |> Selectors.getActiveEditorGroup
+    |> Option.map(EditorGroup.count)
+    |> Option.map(count => count == 1)
+    |> Option.value(~default=false)
   });
-  
 
   wait(~name="Wait for active editor", (state: State.t) => {
     let maybeActiveEditor =
-      state
-      |> Selectors.getActiveEditorGroup
-      |> Selectors.getActiveEditor;
+      state |> Selectors.getActiveEditorGroup |> Selectors.getActiveEditor;
 
     activeEditorRef := maybeActiveEditor;
     maybeActiveEditor != None;
@@ -42,32 +35,24 @@ runTestWithInput(
 
   switch (activeEditorRef^) {
   | None => failwith("We should've had an editor now")
-  | Some(editor) =>
-    dispatch(ViewCloseEditor(editor.editorId));
+  | Some(editor) => dispatch(ViewCloseEditor(editor.editorId))
   };
 
   wait(~name="Verify there are no editors open...", (state: State.t) => {
-        state
-      |> Selectors.getActiveEditorGroup
-      |> Option.map(EditorGroup.count)
-      |> Option.map(count => count == 0)
-      |> Option.value(~default=false);
-  });
-  
-  dispatch(
-    Actions.OpenFileByPath(
-      "regression-733.txt",
-      None,
-      None,
-    ),
-  );
-  
-  wait(~name="...but one reopens when a file is opened", (state: State.t) => {
-      state
-      |> Selectors.getActiveEditorGroup
-      |> Option.map(EditorGroup.count)
-      |> Option.map(count => count == 1)
-      |> Option.value(~default=false);
+    state
+    |> Selectors.getActiveEditorGroup
+    |> Option.map(EditorGroup.count)
+    |> Option.map(count => count == 0)
+    |> Option.value(~default=false)
   });
 
+  dispatch(Actions.OpenFileByPath("regression-733.txt", None, None));
+
+  wait(~name="...but one reopens when a file is opened", (state: State.t) => {
+    state
+    |> Selectors.getActiveEditorGroup
+    |> Option.map(EditorGroup.count)
+    |> Option.map(count => count == 1)
+    |> Option.value(~default=false)
+  });
 });

--- a/integration_test/Regression733Test.re
+++ b/integration_test/Regression733Test.re
@@ -1,0 +1,73 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+open Feature_Editor;
+
+// Regression test case covering #733:
+// Closing all active splits causes no other splits to be opened
+runTestWithInput(
+  ~name="Regression733Test",
+  (input, dispatch, wait, runEffects) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    state.vimMode == Vim.Types.Normal
+  );
+
+  let activeEditorRef = ref(None);
+
+  wait(~name="Verify there is an editor open...", (state: State.t) => {
+      state
+      |> Selectors.getActiveEditorGroup
+      |> Option.map(EditorGroup.count)
+      |> Option.map(count => count == 1)
+      |> Option.value(~default=false);
+  });
+  
+
+  wait(~name="Wait for active editor", (state: State.t) => {
+    let maybeActiveEditor =
+      state
+      |> Selectors.getActiveEditorGroup
+      |> Selectors.getActiveEditor;
+
+    activeEditorRef := maybeActiveEditor;
+    maybeActiveEditor != None;
+  });
+
+  // Modify the file
+  input("o");
+  input("a");
+  input("b");
+  input("c");
+
+  switch (activeEditorRef^) {
+  | None => failwith("We should've had an editor now")
+  | Some(editor) =>
+    dispatch(ViewCloseEditor(editor.editorId));
+  };
+
+  wait(~name="Verify there are no editors open...", (state: State.t) => {
+        state
+      |> Selectors.getActiveEditorGroup
+      |> Option.map(EditorGroup.count)
+      |> Option.map(count => count == 0)
+      |> Option.value(~default=false);
+  });
+  
+  dispatch(
+    Actions.OpenFileByPath(
+      "regression-733.txt",
+      None,
+      None,
+    ),
+  );
+  
+  wait(~name="...but one reopens when a file is opened", (state: State.t) => {
+      state
+      |> Selectors.getActiveEditorGroup
+      |> Option.map(EditorGroup.count)
+      |> Option.map(count => count == 1)
+      |> Option.value(~default=false);
+  });
+
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -34,6 +34,7 @@
            SyntaxServerParentPidTest
            SyntaxServerParentPidCorrectTest
            SyntaxServerReadExceptionTest
+           Regression733Test
            Regression1671Test
            RegressionCommandLineNoCompletionTest
            RegressionDeleteAllLinesTest
@@ -91,6 +92,7 @@
         LineEndingsCRLFTest.exe
         LineEndingsLFTest.exe
         QuickOpenEventuallyCompletesTest.exe
+        Regression733Test.exe
         Regression1671Test.exe
         RegressionCommandLineNoCompletionTest.exe
         RegressionDeleteAllLinesTest.exe

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -115,18 +115,17 @@ let runTest =
 
   let _: unit => unit =
     Revery.Tick.interval(
-      _ =>
-        {
-          let state = currentState^;
-          Revery.Utility.HeadlessWindow.render(
-            headlessWindow,
-            <Oni_UI.Root state />,
-          );
-        },
-        //        Revery.Utility.HeadlessWindow.takeScreenshot(
-        //          headlessWindow,
-        //          "screenshot.png",
-        //        );
+      _ => {
+        let state = currentState^;
+        Revery.Utility.HeadlessWindow.render(
+          headlessWindow,
+          <Oni_UI.Root state />,
+        );
+      },
+      //        Revery.Utility.HeadlessWindow.takeScreenshot(
+      //          headlessWindow,
+      //          "screenshot.png",
+      //        );
       Revery.Time.zero,
     );
 

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -115,17 +115,18 @@ let runTest =
 
   let _: unit => unit =
     Revery.Tick.interval(
-      _ => {
-        let state = currentState^;
-        Revery.Utility.HeadlessWindow.render(
-          headlessWindow,
-          <Oni_UI.Root state />,
-        );
-//        Revery.Utility.HeadlessWindow.takeScreenshot(
-//          headlessWindow,
-//          "screenshot.png",
-//        );
-      },
+      _ =>
+        {
+          let state = currentState^;
+          Revery.Utility.HeadlessWindow.render(
+            headlessWindow,
+            <Oni_UI.Root state />,
+          );
+        },
+        //        Revery.Utility.HeadlessWindow.takeScreenshot(
+        //          headlessWindow,
+        //          "screenshot.png",
+        //        );
       Revery.Time.zero,
     );
 

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -121,10 +121,10 @@ let runTest =
           headlessWindow,
           <Oni_UI.Root state />,
         );
-        Revery.Utility.HeadlessWindow.takeScreenshot(
-          headlessWindow,
-          "screenshot.png",
-        );
+//        Revery.Utility.HeadlessWindow.takeScreenshot(
+//          headlessWindow,
+//          "screenshot.png",
+//        );
       },
       Revery.Time.zero,
     );

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -121,10 +121,10 @@ let runTest =
           headlessWindow,
           <Oni_UI.Root state />,
         );
+          Revery.Utility.HeadlessWindow.takeScreenshot(
+            headlessWindow, "screenshot.png"
+          );
       },
-      //    Revery.Utility.HeadlessWindow.takeScreenshot(
-      //      headlessWindow, "screenshot.png"
-      //    );
       Revery.Time.zero,
     );
 
@@ -152,6 +152,7 @@ let runTest =
 
   let (dispatch, runEffects) =
     Store.StoreThread.start(
+      ~showUpdateChangelog=false,
       ~getUserSettings,
       ~setup,
       ~onAfterDispatch,

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -121,9 +121,10 @@ let runTest =
           headlessWindow,
           <Oni_UI.Root state />,
         );
-          Revery.Utility.HeadlessWindow.takeScreenshot(
-            headlessWindow, "screenshot.png"
-          );
+        Revery.Utility.HeadlessWindow.takeScreenshot(
+          headlessWindow,
+          "screenshot.png",
+        );
       },
       Revery.Time.zero,
     );

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -148,11 +148,8 @@ let isEmpty = model => IntMap.is_empty(model.editors);
 
 let removeEditorById = (state, editorId) => {
   switch (IntMap.find_opt(editorId, state.editors)) {
-  | None =>
-  prerr_endline ("NO EDITOR FOUND: " ++ string_of_int(editorId));
-  state
+  | None => state
   | Some(editor) =>
-    prerr_endline ("FOUND EDITOR: " ++ string_of_int(editorId));
     let bufferId = Feature_Editor.Editor.getBufferId(editor);
     let filteredTabList =
       List.filter(t => editorId != t, state.reverseTabOrder);

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -148,8 +148,11 @@ let isEmpty = model => IntMap.is_empty(model.editors);
 
 let removeEditorById = (state, editorId) => {
   switch (IntMap.find_opt(editorId, state.editors)) {
-  | None => state
+  | None =>
+  prerr_endline ("NO EDITOR FOUND: " ++ string_of_int(editorId));
+  state
   | Some(editor) =>
+    prerr_endline ("FOUND EDITOR: " ++ string_of_int(editorId));
     let bufferId = Feature_Editor.Editor.getBufferId(editor);
     let filteredTabList =
       List.filter(t => editorId != t, state.reverseTabOrder);

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -51,7 +51,6 @@ let reduce = (~defaultFont, v: EditorGroup.t, action: Actions.t) => {
   | Command("workbench.action.nextEditor") => EditorGroup.nextEditor(v)
   | Command("workbench.action.previousEditor") =>
     EditorGroup.previousEditor(v)
-  | ViewCloseEditor(id) => EditorGroup.removeEditorById(v, id)
   | ViewSetActiveEditor(id) =>
     switch (IntMap.find_opt(id, v.editors)) {
     | None => v

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -90,14 +90,45 @@ let isEmpty = (id, model) => {
   };
 };
 
-let removeEmptyEditorGroups = model => {
-  let idToGroup =
-    IntMap.filter(
-      (_, group) => !EditorGroup.isEmpty(group),
-      model.idToGroup,
-    );
+let canClose = (id, model) => {
+  isEmpty(id, model) &&
+  true
+  // Don't close if this is the only editor group left!
+  //List.length(IntMap.bindings(model.idToGroup)) > 1;
+};
 
-  {...model, idToGroup};
+let closeEditor = (~editorId, editorGroups) => {
+  
+    let idToGroup = editorGroups.idToGroup
+      |> IntMap.map(group => EditorGroup.removeEditorById(group, editorId))
+
+  // Keep a handle on the active editor group - we should never
+  // get completely empty!
+  switch (IntMap.find_opt(editorGroups.activeId, idToGroup)) {
+  // We shouldn't be in this state, ever
+  | None => editorGroups
+  | Some(activeEditorGroup) => {
+      let idToGroup = idToGroup
+      |> IntMap.filter((_, group) => !EditorGroup.isEmpty(group));
+
+    let remainingGroupCount = List.length(IntMap.bindings(idToGroup));
+    // We never let the editor groups get totally empty,
+    // otherwise we run into the bad case of:
+    // https://github.com/onivim/oni2/issues/733
+    let idToGroup = if (remainingGroupCount == 0) {
+      IntMap.add(activeEditorGroup.editorGroupId, activeEditorGroup, idToGroup);
+    } else {
+      idToGroup;
+    };
+
+    { ...editorGroups, idToGroup }
+    // There's a chance the active group could've changed, so make sure
+    // we point to one
+    |> ensureActiveId;
+    }
+  }
+
+  
 };
 
 let reduce = (~defaultFont, model, action: Actions.t) => {
@@ -118,7 +149,6 @@ let reduce = (~defaultFont, model, action: Actions.t) => {
   | EditorGroupSelected(editorGroupId) => {...model, activeId: editorGroupId}
 
   | action =>
-    let newModel =
       switch (getActiveEditorGroup(model)) {
       | Some(group) => {
           ...model,
@@ -131,11 +161,5 @@ let reduce = (~defaultFont, model, action: Actions.t) => {
         }
       | None => model
       };
-
-    switch (action) {
-    | ViewCloseEditor(_) =>
-      newModel |> removeEmptyEditorGroups |> ensureActiveId
-    | _ => newModel
-    };
   };
 };

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -83,13 +83,6 @@ let ensureActiveId = model => {
   };
 };
 
-let isEmpty = (id, model) => {
-  switch (IntMap.find_opt(id, model.idToGroup)) {
-  | None => true
-  | Some(group) => EditorGroup.isEmpty(group)
-  };
-};
-
 let closeEditor = (~editorId, editorGroups) => {
   let idToGroup =
     editorGroups.idToGroup

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -91,44 +91,44 @@ let isEmpty = (id, model) => {
 };
 
 let canClose = (id, model) => {
-  isEmpty(id, model) &&
-  true
-  // Don't close if this is the only editor group left!
-  //List.length(IntMap.bindings(model.idToGroup)) > 1;
+  isEmpty(id, model) && true; // Don't close if this is the only editor group left!
+                             //List.length(IntMap.bindings(model.idToGroup)) > 1;
 };
 
 let closeEditor = (~editorId, editorGroups) => {
-  
-    let idToGroup = editorGroups.idToGroup
-      |> IntMap.map(group => EditorGroup.removeEditorById(group, editorId))
+  let idToGroup =
+    editorGroups.idToGroup
+    |> IntMap.map(group => EditorGroup.removeEditorById(group, editorId));
 
   // Keep a handle on the active editor group - we should never
   // get completely empty!
   switch (IntMap.find_opt(editorGroups.activeId, idToGroup)) {
   // We shouldn't be in this state, ever
   | None => editorGroups
-  | Some(activeEditorGroup) => {
-      let idToGroup = idToGroup
-      |> IntMap.filter((_, group) => !EditorGroup.isEmpty(group));
+  | Some(activeEditorGroup) =>
+    let idToGroup =
+      idToGroup |> IntMap.filter((_, group) => !EditorGroup.isEmpty(group));
 
     let remainingGroupCount = List.length(IntMap.bindings(idToGroup));
     // We never let the editor groups get totally empty,
     // otherwise we run into the bad case of:
     // https://github.com/onivim/oni2/issues/733
-    let idToGroup = if (remainingGroupCount == 0) {
-      IntMap.add(activeEditorGroup.editorGroupId, activeEditorGroup, idToGroup);
-    } else {
-      idToGroup;
-    };
+    let idToGroup =
+      if (remainingGroupCount == 0) {
+        IntMap.add(
+          activeEditorGroup.editorGroupId,
+          activeEditorGroup,
+          idToGroup,
+        );
+      } else {
+        idToGroup;
+      };
 
-    { ...editorGroups, idToGroup }
+    {...editorGroups, idToGroup}
     // There's a chance the active group could've changed, so make sure
     // we point to one
     |> ensureActiveId;
-    }
-  }
-
-  
+  };
 };
 
 let reduce = (~defaultFont, model, action: Actions.t) => {
@@ -149,17 +149,17 @@ let reduce = (~defaultFont, model, action: Actions.t) => {
   | EditorGroupSelected(editorGroupId) => {...model, activeId: editorGroupId}
 
   | action =>
-      switch (getActiveEditorGroup(model)) {
-      | Some(group) => {
-          ...model,
-          idToGroup:
-            IntMap.add(
-              model.activeId,
-              EditorGroupReducer.reduce(~defaultFont, group, action),
-              model.idToGroup,
-            ),
-        }
-      | None => model
-      };
+    switch (getActiveEditorGroup(model)) {
+    | Some(group) => {
+        ...model,
+        idToGroup:
+          IntMap.add(
+            model.activeId,
+            EditorGroupReducer.reduce(~defaultFont, group, action),
+            model.idToGroup,
+          ),
+      }
+    | None => model
+    }
   };
 };

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -90,11 +90,6 @@ let isEmpty = (id, model) => {
   };
 };
 
-let canClose = (id, model) => {
-  isEmpty(id, model) && true; // Don't close if this is the only editor group left!
-                             //List.length(IntMap.bindings(model.idToGroup)) > 1;
-};
-
 let closeEditor = (~editorId, editorGroups) => {
   let idToGroup =
     editorGroups.idToGroup

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -10,8 +10,10 @@ let getFirstEditorGroup: t => EditorGroup.t;
 
 let add: (~defaultFont: Service_Font.font, EditorGroup.t, t) => t;
 
+let closeEditor: (~editorId: int, t) => t;
+
 let isActive: (t, EditorGroup.t) => bool;
-let isEmpty: (int, t) => bool;
+let canClose: (int, t) => bool;
 
 let reduce: (~defaultFont: Service_Font.font, t, Actions.t) => t;
 

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -13,7 +13,6 @@ let add: (~defaultFont: Service_Font.font, EditorGroup.t, t) => t;
 let closeEditor: (~editorId: int, t) => t;
 
 let isActive: (t, EditorGroup.t) => bool;
-let canClose: (int, t) => bool;
 
 let reduce: (~defaultFont: Service_Font.font, t, Actions.t) => t;
 

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -66,6 +66,7 @@ let registerCommands = (~dispatch, commands) => {
 
 let start =
     (
+      ~showUpdateChangelog=true,
       ~getUserSettings,
       ~configurationFilePath=None,
       ~keybindingsFilePath=None,
@@ -114,6 +115,7 @@ let start =
   let commandUpdater = CommandStoreConnector.start();
   let (vimUpdater, vimStream) =
     VimStoreConnector.start(
+      ~showUpdateChangelog,
       languageInfo,
       getState,
       getClipboardText,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -53,6 +53,7 @@ let getCommandLineCompletionsMeet = (str: string, position: int) => {
 
 let start =
     (
+      ~showUpdateChangelog: bool,
       languageInfo: Ext.LanguageInfo.t,
       getState: unit => State.t,
       getClipboardText,
@@ -552,7 +553,8 @@ let start =
     Isolinear.Effect.create(~name="vim.init", () => {
       Vim.init();
 
-      if (Core.BuildInfo.commitId == Persistence.Global.version()) {
+      if (Core.BuildInfo.commitId == Persistence.Global.version()
+        || !showUpdateChangelog) {
         dispatch(
           Actions.OpenFileByPath(Core.BufferPath.welcome, None, None),
         );

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -554,7 +554,7 @@ let start =
       Vim.init();
 
       if (Core.BuildInfo.commitId == Persistence.Global.version()
-        || !showUpdateChangelog) {
+          || !showUpdateChangelog) {
         dispatch(
           Actions.OpenFileByPath(Core.BufferPath.welcome, None, None),
         );

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -36,23 +36,30 @@ let start = () => {
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
     | EditorGroupSelected(_) => FocusManager.push(Editor, s)
-    | ViewCloseEditor(_) =>
+    | ViewCloseEditor(editorId) =>
       /* When an editor is closed... lets see if any window splits are empty */
+
+      let editorGroups = Model.EditorGroups.closeEditor(
+        ~editorId,
+        s.editorGroups
+      );
 
       /* Remove splits */
       let layout =
         s.layout
         |> Feature_Layout.windows
-        |> List.filter(editorGroupId =>
-             Model.EditorGroups.isEmpty(editorGroupId, s.editorGroups)
-           )
         |> List.fold_left(
-             (acc, editorGroupId) =>
-               Feature_Layout.removeWindow(editorGroupId, acc),
+             (acc, editorGroupId) => 
+               if (Model.EditorGroups.getEditorGroupById(editorGroups, 
+               editorGroupId) == None) {
+                 Feature_Layout.removeWindow(editorGroupId, acc);
+               } else {
+                  acc
+               },
              s.layout,
            );
 
-      {...s, layout};
+      {...s, editorGroups, layout};
 
     | OpenFileByPath(_) => FocusManager.push(Editor, s)
 

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -39,22 +39,23 @@ let start = () => {
     | ViewCloseEditor(editorId) =>
       /* When an editor is closed... lets see if any window splits are empty */
 
-      let editorGroups = Model.EditorGroups.closeEditor(
-        ~editorId,
-        s.editorGroups
-      );
+      let editorGroups =
+        Model.EditorGroups.closeEditor(~editorId, s.editorGroups);
 
       /* Remove splits */
       let layout =
         s.layout
         |> Feature_Layout.windows
         |> List.fold_left(
-             (acc, editorGroupId) => 
-               if (Model.EditorGroups.getEditorGroupById(editorGroups, 
-               editorGroupId) == None) {
+             (acc, editorGroupId) =>
+               if (Model.EditorGroups.getEditorGroupById(
+                     editorGroups,
+                     editorGroupId,
+                   )
+                   == None) {
                  Feature_Layout.removeWindow(editorGroupId, acc);
                } else {
-                  acc
+                 acc;
                },
              s.layout,
            );

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -175,7 +175,7 @@ module Styles = {
 };
 
 let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
-  let State.{vimMode: mode, uiFont, _} = state;
+  let State.{vimMode: mode, uiFont, editorFont, _} = state;
 
   let isActive = EditorGroups.isActive(state.editorGroups, editorGroup);
 
@@ -193,7 +193,7 @@ let make = (~state: State.t, ~theme, ~editorGroup: EditorGroup.t, ()) => {
     let editorContainer =
       switch (EditorGroup.getActiveEditor(editorGroup)) {
       | Some(editor) => <Parts.EditorContainer editor state theme isActive />
-      | None => React.empty
+      | None => <WelcomeView theme editorFont uiFont />
       };
 
     if (showTabs) {


### PR DESCRIPTION
__Issue:__ There are a few ways, like #733 , where it was possible to get to a state where all buffers are closed and there is a blank screen. If that wasn't bad enough... you can't even reopen any buffers, you're just stuck on the blank screen!

__Defect:__ We'd clear out all window splits and editor groups in this case, but once they're cleared, there wasn't a way to get them back.

__Fix:__ Consolidate the 'close-editor' logic - the `editorGroups` and window layout are tightly coupled, so bring those together - we may want to think about merging these closer together. But this factors out some hard-to-follow nested reducer logic. 

Fixes #733 