### PR TITLE
chore(CI): Fix CentOS 7 installation of git2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,8 +93,6 @@ jobs:
     displayName: 'docker: build Dockerfile'
   - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
     displayName: 'docker: ls -a'
-  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && git --version'
-    displayName: 'docker: git version (before updating)'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/install-git.sh'
     displayName: 'docker: install git v2'
   - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && git --version'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
   - template: .ci/clean-linux-deps.yml
   - script: docker build -t centos scripts/docker/centos
     displayName: 'docker: build Dockerfile'
-  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
+  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'ls -a'
     displayName: 'docker: ls -a'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/install-git.sh'
     displayName: 'docker: install git v2'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,12 +91,6 @@ jobs:
   - template: .ci/clean-linux-deps.yml
   - script: docker build -t centos scripts/docker/centos
     displayName: 'docker: build Dockerfile'
-  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'ls -a'
-    displayName: 'docker: ls -a'
-  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/install-git.sh'
-    displayName: 'docker: install git v2'
-  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'echo $PATH'
-    displayName: 'docker: Get path'
   - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && git --version'
     displayName: 'docker: git version (after updating)'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,12 @@ jobs:
     displayName: 'docker: build Dockerfile'
   - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ls -a'
     displayName: 'docker: ls -a'
+  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && git --version'
+    displayName: 'docker: git version (before updating)'
+  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/install-git.sh'
+    displayName: 'docker: install git v2'
+  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && git --version'
+    displayName: 'docker: git version (after updating)'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
     displayName: 'docker: build Onivim 2'
   - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,8 @@ jobs:
     displayName: 'docker: ls -a'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/install-git.sh'
     displayName: 'docker: install git v2'
+  - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'echo $PATH'
+    displayName: 'docker: Get path'
   - script: docker run --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && git --version'
     displayName: 'docker: git version (after updating)'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -1,10 +1,13 @@
 FROM centos:7
 
+RUN pwd
+RUN ls
+
 RUN yum -y update
 
 RUN yum -y remove git
 RUN yum -y install perl perl-Thread-Queue perl-devel
-RUN ./scripts/install-git.sh
+RUN ./oni2/scripts/install-git.sh
 RUN git --version
 
 RUN yum -y install centos-release-scl

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -26,9 +26,9 @@ RUN npm -v
 RUN npm install --global --unsafe-perm=true esy@0.6.2
 RUN npm install --global node-gyp
 
-RUN yum -y install epel-release
 RUN yum -y remove git
-RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum -y install https://repo.ius.io/ius-release-el7.rpm
 RUN yum -y install git2u-all
 
 RUN yum -y install nasm

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -2,6 +2,11 @@ FROM centos:7
 
 RUN yum -y update
 
+RUN yum -y remove git
+RUN yum -y install perl perl-Thread-Queue perl-devel
+RUN sudo bash ./scripts/install-git.sh
+RUN git --version
+
 RUN yum -y install centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum -y install llvm-toolset-7.0
@@ -13,8 +18,6 @@ RUN yum -y install nodejs npm coreutils grep tar sed gawk diffutils autoconf
 
 RUN yum -y install file fuse fuse-devel wget bzip2-devel libXt-devel libSM-devel libICE-devel ncurses-devel libacl-devel libxrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel mesa-libGLU-devel gtk3-devel perl-Digest-SHA bzip2 m4 patch which cmake3 git
 
-RUN yum -y install perl perl-Thread-Queue
-
 RUN yum -y install /usr/lib64/libasan.so.0.0.0
 
 RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/colm-0.13.0.4-2.el7.x86_64.rpm
@@ -25,10 +28,5 @@ RUN npm -v
 
 RUN npm install --global --unsafe-perm=true esy@0.6.2
 RUN npm install --global node-gyp
