### PR TITLE
fix(exthost/#1839): Fix crash when switching JS files

### DIFF
--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -107,6 +107,8 @@ let start =
         Log.tracef(m =>
           m("RequestJSONArgs: %d %d %s", requestId, rpcId, method)
         );
+        prerr_endline ("before args");
+        prerr_endline ("ARGS: " ++ Yojson.Safe.to_string(args));
         let req = Handlers.handle(rpcId, method, args);
         switch (req) {
         | Ok(msg) =>

--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -107,8 +107,6 @@ let start =
         Log.tracef(m =>
           m("RequestJSONArgs: %d %d %s", requestId, rpcId, method)
         );
-        prerr_endline ("before args");
-        prerr_endline ("ARGS: " ++ Yojson.Safe.to_string(args));
         let req = Handlers.handle(rpcId, method, args);
         switch (req) {
         | Ok(msg) =>

--- a/src/Exthost/dune
+++ b/src/Exthost/dune
@@ -1,5 +1,6 @@
 (library
     (name Exthost)
+    (inline_tests)
     (libraries timber base Oni2.core Oni2.core.kernel Oni2.exthost.extension Oni2.exthost.protocol Oni2.exthost.transport luv yojson decoders-yojson)
-    (preprocess (pps ppx_let ppx_deriving.show ppx_deriving_yojson))
+    (preprocess (pps ppx_let ppx_deriving.show ppx_deriving_yojson ppx_inline_test))
     (public_name Oni2.exthost))


### PR DESCRIPTION
__Issue:__ As described in #1839 and #1840 - when opening a second javascript file, the editor would crash on parsing a `$changeMany` message from the extension host.

__Defect:__ This was likely introduced by https://github.com/onivim/oni2/pull/1835, in which we send 'close' messages more aggressively for buffers not in view. In the case where a buffer (textDocument) was closed, we'd get a `$changeMany` request from the extension host with `null` as the diagnostics. We expect an array, and we currently use a parse strategy that throws (even though we shouldn't throw - we should return the `result` corresponding to the parse).

__Fix:__ Switch from using `Yojson.Safe.Util.to_list` - which throws - to a decoder-based strategy, which returns a `result`.

__Next steps:__
- Upgrade the typescript extension - it is using some legacy APIs that are also causing problems, aside from the bug itself.
- Double-check the new buffer close behavior - we might want to be less aggressive, in order to keep diagnostics around for buffers that aren't visible.
