### PR TITLE
feat(workspace/#463): split resizing by mouse

### DIFF
--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -406,7 +406,11 @@ let rec resizeSplit = (~path, ~delta, model) => {
         |> List.filter_map(nodeWeight)
         |> List.fold_left((+.), 0.)
         |> max(1.);
-
+      let minimumWeight =
+        min(
+          0.1 *. totalWeight,
+          totalWeight /. float(List.length(children)),
+        );
       let deltaWeight = totalWeight *. delta;
 
       Split(
@@ -415,9 +419,15 @@ let rec resizeSplit = (~path, ~delta, model) => {
         children
         |> List.mapi((i, child) =>
              if (i == index) {
-               updateWeight(weight => weight +. deltaWeight, child);
+               updateWeight(
+                 weight => max(weight +. deltaWeight, minimumWeight),
+                 child,
+               );
              } else if (i == index + 1) {
-               updateWeight(weight => weight -. deltaWeight, child);
+               updateWeight(
+                 weight => max(weight -. deltaWeight, minimumWeight),
+                 child,
+               );
              } else {
                child;
              }

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -31,16 +31,19 @@ let nodeWeight =
   | Window(Weight(weight), _) => Some(weight);
 
 [@deriving show({with_path: false})]
-type sizedWindow('id) = {
-  id: 'id,
+type sized('id) = {
   x: int,
   y: int,
   width: int,
   height: int,
+  kind: [
+    | `Split([ | `Horizontal | `Vertical], list(sized('id)))
+    | `Window('id)
+  ],
 };
 
 module Internal = {
-  let intersects = (x, y, split) => {
+  let contains = (x, y, split) => {
     x >= split.x
     && x <= split.x
     + split.width
@@ -49,7 +52,16 @@ module Internal = {
     + split.height;
   };
 
-  let move = (id, dirX, dirY, splits) => {
+  let rec sizedWindows = node =>
+    switch (node) {
+    | {kind: `Window(_), _} => [node]
+    | {kind: `Split(_, children), _} =>
+      children |> List.map(sizedWindows) |> List.concat
+    };
+
+  let move = (targetId, dirX, dirY, node) => {
+    let splits = sizedWindows(node);
+
     let (minX, minY, maxX, maxY, deltaX, deltaY) =
       List.fold_left(
         (prev, cur) => {
@@ -68,15 +80,11 @@ module Internal = {
         splits,
       );
 
-    let splitInfo = List.filter(s => s.id == id, splits);
-
-    if (splitInfo == []) {
-      None;
-    } else {
-      let startSplit = List.hd(splitInfo);
-
-      let curX = ref(startSplit.x + startSplit.width / 2);
-      let curY = ref(startSplit.y + startSplit.height / 2);
+    switch (List.find_opt(split => split.kind == `Window(targetId), splits)) {
+    | None => None
+    | Some(target) =>
+      let curX = ref(target.x + target.width / 2);
+      let curY = ref(target.y + target.height / 2);
       let found = ref(false);
       let result = ref(None);
 
@@ -88,15 +96,16 @@ module Internal = {
         let x = curX^;
         let y = curY^;
 
-        let intersects =
-          List.filter(
-            s => s.id != startSplit.id && intersects(x, y, s),
+        switch (
+          List.find_opt(
+            s => s.kind != `Window(targetId) && contains(x, y, s),
             splits,
-          );
-
-        if (intersects != []) {
-          result := Some(List.hd(intersects).id);
+          )
+        ) {
+        | Some({kind: `Window(id), _}) =>
+          result := Some(id);
           found := true;
+        | _ => ()
         };
 
         curX := x + dirX * deltaX;
@@ -145,6 +154,58 @@ let windows = tree => {
   };
 
   traverse(tree, []);
+};
+
+let rec layout = (x, y, width, height, tree) => {
+  switch (tree) {
+  | Split(direction, _, children) =>
+    let totalWeight =
+      children
+      |> List.filter_map(nodeWeight)
+      |> List.fold_left((+.), 0.)
+      |> max(1.);
+
+    let sizedChildren =
+      (
+        switch (direction) {
+        | `Horizontal =>
+          let unitHeight = float(height) /. totalWeight;
+          List.fold_left(
+            ((y, acc), child) => {
+              switch (nodeSize(child)) {
+              | Weight(weight) =>
+                let height = int_of_float(unitHeight *. weight);
+                let sized = layout(x, y, width, height, child);
+                (y + height, [sized, ...acc]);
+              }
+            },
+            (y, []),
+            children,
+          );
+
+        | `Vertical =>
+          let unitWidth = float(width) /. totalWeight;
+          List.fold_left(
+            ((x, acc), child) => {
+              switch (nodeSize(child)) {
+              | Weight(weight) =>
+                let width = int_of_float(unitWidth *. weight);
+                let sized = layout(x, y, width, height, child);
+                (x + width, [sized, ...acc]);
+              }
+            },
+            (x, []),
+            children,
+          );
+        }
+      )
+      |> snd
+      |> List.rev;
+
+    {x, y, width, height, kind: `Split((direction, sizedChildren))};
+
+  | Window(_, id) => {x, y, width, height, kind: `Window(id)}
+  };
 };
 
 let addWindow = (~target=None, ~position, direction, id, tree) => {
@@ -239,55 +300,6 @@ let removeWindow = (target, tree) => {
     | node => Some(node);
 
   traverse(tree) |> Option.value(~default=empty);
-};
-
-let rec layout = (x, y, width, height, tree) => {
-  switch (tree) {
-  | Split(direction, _, children) =>
-    let totalWeight =
-      children
-      |> List.filter_map(nodeWeight)
-      |> List.fold_left((+.), 0.)
-      |> max(1.);
-
-    (
-      switch (direction) {
-      | `Horizontal =>
-        let unitHeight = float(height) /. totalWeight;
-        List.fold_left(
-          ((y, acc), child) => {
-            switch (nodeSize(child)) {
-            | Weight(weight) =>
-              let height = int_of_float(unitHeight *. weight);
-              let windows = layout(x, y, width, height, child);
-              (y + height, windows @ acc);
-            }
-          },
-          (y, []),
-          children,
-        );
-
-      | `Vertical =>
-        let unitWidth = float(width) /. totalWeight;
-        List.fold_left(
-          ((x, acc), child) => {
-            switch (nodeSize(child)) {
-            | Weight(weight) =>
-              let width = int_of_float(unitWidth *. weight);
-              let windows = layout(x, y, width, height, child);
-              (x + width, windows @ acc);
-            }
-          },
-          (x, []),
-          children,
-        );
-      }
-    )
-    |> snd
-    |> List.rev;
-
-  | Window(_, id) => [{id, x, y, width, height}]
-  };
 };
 
 let moveCore = (current, dirX, dirY, tree) => {

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -16,16 +16,19 @@ type t('id) =
   | Window(size, 'id);
 
 [@deriving show]
-type sizedWindow('id) = {
-  id: 'id,
+type sized('id) = {
   x: int,
   y: int,
   width: int,
   height: int,
+  kind: [
+    | `Split([ | `Horizontal | `Vertical], list(sized('id)))
+    | `Window('id)
+  ],
 };
 
 module Internal: {
-  let move: ('id, int, int, list(sizedWindow('id))) => option('id); // only used for tests
+  let move: ('id, int, int, sized('id)) => option('id); // only used for tests
 };
 
 let initial: t('id);
@@ -42,7 +45,7 @@ let addWindow:
   t('id);
 let removeWindow: ('id, t('id)) => t('id);
 
-let layout: (int, int, int, int, t('id)) => list(sizedWindow('id));
+let layout: (int, int, int, int, t('id)) => sized('id);
 
 let move: (direction, 'id, t('id)) => 'id;
 let moveLeft: ('id, t('id)) => 'id;

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -58,4 +58,5 @@ let rotateBackward: ('id, t('id)) => t('id);
 
 let resizeWindow:
   ([ | `Horizontal | `Vertical], 'id, float, t('id)) => t('id);
+let resizeSplit: (~path: list(int), ~delta: float, t('id)) => t('id);
 let resetWeights: t('id) => t('id);

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -190,6 +190,10 @@ type t =
   | WindowMinimized
   | WindowRestored
   | WindowCloseBlocked
+  | WindowHandleDragged({
+      path: list(int),
+      delta: float,
+    })
   | WriteFailure
   | NewTextContentProvider({
       handle: int,

--- a/src/Store/WindowsStoreConnector.re
+++ b/src/Store/WindowsStoreConnector.re
@@ -114,6 +114,11 @@ let start = () => {
         layout: Feature_Layout.resetWeights(s.layout),
       }
 
+    | WindowHandleDragged({path, delta}) => {
+        ...s,
+        layout: Feature_Layout.resizeSplit(~path, ~delta, s.layout),
+      }
+
     | _ => s
     };
 

--- a/src/UI/EditorLayoutView.re
+++ b/src/UI/EditorLayoutView.re
@@ -17,12 +17,6 @@ module Styles = {
 
   let container = [flexGrow(1), flexDirection(`Row)];
 
-  let split = direction => [
-    flexDirection(direction == `Vertical ? `Row : `Column),
-    backgroundColor(direction == `Vertical ? Colors.red : Colors.blue),
-    flexGrow(1),
-  ];
-
   let verticalHandle = (node: Feature_Layout.sized(_)) => [
     cursor(MouseCursors.horizontalResize),
     position(`Absolute),

--- a/src/UI/EditorLayoutView.re
+++ b/src/UI/EditorLayoutView.re
@@ -8,6 +8,10 @@ open Revery;
 open UI;
 open Oni_Model;
 
+module Constants = {
+  let handleSize = 10;
+};
+
 module Styles = {
   open Style;
 
@@ -22,9 +26,9 @@ module Styles = {
   let verticalHandle = (node: Feature_Layout.sized(_)) => [
     cursor(MouseCursors.horizontalResize),
     position(`Absolute),
-    left(node.x + node.width - 5),
+    left(node.x + node.width - Constants.handleSize / 2),
     top(node.y),
-    width(10),
+    width(Constants.handleSize),
     height(node.height),
   ];
 
@@ -32,9 +36,9 @@ module Styles = {
     cursor(MouseCursors.verticalResize),
     position(`Absolute),
     left(node.x),
-    top(node.y + node.height - 5),
+    top(node.y + node.height - Constants.handleSize / 2),
     width(node.width),
-    height(10),
+    height(Constants.handleSize),
   ];
 };
 

--- a/src/UI/EditorLayoutView.re
+++ b/src/UI/EditorLayoutView.re
@@ -19,45 +19,138 @@ module Styles = {
     flexGrow(1),
   ];
 
-  let handle = direction => [
-    direction == `Vertical ? width(3) : height(3),
-    cursor(
-      direction == `Vertical
-        ? MouseCursors.horizontalResize : MouseCursors.verticalResize,
-    ),
+  let verticalHandle = (node: Feature_Layout.sized(_)) => [
+    cursor(MouseCursors.horizontalResize),
+    position(`Absolute),
+    left(node.x + node.width - 5),
+    top(node.y),
+    width(10),
+    height(node.height),
+  ];
+
+  let horizontalHandle = (node: Feature_Layout.sized(_)) => [
+    cursor(MouseCursors.verticalResize),
+    position(`Absolute),
+    left(node.x),
+    top(node.y + node.height - 5),
+    width(node.width),
+    height(10),
   ];
 };
 
-let rec nodeView =
-        (~state, ~theme, ~editorGroups, ~node: Feature_Layout.t(_), ()) => {
-  switch (node) {
-  | Split(direction, _, children) =>
-    <View style={Styles.split(direction)}>
-      {children
-       |> List.map(node => <nodeView state theme editorGroups node />)
-       |> Base.List.intersperse(
-            ~sep=<View style={Styles.handle(direction)} />,
-          )
-       |> React.listToElement}
-    </View>
+let%component handleView =
+              (~direction, ~node: Feature_Layout.sized(_), ~onDrag, ()) => {
+  let%hook (captureMouse, _state) =
+    Hooks.mouseCapture(
+      ~onMouseMove=
+        ((lastX, lastY), evt) => {
+          let delta =
+            switch (direction) {
+            | `Vertical => evt.mouseX -. lastX
+            | `Horizontal => evt.mouseY -. lastY
+            };
 
-  | Window(_, id) =>
+          onDrag(delta);
+          Some((evt.mouseX, evt.mouseY));
+        },
+      ~onMouseUp=(_, _) => None,
+      (),
+    );
+
+  let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
+    captureMouse((evt.mouseX, evt.mouseY));
+  };
+
+  <View
+    onMouseDown
+    style={
+      direction == `Vertical
+        ? Styles.verticalHandle(node) : Styles.horizontalHandle(node)
+    }
+  />;
+};
+
+let rec nodeView =
+        (
+          ~state,
+          ~theme,
+          ~editorGroups,
+          ~path=[],
+          ~node: Feature_Layout.sized(_),
+          (),
+        ) => {
+  switch (node.kind) {
+  | `Split(direction, children) =>
+    let parent = node;
+
+    let rec loop = (index, children) => {
+      let path = [index, ...path];
+
+      switch (children) {
+      | [] => []
+      | [node] => [<nodeView state theme editorGroups path node />]
+
+      | [node, ...[_, ..._] as rest] =>
+        let onDrag = delta => {
+          let total = direction == `Vertical ? parent.width : parent.height;
+          GlobalContext.current().dispatch(
+            Actions.WindowHandleDragged({
+              path: List.rev(path),
+              delta: delta /. float(total) // normalized
+            }),
+          );
+        };
+        [
+          <nodeView state theme editorGroups path node />,
+          <handleView direction node onDrag />,
+          ...loop(index + 1, rest),
+        ];
+      };
+    };
+
+    loop(0, children) |> React.listToElement;
+
+  | `Window(id) =>
     switch (EditorGroups.getEditorGroupById(editorGroups, id)) {
     | Some(editorGroup) =>
-//      <EditorGroupView state theme editorGroup />
-      <View style=Style.[backgroundColor(Colors.green |> Color.multiplyAlpha(0.5)), flexGrow(1)] />
+      <View
+        style=Style.[
+          position(`Absolute),
+          left(node.x),
+          top(node.y),
+          width(node.width),
+          height(node.height),
+        ]>
+        <EditorGroupView state theme editorGroup />
+      </View>
     | None => React.empty
     }
   };
 };
 
-let make = (~state: State.t, ~theme, ()) => {
-  <View style=Styles.container>
-    <nodeView
-      state
-      theme
-      editorGroups={state.editorGroups}
-      node={state.layout}
-    />
+let%component make = (~state: State.t, ~theme, ()) => {
+  let%hook (maybeDimensions, setDimensions) = Hooks.state(None);
+  let children =
+    switch (maybeDimensions) {
+    | Some((width, height)) =>
+      let sizedLayout =
+        Feature_Layout.layout(0, 0, width, height, state.layout);
+
+      <nodeView
+        state
+        theme
+        editorGroups={state.editorGroups}
+        node=sizedLayout
+      />;
+
+    | None => React.empty
+    };
+
+  <View
+    onDimensionsChanged={dim =>
+      setDimensions(_ => Some((dim.width, dim.height)))
+    }
+    style=Styles.container>
+    children
   </View>;
 };

--- a/src/UI/EditorLayoutView.re
+++ b/src/UI/EditorLayoutView.re
@@ -8,17 +8,10 @@ open Revery;
 open UI;
 open Oni_Model;
 
-let splitContainer = Style.[flexGrow(1), flexDirection(`Row)];
+module Styles = {
+  open Style;
 
-let splitStyle = Style.[flexGrow(1)];
-
-let parentStyle = direction => {
-  let flexDir =
-    switch (direction) {
-    | `Vertical => `Row
-    | `Horizontal => `Column
-    };
-  Style.[flexGrow(1), flexDirection(flexDir)];
+  let container = [flexGrow(1), flexDirection(`Row)];
 };
 
 let renderTree = (~width, ~height, state: State.t, theme, tree) => {
@@ -54,17 +47,11 @@ let%component make = (~state: State.t, ~theme, ()) => {
     | None => React.empty
     };
 
-  let splits =
-    [
-      <View
-        onDimensionsChanged={dim =>
-          setDimensions(_ => Some((dim.width, dim.height)))
-        }
-        style=Style.[flexGrow(1)]>
-        children
-      </View>,
-    ]
-    |> React.listToElement;
-
-  <View style=splitContainer> splits </View>;
+  <View
+    style=Styles.container
+    onDimensionsChanged={dim =>
+      setDimensions(_ => Some((dim.width, dim.height)))
+    }>
+    children
+  </View>;
 };

--- a/test/Model/WindowTreeLayoutTests.re
+++ b/test/Model/WindowTreeLayoutTests.re
@@ -28,11 +28,21 @@ describe("WindowTreeLayout", ({describe, _}) => {
       let layoutItems = Layout.layout(0, 0, 300, 300, splits);
 
       expect.equal(
-        Layout.[
-          {id: 3, width: 300, height: 100, x: 0, y: 0},
-          {id: 2, width: 300, height: 100, x: 0, y: 100},
-          {id: 1, width: 300, height: 100, x: 0, y: 200},
-        ],
+        Layout.{
+          x: 0,
+          y: 0,
+          width: 300,
+          height: 300,
+          kind:
+            `Split((
+              `Horizontal,
+              [
+                {kind: `Window(3), x: 0, y: 0, width: 300, height: 100},
+                {kind: `Window(2), x: 0, y: 100, width: 300, height: 100},
+                {kind: `Window(1), x: 0, y: 200, width: 300, height: 100},
+              ],
+            )),
+        },
         layoutItems,
       );
 
@@ -60,10 +70,20 @@ describe("WindowTreeLayout", ({describe, _}) => {
       let layoutItems = Layout.layout(0, 0, 200, 200, splits);
 
       expect.equal(
-        Layout.[
-          {id: 2, width: 100, height: 200, x: 0, y: 0},
-          {id: 1, width: 100, height: 200, x: 100, y: 0},
-        ],
+        Layout.{
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+          kind:
+            `Split((
+              `Vertical,
+              [
+                {kind: `Window(2), x: 0, y: 0, width: 100, height: 200},
+                {kind: `Window(1), x: 100, y: 0, width: 100, height: 200},
+              ],
+            )),
+        },
         layoutItems,
       );
     });
@@ -82,10 +102,20 @@ describe("WindowTreeLayout", ({describe, _}) => {
       let layoutItems = Layout.layout(0, 0, 200, 200, splits);
 
       expect.equal(
-        Layout.[
-          {id: 2, width: 200, height: 100, x: 0, y: 0},
-          {id: 1, width: 200, height: 100, x: 0, y: 100},
-        ],
+        Layout.{
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+          kind:
+            `Split((
+              `Horizontal,
+              [
+                {kind: `Window(2), x: 0, y: 0, width: 200, height: 100},
+                {kind: `Window(1), x: 0, y: 100, width: 200, height: 100},
+              ],
+            )),
+        },
         layoutItems,
       );
     });
@@ -105,11 +135,45 @@ describe("WindowTreeLayout", ({describe, _}) => {
       let layoutItems = Layout.layout(0, 0, 200, 200, splits);
 
       expect.equal(
-        Layout.[
-          {id: 2, width: 200, height: 100, x: 0, y: 0},
-          {id: 1, width: 100, height: 100, x: 100, y: 100},
-          {id: 3, width: 100, height: 100, x: 0, y: 100},
-        ],
+        Layout.{
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+          kind:
+            `Split((
+              `Horizontal,
+              [
+                {kind: `Window(2), x: 0, y: 0, width: 200, height: 100},
+                {
+                  x: 0,
+                  y: 100,
+                  width: 200,
+                  height: 100,
+                  kind:
+                    `Split((
+                      `Vertical,
+                      [
+                        {
+                          kind: `Window(3),
+                          x: 0,
+                          y: 100,
+                          width: 100,
+                          height: 100,
+                        },
+                        {
+                          kind: `Window(1),
+                          x: 100,
+                          y: 100,
+                          width: 100,
+                          height: 100,
+                        },
+                      ],
+                    )),
+                },
+              ],
+            )),
+        },
         layoutItems,
       );
     });


### PR DESCRIPTION
![mouse-resizing](https://user-images.githubusercontent.com/5207036/82660639-059e2b00-9c2b-11ea-93ae-4a98f172a999.gif)

No need to look too closely at the code, at least the `Feature_Layout` implementation, as I'm planning on refactoring this to use pixel coordinates instead of weight since I've eventually realized that this is an inherent part of the problem domain.

There's also a bit of wonkiness with the handle not properly tracking the mouse once it hits a limit. This is because the mouse coordinates from the events are relative to the window, while the handle and splits are positioned relative to their positional container, so the resizing is done through relative change, which works fine until it is constrained and the handle remains in place while the mouse continues to move. The behaviour is predictable though, and might be easier (or just different) to fix after refactoring, so I think it's fine for now.

Fixes #463