### PR TITLE
fix(cli/#1783): add back custom extension dir option

### DIFF
--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -86,7 +86,7 @@ let start =
       ~minimize,
       ~window: option(Revery.Window.t),
       ~filesToOpen=[],
-      ~overriddenExtensionsDir=?,
+      ~overriddenExtensionsDir=None,
       ~shouldLoadExtensions=true,
       ~shouldSyntaxHighlight=true,
       ~shouldLoadConfiguration=true,

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -263,6 +263,7 @@ if (cliOptions.syntaxHighlightService) {
         ~shouldLoadExtensions=cliOptions.shouldLoadConfiguration,
         ~shouldSyntaxHighlight=cliOptions.shouldSyntaxHighlight,
         ~shouldLoadConfiguration=cliOptions.shouldLoadConfiguration,
+        ~overriddenExtensionsDir=cliOptions.overriddenExtensionsDir,
         ~quit,
         (),
       );

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -40,13 +40,13 @@ let spec =
     (
       "--disable-syntax-highlighting",
       passthrough,
-      "Turn off syntax highlighting.",
+      " Turn off syntax highlighting.",
     ),
-    ("--disable-extensions", passthrough, "Turn off extension loading."),
+    ("--disable-extensions", passthrough, " Turn off extension loading."),
     (
       "--disable-configuration",
       passthrough,
-      "Do not load user configuration (use default configuration).",
+      " Do not load user configuration (use default configuration).",
     ),
     (
       "--install-extension",


### PR DESCRIPTION
Fix #1783.

Add back the plumbing for the CLI flag to specify a custom extension folder.