### PR TITLE
feat(exthost): Hook up provide*Formatting APIs

### DIFF
--- a/src/Exthost/Edit.re
+++ b/src/Exthost/Edit.re
@@ -1,15 +1,21 @@
 open Oni_Core;
 
 module SingleEditOperation = {
-	type t = {
-		range: OneBasedRange.t,
-		text: option(string),
-		forceMoveMarkers: bool,
-	}
+  type t = {
+    range: OneBasedRange.t,
+    text: option(string),
+    forceMoveMarkers: bool,
+  };
 
-	let decode = Json.Decode.(obj(({field, _}) => {
-		range: field.required("range",OneBasedRange.decode),
-		text: field.optional("text", string),
-		forceMoveMarkers: field.withDefault("forceMoveMarkers", false, bool),
-	}));
+  let decode =
+    Json.Decode.(
+      obj(({field, _}) =>
+        {
+          range: field.required("range", OneBasedRange.decode),
+          text: field.optional("text", string),
+          forceMoveMarkers:
+            field.withDefault("forceMoveMarkers", false, bool),
+        }
+      )
+    );
 };

--- a/src/Exthost/Edit.re
+++ b/src/Exthost/Edit.re
@@ -1,0 +1,15 @@
+open Oni_Core;
+
+module SingleEditOperation = {
+	type t = {
+		range: OneBasedRange.t,
+		text: option(string),
+		forceMoveMarkers: bool,
+	}
+
+	let decode = Json.Decode.(obj(({field, _}) => {
+		range: field.required("range",OneBasedRange.decode),
+		text: field.optional("text", string),
+		forceMoveMarkers: field.withDefault("forceMoveMarkers", false, bool),
+	}));
+};

--- a/src/Exthost/ExtensionId.re
+++ b/src/Exthost/ExtensionId.re
@@ -1,5 +1,6 @@
 open Oni_Core;
 
+[@deriving show]
 type t = string;
 
 let decode =

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -14,6 +14,7 @@ module DocumentFilter = DocumentFilter;
 module DocumentHighlight = DocumentHighlight;
 module DocumentSelector = DocumentSelector;
 module DocumentSymbol = DocumentSymbol;
+module Edit = Edit;
 module Eol = Eol;
 module Hover = Hover;
 module Label = Label;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -16,6 +16,7 @@ module DocumentSelector = DocumentSelector;
 module DocumentSymbol = DocumentSymbol;
 module Edit = Edit;
 module Eol = Eol;
+module ExtensionId = ExtensionId;
 module Hover = Hover;
 module Label = Label;
 module Location = Location;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -17,6 +17,7 @@ module DocumentSymbol = DocumentSymbol;
 module Edit = Edit;
 module Eol = Eol;
 module ExtensionId = ExtensionId;
+module FormattingOptions = FormattingOptions;
 module Hover = Hover;
 module Label = Label;
 module Location = Location;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -100,6 +100,13 @@ module Edit: {
   }
 };
 
+module ExtensionId: {
+  [@deriving show]
+  type t = string;
+
+  let decode: Json.decoder(t);
+};
+
 module DefinitionLink: {
   type t = {
     uri: Uri.t,
@@ -736,6 +743,24 @@ module Msg: {
           handle: int,
           selector: DocumentSelector.t,
         })
+      | RegisterDocumentFormattingSupport({
+          handle: int,
+          selector: DocumentSelector.t,
+          extensionId: ExtensionId.t,
+          displayName: string,
+      })
+      | RegisterRangeFormattingSupport({
+          handle: int,
+          selector: DocumentSelector.t,
+          extensionId: ExtensionId.t,
+          displayName: string,
+      })
+      | RegisterOnTypeFormattingSupport({
+          handle: int,
+          selector: DocumentSelector.t,
+          autoFormatTriggerCharacters: list(string),
+          extensionId: ExtensionId.t,
+      })
       | Unregister({handle: int});
   };
 

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -434,6 +434,15 @@ module Eol: {
   let encode: Json.encoder(t);
 };
 
+module FormattingOptions: {
+  type t = {
+    tabSize: int,
+    insertSpaces: bool,
+  };
+
+  let encode: Json.encoder(t);
+};
+
 module ModelAddedDelta: {
   type t = {
     uri: Uri.t,
@@ -1097,6 +1106,33 @@ module Request: {
         Client.t
       ) =>
       Lwt.t(option(SignatureHelp.Response.t));
+
+    let provideDocumentFormattingEdits: (
+      ~handle: int,
+      ~resource: Uri.t,
+      ~options: FormattingOptions.t,
+      Client.t
+    ) =>
+    Lwt.t(option(list(Edit.SingleEditOperation.t)));
+
+    let provideDocumentRangeFormattingEdits: (
+      ~handle: int,
+      ~resource: Uri.t,
+      ~range: OneBasedRange.t,
+      ~options: FormattingOptions.t,
+      Client.t
+    ) =>
+    Lwt.t(option(list(Edit.SingleEditOperation.t)));
+
+    let provideOnTypeFormattingEdits: (
+      ~handle: int,
+      ~resource: Uri.t,
+      ~position: OneBasedPosition.t,
+      ~character: string,
+      ~options: FormattingOptions.t,
+      Client.t
+    ) =>
+    Lwt.t(option(list(Edit.SingleEditOperation.t)));
 
     let releaseSignatureHelp: (~handle: int, ~id: int, Client.t) => unit;
   };

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -97,7 +97,7 @@ module Edit: {
     };
 
     let decode: Json.decoder(t);
-  }
+  };
 };
 
 module ExtensionId: {
@@ -757,19 +757,19 @@ module Msg: {
           selector: DocumentSelector.t,
           extensionId: ExtensionId.t,
           displayName: string,
-      })
+        })
       | RegisterRangeFormattingSupport({
           handle: int,
           selector: DocumentSelector.t,
           extensionId: ExtensionId.t,
           displayName: string,
-      })
+        })
       | RegisterOnTypeFormattingSupport({
           handle: int,
           selector: DocumentSelector.t,
           autoFormatTriggerCharacters: list(string),
           extensionId: ExtensionId.t,
-      })
+        })
       | Unregister({handle: int});
   };
 
