### PR TITLE
fix(macos): Crash when sending input to libvim

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -124,7 +124,7 @@ if (process.platform == "linux") {
       CFBundleVersion: `${package.version}`,
       CFBundlePackageType: "APPL",
       CFBundleSignature: "????",
-      CFBundleExecutable: "Oni2_editor",
+      CFBundleExecutable: "Oni2",
       NSHighResolutionCapable: true,
       CFBundleDocumentTypes: package.build.fileAssociations.map(fileAssoc => {
             return {


### PR DESCRIPTION
Fixes a regression in  the packaged builds, where input handling fails. Need to investigate the full fix, as this removes the capability to open files from finder (since the app delegate is no longer registered) - but fixes the input regression.

I suspect the issue is a `tty` issue - where there is a difference in the tty/channel configuration when running directly as the `CFBundleExecutable` versus being spun up by the launcher process, as was done previously. `libvim` should be agnostic of the terminal or environment - but there are still places where it's dependent on terminal on config.