### PR TITLE
fix(exthost): Assertion Failure - document already exists

### DIFF
--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -1,5 +1,7 @@
 open Oni_Core;
 
+module Log = (val Log.withNamespace("Service_Exthost"));
+
 module Effects = {
   module SCM = {
     let provideOriginalResource = (~handles, extHostClient, path, toMsg) =>
@@ -32,3 +34,48 @@ module Effects = {
       );
   };
 };
+
+module MutableState = {
+  let activatedFileTypes: Hashtbl.t(string, bool) = Hashtbl.create(16);
+
+};
+
+module Internal = {
+  let bufferMetadataToModelAddedDelta =
+      (~version, ~filePath, ~fileType: option(string)) =>
+    switch (filePath, fileType) {
+    | (Some(fp), Some(ft)) =>
+      Log.trace("Creating model for filetype: " ++ ft);
+
+      Some(
+        Exthost.ModelAddedDelta.create(
+          ~versionId=version,
+          ~lines=[""],
+          ~modeId=ft,
+          ~isDirty=true,
+          Uri.fromPath(fp),
+        ),
+      );
+    | _ => None
+    };
+
+  let activateFileType = (~client,fileType: option(string)) =>
+    fileType
+    |> Option.iter(ft =>
+         if (!Hashtbl.mem(MutableState.activatedFileTypes, ft)) {
+           // If no entry, we haven't activated yet
+           Exthost.Request.ExtensionService.activateByEvent(
+             ~event="onLanguage:" ++ ft,
+             client,
+           );
+           Hashtbl.add(MutableState.activatedFileTypes, ft, true);
+         }
+       );
+};
+
+module Sub = {
+  let buffer = (
+    ~buffer,
+    ~client,
+  ) => Isolinear.Sub.none;
+}

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -15,3 +15,10 @@ module Effects: {
       Isolinear.Effect.t(_);
   };
 };
+
+module Sub: {
+  let buffer: (
+    ~buffer: Oni_Core.Buffer.t,
+    ~client: Exthost.Client.t,
+  ) => Isolinear.Sub.t(_);
+};

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -17,8 +17,7 @@ module Effects: {
 };
 
 module Sub: {
-  let buffer: (
-    ~buffer: Oni_Core.Buffer.t,
-    ~client: Exthost.Client.t,
-  ) => Isolinear.Sub.t(_);
+  let buffer:
+    (~buffer: Oni_Core.Buffer.t, ~client: Exthost.Client.t) =>
+    Isolinear.Sub.t(unit);
 };

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -37,45 +37,6 @@ module Internal = {
 };
 
 let start = (extensions, extHostClient: Exthost.Client.t) => {
-  let activatedFileTypes: Hashtbl.t(string, bool) = Hashtbl.create(16);
-
-  let activateFileType = (fileType: option(string)) =>
-    fileType
-    |> Option.iter(ft =>
-         if (!Hashtbl.mem(activatedFileTypes, ft)) {
-           // If no entry, we haven't activated yet
-           Exthost.Request.ExtensionService.activateByEvent(
-             ~event="onLanguage:" ++ ft,
-             extHostClient,
-           );
-           Hashtbl.add(activatedFileTypes, ft, true);
-         }
-       );
-
-  let sendBufferEnterEffect = (~version, ~filePath, ~fileType) =>
-    Isolinear.Effect.create(~name="exthost.bufferEnter", () =>
-      switch (
-        Internal.bufferMetadataToModelAddedDelta(
-          ~version,
-          ~filePath,
-          ~fileType,
-        )
-      ) {
-      | None => ()
-      | Some((v: Exthost.ModelAddedDelta.t)) =>
-        activateFileType(fileType);
-        let addedDelta =
-          Exthost.DocumentsAndEditorsDelta.create(
-            ~removedDocuments=[],
-            ~addedDocuments=[v],
-          );
-        Exthost.Request.DocumentsAndEditors.acceptDocumentsAndEditorsDelta(
-          ~delta=addedDelta,
-          extHostClient,
-        );
-      }
-    );
-
   let modelChangedEffect = (buffers: Buffers.t, update: BufferUpdate.t) =>
     Isolinear.Effect.create(~name="exthost.bufferUpdate", () =>
       switch (Buffers.getBuffer(update.id, buffers)) {
@@ -250,19 +211,16 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
 
     | VimDirectoryChanged(path) => (state, changeWorkspaceEffect(path))
 
-    | BufferEnter({id, version, filePath, fileType, _}) =>
+    | BufferEnter({id, filePath, _}) =>
       let eff =
         switch (filePath) {
         | Some(path) =>
-          Isolinear.Effect.batch([
-            Feature_SCM.Effects.getOriginalUri(
-              extHostClient, state.scm, path, uri =>
-              Actions.GotOriginalUri({bufferId: id, uri})
-            ),
-            sendBufferEnterEffect(~version, ~filePath, ~fileType),
-          ])
+          Feature_SCM.Effects.getOriginalUri(
+            extHostClient, state.scm, path, uri =>
+            Actions.GotOriginalUri({bufferId: id, uri})
+          )
 
-        | None => sendBufferEnterEffect(~version, ~filePath, ~fileType)
+        | None => Isolinear.Effect.none
         };
       (state, eff);
 


### PR DESCRIPTION
__Issue:__ We'd see assertion failures from the extension host when opening a buffer, like:
```
[ERROR]    +1ms Oni2.Extension.ClientStore : {"$isError":true,"name":"Error","message":"Assertion failed (document 'file:///Users/bryphe/oni2/NodeTask2.re already exists!')","stack":"Error: Assertion failed (document 'file:///Users/bryphe/oni2/NodeTask2.re already exists!')
```

__Defect:__ We were sending multiple requests to add the document.

__Fix:__ Move the document synchronization (at least the adding / removing) to a subscription - this will always keep it in sync with the set of buffers in view. We can also use a similar subscription model to keep the list of visible editors in sync with the extension host, and this will also simplify keeping the filetype in sync (ie, to finish up #933)