@@ -1107,32 +1107,35 @@ module Request: {
       ) =>
       Lwt.t(option(SignatureHelp.Response.t));
 
-    let provideDocumentFormattingEdits: (
-      ~handle: int,
-      ~resource: Uri.t,
-      ~options: FormattingOptions.t,
-      Client.t
-    ) =>
-    Lwt.t(option(list(Edit.SingleEditOperation.t)));
+    let provideDocumentFormattingEdits:
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~options: FormattingOptions.t,
+        Client.t
+      ) =>
+      Lwt.t(option(list(Edit.SingleEditOperation.t)));
 
-    let provideDocumentRangeFormattingEdits: (
-      ~handle: int,
-      ~resource: Uri.t,
-      ~range: OneBasedRange.t,
-      ~options: FormattingOptions.t,
-      Client.t
-    ) =>
-    Lwt.t(option(list(Edit.SingleEditOperation.t)));
+    let provideDocumentRangeFormattingEdits:
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~range: OneBasedRange.t,
+        ~options: FormattingOptions.t,
+        Client.t
+      ) =>
+      Lwt.t(option(list(Edit.SingleEditOperation.t)));
 
-    let provideOnTypeFormattingEdits: (
-      ~handle: int,
-      ~resource: Uri.t,
-      ~position: OneBasedPosition.t,
-      ~character: string,
-      ~options: FormattingOptions.t,
-      Client.t
-    ) =>
-    Lwt.t(option(list(Edit.SingleEditOperation.t)));
+    let provideOnTypeFormattingEdits:
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~position: OneBasedPosition.t,
+        ~character: string,
+        ~options: FormattingOptions.t,
+        Client.t
+      ) =>
+      Lwt.t(option(list(Edit.SingleEditOperation.t)));
 
     let releaseSignatureHelp: (~handle: int, ~id: int, Client.t) => unit;
   };

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -88,6 +88,18 @@ module MarkdownString: {
   let decode: Json.decoder(t);
 };
 
+module Edit: {
+  module SingleEditOperation: {
+    type t = {
+      range: OneBasedRange.t,
+      text: option(string),
+      forceMoveMarkers: bool,
+    };
+
+    let decode: Json.decoder(t);
+  }
+};
+
 module DefinitionLink: {
   type t = {
     uri: Uri.t,

--- a/src/Exthost/FormattingOptions.re
+++ b/src/Exthost/FormattingOptions.re
@@ -1,0 +1,11 @@
+open Oni_Core;
+
+type t = {
+	tabSize: int,
+	insertSpaces: bool,
+};
+
+let encode = opts => Json.Encode.(obj([
+	("tabSize", opts.tabSize |> int),
+	("insertSpaces", opts.insertSpaces |> bool)
+]));

--- a/src/Exthost/FormattingOptions.re
+++ b/src/Exthost/FormattingOptions.re
@@ -1,11 +1,14 @@
 open Oni_Core;
 
 type t = {
-	tabSize: int,
-	insertSpaces: bool,
+  tabSize: int,
+  insertSpaces: bool,
 };
 
-let encode = opts => Json.Encode.(obj([
-	("tabSize", opts.tabSize |> int),
-	("insertSpaces", opts.insertSpaces |> bool)
-]));
+let encode = opts =>
+  Json.Encode.(
+    obj([
+      ("tabSize", opts.tabSize |> int),
+      ("insertSpaces", opts.insertSpaces |> bool),
+    ])
+  );

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -462,7 +462,81 @@ module LanguageFeatures = {
       };
 
       ret |> Result.map_error(string_of_error);
+    | (
+        "$registerDocumentFormattingSupport",
+        `List([`Int(handle), selectorJson, extensionIdJson, displayNameJson]),
+      ) => 
+      open Json.Decode;
 
