### PR TITLE
feat(exthost): Additional status bar item functionality

### DIFF
--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -16,13 +16,13 @@ function activate(context) {
     item.command = "open sesame";
     item.color = new vscode.ThemeColor("foreground");
     item.command = "oni.developer.statusBarClicked";
-    item.text = "$(alert) Developer";
+    item.text = "Developer";
     item.show();
 
     let cleanup = (disposable) => context.subscriptions.push(disposable);
     
     cleanup(vscode.commands.registerCommand('developer.oni.statusBarClicked', () => {
-        vscode.window.showWarningMessage('You clickded developer');
+        vscode.window.showWarningMessage('You clicked developer');
     }));
 
     cleanup(vscode.languages.registerDefinitionProvider('oni-dev', {

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -15,10 +15,15 @@ function activate(context) {
     let item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1000);
     item.command = "open sesame";
     item.color = new vscode.ThemeColor("foreground");
-    item.text = "Developer";
+    item.command = "oni.developer.statusBarClicked";
+    item.text = "$(alert) Developer";
     item.show();
 
     let cleanup = (disposable) => context.subscriptions.push(disposable);
+    
+    cleanup(vscode.commands.registerCommand('developer.oni.statusBarClicked', () => {
+        vscode.window.showWarningMessage('You clickded developer');
+    }));
 
     cleanup(vscode.languages.registerDefinitionProvider('oni-dev', {
         provideDefinition: (document, _position, _token) => {

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -13,9 +13,8 @@ function activate(context) {
     }
     // Create a simple status bar
     let item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1000);
-    item.command = "open sesame";
     item.color = new vscode.ThemeColor("foreground");
-    item.command = "oni.developer.statusBarClicked";
+    item.command = "developer.oni.statusBarClicked";
     item.text = "Developer";
     item.show();
 

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -13,6 +13,8 @@ function activate(context) {
     }
     // Create a simple status bar
     let item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1000);
+    item.command = "open sesame";
+    item.color = new vscode.ThemeColor("foreground");
     item.text = "Developer";
     item.show();
 

--- a/src/Exthost/Command.re
+++ b/src/Exthost/Command.re
@@ -1,0 +1,19 @@
+open Oni_Core;
+
+type t = {
+	id: string,
+	title: option(string),
+};
+
+module Decode = {
+	let decode = {
+		Json.Decode.(
+		obj(({field, _}) => {
+			id: field.required("id", string),
+			title: field.optional("title", string),
+		})
+		);
+	};
+};
+
+let decode = Decode.decode;

--- a/src/Exthost/Command.re
+++ b/src/Exthost/Command.re
@@ -1,5 +1,6 @@
 open Oni_Core;
 
+[@deriving show]
 type t = {
 	id: string,
 	title: option(string),

--- a/src/Exthost/Command.re
+++ b/src/Exthost/Command.re
@@ -2,19 +2,21 @@ open Oni_Core;
 
 [@deriving show]
 type t = {
-	id: string,
-	title: option(string),
+  id: string,
+  title: option(string),
 };
 
 module Decode = {
-	let decode = {
-		Json.Decode.(
-		obj(({field, _}) => {
-			id: field.required("id", string),
-			title: field.optional("title", string),
-		})
-		);
-	};
+  let decode = {
+    Json.Decode.(
+      obj(({field, _}) =>
+        {
+          id: field.required("id", string),
+          title: field.optional("title", string),
+        }
+      )
+    );
+  };
 };
 
 let decode = Decode.decode;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -14,6 +14,7 @@ module DocumentHighlight = DocumentHighlight;
 module DocumentSelector = DocumentSelector;
 module DocumentSymbol = DocumentSymbol;
 module Eol = Eol;
+module Label = Label;
 module Location = Location;
 module ModelAddedDelta = ModelAddedDelta;
 module ModelChangedEvent = ModelChangedEvent;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -4,6 +4,7 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module Command = Command;
 module CompletionContext = CompletionContext;
 module CompletionKind = CompletionKind;
 module DefinitionLink = DefinitionLink;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -149,13 +149,13 @@ module ReferenceContext: {
 
 module Label: {
   type segment =
-  | Text(string)
-  | Icon(string);
+    | Text(string)
+    | Icon(string);
 
   type t = list(segment);
 
   let of_string: string => t;
-  
+
   let decode: Json.decoder(t);
 };
 
@@ -664,7 +664,7 @@ module Msg: {
           alignment,
           priority: int,
         })
-     | Dispose({ id: int});
+      | Dispose({id: int});
   };
 
   [@deriving show]

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -147,6 +147,18 @@ module ReferenceContext: {
   let encode: Json.encoder(t);
 };
 
+module Label: {
+  type segment =
+  | Text(string)
+  | Icon(string);
+
+  type t = list(segment);
+
+  let of_string: string => t;
+  
+  let decode: Json.decoder(t);
+};
+
 module SCM: {
   [@deriving show({with_path: false})]
   type command = {
@@ -651,7 +663,8 @@ module Msg: {
           source: string,
           alignment,
           priority: int,
-        });
+        })
+     | Dispose({ id: int});
   };
 
   [@deriving show]

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -6,6 +6,7 @@ module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
 module Command: {
+  [@deriving show]
   type t = {
     id: string,
     title: option(string),
@@ -673,6 +674,7 @@ module Msg: {
           label: Label.t,
           source: string,
           alignment,
+          command: option(Command.t),
           priority: int,
         })
       | Dispose({id: int});

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -148,10 +148,12 @@ module ReferenceContext: {
 };
 
 module Label: {
+  [@deriving show]
   type segment =
     | Text(string)
     | Icon(string);
 
+  [@deriving show]
   type t = list(segment);
 
   let of_string: string => t;
@@ -659,7 +661,7 @@ module Msg: {
     type msg =
       | SetEntry({
           id: string,
-          text: string,
+          label: Label.t,
           source: string,
           alignment,
           priority: int,

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -5,6 +5,15 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module Command: {
+  type t = {
+    id: string,
+    title: option(string),
+  };
+
+  let decode: Json.decoder(t);
+};
+
 module CompletionContext: {
   type triggerKind =
     | Invoke

--- a/src/Exthost/Label.re
+++ b/src/Exthost/Label.re
@@ -1,11 +1,11 @@
 open Oni_Core;
 
-  [@deriving show]
+[@deriving show]
 type segment =
   | Text(string)
   | Icon(string);
 
-  [@deriving show]
+[@deriving show]
 type t = list(segment);
 
 module Parse = {

--- a/src/Exthost/Label.re
+++ b/src/Exthost/Label.re
@@ -1,0 +1,19 @@
+open Oni_Core;
+
+type segment =
+| Text(string)
+| Icon(string);
+
+type t = list(segment);
+  
+module Parse = {
+    let parse = str => [Text(str)];
+}
+
+module Decode = {
+   open Json.Decode;
+   let decode: Json.decoder(t) = string |> map(Parse.parse);
+};
+
+let decode = Decode.decode;
+let of_string = Parse.parse;

--- a/src/Exthost/Label.re
+++ b/src/Exthost/Label.re
@@ -1,9 +1,11 @@
 open Oni_Core;
 
+  [@deriving show]
 type segment =
   | Text(string)
   | Icon(string);
 
+  [@deriving show]
 type t = list(segment);
 
 module Parse = {

--- a/src/Exthost/Label.re
+++ b/src/Exthost/Label.re
@@ -7,8 +7,48 @@ type segment =
 type t = list(segment);
   
 module Parse = {
-    let parse = str => [Text(str)];
-}
+    open Oniguruma;
+    let iconMatcher = OnigRegExp.create("\\$\\((.*)\\)") |> Result.get_ok;
+
+    let rec loop = str => {
+        let len = String.length(str);
+        let matches = OnigRegExp.search(str, 0, iconMatcher);
+
+        if (Array.length(matches) == 0) {
+            [Text(str)]
+        } else {
+            let matchPos = matches[0].startPos;
+            let matchEnd = matches[0].endPos;
+
+            if (matchPos > 0) {
+                [Text(String.sub(str, 0, matchPos)), ...loop(String.sub(str, matchPos, len - matchPos))];
+            } else {
+                let text = OnigRegExp.Match.getText(matches[1]);
+                if (matchEnd == len) {
+                    [Icon(text)]
+                } else {
+                    [Icon(text), ...loop(String.sub(str, matchEnd, len - matchEnd))]
+                }
+            }
+        }
+    };
+
+    let parse = str => {
+
+        let len = String.length(str);
+
+        if (len == 0) {
+            []
+        } else if(len == 1) {
+            [Text(str)]
+        } else if(str.[0] == '"' && str.[len-1]  == '"') {
+            let text = String.sub(str, 1, len - 2);
+            loop(text);
+        } else {
+            [Text(str)]
+        }
+    };
+};
 
 module Decode = {
    open Json.Decode;

--- a/src/Exthost/Label.re
+++ b/src/Exthost/Label.re
@@ -1,58 +1,60 @@
 open Oni_Core;
 
 type segment =
-| Text(string)
-| Icon(string);
+  | Text(string)
+  | Icon(string);
 
 type t = list(segment);
-  
+
 module Parse = {
-    open Oniguruma;
-    let iconMatcher = OnigRegExp.create("\\$\\((.*)\\)") |> Result.get_ok;
+  open Oniguruma;
+  let iconMatcher = OnigRegExp.create("\\$\\((.*)\\)") |> Result.get_ok;
 
-    let rec loop = str => {
-        let len = String.length(str);
-        let matches = OnigRegExp.search(str, 0, iconMatcher);
+  let rec loop = str => {
+    let len = String.length(str);
+    let matches = OnigRegExp.search(str, 0, iconMatcher);
 
-        if (Array.length(matches) == 0) {
-            [Text(str)]
+    if (Array.length(matches) == 0) {
+      [Text(str)];
+    } else {
+      let matchPos = matches[0].startPos;
+      let matchEnd = matches[0].endPos;
+
+      if (matchPos > 0) {
+        [
+          Text(String.sub(str, 0, matchPos)),
+          ...loop(String.sub(str, matchPos, len - matchPos)),
+        ];
+      } else {
+        let text = OnigRegExp.Match.getText(matches[1]);
+        if (matchEnd == len) {
+          [Icon(text)];
         } else {
-            let matchPos = matches[0].startPos;
-            let matchEnd = matches[0].endPos;
-
-            if (matchPos > 0) {
-                [Text(String.sub(str, 0, matchPos)), ...loop(String.sub(str, matchPos, len - matchPos))];
-            } else {
-                let text = OnigRegExp.Match.getText(matches[1]);
-                if (matchEnd == len) {
-                    [Icon(text)]
-                } else {
-                    [Icon(text), ...loop(String.sub(str, matchEnd, len - matchEnd))]
-                }
-            }
-        }
+          [Icon(text), ...loop(String.sub(str, matchEnd, len - matchEnd))];
+        };
+      };
     };
+  };
 
-    let parse = str => {
+  let parse = str => {
+    let len = String.length(str);
 
-        let len = String.length(str);
-
-        if (len == 0) {
-            []
-        } else if(len == 1) {
-            [Text(str)]
-        } else if(str.[0] == '"' && str.[len-1]  == '"') {
-            let text = String.sub(str, 1, len - 2);
-            loop(text);
-        } else {
-            [Text(str)]
-        }
+    if (len == 0) {
+      [];
+    } else if (len == 1) {
+      [Text(str)];
+    } else if (str.[0] == '"' && str.[len - 1] == '"') {
+      let text = String.sub(str, 1, len - 2);
+      loop(text);
+    } else {
+      [Text(str)];
     };
+  };
 };
 
 module Decode = {
-   open Json.Decode;
-   let decode: Json.decoder(t) = string |> map(Parse.parse);
+  open Json.Decode;
+  let decode: Json.decoder(t) = string |> map(Parse.parse);
 };
 
 let decode = Decode.decode;

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -472,8 +472,9 @@ module StatusBar = {
     | Dispose({id: int});
 
   let handle = (method, args: Yojson.Safe.t) => {
-    prerr_endline ("METHOD: " ++ method ++
-    " JSON: " ++ Yojson.Safe.to_string(args));
+    prerr_endline(
+      "METHOD: " ++ method ++ " JSON: " ++ Yojson.Safe.to_string(args),
+    );
     switch (method, args) {
     | (
         "$setEntry",
@@ -492,8 +493,7 @@ module StatusBar = {
       let alignment = stringToAlignment(alignment);
       let priority = int_of_string_opt(priority) |> Option.value(~default=0);
       Ok(SetEntry({id, source, text, alignment, priority}));
-    | ("$dispose", `List([`Int(id)])) =>
-      Ok(Dispose({ id: id}))
+    | ("$dispose", `List([`Int(id)])) => Ok(Dispose({id: id}))
     | _ =>
       Error(
         "Unable to parse method: "

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -468,9 +468,12 @@ module StatusBar = {
         source: string,
         alignment,
         priority: int,
-      });
+      })
+    | Dispose({id: int});
 
   let handle = (method, args: Yojson.Safe.t) => {
+    prerr_endline ("METHOD: " ++ method ++
+    " JSON: " ++ Yojson.Safe.to_string(args));
     switch (method, args) {
     | (
         "$setEntry",
@@ -489,6 +492,8 @@ module StatusBar = {
       let alignment = stringToAlignment(alignment);
       let priority = int_of_string_opt(priority) |> Option.value(~default=0);
       Ok(SetEntry({id, source, text, alignment, priority}));
+    | ("$dispose", `List([`Int(id)])) =>
+      Ok(Dispose({ id: id}))
     | _ =>
       Error(
         "Unable to parse method: "

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -468,24 +468,23 @@ module StatusBar = {
         id: string,
         label: Label.t,
         source: string,
-        alignment: alignment,
+        alignment,
         command: option(ExtCommand.t),
         priority: int,
       })
     | Dispose({id: int});
 
-  let parseCommand = commandJson => switch(commandJson) {
-  | `String(jsonString) => jsonString
+  let parseCommand = commandJson =>
+    switch (commandJson) {
+    | `String(jsonString) =>
+      jsonString
       |> Yojson.Safe.from_string
       |> Json.Decode.decode_value(Json.Decode.nullable(ExtCommand.decode))
-      |> Result.map_error(Json.Decode.string_of_error);
-  | _ => Ok(None)
-  };
+      |> Result.map_error(Json.Decode.string_of_error)
+    | _ => Ok(None)
+    };
 
   let handle = (method, args: Yojson.Safe.t) => {
-    prerr_endline(
-      "METHOD: " ++ method ++ " JSON: " ++ Yojson.Safe.to_string(args),
-    );
     switch (method, args) {
     | (
         "$setEntry",
@@ -500,16 +499,16 @@ module StatusBar = {
           `String(alignment),
           `String(priority),
         ]),
-      ) => {
+      ) =>
       open Base.Result.Let_syntax;
       let alignment = stringToAlignment(alignment);
       let priority = int_of_string_opt(priority) |> Option.value(~default=0);
       let%bind command = parseCommand(commandJson);
-      let%bind label = labelJson 
-      |> Json.Decode.decode_value(Label.decode)
-      |> Result.map_error(Json.Decode.string_of_error);
+      let%bind label =
+        labelJson
+        |> Json.Decode.decode_value(Label.decode)
+        |> Result.map_error(Json.Decode.string_of_error);
       Ok(SetEntry({id, source, label, alignment, priority, command}));
-      }
     | ("$dispose", `List([`Int(id)])) => Ok(Dispose({id: id}))
     | _ =>
       Error(

--- a/src/Model/StatusBarModel.re
+++ b/src/Model/StatusBarModel.re
@@ -16,14 +16,14 @@ module Item = {
   type t = {
     id: string,
     priority: int,
-    text: string,
+    label: Exthost.Label.t,
     alignment: Exthost.Msg.StatusBar.alignment,
   };
 
-  let create = (~id, ~priority, ~text, ~alignment=Left, ()) => {
+  let create = (~id, ~priority, ~label, ~alignment=Left, ()) => {
     id,
     priority,
-    text,
+    label,
     alignment,
   };
 };

--- a/src/Model/StatusBarModel.re
+++ b/src/Model/StatusBarModel.re
@@ -10,7 +10,8 @@ type action =
   | DiagnosticsClicked
   | NotificationClearAllClicked
   | NotificationCountClicked
-  | NotificationsContextMenu;
+  | NotificationsContextMenu
+  | ContributedItemClicked({id: string, command: string});
 
 module Item = {
   type t = {
@@ -18,13 +19,15 @@ module Item = {
     priority: int,
     label: Exthost.Label.t,
     alignment: Exthost.Msg.StatusBar.alignment,
+    command: option(string),
   };
 
-  let create = (~id, ~priority, ~label, ~alignment=Left, ()) => {
+  let create = (~command=?, ~id, ~priority, ~label, ~alignment=Left, ()) => {
     id,
     priority,
     label,
     alignment,
+    command,
   };
 };
 

--- a/src/Model/StatusBarModel.re
+++ b/src/Model/StatusBarModel.re
@@ -11,7 +11,10 @@ type action =
   | NotificationClearAllClicked
   | NotificationCountClicked
   | NotificationsContextMenu
-  | ContributedItemClicked({id: string, command: string});
+  | ContributedItemClicked({
+      id: string,
+      command: string,
+    });
 
 module Item = {
   type t = {

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -323,11 +323,19 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       dispatch(ExtMessageReceived({severity, message, extensionId}));
       None;
 
-    | StatusBar(SetEntry({id, label, alignment, priority, command})) =>
-      let command = command |> Option.map(({id, _}: Exthost.Command.t) => id);
+    | StatusBar(SetEntry({id, label, alignment, priority, command, _})) =>
+      let command =
+        command |> Option.map(({id, _}: Exthost.Command.t) => id);
       dispatch(
         Actions.StatusBarAddItem(
-          StatusBarModel.Item.create(~command?, ~id, ~label, ~alignment, ~priority, ()),
+          StatusBarModel.Item.create(
+            ~command?,
+            ~id,
+            ~label,
+            ~alignment,
+            ~priority,
+            (),
+          ),
         ),
       );
       None;

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -323,10 +323,10 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       dispatch(ExtMessageReceived({severity, message, extensionId}));
       None;
 
-    | StatusBar(SetEntry({id, text, alignment, priority, _})) =>
+    | StatusBar(SetEntry({id, label, alignment, priority, _})) =>
       dispatch(
         Actions.StatusBarAddItem(
-          StatusBarModel.Item.create(~id, ~text, ~alignment, ~priority, ()),
+          StatusBarModel.Item.create(~id, ~label, ~alignment, ~priority, ()),
         ),
       );
       None;

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -323,10 +323,11 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
       dispatch(ExtMessageReceived({severity, message, extensionId}));
       None;
 
-    | StatusBar(SetEntry({id, label, alignment, priority, _})) =>
+    | StatusBar(SetEntry({id, label, alignment, priority, command})) =>
+      let command = command |> Option.map(({id, _}: Exthost.Command.t) => id);
       dispatch(
         Actions.StatusBarAddItem(
-          StatusBarModel.Item.create(~id, ~label, ~alignment, ~priority, ()),
+          StatusBarModel.Item.create(~command?, ~id, ~label, ~alignment, ~priority, ()),
         ),
       );
       None;

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -243,6 +243,11 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
         executeContributedCommandEffect(command, arguments),
       )
 
+    | StatusBar(ContributedItemClicked({command, _})) => (
+        state,
+        executeContributedCommandEffect(command, []),
+    )
+
     | VimDirectoryChanged(path) => (state, changeWorkspaceEffect(path))
 
     | BufferEnter({id, version, filePath, fileType, _}) =>

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -246,7 +246,7 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
     | StatusBar(ContributedItemClicked({command, _})) => (
         state,
         executeContributedCommandEffect(command, []),
-    )
+      )
 
     | VimDirectoryChanged(path) => (state, changeWorkspaceEffect(path))
 

--- a/src/UI/Label.re
+++ b/src/UI/Label.re
@@ -1,0 +1,43 @@
+
+/*
+ * Label.re
+ *
+ * Container to help render Exthost.Label.t
+ */
+
+open Revery;
+open Revery.UI;
+open Oni_Core;
+
+module Styles = {
+  open Style;
+  let text = (~fontSize=11., ~color, uiFont: UiFont.t) => [
+    fontFamily(uiFont.fontFile),
+    Style.fontSize(fontSize),
+    textWrap(TextWrapping.NoWrap),
+    Style.color(color),
+  ];
+};
+  
+ 
+let textToElement = (~color, ~font, ~text) => {
+  <Text style=Styles.text(~color, font) text />
+};
+  
+let make =
+              (
+                ~font,
+                ~color,
+                ~label: Exthost.Label.t,
+                (),
+              ) => {
+
+  open Exthost.Label;
+
+  label
+  |> List.map(fun
+  | Text(text) => textToElement(~color, ~font, ~text)
+  | Icon(_) => React.empty
+  )
+  |> React.listToElement;
+};

--- a/src/UI/Label.re
+++ b/src/UI/Label.re
@@ -8,6 +8,7 @@
 open Revery;
 open Revery.UI;
 open Oni_Core;
+open Oni_Components;
 
 module Styles = {
   open Style;
@@ -23,6 +24,17 @@ module Styles = {
 let textToElement = (~color, ~font, ~text) => {
   <Text style=Styles.text(~color, font) text />
 };
+
+let iconNameToCharacter = fun
+| "alert" => Some(FontAwesome.exclamationTriangle)
+| _ => None;
+
+
+let iconToElement = (~color, icon) => {
+  <View style=Style.[margin(4)]>
+  <FontIcon icon color />
+  </View>
+};
   
 let make =
               (
@@ -37,7 +49,11 @@ let make =
   label
   |> List.map(fun
   | Text(text) => textToElement(~color, ~font, ~text)
-  | Icon(_) => React.empty
+  | Icon(iconName) => 
+      iconName
+      |> iconNameToCharacter
+      |> Option.map(iconToElement(~color))
+      |> Option.value(~default=React.empty)
   )
   |> React.listToElement;
 };

--- a/src/UI/Label.re
+++ b/src/UI/Label.re
@@ -1,4 +1,3 @@
-
 /*
  * Label.re
  *
@@ -19,41 +18,32 @@ module Styles = {
     Style.color(color),
   ];
 };
-  
- 
+
 let textToElement = (~color, ~font, ~text) => {
-  <Text style=Styles.text(~color, font) text />
+  <Text style={Styles.text(~color, font)} text />;
 };
 
-let iconNameToCharacter = fun
-| "alert" => Some(FontAwesome.exclamationTriangle)
-| _ => None;
-
+let iconNameToCharacter =
+  fun
+  | "alert" => Some(FontAwesome.exclamationTriangle)
+  | _ => None;
 
 let iconToElement = (~color, icon) => {
-  <View style=Style.[margin(4)]>
-  <FontIcon icon color />
-  </View>
+  <View style=Style.[margin(4)]> <FontIcon icon color /> </View>;
 };
-  
-let make =
-              (
-                ~font,
-                ~color,
-                ~label: Exthost.Label.t,
-                (),
-              ) => {
 
-  open Exthost.Label;
-
-  label
-  |> List.map(fun
-  | Text(text) => textToElement(~color, ~font, ~text)
-  | Icon(iconName) => 
-      iconName
-      |> iconNameToCharacter
-      |> Option.map(iconToElement(~color))
-      |> Option.value(~default=React.empty)
-  )
-  |> React.listToElement;
+let make = (~font, ~color, ~label: Exthost.Label.t, ()) => {
+  Exthost.Label.(
+    label
+    |> List.map(
+         fun
+         | Text(text) => textToElement(~color, ~font, ~text)
+         | Icon(iconName) =>
+           iconName
+           |> iconNameToCharacter
+           |> Option.map(iconToElement(~color))
+           |> Option.value(~default=React.empty),
+       )
+    |> React.listToElement
+  );
 };

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -112,7 +112,7 @@ let item =
   if (onClick == None && onRightClick == None) {
     <View style> children </View>;
   } else {
-    <Clickable ?onClick ?onRightClick style> children </Clickable>
+    <Clickable ?onClick ?onRightClick style> children </Clickable>;
   };
 };
 
@@ -279,24 +279,26 @@ let%component make =
     Hooks.animation(transitionAnimation);
 
   let toStatusBarElement = (statusItem: Item.t) => {
-
-    let onClick = statusItem.command
-    |> Option.map((command) => {
-      () => GlobalContext.current().dispatch(Actions.StatusBar(
-        ContributedItemClicked({id: statusItem.id, command })
-      ));
-    });
+    let onClick =
+      statusItem.command
+      |> Option.map((command, ()) =>
+           GlobalContext.current().dispatch(
+             Actions.StatusBar(
+               ContributedItemClicked({id: statusItem.id, command}),
+             ),
+           )
+         );
 
     <item ?onClick>
-    <View
-      style=Style.[
-        flexDirection(`Row),
-        justifyContent(`Center),
-        alignItems(`Center),
-      ]>
-    <Label font color=Revery.Colors.white label={statusItem.label} />
-    </View>
-    </item>
+      <View
+        style=Style.[
+          flexDirection(`Row),
+          justifyContent(`Center),
+          alignItems(`Center),
+        ]>
+        <Label font color=Revery.Colors.white label={statusItem.label} />
+      </View>
+    </item>;
   };
 
   let leftItems =

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -278,8 +278,11 @@ let%component make =
   let%hook (yOffset, _animationState, _reset) =
     Hooks.animation(transitionAnimation);
 
-  let toStatusBarElement = (statusBarItem: Item.t) =>
-    <textItem font background theme text={statusBarItem.text} />;
+  let toStatusBarElement = (statusItem: Item.t) => {
+    <item>
+    <Label font color=Revery.Colors.white label={statusItem.label} />
+    </item>
+  };
 
   let leftItems =
     state.statusBar

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -112,7 +112,9 @@ let item =
   if (onClick == None && onRightClick == None) {
     <View style> children </View>;
   } else {
-    <Clickable ?onClick ?onRightClick style> children </Clickable>;
+    <Sneakable ?onClick>
+    <Clickable ?onClick ?onRightClick style> children </Clickable>
+    </Sneakable>
   };
 };
 
@@ -279,7 +281,15 @@ let%component make =
     Hooks.animation(transitionAnimation);
 
   let toStatusBarElement = (statusItem: Item.t) => {
-    <item>
+
+    let onClick = statusItem.command
+    |> Option.map((command) => {
+      () => GlobalContext.current().dispatch(Actions.StatusBar(
+        ContributedItemClicked({id: statusItem.id, command })
+      ));
+    });
+
+    <item ?onClick>
     <View
       style=Style.[
         flexDirection(`Row),

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -280,7 +280,14 @@ let%component make =
 
   let toStatusBarElement = (statusItem: Item.t) => {
     <item>
+    <View
+      style=Style.[
+        flexDirection(`Row),
+        justifyContent(`Center),
+        alignItems(`Center),
+      ]>
     <Label font color=Revery.Colors.white label={statusItem.label} />
+    </View>
     </item>
   };
 

--- a/src/UI/StatusBar.re
+++ b/src/UI/StatusBar.re
@@ -112,9 +112,7 @@ let item =
   if (onClick == None && onRightClick == None) {
     <View style> children </View>;
   } else {
-    <Sneakable ?onClick>
     <Clickable ?onClick ?onRightClick style> children </Clickable>
-    </Sneakable>
   };
 };
 

--- a/test/Exthost/LabelTest.re
+++ b/test/Exthost/LabelTest.re
@@ -1,0 +1,18 @@
+
+open TestFramework;
+
+open Exthost;
+
+describe("Label", ({describe, _}) => {
+  describe("parse", ({test, _}) => {
+  
+    test("raw string should pass through", ({expect, _}) => {
+        let label = Label.of_string("text");
+        expect.equal(label, [Label.Text("text")]);
+    });
+    test("extra quotes should be removed", ({expect, _}) => {
+        let label = Label.of_string("\"text\"");
+        expect.equal(label, [Label.Text("text")]);
+    });
+  });
+});

--- a/test/Exthost/LabelTest.re
+++ b/test/Exthost/LabelTest.re
@@ -6,6 +6,10 @@ open Exthost;
 describe("Label", ({describe, _}) => {
   describe("parse", ({test, _}) => {
   
+    test("empty string", ({expect, _}) => {
+        let label = Label.of_string("");
+        expect.equal(label, []);
+    });
     test("raw string should pass through", ({expect, _}) => {
         let label = Label.of_string("text");
         expect.equal(label, [Label.Text("text")]);
@@ -13,6 +17,14 @@ describe("Label", ({describe, _}) => {
     test("extra quotes should be removed", ({expect, _}) => {
         let label = Label.of_string("\"text\"");
         expect.equal(label, [Label.Text("text")]);
+    });
+    test("lone icon", ({expect, _}) => {
+        let label = Label.of_string("\"$(alert)\"");
+        expect.equal(label, [Label.Icon("alert")]);
+    });
+    test("text and icon", ({expect, _}) => {
+        let label = Label.of_string("\"abc $(alert) def\"");
+        expect.equal(label, [Label.Text("abc "), Label.Icon("alert"), Label.Text(" def")]);
     });
   });
 });

--- a/test/Exthost/LabelTest.re
+++ b/test/Exthost/LabelTest.re
@@ -1,30 +1,31 @@
-
 open TestFramework;
 
 open Exthost;
 
 describe("Label", ({describe, _}) => {
   describe("parse", ({test, _}) => {
-  
     test("empty string", ({expect, _}) => {
-        let label = Label.of_string("");
-        expect.equal(label, []);
+      let label = Label.of_string("");
+      expect.equal(label, []);
     });
     test("raw string should pass through", ({expect, _}) => {
-        let label = Label.of_string("text");
-        expect.equal(label, [Label.Text("text")]);
+      let label = Label.of_string("text");
+      expect.equal(label, [Label.Text("text")]);
     });
     test("extra quotes should be removed", ({expect, _}) => {
-        let label = Label.of_string("\"text\"");
-        expect.equal(label, [Label.Text("text")]);
+      let label = Label.of_string("\"text\"");
+      expect.equal(label, [Label.Text("text")]);
     });
     test("lone icon", ({expect, _}) => {
-        let label = Label.of_string("\"$(alert)\"");
-        expect.equal(label, [Label.Icon("alert")]);
+      let label = Label.of_string("\"$(alert)\"");
+      expect.equal(label, [Label.Icon("alert")]);
     });
     test("text and icon", ({expect, _}) => {
-        let label = Label.of_string("\"abc $(alert) def\"");
-        expect.equal(label, [Label.Text("abc "), Label.Icon("alert"), Label.Text(" def")]);
+      let label = Label.of_string("\"abc $(alert) def\"");
+      expect.equal(
+        label,
+        [Label.Text("abc "), Label.Icon("alert"), Label.Text(" def")],
+      );
     });
-  });
+  })
 });

--- a/test/Exthost/StatusBarTest.re
+++ b/test/Exthost/StatusBarTest.re
@@ -6,8 +6,8 @@ describe("StatusBar", ({test, _}) => {
   test("receives status bar message on activation", _ => {
     let waitForStatusBar =
       fun
-      | Msg.StatusBar(SetEntry({text, _})) => {
-          String.equal(text, "\"Hello!\"");
+      | Msg.StatusBar(SetEntry({label, _})) => {
+          label == Label.[Text("Hello!")];
         }
       | _ => false;
 


### PR DESCRIPTION
Several of the extensions have custom status bars to help report language server state (ie, `python` shows the active interpreter, `go` lets you know if you need additional tools, etc), and this helps wire up some additional functionality:
- Execute contributed commands when clicking on status bar items
- Implement initial icon-label parsing
- Fix unescaped `"` characters in custom status bars