### PR TITLE
perf(exthost): Switch info -> info in onBeforeMsg

### DIFF
--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -323,7 +323,9 @@ let start =
   let _unsubscribe: unit => unit = Store.onModelChanged(onStateChanged);
 
   let _unsubscribe: unit => unit =
-    Store.onBeforeMsg(msg => DispatchLog.infof(m => m("dispatch: %s", Model.Actions.show(msg))));
+    Store.onBeforeMsg(msg =>
+      DispatchLog.infof(m => m("dispatch: %s", Model.Actions.show(msg)))
+    );
 
   let dispatch = Store.dispatch;
 

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -323,7 +323,7 @@ let start =
   let _unsubscribe: unit => unit = Store.onModelChanged(onStateChanged);
 
   let _unsubscribe: unit => unit =
-    Store.onBeforeMsg(msg => {DispatchLog.info(Model.Actions.show(msg))});
+    Store.onBeforeMsg(msg => DispatchLog.infof(m => m("dispatch: %s", Model.Actions.show(msg))));
 
   let dispatch = Store.dispatch;
 


### PR DESCRIPTION
We were running the `Msg.show` for every action dispatched to the store, and `Msg.show` does some heavy allocations to produce the `string` associated with the `Msg.t`. This switches to use `Log.infof`, which will only call the callback function if logging is enabled.