+      let ret = {
+        open Base.Result.Let_syntax;
+        let%bind selector =
+          selectorJson |> decode_value(list(DocumentFilter.decode));
+
+        let%bind extensionId =
+          extensionIdJson |> decode_value(ExtensionId.decode);
+
+        let%bind displayName =
+          displayNameJson |> decode_value(string);
+
+        Ok(RegisterDocumentFormattingSupport({
+          handle,
+          selector,
+          extensionId,
+          displayName,
+        }));
+      };
+      ret |> Result.map_error(string_of_error);
+    | (
+        "$registerRangeFormattingSupport",
+        `List([`Int(handle), selectorJson, extensionIdJson, displayNameJson]),
+      ) => 
+      open Json.Decode;
+
+      let ret = {
+        open Base.Result.Let_syntax;
+        let%bind selector =
+          selectorJson |> decode_value(list(DocumentFilter.decode));
+
+        let%bind extensionId =
+          extensionIdJson |> decode_value(ExtensionId.decode);
+
+        let%bind displayName =
+          displayNameJson |> decode_value(string);
+
+        Ok(RegisterRangeFormattingSupport({
+          handle,
+          selector,
+          extensionId,
+          displayName,
+        }));
+      };
+      ret |> Result.map_error(string_of_error);
+    | (
+        "$registerOnTypeFormattingSupport",
+        `List([`Int(handle), selectorJson,  triggerCharacterJson, extensionIdJson]),
+      ) => 
+      open Json.Decode;
+
+      let ret = {
+        open Base.Result.Let_syntax;
+        let%bind selector =
+          selectorJson |> decode_value(list(DocumentFilter.decode));
+
+        let%bind triggerCharacters = triggerCharacterJson
+        |> decode_value(list(string));
+        let%bind extensionId =
+          extensionIdJson |> decode_value(ExtensionId.decode);
+
+
+        Ok(RegisterOnTypeFormattingSupport({
+          handle,
+          selector,
+          autoFormatTriggerCharacters: triggerCharacters,
+          extensionId,
+        }));
+      };
+      ret |> Result.map_error(string_of_error);
     | _ =>
       Error(
         Printf.sprintf(

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -311,6 +311,24 @@ module LanguageFeatures = {
         handle: int,
         selector: list(DocumentFilter.t),
       })
+    | RegisterDocumentFormattingSupport({
+        handle: int,
+        selector: DocumentSelector.t,
+        extensionId: ExtensionId.t,
+        displayName: string,
+    })
+    | RegisterRangeFormattingSupport({
+        handle: int,
+        selector: DocumentSelector.t,
+        extensionId: ExtensionId.t,
+        displayName: string,
+    })
+    | RegisterOnTypeFormattingSupport({
+        handle: int,
+        selector: DocumentSelector.t,
+        autoFormatTriggerCharacters: list(string),
+        extensionId: ExtensionId.t,
+    })
     | Unregister({handle: int});
 
   let parseDocumentSelector = json => {

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -316,19 +316,19 @@ module LanguageFeatures = {
         selector: DocumentSelector.t,
         extensionId: ExtensionId.t,
         displayName: string,
-    })
+      })
     | RegisterRangeFormattingSupport({
         handle: int,
         selector: DocumentSelector.t,
         extensionId: ExtensionId.t,
         displayName: string,
-    })
+      })
     | RegisterOnTypeFormattingSupport({
         handle: int,
         selector: DocumentSelector.t,
         autoFormatTriggerCharacters: list(string),
         extensionId: ExtensionId.t,
-    })
+      })
     | Unregister({handle: int});
 
   let parseDocumentSelector = json => {
@@ -464,8 +464,13 @@ module LanguageFeatures = {
       ret |> Result.map_error(string_of_error);
     | (
         "$registerDocumentFormattingSupport",
-        `List([`Int(handle), selectorJson, extensionIdJson, displayNameJson]),
-      ) => 
+        `List([
+          `Int(handle),
+          selectorJson,
+          extensionIdJson,
+          displayNameJson,
+        ]),
+      ) =>
       open Json.Decode;
 
       let ret = {
@@ -476,21 +481,27 @@ module LanguageFeatures = {
         let%bind extensionId =
           extensionIdJson |> decode_value(ExtensionId.decode);
 
-        let%bind displayName =
-          displayNameJson |> decode_value(string);
+        let%bind displayName = displayNameJson |> decode_value(string);
 
-        Ok(RegisterDocumentFormattingSupport({
-          handle,
-          selector,
-          extensionId,
-          displayName,
-        }));
+        Ok(
+          RegisterDocumentFormattingSupport({
+            handle,
+            selector,
+            extensionId,
+            displayName,
+          }),
+        );
       };
       ret |> Result.map_error(string_of_error);
     | (
         "$registerRangeFormattingSupport",
-        `List([`Int(handle), selectorJson, extensionIdJson, displayNameJson]),
-      ) => 
+        `List([
+          `Int(handle),
+          selectorJson,
+          extensionIdJson,
+          displayNameJson,
+        ]),
+      ) =>
       open Json.Decode;
 
       let ret = {
@@ -501,21 +512,27 @@ module LanguageFeatures = {
         let%bind extensionId =
           extensionIdJson |> decode_value(ExtensionId.decode);
 
-        let%bind displayName =
-          displayNameJson |> decode_value(string);
+        let%bind displayName = displayNameJson |> decode_value(string);
 
-        Ok(RegisterRangeFormattingSupport({
-          handle,
-          selector,
-          extensionId,
-          displayName,
-        }));
+        Ok(
+          RegisterRangeFormattingSupport({
+            handle,
+            selector,
+            extensionId,
+            displayName,
+          }),
+        );
       };
       ret |> Result.map_error(string_of_error);
     | (
         "$registerOnTypeFormattingSupport",
-        `List([`Int(handle), selectorJson,  triggerCharacterJson, extensionIdJson]),
-      ) => 
+        `List([
+          `Int(handle),
+          selectorJson,
+          triggerCharacterJson,
+          extensionIdJson,
+        ]),
+      ) =>
       open Json.Decode;
 
       let ret = {
@@ -523,18 +540,19 @@ module LanguageFeatures = {
         let%bind selector =
           selectorJson |> decode_value(list(DocumentFilter.decode));
 
-        let%bind triggerCharacters = triggerCharacterJson
-        |> decode_value(list(string));
+        let%bind triggerCharacters =
+          triggerCharacterJson |> decode_value(list(string));
         let%bind extensionId =
           extensionIdJson |> decode_value(ExtensionId.decode);
 
-
-        Ok(RegisterOnTypeFormattingSupport({
-          handle,
-          selector,
-          autoFormatTriggerCharacters: triggerCharacters,
-          extensionId,
-        }));
+        Ok(
+          RegisterOnTypeFormattingSupport({
+            handle,
+            selector,
+            autoFormatTriggerCharacters: triggerCharacters,
+            extensionId,
+          }),
+        );
       };
       ret |> Result.map_error(string_of_error);
     | _ =>

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -366,9 +366,8 @@ module LanguageFeatures = {
         ),
       client,
     );
