### PR TITLE
fix(exthost): Fix error when trying to read package metadata

### DIFF
--- a/development_extensions/oni-dev-extension/package.json
+++ b/development_extensions/oni-dev-extension/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-dev-extension",
 	"description": "Development Extension for Oni",
 	"version": "0.0.1",
-	"publisher": "Outrun Labs, LLC",
 	"repository": "https://github.com/onivim/oni2",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -161,12 +161,8 @@ module Scanner: {
     };
   };
 
-  let load:
-    (~category: category, string) =>
-    option(ScanResult.t);
-  let scan:
-    (~category: category, string) =>
-    list(ScanResult.t);
+  let load: (~category: category, string) => option(ScanResult.t);
+  let scan: (~category: category, string) => list(ScanResult.t);
 };
 
 module InitData: {

--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -121,7 +121,7 @@ module Manifest: {
     author: string,
     displayName: option(LocalizedToken.t),
     description: option(string),
-    // publisher: option(string),
+    publisher: option(string),
     main: option(string),
     icon: option(string),
     categories: list(string),
@@ -131,7 +131,6 @@ module Manifest: {
     extensionDependencies: list(string),
     extensionPack: list(string),
     extensionKind: kind,
-    // TODO: Bring back
     contributes: Contributions.t,
     enableProposedApi: bool,
   }
@@ -163,10 +162,10 @@ module Scanner: {
   };
 
   let load:
-    (~prefix: option(string)=?, ~category: category, string) =>
+    (~category: category, string) =>
     option(ScanResult.t);
   let scan:
-    (~prefix: option(string)=?, ~category: category, string) =>
+    (~category: category, string) =>
     list(ScanResult.t);
 };
 

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -16,8 +16,7 @@ module Extension = {
   };
 
   let ofManifestAndPath = (manifest: Manifest.t, path: string) => {
-    // TODO: Is identifier right?
-    identifier: manifest.name,
+    identifier: Manifest.identifier(manifest),
     extensionLocation: path |> Uri.fromPath,
     name: manifest.name,
     main: manifest.main,

--- a/src/Exthost/Extension/Manifest.re
+++ b/src/Exthost/Extension/Manifest.re
@@ -32,12 +32,11 @@ and kind =
   | Ui
   | Workspace;
 
-
-let identifier = (manifest) => {
+let identifier = manifest => {
   switch (manifest.publisher) {
   | Some(publisher) => publisher ++ "." ++ manifest.name
   | None => manifest.name
-  }
+  };
 };
 
 module Decode = {

--- a/src/Exthost/Extension/Manifest.re
+++ b/src/Exthost/Extension/Manifest.re
@@ -14,7 +14,7 @@ type t = {
   author: string,
   displayName: option(LocalizedToken.t),
   description: option(string),
-  // publisher: option(string),
+  publisher: option(string),
   main: option(string),
   icon: option(string),
   categories: list(string),
@@ -31,6 +31,14 @@ type t = {
 and kind =
   | Ui
   | Workspace;
+
+
+let identifier = (manifest) => {
+  switch (manifest.publisher) {
+  | Some(publisher) => publisher ++ "." ++ manifest.name
+  | None => manifest.name
+  }
+};
 
 module Decode = {
   open Json.Decode;
@@ -65,6 +73,7 @@ module Decode = {
             ),
           displayName: field.optional("displayName", LocalizedToken.decode),
           description: field.optional("description", string),
+          publisher: field.optional("publisher", string),
           main: field.optional("main", string),
           icon: field.optional("icon", string),
           categories: field.withDefault("categories", [], list(string)),

--- a/src/Exthost/Extension/Scanner.re
+++ b/src/Exthost/Extension/Scanner.re
@@ -34,7 +34,7 @@ let _getLocalizations = path =>
     LocalizationDictionary.initial;
   };
 
-let load = (~prefix=None, ~category, packageFile) => {
+let load = (~category, packageFile) => {
   let json = Yojson.Safe.from_file(packageFile);
   let directory = Filename.dirname(packageFile);
   let nlsPath = Path.join(directory, "package.nls.json");
@@ -55,11 +55,6 @@ let load = (~prefix=None, ~category, packageFile) => {
     let manifest =
       parsedManifest
       |> remapManifest(directory)
-      |> Manifest.updateName(name =>
-           prefix
-           |> Option.map(prefix => prefix ++ "." ++ name)
-           |> Option.value(~default=name)
-         )
       |> localize;
 
     Some(ScanResult.{category, manifest, path: directory});
@@ -76,13 +71,13 @@ let load = (~prefix=None, ~category, packageFile) => {
   };
 };
 
-let scan = (~prefix=None, ~category, directory: string) => {
+let scan = (~category, directory: string) => {
   Sys.readdir(directory)
   |> Array.to_list
   |> List.map(Path.join(directory))
   |> List.filter(Sys.is_directory)
   |> List.map(dir => Path.join(dir, "package.json"))
   |> List.filter(Sys.file_exists)
-  |> List.map(load(~category, ~prefix))
+  |> List.map(load(~category))
   |> List.filter_map(Fun.id);
 };

--- a/src/Exthost/Extension/Scanner.re
+++ b/src/Exthost/Extension/Scanner.re
@@ -52,10 +52,7 @@ let load = (~category, packageFile) => {
 
   switch (Json.Decode.decode_value(Manifest.decode, json)) {
   | Ok(parsedManifest) =>
-    let manifest =
-      parsedManifest
-      |> remapManifest(directory)
-      |> localize;
+    let manifest = parsedManifest |> remapManifest(directory) |> localize;
 
     Some(ScanResult.{category, manifest, path: directory});
 

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -410,18 +410,6 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       ~windows_hide=true,
       ~windows_hide_console=true,
       ~windows_hide_gui=true,
-      ~redirect=[
-        Luv.Process.inherit_fd(
-          ~fd=Luv.Process.stdin,
-          ~from_parent_fd=Luv.Process.stdin,
-          (),
-        ),
-        Luv.Process.inherit_fd(
-          ~fd=Luv.Process.stdout,
-          ~from_parent_fd=Luv.Process.stderr,
-          (),
-        ),
-      ],
       nodePath,
       [nodePath, extHostScriptPath],
     )

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -410,6 +410,18 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       ~windows_hide=true,
       ~windows_hide_console=true,
       ~windows_hide_gui=true,
+      ~redirect=[
+        Luv.Process.inherit_fd(
+          ~fd=Luv.Process.stdin,
+          ~from_parent_fd=Luv.Process.stdin,
+          (),
+        ),
+        Luv.Process.inherit_fd(
+          ~fd=Luv.Process.stdout,
+          ~from_parent_fd=Luv.Process.stderr,
+          (),
+        ),
+      ],
       nodePath,
       [nodePath, extHostScriptPath],
     )

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -27,7 +27,6 @@ let discoverExtensions =
           Scanner.scan(
             // The extension host assumes bundled extensions start with 'vscode.'
             ~category=Bundled,
-            ~prefix=Some("vscode"),
             setup.bundledExtensionsPath,
           );
 

--- a/test/Exthost/ExtensionsTest.re
+++ b/test/Exthost/ExtensionsTest.re
@@ -1,0 +1,57 @@
+open TestFramework;
+
+open Oni_Core;
+open Exthost;
+
+module TestExtensionsEvent = {
+  type t = {
+    name: string,
+  };
+
+  let decode = {
+    Json.Decode.(
+      obj(({field, _}) =>
+        {
+          name: field.required("name", string),
+        }
+      )
+    );
+  };
+};
+
+let waitForExtensionsEvent = (~name, f, context) => {
+  context
+  |> Test.waitForMessage(
+       ~name,
+       fun
+       | Msg.MessageService(ShowMessage({message, _})) => {
+           message
+           |> Yojson.Safe.from_string
+           |> Json.Decode.decode_value(TestExtensionsEvent.decode)
+           |> Result.map(f)
+           |> Result.value(~default=false);
+         }
+       | _ => false,
+     );
+};
+
+// Test cases for the vscode extesnsions API:
+// https://code.visualstudio.com/api/references/vscode-api#extensions
+describe("ExtensionsTest", ({test, _}) => {
+  test("change workspaces", ({expect, _}) => {
+    Test.startWithExtensions(["oni-extensions"])
+    |> Test.waitForExtensionActivation("outrunlabs.oni-extensions")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[`String("outrunlabs.oni-extensions")],
+           ~command="testExtensions.getPackageJSON",
+         ),
+       )
+    |> waitForExtensionsEvent(~name="Extensions PackageJSON", (json) => {
+       expect.string(json.name).toEqual("oni-extensions");
+       true;
+    })
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+});

--- a/test/Exthost/ExtensionsTest.re
+++ b/test/Exthost/ExtensionsTest.re
@@ -4,17 +4,11 @@ open Oni_Core;
 open Exthost;
 
 module TestExtensionsEvent = {
-  type t = {
-    name: string,
-  };
+  type t = {name: string};
 
   let decode = {
     Json.Decode.(
-      obj(({field, _}) =>
-        {
-          name: field.required("name", string),
-        }
-      )
+      obj(({field, _}) => {name: field.required("name", string)})
     );
   };
 };
@@ -47,10 +41,10 @@ describe("ExtensionsTest", ({test, _}) => {
            ~command="testExtensions.getPackageJSON",
          ),
        )
-    |> waitForExtensionsEvent(~name="Extensions PackageJSON", (json) => {
-       expect.string(json.name).toEqual("oni-extensions");
-       true;
-    })
+    |> waitForExtensionsEvent(~name="Extensions PackageJSON", json => {
+         expect.string(json.name).toEqual("oni-extensions");
+         true;
+       })
     |> Test.terminate
     |> Test.waitForProcessClosed
   })

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -47,7 +47,7 @@ let startWithExtensions =
     extensions
     |> List.map(Rench.Path.join(rootPath))
     |> List.map(p => Rench.Path.join(p, "package.json"))
-    |> List.map(Scanner.load(~prefix=None, ~category=Scanner.Bundled))
+    |> List.map(Scanner.load(~category=Scanner.Bundled))
     |> List.filter_map(v => v)
     |> List.map((Extension.Scanner.ScanResult.{manifest, path, _}) => {
          InitData.Extension.ofManifestAndPath(manifest, path)

--- a/test/collateral/extensions/oni-activation-events/package.json
+++ b/test/collateral/extensions/oni-activation-events/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-activation-events",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-always-activate/package.json
+++ b/test/collateral/extensions/oni-always-activate/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-always-activate",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-basic-events/package.json
+++ b/test/collateral/extensions/oni-basic-events/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-basic-events",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-configuration/package.json
+++ b/test/collateral/extensions/oni-configuration/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-configuration",
 	"description": "Configuration API test",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-diagnostics/package.json
+++ b/test/collateral/extensions/oni-diagnostics/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-diagnostics",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-document-sync/package.json
+++ b/test/collateral/extensions/oni-document-sync/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-document-sync",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-extensions/extension.js
+++ b/test/collateral/extensions/oni-extensions/extension.js
@@ -1,0 +1,31 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	const showData = (val) => {
+		vscode.window.showInformationMessage(JSON.stringify(val));
+	};
+	
+	const disposable0 = vscode.commands.registerCommand("testExtensions.getPackageJSON", (args) => {
+		
+		const extension = vscode.extensions.getExtension(args);
+		showData(extension.packageJSON);
+	});
+
+	context.subscriptions.push(disposable0);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-extensions/package.json
+++ b/test/collateral/extensions/oni-extensions/package.json
@@ -1,7 +1,8 @@
 {
-	"name": "oni-workspace",
-	"description": "Minimal HelloWorld example for VS Code",
+	"name": "oni-extensions",
+	"description": "Test extension to exercise the vscode.extensions API",
 	"version": "0.0.1",
+	"publisher": "outrunlabs",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-language-features/package.json
+++ b/test/collateral/extensions/oni-language-features/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-language-features",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-scm/package.json
+++ b/test/collateral/extensions/oni-scm/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-scm",
 	"description": "SCM extension for Onivim tests",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-uri/package.json
+++ b/test/collateral/extensions/oni-uri/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-uri",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"

--- a/test/collateral/extensions/oni-virtual-document/package.json
+++ b/test/collateral/extensions/oni-virtual-document/package.json
@@ -2,7 +2,6 @@
 	"name": "oni-virtual-document",
 	"description": "Minimal HelloWorld example for VS Code",
 	"version": "0.0.1",
-	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {
 		"vscode": "^1.25.0"


### PR DESCRIPTION
__Issue:__ The python fails with an error when trying to read the extension metadata via the `vscode.extensions` API, here:

```
    const extensions = (require('vscode') as typeof import('vscode')).extensions;
    // tslint:disable-next-line:no-non-null-assertion
    const extension = extensions.getExtension(extensionId)!;
    // tslint:disable-next-line:no-unsafe-any
    const extensionVersion = extension.packageJSON.version;
```

__Defect:__ The extension IDs we were sending to the extension host were improperly constructed. To be in sync with the extension host, they should be of the form `publisher.name`.

__Fix:__ Correctly construct the extension ID.

This gets us to the next round of blockers of the Python extension - it requires the `workspace.fs` API to implemented (it uses these operations to look for the `.env` / virtual environment setup).