### PR TITLE
chore: reformat package.json with esy add

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "license": "MIT",
   "esy": {
     "build": "refmterr dune build -p libvim,Oni2 -j4",
-    "buildEnv": {
-      "MACOSX_DEPLOYMENT_TARGET": "10.12"
-    },
+    "buildEnv": { "MACOSX_DEPLOYMENT_TARGET": "10.12" },
     "install": [
       "esy-installer Oni2.install",
       "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': 'echo'}\"",
@@ -21,333 +19,172 @@
       {
         "name": "Plain text",
         "role": "Editor",
-        "icon": {
-          "mac": "plaintext.icns"
-        },
-        "ext": [
-          ".txt",
-          ".README",
-          ".LICENSE"
-        ]
+        "icon": { "mac": "plaintext.icns" },
+        "ext": [ ".txt", ".README", ".LICENSE" ]
       },
       {
         "name": "YAML document",
         "role": "Editor",
-        "icon": {
-          "mac": "yaml.icns"
-        },
-        "ext": [
-          ".yml",
-          ".yaml"
-        ]
+        "icon": { "mac": "yaml.icns" },
+        "ext": [ ".yml", ".yaml" ]
       },
       {
         "name": "Git configuration",
         "role": "Editor",
-        "icon": {
-          "mac": "git.icns"
-        },
-        "ext": [
-          ".gitignore",
-          ".gitconfig",
-          ".gitattributes"
-        ]
+        "icon": { "mac": "git.icns" },
+        "ext": [ ".gitignore", ".gitconfig", ".gitattributes" ]
       },
       {
         "name": "Docker configuration",
         "role": "Editor",
-        "icon": {
-          "mac": "docker.icns"
-        },
-        "ext": [
-          ".Dockerfile"
-        ]
+        "icon": { "mac": "docker.icns" },
+        "ext": [ ".Dockerfile" ]
       },
       {
         "name": "OPAM configuration",
         "role": "Editor",
-        "icon": {
-          "mac": "opam.icns"
-        },
-        "ext": [
-          ".opam"
-        ]
+        "icon": { "mac": "opam.icns" },
+        "ext": [ ".opam" ]
       },
       {
         "name": "Dune configuration",
         "role": "Editor",
-        "icon": {
-          "mac": "dune.icns"
-        },
-        "ext": [
-          ".dune",
-          ".dune-project"
-        ]
+        "icon": { "mac": "dune.icns" },
+        "ext": [ ".dune", ".dune-project" ]
       },
       {
         "name": "ReasonML source",
         "role": "Editor",
-        "icon": {
-          "mac": "reasonml.icns"
-        },
-        "ext": [
-          ".re",
-          ".rei"
-        ]
+        "icon": { "mac": "reasonml.icns" },
+        "ext": [ ".re", ".rei" ]
       },
       {
         "name": "OCaml source",
         "role": "Editor",
-        "icon": {
-          "mac": "ocaml.icns"
-        },
-        "ext": [
-          ".ml",
-          ".mli"
-        ]
+        "icon": { "mac": "ocaml.icns" },
+        "ext": [ ".ml", ".mli" ]
       },
       {
         "name": "C source",
         "role": "Editor",
-        "icon": {
-          "mac": "c.icns"
-        },
-        "ext": [
-          ".c"
-        ]
+        "icon": { "mac": "c.icns" },
+        "ext": [ ".c" ]
       },
       {
         "name": "C++ source",
-        "icon": {
-          "mac": "cpp.icns"
-        },
+        "icon": { "mac": "cpp.icns" },
         "role": "Editor",
         "ext": [
-          ".cpp",
-          ".cc",
-          ".cxx",
-          ".hpp",
-          ".hh",
-          ".hxx",
-          ".h",
-          ".ino",
-          ".inl",
+          ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".ino", ".inl",
           ".ipp"
         ]
       },
       {
         "name": "Make configuration",
         "role": "Editor",
-        "icon": {
-          "mac": "makefile.icns"
-        },
-        "ext": [
-          ".Makefile"
-        ]
+        "icon": { "mac": "makefile.icns" },
+        "ext": [ ".Makefile" ]
       },
       {
         "name": "Cascading style sheet",
         "role": "Editor",
-        "icon": {
-          "mac": "css.icns"
-        },
-        "ext": [
-          ".css"
-        ]
+        "icon": { "mac": "css.icns" },
+        "ext": [ ".css" ]
       },
       {
         "name": "HTML document",
         "role": "Editor",
-        "icon": {
-          "mac": "html.icns"
-        },
+        "icon": { "mac": "html.icns" },
         "ext": [
-          ".html",
-          ".htm",
-          ".shtml",
-          ".xhtml",
-          ".mdoc",
-          ".jsp",
-          ".asp",
-          ".aspx",
-          ".jshtm",
-          ".volt",
-          ".ejs",
-          ".rhtml"
+          ".html", ".htm", ".shtml", ".xhtml", ".mdoc", ".jsp", ".asp",
+          ".aspx", ".jshtm", ".volt", ".ejs", ".rhtml"
         ]
       },
       {
         "name": "PHP source",
         "role": "Editor",
-        "icon": {
-          "mac": "php.icns"
-        },
-        "ext": [
-          ".php",
-          ".php5",
-          ".php7"
-        ]
+        "icon": { "mac": "php.icns" },
+        "ext": [ ".php", ".php5", ".php7" ]
       },
       {
         "name": "XML document",
         "role": "Editor",
-        "icon": {
-          "mac": "xml.icns"
-        },
-        "ext": [
-          ".xml",
-          ".xaml"
-        ]
+        "icon": { "mac": "xml.icns" },
+        "ext": [ ".xml", ".xaml" ]
       },
       {
         "name": "SVG image",
         "role": "Editor",
-        "icon": {
-          "mac": "svg.icns"
-        },
-        "ext": [
-          ".svg",
-          ".svgz"
-        ]
+        "icon": { "mac": "svg.icns" },
+        "ext": [ ".svg", ".svgz" ]
       },
       {
         "name": "Java source",
         "role": "Editor",
-        "icon": {
-          "mac": "java.icns"
-        },
-        "ext": [
-          ".java",
-          ".jav"
-        ]
+        "icon": { "mac": "java.icns" },
+        "ext": [ ".java", ".jav" ]
       },
       {
         "name": "Javascript source",
         "role": "Editor",
-        "icon": {
-          "mac": "javascript.icns"
-        },
-        "ext": [
-          ".js",
-          ".es6",
-          ".mjs",
-          ".pac"
-        ]
+        "icon": { "mac": "javascript.icns" },
+        "ext": [ ".js", ".es6", ".mjs", ".pac" ]
       },
       {
         "name": "JSON",
         "role": "Editor",
-        "icon": {
-          "mac": "json.icns"
-        },
+        "icon": { "mac": "json.icns" },
         "ext": [
-          ".json",
-          ".bowerrc",
-          ".jshintrc",
-          ".jscsrc",
-          ".eslintrc",
-          ".swcrc",
-          ".webmanifest",
-          ".js.map",
-          ".css.map"
+          ".json", ".bowerrc", ".jshintrc", ".jscsrc", ".eslintrc", ".swcrc",
+          ".webmanifest", ".js.map", ".css.map"
         ]
       },
       {
         "name": "JSON with Comments",
         "role": "Editor",
-        "icon": {
-          "mac": "json.icns"
-        },
-        "ext": [
-          ".hintrc",
-          ".babelrc",
-          ".jsonc"
-        ]
+        "icon": { "mac": "json.icns" },
+        "ext": [ ".hintrc", ".babelrc", ".jsonc" ]
       },
       {
         "name": "Markdown Source",
-        "icon": {
-          "mac": "markdown.icns"
-        },
+        "icon": { "mac": "markdown.icns" },
         "role": "Editor",
         "ext": [
-          ".md",
-          ".mkd",
-          ".mdwn",
-          ".mdown",
-          ".markdown",
-          ".markdn",
-          ".mdtxt",
-          ".mdtext",
-          ".workbook"
+          ".md", ".mkd", ".mdwn", ".mdown", ".markdown", ".markdn", ".mdtxt",
+          ".mdtext", ".workbook"
         ]
       },
       {
         "name": "Python Source",
-        "icon": {
-          "mac": "python.icns"
-        },
+        "icon": { "mac": "python.icns" },
         "role": "Editor",
         "ext": [
-          ".py",
-          ".rpy",
-          ".pyw",
-          ".cpy",
-          ".gyp",
-          ".gypi",
-          ".snakefile",
-          ".smk",
-          ".pyi",
-          ".ipy"
+          ".py", ".rpy", ".pyw", ".cpy", ".gyp", ".gypi", ".snakefile",
+          ".smk", ".pyi", ".ipy"
         ]
       },
       {
         "name": "Shell source",
         "role": "Editor",
-        "icon": {
-          "mac": "shell.icns"
-        },
+        "icon": { "mac": "shell.icns" },
         "ext": [
-          ".sh",
-          ".bash",
-          ".bashrc",
-          ".bash_aliases",
-          ".bash_profile",
-          ".bash_login",
-          ".ebuild",
-          ".install",
-          ".profile",
-          ".bash_logout",
-          ".zsh",
-          ".zshrc",
-          ".zprofile",
-          ".zlogin",
-          ".zlogout",
-          ".zshenv",
-          ".zsh-theme",
-          ".ksh",
-          ".command"
+          ".sh", ".bash", ".bashrc", ".bash_aliases", ".bash_profile",
+          ".bash_login", ".ebuild", ".install", ".profile", ".bash_logout",
+          ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv",
+          ".zsh-theme", ".ksh", ".command"
         ]
       },
       {
         "name": "Typescript",
         "role": "Editor",
-        "icon": {
-          "mac": "typescript.icns"
-        },
-        "ext": [
-          ".ts"
-        ]
+        "icon": { "mac": "typescript.icns" },
+        "ext": [ ".ts" ]
       },
       {
         "name": "Typescript React",
         "role": "Editor",
-        "icon": {
-          "mac": "typescript.icns"
-        },
-        "ext": [
-          ".tsx"
-        ]
+        "icon": { "mac": "typescript.icns" },
+        "ext": [ ".tsx" ]
       }
     ]
   },
