### PR TITLE
chore(CI): Fix CentOS ius repo path

### DIFF
--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -24,7 +24,7 @@ RUN npm install --global --unsafe-perm=true esy@0.6.2
 RUN npm install --global node-gyp
 
 RUN yum -y install nasm
-RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+RUN yum -y install https://repo.ius.io/ius-release-el7.rpm
 RUN yum -y remove git
 RUN yum -y install epel-release
 RUN yum -y install git222


### PR DESCRIPTION
The link we were using was deprecated according to: https://github.com/iusrepo/announce/issues/18