-  
-  let provideDocumentFormattingEdits =
-  (~handle, ~resource, ~options, client) => {
+
+  let provideDocumentFormattingEdits = (~handle, ~resource, ~options, client) => {
     Client.request(
       ~decoder=Json.Decode.(nullable(list(Edit.SingleEditOperation.decode))),
       ~usesCancellationToken=true,
@@ -378,15 +377,14 @@ module LanguageFeatures = {
         `List([
           `Int(handle),
           Uri.to_yojson(resource),
-          options
-          |> Json.Encode.encode_value(FormattingOptions.encode)
+          options |> Json.Encode.encode_value(FormattingOptions.encode),
         ]),
       client,
     );
   };
-  
+
   let provideDocumentRangeFormattingEdits =
-  (~handle, ~resource, ~range, ~options, client) => {
+      (~handle, ~resource, ~range, ~options, client) => {
     Client.request(
       ~decoder=Json.Decode.(nullable(list(Edit.SingleEditOperation.decode))),
       ~usesCancellationToken=true,
@@ -397,15 +395,14 @@ module LanguageFeatures = {
           `Int(handle),
           Uri.to_yojson(resource),
           OneBasedRange.to_yojson(range),
-          options
-          |> Json.Encode.encode_value(FormattingOptions.encode)
+          options |> Json.Encode.encode_value(FormattingOptions.encode),
         ]),
       client,
     );
   };
 
   let provideOnTypeFormattingEdits =
-  (~handle, ~resource, ~position, ~character, ~options, client) => {
+      (~handle, ~resource, ~position, ~character, ~options, client) => {
     Client.request(
       ~decoder=Json.Decode.(nullable(list(Edit.SingleEditOperation.decode))),
       ~usesCancellationToken=true,
@@ -417,8 +414,7 @@ module LanguageFeatures = {
           Uri.to_yojson(resource),
           OneBasedPosition.to_yojson(position),
           `String(character),
-          options
-          |> Json.Encode.encode_value(FormattingOptions.encode)
+          options |> Json.Encode.encode_value(FormattingOptions.encode),
         ]),
       client,
     );

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -366,6 +366,63 @@ module LanguageFeatures = {
         ),
       client,
     );
