### PR TITLE
chore(windows): Investigate syntax health failure

### DIFF
--- a/src/Core/Utility/File.re
+++ b/src/Core/Utility/File.re
@@ -1,0 +1,23 @@
+
+let exists = (filePath) => {
+	Unix.stat(filePath).st_kind == S_REG;
+};
+
+
+let readAllLines = (filePath) => {
+
+		let lines = ref([]);
+	
+	  let channel = open_in(filePath);
+	  try({
+      while (true) {
+        let line = input_line(channel);
+        lines := [line, ...lines^];
+      };
+	  lines^ |> List.rev
+	  }) {
+	  | End_of_file => close_in(channel);
+	  lines^ |> List.rev;
+	  }
+	
+};

--- a/src/Core/Utility/File.re
+++ b/src/Core/Utility/File.re
@@ -1,6 +1,7 @@
-let exists = filePath => {
-  Unix.stat(filePath).st_kind == S_REG;
-};
+let exists = filePath =>
+  try(Unix.stat(filePath).st_kind == S_REG) {
+  | Unix.Unix_error(_) => false
+  };
 
 let readAllLines = filePath => {
   let lines = ref([]);

--- a/src/Core/Utility/File.re
+++ b/src/Core/Utility/File.re
@@ -1,23 +1,22 @@
-
-let exists = (filePath) => {
-	Unix.stat(filePath).st_kind == S_REG;
+let exists = filePath => {
+  Unix.stat(filePath).st_kind == S_REG;
 };
 
+let readAllLines = filePath => {
+  let lines = ref([]);
 
-let readAllLines = (filePath) => {
-
-		let lines = ref([]);
-	
-	  let channel = open_in(filePath);
-	  try({
+  let channel = open_in(filePath);
+  try(
+    {
       while (true) {
         let line = input_line(channel);
         lines := [line, ...lines^];
       };
-	  lines^ |> List.rev
-	  }) {
-	  | End_of_file => close_in(channel);
-	  lines^ |> List.rev;
-	  }
-	
+      lines^ |> List.rev;
+    }
+  ) {
+  | End_of_file =>
+    close_in(channel);
+    lines^ |> List.rev;
+  };
 };

--- a/src/Core/Utility/Utility.re
+++ b/src/Core/Utility/Utility.re
@@ -1,6 +1,7 @@
 module ArrayEx = ArrayEx;
 module ChunkyQueue = ChunkyQueue;
 module Cache = Cache;
+module File = File;
 module FunEx = FunEx;
 module IndexEx = IndexEx;
 module IntEx = IntEx;

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -53,11 +53,12 @@ let getEnvironment = (~namedPipe, ~parentPid, ~additionalEnv) => {
          (EnvironmentVariables.parentPid, parentPid),
          ...items,
        ]
-       @ additionalEnv,
+       @ additionalEnv
      );
 };
 
-let startProcess = (~executablePath, ~namedPipe, ~parentPid, ~onClose, ~additionalEnv) => {
+let startProcess =
+    (~executablePath, ~namedPipe, ~parentPid, ~onClose, ~additionalEnv) => {
   getEnvironment(~namedPipe, ~parentPid, ~additionalEnv)
   |> Utility.ResultEx.flatMap(environment => {
        ClientLog.debugf(m =>
@@ -161,7 +162,13 @@ let start =
   Transport.start(~namedPipe, ~dispatch)
   |> Utility.ResultEx.tap(transport => _transport := Some(transport))
   |> Utility.ResultEx.flatMap(transport => {
-       startProcess(~executablePath, ~parentPid, ~namedPipe, ~onClose, ~additionalEnv)
+       startProcess(
+         ~executablePath,
+         ~parentPid,
+         ~namedPipe,
+         ~onClose,
+         ~additionalEnv,
+       )
        |> Result.map(process => {transport, process, nextId: ref(0)})
      });
 };

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -42,7 +42,7 @@ let write = ({transport, nextId, _}: t, msg: Protocol.ClientToServer.t) => {
   writeTransport(~id, transport, msg);
 };
 
-let getEnvironment = (~namedPipe, ~parentPid) => {
+let getEnvironment = (~namedPipe, ~parentPid, ~additionalEnv) => {
   let filterOutLogFile = List.filter(env => fst(env) != "ONI2_LOG_FILE");
 
   Luv.Env.environ()
@@ -53,11 +53,12 @@ let getEnvironment = (~namedPipe, ~parentPid) => {
          (EnvironmentVariables.parentPid, parentPid),
          ...items,
        ]
+       @ additionalEnv,
      );
 };
 
-let startProcess = (~executablePath, ~namedPipe, ~parentPid, ~onClose) => {
-  getEnvironment(~namedPipe, ~parentPid)
+let startProcess = (~executablePath, ~namedPipe, ~parentPid, ~onClose, ~additionalEnv) => {
+  getEnvironment(~namedPipe, ~parentPid, ~additionalEnv)
   |> Utility.ResultEx.flatMap(environment => {
        ClientLog.debugf(m =>
          m(
@@ -104,6 +105,7 @@ let start =
       ~onClose=_ => (),
       ~onHighlights,
       ~onHealthCheckResult,
+      ~additionalEnv=[],
       languageInfo,
       setup,
     ) => {
@@ -159,7 +161,7 @@ let start =
   Transport.start(~namedPipe, ~dispatch)
   |> Utility.ResultEx.tap(transport => _transport := Some(transport))
   |> Utility.ResultEx.flatMap(transport => {
-       startProcess(~executablePath, ~parentPid, ~namedPipe, ~onClose)
+       startProcess(~executablePath, ~parentPid, ~namedPipe, ~onClose, ~additionalEnv)
        |> Result.map(process => {transport, process, nextId: ref(0)})
      });
 };

--- a/src/Syntax_Client/Oni_Syntax_Client.rei
+++ b/src/Syntax_Client/Oni_Syntax_Client.rei
@@ -22,6 +22,7 @@ let start:
     ~onHighlights: (~bufferId: int, ~tokens: list(Protocol.TokenUpdate.t)) =>
                    unit,
     ~onHealthCheckResult: bool => unit,
+    ~additionalEnv: list((string, string))=?,
     Oni_Extensions.LanguageInfo.t,
     Setup.t
   ) =>

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -181,7 +181,7 @@ let mainChecks = [
           ~onHealthCheckResult=res => {healthCheckResult := res},
           ~additionalEnv=[
             // Get stack trace on crash
-            ("OCAMLRUNPARAM", "b")
+            ("OCAMLRUNPARAM", "b"),
           ],
           Oni_Extensions.LanguageInfo.initial,
           setup,

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -250,6 +250,24 @@ let run = (~checks, _cli) => {
 
   Log.info("");
 
+  let printCrashLog = () => {
+  Log.info("Checking for crash log...");
+    
+    if (File.exists("onivim2-crash.log")) {
+      Log.error("Crash log found:");
+      Log.error ("---")
+      let lines = File.readAllLines("onivim2-crash.log");
+      lines
+      |> List.iter(Log.error);
+      Log.error ("---")
+    } else {
+      Log.info ("No crash log found!")
+    }
+  
+  };
+
+  printCrashLog();
+
   Log.info("All systems go.");
   Log.info("Checking for remaining threads...");
   ThreadHelper.showRunningThreads() |> Log.info;

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -179,6 +179,10 @@ let mainChecks = [
           ~onClose=_ => {closed := true},
           ~onHighlights=(~bufferId as _, ~tokens as _) => (),
           ~onHealthCheckResult=res => {healthCheckResult := res},
+          ~additionalEnv=[
+            // Get stack trace on crash
+            ("OCAMLRUNPARAM", "b")
+          ],
           Oni_Extensions.LanguageInfo.initial,
           setup,
         )

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -251,19 +251,17 @@ let run = (~checks, _cli) => {
   Log.info("");
 
   let printCrashLog = () => {
-  Log.info("Checking for crash log...");
-    
+    Log.info("Checking for crash log...");
+
     if (File.exists("onivim2-crash.log")) {
       Log.error("Crash log found:");
-      Log.error ("---")
+      Log.error("---");
       let lines = File.readAllLines("onivim2-crash.log");
-      lines
-      |> List.iter(Log.error);
-      Log.error ("---")
+      lines |> List.iter(Log.error);
+      Log.error("---");
     } else {
-      Log.info ("No crash log found!")
-    }
-  
+      Log.info("No crash log found!");
+    };
   };
 
   printCrashLog();


### PR DESCRIPTION
The healthcheck for windows, for the syntax server, has been failing - an exit code of 2 intermittently comes from the syntax service, but just for the windows builds.

An exit code of 2 is usually indicative of an ocaml exception, so we should be dropping a crash log in that case - this updates the health check to look for a crash log and output the results to give us a clue on where it is crashing.