### PR TITLE
fix(sneak/#1394): Navigation between splits

### DIFF
--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -181,9 +181,6 @@ let runTest =
   InitLog.info("Sending init event");
 
   Oni_UI.GlobalContext.set({
-    openEditorById: id => {
-      dispatch(Model.Actions.ViewSetActiveEditor(id));
-    },
     closeEditorById: id => dispatch(Model.Actions.ViewCloseEditor(id)),
     editorScrollDelta: (~editorId, ~deltaY, ()) =>
       dispatch(Model.Actions.EditorScroll(editorId, deltaY)),

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -114,6 +114,7 @@ type t =
   | EditorScroll(Feature_Editor.EditorId.t, float)
   | EditorScrollToLine(Feature_Editor.EditorId.t, int)
   | EditorScrollToColumn(Feature_Editor.EditorId.t, int)
+  | EditorTabClicked(int)
   | Notification(Feature_Notification.msg)
   | ExtMessageReceived({
       severity: [@opaque] Exthost.Msg.MessageService.severity,
@@ -162,7 +163,6 @@ type t =
   | TokenThemeLoaded([@opaque] TokenTheme.t)
   | ThemeLoadError(string)
   | ViewCloseEditor(int)
-  | ViewSetActiveEditor(int)
   | EnableZenMode
   | DisableZenMode
   | CopyActiveFilepathToClipboard

--- a/src/Model/EditorGroup.re
+++ b/src/Model/EditorGroup.re
@@ -36,9 +36,15 @@ let getActiveEditor = model =>
   | None => None
   };
 
+let hasEditor = (~editorId, model) => {
+  IntMap.mem(editorId, model.editors);
+};
+
 let setActiveEditor = (model, editorId) => {
-  ...model,
-  activeEditorId: Some(editorId),
+  switch (IntMap.find_opt(editorId, model.editors)) {
+  | None => model
+  | Some(_) => {...model, activeEditorId: Some(editorId)}
+  };
 };
 
 let setBufferFont = (~bufferId, ~font, group) => {

--- a/src/Model/EditorGroup.rei
+++ b/src/Model/EditorGroup.rei
@@ -14,6 +14,8 @@ let create: unit => t;
 // [count] gets the number of editors in the group
 let count: t => int;
 
+let hasEditor: (~editorId: int, t) => bool;
+
 let getActiveEditor: t => option(Feature_Editor.Editor.t);
 let setActiveEditor: (t, int) => t;
 let getEditorById: (int, t) => option(Feature_Editor.Editor.t);

--- a/src/Model/EditorGroupReducer.re
+++ b/src/Model/EditorGroupReducer.re
@@ -51,11 +51,6 @@ let reduce = (~defaultFont, v: EditorGroup.t, action: Actions.t) => {
   | Command("workbench.action.nextEditor") => EditorGroup.nextEditor(v)
   | Command("workbench.action.previousEditor") =>
     EditorGroup.previousEditor(v)
-  | ViewSetActiveEditor(id) =>
-    switch (IntMap.find_opt(id, v.editors)) {
-    | None => v
-    | Some(_) => {...v, activeEditorId: Some(id)}
-    }
   | _ => v
   };
 };

--- a/src/Model/EditorGroups.re
+++ b/src/Model/EditorGroups.re
@@ -43,6 +43,27 @@ let add = (~defaultFont, editorGroup, model) => {
   };
 };
 
+let setActiveEditor = (~editorId, model) => {
+  let (activeId, idToGroup) =
+    IntMap.fold(
+      (editorGroupId, editorGroup, acc) =>
+        if (EditorGroup.hasEditor(~editorId, editorGroup)) {
+          let (_, idToGroup) = acc;
+          let newEditorGroup =
+            EditorGroup.setActiveEditor(editorGroup, editorId);
+          let idToGroup' =
+            IntMap.add(editorGroup.editorGroupId, newEditorGroup, idToGroup);
+          (editorGroupId, idToGroup');
+        } else {
+          acc;
+        },
+      model.idToGroup,
+      (model.activeId, model.idToGroup),
+    );
+
+  {...model, activeId, idToGroup};
+};
+
 let getEditorGroupById = (model, id) => IntMap.find_opt(id, model.idToGroup);
 
 let getFirstEditorGroup = ({idToGroup, _}) => {

--- a/src/Model/EditorGroups.rei
+++ b/src/Model/EditorGroups.rei
@@ -17,3 +17,5 @@ let isActive: (t, EditorGroup.t) => bool;
 let reduce: (~defaultFont: Service_Font.font, t, Actions.t) => t;
 
 let setBufferFont: (~bufferId: int, ~font: Service_Font.font, t) => t;
+
+let setActiveEditor: (~editorId: int, t) => t;

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -36,6 +36,10 @@ let start = () => {
   let windowUpdater = (s: Model.State.t, action: Model.Actions.t) =>
     switch (action) {
     | EditorGroupSelected(_) => FocusManager.push(Editor, s)
+    | EditorTabClicked(editorId) => {
+        ...s,
+        editorGroups: EditorGroups.setActiveEditor(~editorId, s.editorGroups),
+      }
     | ViewCloseEditor(editorId) =>
       /* When an editor is closed... lets see if any window splits are empty */
 

--- a/src/UI/GlobalContext.re
+++ b/src/UI/GlobalContext.re
@@ -18,7 +18,6 @@ type editorSetScroll =
 type t = {
   editorScrollDelta,
   editorSetScroll,
-  openEditorById: int => unit,
   closeEditorById: int => unit,
   dispatch: Actions.t => unit,
 };
@@ -29,7 +28,6 @@ let viewNoop: Views.viewOperation =
 let default = {
   editorScrollDelta: (~editorId as _, ~deltaY as _, ()) => (),
   editorSetScroll: (~editorId as _, ~scrollY as _, ()) => (),
-  openEditorById: _ => (),
   dispatch: _ => (),
   closeEditorById: _ => (),
 };

--- a/src/UI/Tabs.re
+++ b/src/UI/Tabs.re
@@ -53,7 +53,11 @@ let toTab =
     uiFont
     mode
     icon
-    onClick={() => GlobalContext.current().openEditorById(tabInfo.editorId)}
+    onClick={() =>
+      GlobalContext.current().dispatch(
+        Model.Actions.EditorTabClicked(tabInfo.editorId),
+      )
+    }
     onClose={() => GlobalContext.current().closeEditorById(tabInfo.editorId)}
   />;
 };

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -292,9 +292,6 @@ if (cliOptions.syntaxHighlightService) {
       Window.onMoved(window, _ => persistWorkspace());
 
     GlobalContext.set({
-      openEditorById: id => {
-        dispatch(Model.Actions.ViewSetActiveEditor(id));
-      },
       closeEditorById: id => dispatch(Model.Actions.ViewCloseEditor(id)),
       editorScrollDelta: (~editorId, ~deltaY, ()) =>
         dispatch(Model.Actions.EditorScroll(editorId, deltaY)),

--- a/test/Model/EditorGroupsTests.re
+++ b/test/Model/EditorGroupsTests.re
@@ -1,0 +1,46 @@
+open Oni_Model;
+open TestFramework;
+
+let createEditorBuffer = (~id) => {
+  Oni_Core.Buffer.ofLines(~id, [||])
+  |> Feature_Editor.EditorBuffer.ofBuffer;
+}
+
+describe("EditorGroups", ({describe, _}) => {
+
+describe("setActiveEditor", ({test, _}) => {
+  test("should work between editor groups", ({expect, _}) => {
+    let editorGroups = EditorGroups.create();
+    let defaultFont = Service_Font.default;
+
+    let buffer1 = createEditorBuffer(~id=1);
+    let buffer2 = createEditorBuffer(~id=2);
+
+    let (editorGroup1, editor1Id) = EditorGroup.create()
+    |> EditorGroup.getOrCreateEditorForBuffer(~font=defaultFont, ~buffer=buffer1);
+
+    let (editorGroup2, editor2Id) = EditorGroup.create()
+    |> EditorGroup.getOrCreateEditorForBuffer(~font=defaultFont, ~buffer=buffer2);
+
+
+    let editorGroups = editorGroups
+    |> EditorGroups.add(~defaultFont, editorGroup1)
+    |> EditorGroups.add(~defaultFont, editorGroup2)
+    |> EditorGroups.setActiveEditor(~editorId=editor1Id);
+
+    // Verify first group is active
+    expect.int(EditorGroups.activeGroupId(editorGroups)).toBe(
+      editorGroup1.editorGroupId
+    );
+
+    // Switch to editor2
+    // EditorGroup2 should now be the active one!
+    let editorGroups = editorGroups
+    |> EditorGroups.setActiveEditor(~editorId=editor2Id);
+
+    expect.int(EditorGroups.activeGroupId(editorGroups)).toBe(
+      editorGroup2.editorGroupId
+    );
+  });
+});
+});

--- a/test/Model/EditorGroupsTests.re
+++ b/test/Model/EditorGroupsTests.re
@@ -2,45 +2,51 @@ open Oni_Model;
 open TestFramework;
 
 let createEditorBuffer = (~id) => {
-  Oni_Core.Buffer.ofLines(~id, [||])
-  |> Feature_Editor.EditorBuffer.ofBuffer;
-}
+  Oni_Core.Buffer.ofLines(~id, [||]) |> Feature_Editor.EditorBuffer.ofBuffer;
+};
 
 describe("EditorGroups", ({describe, _}) => {
+  describe("setActiveEditor", ({test, _}) => {
+    test("should work between editor groups", ({expect, _}) => {
+      let editorGroups = EditorGroups.create();
+      let defaultFont = Service_Font.default;
 
-describe("setActiveEditor", ({test, _}) => {
-  test("should work between editor groups", ({expect, _}) => {
-    let editorGroups = EditorGroups.create();
-    let defaultFont = Service_Font.default;
+      let buffer1 = createEditorBuffer(~id=1);
+      let buffer2 = createEditorBuffer(~id=2);
 
-    let buffer1 = createEditorBuffer(~id=1);
-    let buffer2 = createEditorBuffer(~id=2);
+      let (editorGroup1, editor1Id) =
+        EditorGroup.create()
+        |> EditorGroup.getOrCreateEditorForBuffer(
+             ~font=defaultFont,
+             ~buffer=buffer1,
+           );
 
-    let (editorGroup1, editor1Id) = EditorGroup.create()
-    |> EditorGroup.getOrCreateEditorForBuffer(~font=defaultFont, ~buffer=buffer1);
+      let (editorGroup2, editor2Id) =
+        EditorGroup.create()
+        |> EditorGroup.getOrCreateEditorForBuffer(
+             ~font=defaultFont,
+             ~buffer=buffer2,
+           );
 
-    let (editorGroup2, editor2Id) = EditorGroup.create()
-    |> EditorGroup.getOrCreateEditorForBuffer(~font=defaultFont, ~buffer=buffer2);
+      let editorGroups =
+        editorGroups
+        |> EditorGroups.add(~defaultFont, editorGroup1)
+        |> EditorGroups.add(~defaultFont, editorGroup2)
+        |> EditorGroups.setActiveEditor(~editorId=editor1Id);
 
+      // Verify first group is active
+      expect.int(EditorGroups.activeGroupId(editorGroups)).toBe(
+        editorGroup1.editorGroupId,
+      );
 
-    let editorGroups = editorGroups
-    |> EditorGroups.add(~defaultFont, editorGroup1)
-    |> EditorGroups.add(~defaultFont, editorGroup2)
-    |> EditorGroups.setActiveEditor(~editorId=editor1Id);
+      // Switch to editor2
+      // EditorGroup2 should now be the active one!
+      let editorGroups =
+        editorGroups |> EditorGroups.setActiveEditor(~editorId=editor2Id);
 
-    // Verify first group is active
-    expect.int(EditorGroups.activeGroupId(editorGroups)).toBe(
-      editorGroup1.editorGroupId
-    );
-
-    // Switch to editor2
-    // EditorGroup2 should now be the active one!
-    let editorGroups = editorGroups
-    |> EditorGroups.setActiveEditor(~editorId=editor2Id);
-
-    expect.int(EditorGroups.activeGroupId(editorGroups)).toBe(
-      editorGroup2.editorGroupId
-    );
-  });
-});
+      expect.int(EditorGroups.activeGroupId(editorGroups)).toBe(
+        editorGroup2.editorGroupId,
+      );
+    })
+  })
 });


### PR DESCRIPTION
__Issue:__ Sneak mode wasn't working when using it to switch between splits

__Defect:__ The `ViewSetActiveEditor` action was only being dispatched on the currently-active editor.

__Fix:__
- Remove the confusing nested-reducer logic here, and create a top-level function on the `EditorGroups`
- Rename the imperative `ViewSetActiveEditor` to the more descriptive `EditorTabClicked`

Along with #1776 , this fixes #1394 