### PR TITLE
feature(exthost): Support sending replies from Onivim 2 -> Extension Host

### DIFF
--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -21,6 +21,7 @@ module ModelContentChange = ModelContentChange;
 module OneBasedPosition = OneBasedPosition;
 module OneBasedRange = OneBasedRange;
 module ReferenceContext = ReferenceContext;
+module Reply = Reply;
 module SCM = SCM;
 module SuggestItem = SuggestItem;
 module SuggestResult = SuggestResult;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -428,6 +428,14 @@ module ThemeColor: {
 };
 
 module Msg: {
+
+  module Clipboard: {
+    [@deriving show]
+    type msg =
+    | ReadText
+    | WriteText(string);
+  };
+
   module Commands: {
     [@deriving show]
     type msg =
@@ -658,6 +666,7 @@ module Msg: {
   type t =
     | Connected
     | Ready
+    | Clipboard(Clipboard.msg)
     | Commands(Commands.msg)
     | DebugService(DebugService.msg)
     | Decorations(Decorations.msg)

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -686,11 +686,20 @@ module NamedPipe: {
   let toString: t => string;
 };
 
-module Client: {
+module Reply: {
   type t;
 
-  // TODO
-  type reply = unit;
+  let none: t;
+
+  let error: string => t;
+
+  let okEmpty: t;
+
+  let okJson: Yojson.Safe.t => t;
+};
+
+module Client: {
+  type t;
 
   let start:
     (
@@ -698,7 +707,11 @@ module Client: {
       ~initialWorkspace: WorkspaceData.t=?,
       ~namedPipe: NamedPipe.t,
       ~initData: Extension.InitData.t,
-      ~handler: Msg.t => option(reply),
+      // TODO:
+      // Is there a way to use GADT's to strongly-type the reply from the request?
+      // Right now, we take arbitrary JSON responses, without help from the type
+      // system that these are correct.
+      ~handler: Msg.t => Lwt.t(Reply.t),
       ~onError: string => unit,
       unit
     ) =>

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -428,12 +428,11 @@ module ThemeColor: {
 };
 
 module Msg: {
-
   module Clipboard: {
     [@deriving show]
     type msg =
-    | ReadText
-    | WriteText(string);
+      | ReadText
+      | WriteText(string);
   };
 
   module Commands: {

--- a/src/Exthost/Handlers.re
+++ b/src/Exthost/Handlers.re
@@ -65,10 +65,10 @@ let handlers =
   [
     mainNotImplemented("MainThreadAuthentication"),
     main(
-    ~handler=Msg.Clipboard.handle,
-    ~mapper=msg => Msg.Clipboard(msg),
-    "MainThreadClipboard",
-   ),
+      ~handler=Msg.Clipboard.handle,
+      ~mapper=msg => Msg.Clipboard(msg),
+      "MainThreadClipboard",
+    ),
     main(
       ~handler=Msg.Commands.handle,
       ~mapper=msg => Msg.Commands(msg),

--- a/src/Exthost/Handlers.re
+++ b/src/Exthost/Handlers.re
@@ -64,7 +64,11 @@ let ext = name => {
 let handlers =
   [
     mainNotImplemented("MainThreadAuthentication"),
-    mainNotImplemented("MainThreadClipboard"),
+    main(
+    ~handler=Msg.Clipboard.handle,
+    ~mapper=msg => Msg.Clipboard(msg),
+    "MainThreadClipboard",
+   ),
     main(
       ~handler=Msg.Commands.handle,
       ~mapper=msg => Msg.Commands(msg),

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -1,5 +1,23 @@
 open Oni_Core;
 open Oni_Core.Utility;
+
+module Clipboard = {
+  [@deriving show]
+  type msg =
+  | ReadText
+  | WriteText(string);
+  
+  let handle = (method, args: Yojson.Safe.t) => {
+    switch (method, args) {
+    | ("$readText", _) =>
+      Ok(ReadText);
+    | ("$writeText", `List([`String(text)])) =>
+      Ok(WriteText(text))
+    | _ => Error("Unhandled clipboard method: " ++ method)
+    };
+  };
+};
+
 module Commands = {
   [@deriving show]
   type msg =
@@ -716,6 +734,7 @@ module TerminalService = {
 type t =
   | Connected
   | Ready
+  | Clipboard(Clipboard.msg)
   | Commands(Commands.msg)
   | DebugService(DebugService.msg)
   | Decorations(Decorations.msg)

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -4,15 +4,13 @@ open Oni_Core.Utility;
 module Clipboard = {
   [@deriving show]
   type msg =
-  | ReadText
-  | WriteText(string);
-  
+    | ReadText
+    | WriteText(string);
+
   let handle = (method, args: Yojson.Safe.t) => {
     switch (method, args) {
-    | ("$readText", _) =>
-      Ok(ReadText);
-    | ("$writeText", `List([`String(text)])) =>
-      Ok(WriteText(text))
+    | ("$readText", _) => Ok(ReadText)
+    | ("$writeText", `List([`String(text)])) => Ok(WriteText(text))
     | _ => Error("Unhandled clipboard method: " ++ method)
     };
   };

--- a/src/Exthost/Protocol/Exthost_Protocol.re
+++ b/src/Exthost/Protocol/Exthost_Protocol.re
@@ -310,7 +310,7 @@ module Message = {
       bufferToPacket(~buffer);
     | ReplyError({error, _}) =>
       writePreamble(~buffer, ~msgType=replyErrError, ~requestId);
-      writeLongString(buffer, error);
+      writeLongString(buffer, "\"" ++ error ++ "\"");
       bufferToPacket(~buffer);
     };
   };

--- a/src/Exthost/Reply.re
+++ b/src/Exthost/Reply.re
@@ -1,0 +1,13 @@
+type t =
+  | Nothing
+  | OkEmpty
+  | OkJson({json: Yojson.Safe.t})
+  | ErrorMessage({message: string});
+
+let none = Nothing;
+
+let okEmpty = OkEmpty;
+
+let error = message => ErrorMessage({message: message});
+
+let okJson = json => OkJson({json: json});

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -260,23 +260,23 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
         ~dispatch=msg => dispatch(Actions.SCM(msg)),
         msg,
       );
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | LanguageFeatures(
         RegisterDocumentSymbolProvider({handle, selector, label}),
       ) =>
       withClient(onRegisterDocumentSymbolProvider(handle, selector, label));
-      None;
+      Lwt.return(Reply.okEmpty);
     | LanguageFeatures(RegisterDefinitionSupport({handle, selector})) =>
       withClient(onRegisterDefinitionProvider(handle, selector));
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | LanguageFeatures(RegisterDocumentHighlightProvider({handle, selector})) =>
       withClient(onRegisterDocumentHighlightProvider(handle, selector));
-      None;
+      Lwt.return(Reply.okEmpty);
     | LanguageFeatures(RegisterReferenceSupport({handle, selector})) =>
       withClient(onRegisterReferencesProvider(handle, selector));
-      None;
+      Lwt.return(Reply.okEmpty);
     | LanguageFeatures(
         RegisterSuggestSupport({
           handle,
@@ -286,42 +286,42 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
         }),
       ) =>
       withClient(onRegisterSuggestProvider(handle, selector));
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | Diagnostics(Clear({owner})) =>
       dispatch(Actions.DiagnosticsClear(owner));
-      None;
+      Lwt.return(Reply.okEmpty);
     | Diagnostics(ChangeMany({owner, entries})) =>
       onDiagnosticsChangeMany(owner, entries);
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | DocumentContentProvider(RegisterTextContentProvider({handle, scheme})) =>
       dispatch(NewTextContentProvider({handle, scheme}));
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | DocumentContentProvider(UnregisterTextContentProvider({handle})) =>
       dispatch(LostTextContentProvider({handle: handle}));
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | Decorations(RegisterDecorationProvider({handle, label})) =>
       dispatch(NewDecorationProvider({handle, label}));
-      None;
+      Lwt.return(Reply.okEmpty);
     | Decorations(UnregisterDecorationProvider({handle})) =>
       dispatch(LostDecorationProvider({handle: handle}));
-      None;
+      Lwt.return(Reply.okEmpty);
     | Decorations(DecorationsDidChange({handle, uris})) =>
       dispatch(DecorationsChanged({handle, uris}));
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | ExtensionService(DidActivateExtension({extensionId, _})) =>
       dispatch(
         Actions.Extension(Oni_Model.Extensions.Activated(extensionId)),
       );
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | MessageService(ShowMessage({severity, message, extensionId})) =>
       dispatch(ExtMessageReceived({severity, message, extensionId}));
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | StatusBar(SetEntry({id, text, alignment, priority, _})) =>
       dispatch(
@@ -329,12 +329,12 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
           StatusBarModel.Item.create(~id, ~text, ~alignment, ~priority, ()),
         ),
       );
-      None;
+      Lwt.return(Reply.okEmpty);
 
     | TerminalService(msg) =>
       Service_Terminal.handleExtensionMessage(msg);
-      None;
-    | _ => None
+      Lwt.return(Reply.okEmpty);
+    | _ => Lwt.return(Reply.okEmpty)
     };
   };
 

--- a/test/Exthost/ClipboardTest.re
+++ b/test/Exthost/ClipboardTest.re
@@ -1,6 +1,5 @@
 open TestFramework;
 
-open Oni_Core;
 open Exthost;
 
 let waitForWriteText = (f, context) => {
@@ -8,15 +7,13 @@ let waitForWriteText = (f, context) => {
   |> Test.waitForMessage(
        ~name="Wait for Clipboard(WriteText(msg))",
        fun
-       | Msg.Clipboard(WriteText(message)) =>
-         f(message)
+       | Msg.Clipboard(WriteText(message)) => f(message)
        | _ => false,
      );
 };
 
 describe("ClipboardTest", ({test, _}) => {
   test("write text", _ => {
-
     Test.startWithExtensions(["oni-clipboard"])
     |> Test.waitForExtensionActivation("oni-clipboard")
     |> Test.withClient(
@@ -28,12 +25,13 @@ describe("ClipboardTest", ({test, _}) => {
     |> waitForWriteText(String.equal("hello clipboard"))
     |> Test.terminate
     |> Test.waitForProcessClosed
-  })
+  });
   test("read text success", _ => {
-    let handler = fun
-    | Msg.Clipboard(ReadText) => Lwt.return(Reply.okJson(`String("clipboard text")))
-    | _ => Lwt.return(Reply.okEmpty)
-    ;
+    let handler =
+      fun
+      | Msg.Clipboard(ReadText) =>
+        Lwt.return(Reply.okJson(`String("clipboard text")))
+      | _ => Lwt.return(Reply.okEmpty);
 
     Test.startWithExtensions(~handler, ["oni-clipboard"])
     |> Test.waitForExtensionActivation("oni-clipboard")
@@ -45,13 +43,14 @@ describe("ClipboardTest", ({test, _}) => {
        )
     |> waitForWriteText(String.equal("success:clipboard text"))
     |> Test.terminate
-    |> Test.waitForProcessClosed
-  })
+    |> Test.waitForProcessClosed;
+  });
   test("read text failure", _ => {
-    let handler = fun
-    | Msg.Clipboard(ReadText) => Lwt.return(Reply.error("can't handle it"))
-    | _ => Lwt.return(Reply.okEmpty)
-    ;
+    let handler =
+      fun
+      | Msg.Clipboard(ReadText) =>
+        Lwt.return(Reply.error("can't handle it"))
+      | _ => Lwt.return(Reply.okEmpty);
 
     Test.startWithExtensions(~handler, ["oni-clipboard"])
     |> Test.waitForExtensionActivation("oni-clipboard")
@@ -63,6 +62,6 @@ describe("ClipboardTest", ({test, _}) => {
        )
     |> waitForWriteText(String.equal("failed"))
     |> Test.terminate
-    |> Test.waitForProcessClosed
-  })
+    |> Test.waitForProcessClosed;
+  });
 });

--- a/test/Exthost/ClipboardTest.re
+++ b/test/Exthost/ClipboardTest.re
@@ -1,0 +1,68 @@
+open TestFramework;
+
+open Oni_Core;
+open Exthost;
+
+let waitForWriteText = (f, context) => {
+  context
+  |> Test.waitForMessage(
+       ~name="Wait for Clipboard(WriteText(msg))",
+       fun
+       | Msg.Clipboard(WriteText(message)) =>
+         f(message)
+       | _ => false,
+     );
+};
+
+describe("ClipboardTest", ({test, _}) => {
+  test("write text", _ => {
+
+    Test.startWithExtensions(["oni-clipboard"])
+    |> Test.waitForExtensionActivation("oni-clipboard")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[`String("hello clipboard")],
+           ~command="clipboard.setText",
+         ),
+       )
+    |> waitForWriteText(String.equal("hello clipboard"))
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+  test("read text success", _ => {
+    let handler = fun
+    | Msg.Clipboard(ReadText) => Lwt.return(Reply.okJson(`String("clipboard text")))
+    | _ => Lwt.return(Reply.okEmpty)
+    ;
+
+    Test.startWithExtensions(~handler, ["oni-clipboard"])
+    |> Test.waitForExtensionActivation("oni-clipboard")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="clipboard.getText",
+         ),
+       )
+    |> waitForWriteText(String.equal("success:clipboard text"))
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+  test("read text failure", _ => {
+    let handler = fun
+    | Msg.Clipboard(ReadText) => Lwt.return(Reply.error("can't handle it"))
+    | _ => Lwt.return(Reply.okEmpty)
+    ;
+
+    Test.startWithExtensions(~handler, ["oni-clipboard"])
+    |> Test.waitForExtensionActivation("oni-clipboard")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="clipboard.getText",
+         ),
+       )
+    |> waitForWriteText(String.equal("failed"))
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+});

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -15,7 +15,7 @@ type t = {
   messages: ref(list(Msg.t)),
 };
 
-let noopHandler = _ => None;
+let noopHandler = _ => Lwt.return(Reply.okEmpty);
 let noopErrorHandler = _ => ();
 
 let startWithExtensions =

--- a/test/collateral/extensions/oni-clipboard/extension.js
+++ b/test/collateral/extensions/oni-clipboard/extension.js
@@ -1,0 +1,49 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	const showData = (val) => {
+		vscode.window.showInformationMessage(JSON.stringify(val));
+	};
+
+	const sendSuccess = (text) => {
+		vscode.env.clipboard.writeText("success:" + text);
+	};
+
+	const sendFailure = (err) => {
+		vscode.env.clipboard.writeText("failed");
+		showData({
+			type: "clipboard.getText",
+			result: "failure",
+			error: err.toString(),
+		});
+	};
+
+	const disposable0 = vscode.commands.registerCommand("clipboard.getText", () => {
+		vscode.env.clipboard.readText().then(
+			sendSuccess,
+			sendFailure
+		);
+	});
+	const disposable1 = vscode.commands.registerCommand("clipboard.setText", (arg) => {
+		vscode.env.clipboard.writeText(arg);
+	});
+	
+	context.subscriptions.push(disposable0);	
+	context.subscriptions.push(disposable1);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-clipboard/package.json
+++ b/test/collateral/extensions/oni-clipboard/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "oni-clipboard",
+	"description": "Test case for vscode.clipboard API",
+	"version": "0.0.1",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": ["*"],
+	"main": "./extension.js",
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
For the next round of blockers for the extension (ie, implementing the `workspace.fs.stat` API for the python plugin), we need to be able to respond to the extensions correctly for queries like that.

This implements initial plumbing to reply back to the extension host, along with implementing a really simple API to exercise it (the `vscode.env.clipboard` API).

It would be nice to have a more type-safe way to implement this, as ultimately we are responding with just raw JSON - I believe we could use GADTs to tag the `Msg.t` with an expected return type, but I wasn't able to hook it up all the way through. Something to think about though for next steps - it'd be great to have the replies type-safe.

In addition, we want to support having asynchronous replies (for example, we don't want an extension to be able to spam us with synchronous file system queries), so the reply type is now an Lwt promise.