-
-RUN yum -y remove git
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum -y install https://repo.ius.io/ius-release-el7.rpm
-RUN yum -y install git2u-all
 
 RUN yum -y install nasm

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -28,4 +28,7 @@ RUN npm install --global --unsafe-perm=true esy@0.6.2
 RUN npm install --global node-gyp
 
 RUN yum -y install nasm
+RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum -y remove git
+RUN yum -y install epel-release
+RUN yum -y install git222

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -13,6 +13,8 @@ RUN yum -y install nodejs npm coreutils grep tar sed gawk diffutils autoconf
 
 RUN yum -y install file fuse fuse-devel wget bzip2-devel libXt-devel libSM-devel libICE-devel ncurses-devel libacl-devel libxrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel mesa-libGLU-devel gtk3-devel perl-Digest-SHA bzip2 m4 patch which cmake3 git
 
+RUN yum -y install perl perl-Thread-Queue
+
 RUN yum -y install /usr/lib64/libasan.so.0.0.0
 
 RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/colm-0.13.0.4-2.el7.x86_64.rpm

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -1,8 +1,5 @@
 FROM centos:7
 
-RUN pwd
-RUN ls
-
 RUN yum -y update
 
 RUN yum -y install centos-release-scl
@@ -21,9 +18,6 @@ RUN yum -y install /usr/lib64/libasan.so.0.0.0
 RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/colm-0.13.0.4-2.el7.x86_64.rpm
 RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/r/ragel-7.0.0.9-2.el7.x86_64.rpm
 
-RUN node -v
-RUN npm -v
-
 RUN npm install --global --unsafe-perm=true esy@0.6.2
 RUN npm install --global node-gyp
 
@@ -32,4 +26,7 @@ RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum -y remove git
 RUN yum -y install epel-release
 RUN yum -y install git222
+
+RUN node -v
+RUN npm -v
 RUN git --version

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -32,3 +32,4 @@ RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum -y remove git
 RUN yum -y install epel-release
 RUN yum -y install git222
+RUN git --version

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -28,7 +28,7 @@ RUN npm install --global node-gyp
 
 RUN yum -y install epel-release
 RUN yum -y remove git
-RUN rpm -U https://centos7.iuscommunity.org/ius-release.rpm
-RUN yum -y install git2u
+RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+RUN yum -y install git2u-all
 
 RUN yum -y install nasm

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -5,11 +5,6 @@ RUN ls
 
 RUN yum -y update
 
-RUN yum -y remove git
-RUN yum -y install perl perl-Thread-Queue perl-devel
-RUN ./oni2/scripts/install-git.sh
-RUN git --version
-
 RUN yum -y install centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum -y install llvm-toolset-7.0
@@ -33,3 +28,4 @@ RUN npm install --global --unsafe-perm=true esy@0.6.2
 RUN npm install --global node-gyp
 
 RUN yum -y install nasm
+RUN yum -y remove git

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -4,7 +4,7 @@ RUN yum -y update
 
 RUN yum -y remove git
 RUN yum -y install perl perl-Thread-Queue perl-devel
-RUN sudo bash ./scripts/install-git.sh
+RUN ./scripts/install-git.sh
 RUN git --version
 
 RUN yum -y install centos-release-scl

--- a/scripts/install-git.sh
+++ b/scripts/install-git.sh
@@ -1,6 +1,0 @@
-wget https://github.com/git/git/archive/v2.26.2.tar.gz -O git.tar.gz
-tar -zxf git.tar.gz
-cd git-*
-make configure
-./configure --prefix=/usr/local
-make install

--- a/scripts/install-git.sh
+++ b/scripts/install-git.sh
@@ -1,0 +1,6 @@
+wget https://github.com/git/git/archive/v2.26.2.tar.gz -O git.tar.gz
+tar -zxf git.tar.gz
+cd git-*
+make configure
+./configure --prefix=/usr/local
+make install


### PR DESCRIPTION
CentOS 7 defaults to having `git` v1, but we need v2 for our dependencies - this updates the script to pick up git v2+