@@ -364,49 +201,49 @@
     "clean-extensions": "esy b bash ./scripts/clean-extensions.sh"
   },
   "dependencies": {
-    "@opam/reason": "^3.6.0",
+    "@esy-ocaml/libffi": "*",
+    "@glennsl/timber": "1.0.0",
     "@opam/charInfo_width": "*",
+    "@opam/decoders-yojson": "^0.4.0",
+    "@opam/dir": "*",
     "@opam/dune": "2.5.0",
     "@opam/dune-configurator": "*",
+    "@opam/fmt": "^0.8.8",
+    "@opam/fp": "*",
+    "@opam/fs": "*",
+    "@opam/logs": "^0.7.0",
+    "@opam/luv": "~0.5.1",
     "@opam/lwt": "*",
+    "@opam/markup": "^0.8.2",
     "@opam/ocamlbuild": "*",
     "@opam/ppx_deriving": "*",
     "@opam/ppx_deriving_yojson": "*",
+    "@opam/ppx_inline_test": "v0.13.1",
     "@opam/ppx_let": "v0.13.0",
     "@opam/ppxlib": ">=0.10.0",
+    "@opam/re": "*",
+    "@opam/reason": "^3.6.0",
+    "@opam/uucp": "*",
+    "@opam/uutf": "*",
     "@opam/yojson": "1.7.0",
     "axios": "^0.19.0",
+    "editor-core-types": "*",
+    "editor-input": "*",
     "esy-macdylibbundler": "*",
+    "esy-sdl2": "*",
+    "esy-skia": "*",
     "isolinear": "^3.0.0",
     "libvim": "8.10869.44",
     "ocaml": "~4.7.0",
-    "reason-sdl2": "^2.10.2020",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#ae1fd34",
+    "reason-sdl2": "^2.10.2020",
+    "reason-textmate": "^3.1.2",
+    "reason-tree-sitter": "^1.0.1001",
     "reasonFuzz": "*",
+    "refmterr": "*",
     "rench": "1.7.1",
     "revery": "0.30.0",
-    "revery-terminal": "*",
-    "reason-tree-sitter": "^1.0.1001",
-    "reason-textmate": "^3.1.2",
-    "esy-sdl2": "*",
-    "esy-skia": "*",
-    "@opam/fmt": "^0.8.8",
-    "@opam/logs": "^0.7.0",
-    "@opam/re": "*",
-    "editor-core-types": "*",
-    "editor-input": "*",
-    "@glennsl/timber": "1.0.0",
-    "refmterr": "*",
-    "@esy-ocaml/libffi": "*",
-    "@opam/decoders-yojson": "^0.4.0",
-    "@opam/uutf": "*",
-    "@opam/uucp": "*",
-    "@opam/luv": "~0.5.1",
-    "@opam/fs": "*",
-    "@opam/fp": "*",
-    "@opam/dir": "*",
-    "@opam/markup": "^0.8.2",
-    "@opam/ppx_inline_test": "v0.13.1"
+    "revery-terminal": "*"
   },
   "resolutions": {
     "@esy-ocaml/libffi": "onivim/libffi#590b041",


### PR DESCRIPTION
This should make using `esy add` in the future less noisy.