### PR TITLE
fix(ux): mouse capture issues

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "48e3daa64897c89dc48413a6c57c0eb3",
+  "checksum": "3fd3e130b7d6f99d979244b0ee0f4722",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#22155c7@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+    "revery@github:revery-ui/revery#c3b0947@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#22155c7",
+      "version": "github:revery-ui/revery#c3b0947",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#22155c7" ]
+        "source": [ "github:revery-ui/revery#c3b0947" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1156,7 +1156,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "48e3daa64897c89dc48413a6c57c0eb3",
+  "checksum": "3fd3e130b7d6f99d979244b0ee0f4722",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#22155c7@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+    "revery@github:revery-ui/revery#c3b0947@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#22155c7",
+      "version": "github:revery-ui/revery#c3b0947",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#22155c7" ]
+        "source": [ "github:revery-ui/revery#c3b0947" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1156,7 +1156,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "48e3daa64897c89dc48413a6c57c0eb3",
+  "checksum": "3fd3e130b7d6f99d979244b0ee0f4722",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#22155c7@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+    "revery@github:revery-ui/revery#c3b0947@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#22155c7",
+      "version": "github:revery-ui/revery#c3b0947",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#22155c7" ]
+        "source": [ "github:revery-ui/revery#c3b0947" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1156,7 +1156,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
   "resolutions": {
     "@esy-ocaml/libffi": "onivim/libffi#590b041",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "revery": "revery-ui/revery#22155c7",
+    "revery": "revery-ui/revery#c3b0947",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-skia": "revery-ui/esy-skia#d60e5fe",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e0f2e30f9d4c84fbccc7b7e7b4430e3c",
+  "checksum": "60ab38958461aecdbfb6636e25217e5d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#91bad1f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#b17ce17@d41d8cd9",
         "@glennsl/timber@1.0.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#22155c7@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+    "revery@github:revery-ui/revery#c3b0947@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#22155c7",
+      "version": "github:revery-ui/revery#c3b0947",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#22155c7" ]
+        "source": [ "github:revery-ui/revery#c3b0947" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1156,7 +1156,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#4e8ca1c@d41d8cd9",
-        "revery@github:revery-ui/revery#22155c7@d41d8cd9",
+        "revery@github:revery-ui/revery#c3b0947@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",


### PR DESCRIPTION
This brings in a new and improved hook-based mouse capture API which should resolve several cases where the mouse capture gets "stuck". It was also supposed to fix the wonky minimap mouse dragging (#441), but no luck figuring that out yet. This is on par with the current behaviour though, so can still be merged as-is to unblock other tasks.

Should fix #817. ~~Might address #250. These depend a bit on interpretation though.~~