+  
+  let provideDocumentFormattingEdits =
+  (~handle, ~resource, ~options, client) => {
+    Client.request(
+      ~decoder=Json.Decode.(nullable(list(Edit.SingleEditOperation.decode))),
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$provideDocumentFormattingEdits",
+      ~args=
+        `List([
+          `Int(handle),
+          Uri.to_yojson(resource),
+          options
+          |> Json.Encode.encode_value(FormattingOptions.encode)
+        ]),
+      client,
+    );
+  };
+  
+  let provideDocumentRangeFormattingEdits =
+  (~handle, ~resource, ~range, ~options, client) => {
+    Client.request(
+      ~decoder=Json.Decode.(nullable(list(Edit.SingleEditOperation.decode))),
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$provideDocumentRangeFormattingEdits",
+      ~args=
+        `List([
+          `Int(handle),
+          Uri.to_yojson(resource),
+          OneBasedRange.to_yojson(range),
+          options
+          |> Json.Encode.encode_value(FormattingOptions.encode)
+        ]),
+      client,
+    );
+  };
+
+  let provideOnTypeFormattingEdits =
+  (~handle, ~resource, ~position, ~character, ~options, client) => {
+    Client.request(
+      ~decoder=Json.Decode.(nullable(list(Edit.SingleEditOperation.decode))),
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$provideOnTypeFormattingEdits",
+      ~args=
+        `List([
+          `Int(handle),
+          Uri.to_yojson(resource),
+          OneBasedPosition.to_yojson(position),
+          `String(character),
+          options
+          |> Json.Encode.encode_value(FormattingOptions.encode)
+        ]),
+      client,
+    );
+  };
 };
 
 module SCM = {

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -481,27 +481,32 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
     })
   });
   describe("formatting", ({test, _}) => {
+    let formattingOptions =
+      FormattingOptions.{tabSize: 2, insertSpaces: true};
+
+    let expectedRange =
+      OneBasedRange.{
+        startLineNumber: 2,
+        endLineNumber: 4,
+        startColumn: 3,
+        endColumn: 5,
+      };
+
     test("document formatting", ({expect, _}) => {
       let documentFormattingHandle = ref(-1);
 
-//      let getSignatureHelp = client =>
-//        Request.LanguageFeatures.provideSignatureHelp(
-//          ~handle=signatureHelpHandle^,
-//          ~position=OneBasedPosition.{lineNumber: 2, column: 2},
-//          ~resource=testUri,
-//          ~context=
-//            SignatureHelp.RequestContext.{
-//              triggerKind: SignatureHelp.TriggerKind.Invoke,
-//              triggerCharacter: None,
-//              isRetrigger: false,
-//            },
-//          client,
-//        );
+      let getDocumentFormatEdits = client =>
+        Request.LanguageFeatures.provideDocumentFormattingEdits(
+          ~handle=documentFormattingHandle^,
+          ~resource=testUri,
+          ~options=formattingOptions,
+          client,
+        );
 
       let waitForRegisterDocumentFormattingSupport =
         fun
         | Msg.LanguageFeatures(
-            RegisterDocumentFormattingSupport({handle,  _}),
+            RegisterDocumentFormattingSupport({handle, _}),
           ) => {
             documentFormattingHandle := handle;
             true;
@@ -518,57 +523,42 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
              ~delta=addedDelta,
            ),
          )
-//      |> Test.withClientRequest(
-//           ~name="Get signature help",
-//           ~validate=
-//             (signatureHelp: option(Exthost.SignatureHelp.Response.t)) => {
-//               open Exthost.SignatureHelp;
-//
-//               expect.equal(
-//                 signatureHelp,
-//                 Some({
-//                   id: 1,
-//                   signatures: [
-//                     Signature.{
-//                       label: "signature 1",
-//                       parameters: [
-//                         ParameterInformation.{label: "parameter 1"},
-//                       ],
-//                     },
-//                   ],
-//                   activeSignature: 0,
-//                   activeParameter: 0,
-//                 }),
-//               );
-//
-//               true;
-//             },
-//           getSignatureHelp,
-//         )
+      |> Test.withClientRequest(
+           ~name="get document formatting",
+           ~validate=
+             (edits: option(list(Edit.SingleEditOperation.t))) => {
+               expect.equal(
+                 edits,
+                 Some([
+                   Edit.SingleEditOperation.{
+                     range: expectedRange,
+                     text: Some("document"),
+                     forceMoveMarkers: false,
+                   },
+                 ]),
+               );
+
+               true;
+             },
+           getDocumentFormatEdits,
+         )
       |> finishTest;
-    })
+    });
     test("range formatting", ({expect, _}) => {
       let documentRangeFormattingHandle = ref(-1);
 
-//      let getSignatureHelp = client =>
-//        Request.LanguageFeatures.provideSignatureHelp(
-//          ~handle=signatureHelpHandle^,
-//          ~position=OneBasedPosition.{lineNumber: 2, column: 2},
-//          ~resource=testUri,
-//          ~context=
-//            SignatureHelp.RequestContext.{
-//              triggerKind: SignatureHelp.TriggerKind.Invoke,
-//              triggerCharacter: None,
-//              isRetrigger: false,
-//            },
-//          client,
-//        );
+      let getDocumentRangeFormattingEdits = client =>
+        Request.LanguageFeatures.provideDocumentRangeFormattingEdits(
+          ~handle=documentRangeFormattingHandle^,
+          ~range=expectedRange,
+          ~resource=testUri,
+          ~options=formattingOptions,
+          client,
+        );
 
       let waitForRegisterRangeFormattingSupport =
         fun
-        | Msg.LanguageFeatures(
-            RegisterRangeFormattingSupport({handle,  _}),
-          ) => {
+        | Msg.LanguageFeatures(RegisterRangeFormattingSupport({handle, _})) => {
             documentRangeFormattingHandle := handle;
             true;
           }
@@ -584,57 +574,43 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
              ~delta=addedDelta,
            ),
          )
-//      |> Test.withClientRequest(
-//           ~name="Get signature help",
-//           ~validate=
-//             (signatureHelp: option(Exthost.SignatureHelp.Response.t)) => {
-//               open Exthost.SignatureHelp;
-//
-//               expect.equal(
-//                 signatureHelp,
-//                 Some({
-//                   id: 1,
-//                   signatures: [
-//                     Signature.{
-//                       label: "signature 1",
-//                       parameters: [
-//                         ParameterInformation.{label: "parameter 1"},
-//                       ],
-//                     },
-//                   ],
-//                   activeSignature: 0,
-//                   activeParameter: 0,
-//                 }),
-//               );
-//
-//               true;
-//             },
-//           getSignatureHelp,
-//         )
+      |> Test.withClientRequest(
+           ~name="get document range formatting",
+           ~validate=
+             (edits: option(list(Edit.SingleEditOperation.t))) => {
+               expect.equal(
+                 edits,
+                 Some([
+                   Edit.SingleEditOperation.{
+                     range: expectedRange,
+                     text: Some("range"),
+                     forceMoveMarkers: false,
+                   },
+                 ]),
+               );
+
+               true;
+             },
+           getDocumentRangeFormattingEdits,
+         )
       |> finishTest;
     });
     test("on type formatting", ({expect, _}) => {
       let onTypeFormattingHandle = ref(-1);
 
-//      let getSignatureHelp = client =>
-//        Request.LanguageFeatures.provideSignatureHelp(
-//          ~handle=signatureHelpHandle^,
-//          ~position=OneBasedPosition.{lineNumber: 2, column: 2},
-//          ~resource=testUri,
-//          ~context=
-//            SignatureHelp.RequestContext.{
-//              triggerKind: SignatureHelp.TriggerKind.Invoke,
-//              triggerCharacter: None,
-//              isRetrigger: false,
-//            },
-//          client,
-//        );
+      let getOnTypeFormattingEdits = client =>
+        Request.LanguageFeatures.provideOnTypeFormattingEdits(
+          ~handle=onTypeFormattingHandle^,
+          ~resource=testUri,
+          ~position=OneBasedPosition.{lineNumber: 1, column: 1},
+          ~character="{",
+          ~options=formattingOptions,
+          client,
+        );
 
       let waitForRegisterOnTypeFormattingSupport =
         fun
-        | Msg.LanguageFeatures(
-            RegisterOnTypeFormattingSupport({handle,  _}),
-          ) => {
+        | Msg.LanguageFeatures(RegisterOnTypeFormattingSupport({handle, _})) => {
             onTypeFormattingHandle := handle;
             true;
           }
@@ -650,34 +626,26 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
              ~delta=addedDelta,
            ),
          )
-//      |> Test.withClientRequest(
-//           ~name="Get signature help",
-//           ~validate=
-//             (signatureHelp: option(Exthost.SignatureHelp.Response.t)) => {
-//               open Exthost.SignatureHelp;
-//
-//               expect.equal(
-//                 signatureHelp,
-//                 Some({
-//                   id: 1,
-//                   signatures: [
-//                     Signature.{
-//                       label: "signature 1",
-//                       parameters: [
-//                         ParameterInformation.{label: "parameter 1"},
-//                       ],
-//                     },
-//                   ],
-//                   activeSignature: 0,
-//                   activeParameter: 0,
-//                 }),
-//               );
-//
-//               true;
-//             },
-//           getSignatureHelp,
-//         )
+      |> Test.withClientRequest(
+           ~name="get on type formatting",
+           ~validate=
+             (edits: option(list(Edit.SingleEditOperation.t))) => {
+               expect.equal(
+                 edits,
+                 Some([
+                   Edit.SingleEditOperation.{
+                     range: expectedRange,
+                     text: Some("as-you-type"),
+                     forceMoveMarkers: false,
+                   },
+                 ]),
+               );
+
+               true;
+             },
+           getOnTypeFormattingEdits,
+         )
       |> finishTest;
-    })
+    });
   });
 });

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -480,4 +480,72 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
       |> finishTest;
     })
   });
+  describe("formatting", ({test, _}) => {
+    test("document formatting", ({expect, _}) => {
+      let documentFormattingHandle = ref(-1);
+
+//      let getSignatureHelp = client =>
+//        Request.LanguageFeatures.provideSignatureHelp(
+//          ~handle=signatureHelpHandle^,
+//          ~position=OneBasedPosition.{lineNumber: 2, column: 2},
+//          ~resource=testUri,
+//          ~context=
+//            SignatureHelp.RequestContext.{
+//              triggerKind: SignatureHelp.TriggerKind.Invoke,
+//              triggerCharacter: None,
+//              isRetrigger: false,
+//            },
+//          client,
+//        );
+
+      let waitForRegisterDocumentFormattingSupport =
+        fun
+        | Msg.LanguageFeatures(
+            RegisterDocumentFormattingSupport({handle,  _}),
+          ) => {
+            documentFormattingHandle := handle;
+            true;
+          }
+        | _ => false;
+
+      startTest()
+      |> Test.waitForMessage(
+           ~name="RegisterDocumentFormattingSupport",
+           waitForRegisterDocumentFormattingSupport,
+         )
+      |> Test.withClient(
+           Request.DocumentsAndEditors.acceptDocumentsAndEditorsDelta(
+             ~delta=addedDelta,
+           ),
+         )
+//      |> Test.withClientRequest(
+//           ~name="Get signature help",
+//           ~validate=
+//             (signatureHelp: option(Exthost.SignatureHelp.Response.t)) => {
+//               open Exthost.SignatureHelp;
+//
+//               expect.equal(
+//                 signatureHelp,
+//                 Some({
+//                   id: 1,
+//                   signatures: [
+//                     Signature.{
+//                       label: "signature 1",
+//                       parameters: [
+//                         ParameterInformation.{label: "parameter 1"},
+//                       ],
+//                     },
+//                   ],
+//                   activeSignature: 0,
+//                   activeParameter: 0,
+//                 }),
+//               );
+//
+//               true;
+//             },
+//           getSignatureHelp,
+//         )
+      |> finishTest;
+    })
+  });
 });

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -547,5 +547,137 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
 //         )
       |> finishTest;
     })
+    test("range formatting", ({expect, _}) => {
+      let documentRangeFormattingHandle = ref(-1);
+
+//      let getSignatureHelp = client =>
+//        Request.LanguageFeatures.provideSignatureHelp(
+//          ~handle=signatureHelpHandle^,
+//          ~position=OneBasedPosition.{lineNumber: 2, column: 2},
+//          ~resource=testUri,
+//          ~context=
+//            SignatureHelp.RequestContext.{
+//              triggerKind: SignatureHelp.TriggerKind.Invoke,
+//              triggerCharacter: None,
+//              isRetrigger: false,
+//            },
+//          client,
+//        );
+
+      let waitForRegisterRangeFormattingSupport =
+        fun
+        | Msg.LanguageFeatures(
+            RegisterRangeFormattingSupport({handle,  _}),
+          ) => {
+            documentRangeFormattingHandle := handle;
+            true;
+          }
+        | _ => false;
+
+      startTest()
+      |> Test.waitForMessage(
+           ~name="RegisterRangeFormattingSupport",
+           waitForRegisterRangeFormattingSupport,
+         )
+      |> Test.withClient(
+           Request.DocumentsAndEditors.acceptDocumentsAndEditorsDelta(
+             ~delta=addedDelta,
+           ),
+         )
+//      |> Test.withClientRequest(
+//           ~name="Get signature help",
+//           ~validate=
+//             (signatureHelp: option(Exthost.SignatureHelp.Response.t)) => {
+//               open Exthost.SignatureHelp;
+//
+//               expect.equal(
+//                 signatureHelp,
+//                 Some({
+//                   id: 1,
+//                   signatures: [
+//                     Signature.{
+//                       label: "signature 1",
+//                       parameters: [
+//                         ParameterInformation.{label: "parameter 1"},
+//                       ],
+//                     },
+//                   ],
+//                   activeSignature: 0,
+//                   activeParameter: 0,
+//                 }),
+//               );
+//
+//               true;
+//             },
+//           getSignatureHelp,
+//         )
+      |> finishTest;
+    });
+    test("on type formatting", ({expect, _}) => {
+      let onTypeFormattingHandle = ref(-1);
+
+//      let getSignatureHelp = client =>
+//        Request.LanguageFeatures.provideSignatureHelp(
+//          ~handle=signatureHelpHandle^,
+//          ~position=OneBasedPosition.{lineNumber: 2, column: 2},
+//          ~resource=testUri,
+//          ~context=
+//            SignatureHelp.RequestContext.{
+//              triggerKind: SignatureHelp.TriggerKind.Invoke,
+//              triggerCharacter: None,
+//              isRetrigger: false,
+//            },
+//          client,
+//        );
+
+      let waitForRegisterOnTypeFormattingSupport =
+        fun
+        | Msg.LanguageFeatures(
+            RegisterOnTypeFormattingSupport({handle,  _}),
+          ) => {
+            onTypeFormattingHandle := handle;
+            true;
+          }
+        | _ => false;
+
+      startTest()
+      |> Test.waitForMessage(
+           ~name="RegisterOnTypeFormattingSupport",
+           waitForRegisterOnTypeFormattingSupport,
+         )
+      |> Test.withClient(
+           Request.DocumentsAndEditors.acceptDocumentsAndEditorsDelta(
+             ~delta=addedDelta,
+           ),
+         )
+//      |> Test.withClientRequest(
+//           ~name="Get signature help",
+//           ~validate=
+//             (signatureHelp: option(Exthost.SignatureHelp.Response.t)) => {
+//               open Exthost.SignatureHelp;
+//
+//               expect.equal(
+//                 signatureHelp,
+//                 Some({
+//                   id: 1,
+//                   signatures: [
+//                     Signature.{
+//                       label: "signature 1",
+//                       parameters: [
+//                         ParameterInformation.{label: "parameter 1"},
+//                       ],
+//                     },
+//                   ],
+//                   activeSignature: 0,
+//                   activeParameter: 0,
+//                 }),
+//               );
+//
+//               true;
+//             },
+//           getSignatureHelp,
+//         )
+      |> finishTest;
+    })
   });
 });

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -34,7 +34,7 @@ let startWithExtensions =
   };
 
   let wrappedHandler = msg => {
-    prerr_endline ("MSG: " ++ Msg.show(msg));
+    prerr_endline("MSG: " ++ Msg.show(msg));
     messages := [msg, ...messages^];
     handler(msg);
   };

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -30,11 +30,11 @@ let startWithExtensions =
   let messages = ref([]);
 
   let errorHandler = err => {
-    prerr_endline("ERROR: " ++ err);
     onError(err);
   };
 
   let wrappedHandler = msg => {
+    prerr_endline ("MSG: " ++ Msg.show(msg));
     messages := [msg, ...messages^];
     handler(msg);
   };

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -30,11 +30,11 @@ let startWithExtensions =
   let messages = ref([]);
 
   let errorHandler = err => {
+    prerr_endline("ERROR: " ++ err);
     onError(err);
   };
 
   let wrappedHandler = msg => {
-    prerr_endline("MSG: " ++ Msg.show(msg));
     messages := [msg, ...messages^];
     handler(msg);
   };

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -33,21 +33,25 @@ function activate(context) {
 		return new vscode.Location(document.uri, pos);
 	};
 
-	const format = (_document, _options, _token) => {
+	const commonFormat = (str) => {
 		return [
 			new vscode.TextEdit(
 				new vscode.Range(1, 2, 3, 4),
-				"insert-indentation-here"
+				str,
 			)
 		];
 	};
 
 	const asYouTypeFormat = (_document, _position, _ch, _options, _token) => {
-		format(_document, _options, _token);
+		return commonFormat("as-you-type");
 	};
 
 	const rangeFormat = (_document, _range, _options, _token) => {
-		format(_document, _options, _token);
+		return commonFormat("range");
+	};
+
+	const format = (_document, _options, _token) => {
+		return commonFormat("document");
 	};
 
 	const documentFormattingProvider = {

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -33,6 +33,29 @@ function activate(context) {
 		return new vscode.Location(document.uri, pos);
 	};
 
+	const format = (_document, _options, _token) => {
+		return [
+			new vscode.TextEdit(
+				new vscode.Range(1, 2, 3, 4),
+				"insert-indentation-here"
+			)
+		];
+	};
+
+	const asYouTypeFormat = (_document, _position, _ch, _options, _token) => {
+		format(_document, _options, _token);
+	};
+
+	const rangeFormat = (_document, _range, _options, _token) => {
+		format(_document, _options, _token);
+	};
+
+	const documentFormattingProvider = {
+		provideDocumentFormattingEdits: format,
+		provideDocumentRangeFormattingEdits: rangeFormat,
+		provideOnTypeFormattingEdits: asYouTypeFormat,
+	};
+
 	const signatureHelpProvider = {
 		provideSignatureHelp: (_document, _position, _token, _context) => {
 			const signature1 = new vscode.SignatureInformation("signature 1", null);
@@ -89,32 +112,26 @@ function activate(context) {
 				new vscode.SymbolInformation("symbol2", vscode.SymbolKind.TypeParameter, "symbol2-container", new vscode.Location(document.uri, position)),
 			];
 		},
-	}
+	};
 
-	const disposable0 = vscode.languages.registerCompletionItemProvider("plaintext", completionProvider, ["."])
-	const disposable1 = vscode.languages.registerDefinitionProvider("plaintext", definitionProvider);
-	const disposable2 = vscode.languages.registerDeclarationProvider("plaintext", declarationProvider);
-	const disposable3 = vscode.languages.registerTypeDefinitionProvider("plaintext", typeDefinitionProvider);
-	const disposable4 = vscode.languages.registerImplementationProvider("plaintext", implementationProvider);
-	const disposable5 = vscode.languages.registerDocumentHighlightProvider("plaintext", documentHighlightProvider);
-	const disposable6 = vscode.languages.registerReferenceProvider("plaintext", referenceProvider);
-	const disposable7 = vscode.languages.registerDocumentSymbolProvider("plaintext", documentSymbolProvider);
-	const disposable8 = vscode.languages.registerSignatureHelpProvider("plaintext", signatureHelpProvider, {
-		triggerCharacters: ["("],
-		retriggerCharacters: [","]
-	});
-	const disposable9 = vscode.languages.registerHoverProvider("plaintext", hoverProvider);
-
-	context.subscriptions.push(disposable0);
-	context.subscriptions.push(disposable1);
-	context.subscriptions.push(disposable2);
-	context.subscriptions.push(disposable3);
-	context.subscriptions.push(disposable4);
-	context.subscriptions.push(disposable5);
-	context.subscriptions.push(disposable6);
-	context.subscriptions.push(disposable7);
-	context.subscriptions.push(disposable8);
-	context.subscriptions.push(disposable9);
+	[
+		vscode.languages.registerCompletionItemProvider("plaintext", completionProvider, ["."]),
+		vscode.languages.registerDefinitionProvider("plaintext", definitionProvider),
+		vscode.languages.registerDeclarationProvider("plaintext", declarationProvider),
+		vscode.languages.registerTypeDefinitionProvider("plaintext", typeDefinitionProvider),
+		vscode.languages.registerImplementationProvider("plaintext", implementationProvider),
+		vscode.languages.registerDocumentHighlightProvider("plaintext", documentHighlightProvider),
+		vscode.languages.registerReferenceProvider("plaintext", referenceProvider),
+		vscode.languages.registerDocumentSymbolProvider("plaintext", documentSymbolProvider),
+		vscode.languages.registerSignatureHelpProvider("plaintext", signatureHelpProvider, {
+			triggerCharacters: ["("],
+			retriggerCharacters: [","]
+		}),
+		vscode.languages.registerHoverProvider("plaintext", hoverProvider),
+		vscode.languages.registerOnTypeFormattingEditProvider("plaintext", documentFormattingProvider, "{"),
+		vscode.languages.registerDocumentFormattingEditProvider("plaintext", documentFormattingProvider, "{"),
+		vscode.languages.registerDocumentRangeFormattingEditProvider("plaintext", documentFormattingProvider, "{")
+	].forEach(subscription => context.subscriptions.push(subscription));
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
This hooks up the extension host APIs for:
- `provideDocumentFormattingEdits`
- `provideDocumentRangeFormattingEdits`
- `provideOnTypeFormattingEdits`

The next step is to wire this up as a format provider for `libvim` - so that we can leverage it with `=`, `gw`, `gq`, etc.
