### PR TITLE
fix(editor/#250): Unintuitive minimap scrolling behavior

### DIFF
--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -22,7 +22,6 @@ let editorSurfaceMinimalState = hwnd => {
       dispatch={_ => ()}
       editor=simpleEditor
       buffer=thousandLineBuffer
-      onScroll={_ => ()}
       onEditorSizeChanged={(_, _, _) => ()}
       onCursorChange={_ => ()}
       bufferHighlights={thousandLineState.bufferHighlights}
@@ -47,7 +46,6 @@ let editorSurfaceThousandLineState = hwnd => {
       dispatch={_ => ()}
       editor=simpleEditor
       buffer=thousandLineBuffer
-      onScroll={_ => ()}
       onEditorSizeChanged={(_, _, _) => ()}
       onCursorChange={_ => ()}
       bufferHighlights={thousandLineState.bufferHighlights}
@@ -72,7 +70,6 @@ let editorSurfaceThousandLineStateWithIndents = hwnd => {
       dispatch={_ => ()}
       editor=simpleEditor
       buffer=thousandLineBuffer
-      onScroll={_ => ()}
       onEditorSizeChanged={(_, _, _) => ()}
       onCursorChange={_ => ()}
       bufferHighlights={thousandLineState.bufferHighlights}
@@ -101,7 +98,6 @@ let editorSurfaceHundredThousandLineStateNoMinimap = hwnd => {
       dispatch={_ => ()}
       editor=simpleEditor
       buffer=thousandLineBuffer
-      onScroll={_ => ()}
       onEditorSizeChanged={(_, _, _) => ()}
       onCursorChange={_ => ()}
       bufferHighlights={thousandLineState.bufferHighlights}
@@ -130,7 +126,6 @@ let editorSurfaceHundredThousandLineState = hwnd => {
       editor=simpleEditor
       dispatch={_ => ()}
       buffer=thousandLineBuffer
-      onScroll={_ => ()}
       onEditorSizeChanged={(_, _, _) => ()}
       onCursorChange={_ => ()}
       bufferHighlights={thousandLineState.bufferHighlights}

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -190,8 +190,6 @@ let runTest =
 
   Oni_UI.GlobalContext.set({
     closeEditorById: id => dispatch(Model.Actions.ViewCloseEditor(id)),
-    editorScrollDelta: (~editorId, ~deltaY, ()) =>
-      dispatch(Model.Actions.EditorScroll(editorId, deltaY)),
     editorSetScroll: (~editorId, ~scrollY, ()) =>
       dispatch(Model.Actions.EditorSetScroll(editorId, scrollY)),
     dispatch,

--- a/src/Core/Utility/OptionEx.re
+++ b/src/Core/Utility/OptionEx.re
@@ -21,6 +21,14 @@ let map3 = (f, a, b, c) =>
   | _ => None
   };
 
+let tap = f =>
+  fun
+  | Some(v) as some => {
+      f(v);
+      some;
+    }
+  | None => None;
+
 let iter2 = (f, a, b) => {
   switch (a, b) {
   | (Some(a), Some(b)) => f(a, b)

--- a/src/Feature/Editor/Colors.re
+++ b/src/Feature/Editor/Colors.re
@@ -33,7 +33,9 @@ type t = {
   scrollbarSliderHoverBackground: Color.t,
   normalModeBackground: Color.t,
   // Minimap
+  minimapBackground: Color.t,
   minimapSliderBackground: Color.t,
+  minimapSliderHoverBackground: Color.t,
   minimapSelectionHighlight: Color.t,
 };
 
@@ -70,5 +72,7 @@ let precompute = theme => {
   normalModeBackground: Oni.normalModeBackground.from(theme),
   // Minimap
   minimapSliderBackground: MinimapSlider.background.from(theme),
+  minimapSliderHoverBackground: MinimapSlider.hoverBackground.from(theme),
   minimapSelectionHighlight: Colors.Minimap.selectionHighlight.from(theme),
+  minimapBackground: Colors.Minimap.background.from(theme),
 };

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -54,11 +54,11 @@ let minimap =
       ~bufferHighlights,
       ~cursorPosition: Location.t,
       ~colors,
+      ~dispatch,
       ~matchingPairs,
       ~bufferSyntaxHighlights,
       ~selectionRanges,
       ~showMinimapSlider,
-      ~onScroll,
       ~editor,
       ~diffMarkers,
       ~diagnosticsMap,
@@ -77,12 +77,15 @@ let minimap =
       bottom(0),
     ];
   let onMouseWheel = (wheelEvent: NodeEvents.mouseWheelEventParams) =>
-    onScroll(wheelEvent.deltaY *. (-150.));
+    dispatch(
+      Msg.MinimapMouseWheel({deltaWheel: wheelEvent.deltaY *. (-1.)}),
+    );
 
   <View style onMouseWheel>
     <Minimap
       editor
       cursorPosition
+      dispatch
       width=minimapPixelWidth
       height={editor.pixelHeight}
       count={Buffer.getNumberOfLines(buffer)}
@@ -99,7 +102,6 @@ let minimap =
       )}
       selection=selectionRanges
       showSlider=showMinimapSlider
-      onScroll
       colors
       bufferHighlights
       diffMarkers
@@ -125,7 +127,6 @@ let%component make =
                 ~mode: Vim.Mode.t,
                 ~bufferHighlights,
                 ~bufferSyntaxHighlights,
-                ~onScroll,
                 ~diagnostics,
                 ~completions,
                 ~tokenTheme,
@@ -247,10 +248,10 @@ let%component make =
   <View style={Styles.container(~colors)} onDimensionsChanged>
     gutterView
     <SurfaceView
-      onScroll
       buffer
       editor
       colors
+      dispatch
       topVisibleLine
       onCursorChange
       cursorPosition
@@ -278,12 +279,12 @@ let%component make =
            bufferHighlights
            cursorPosition
            colors
+           dispatch
            matchingPairs
            bufferSyntaxHighlights
            selectionRanges
            showMinimapSlider={Config.Minimap.showSlider.get(config)}
            diffMarkers
-           onScroll
            bufferWidthInCharacters={layout.bufferWidthInCharacters}
            minimapWidthInPixels={layout.minimapWidthInPixels}
          />

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -70,7 +70,7 @@ let minimap =
   let style =
     Style.[
       position(`Absolute),
-      overflow(`Hidden),
+      //      overflow(`Hidden),
       top(0),
       right(Constants.scrollBarThickness),
       width(minimapPixelWidth),

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -70,7 +70,6 @@ let minimap =
   let style =
     Style.[
       position(`Absolute),
-      //      overflow(`Hidden),
       top(0),
       right(Constants.scrollBarThickness),
       width(minimapPixelWidth),

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -23,6 +23,8 @@ type outmsg =
 type model = Editor.t;
 
 module Constants = {
+  let editorWheelMultiplier = 50.;
+  let minimapWheelMultiplier = 150.;
   let scrollbarWheelMultiplier = 300.;
 };
 
@@ -32,6 +34,25 @@ let update = (editor, msg) => {
   | Msg.VerticalScrollbarBeforeTrackClicked({newPixelScrollY})
   | Msg.VerticalScrollbarMouseDrag({newPixelScrollY}) => (
       Editor.scrollToPixelY(~pixelY=newPixelScrollY, editor),
+      Nothing,
+    )
+  | Msg.MinimapMouseWheel({deltaWheel}) => (
+      Editor.scrollDeltaPixelY(
+        ~pixelY=deltaWheel *. Constants.minimapWheelMultiplier,
+        editor,
+      ),
+      Nothing,
+    )
+  | Msg.MinimapDragged({newPixelScrollY})
+  | Msg.MinimapClicked({newPixelScrollY}) => (
+      Editor.scrollToPixelY(~pixelY=newPixelScrollY, editor),
+      Nothing,
+    )
+  | Msg.EditorMouseWheel({deltaWheel}) => (
+      Editor.scrollDeltaPixelY(
+        ~pixelY=deltaWheel *. Constants.editorWheelMultiplier,
+        editor,
+      ),
       Nothing,
     )
   | Msg.VerticalScrollbarMouseWheel({deltaWheel}) => (

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -43,8 +43,11 @@ let update = (editor, msg) => {
       ),
       Nothing,
     )
-  | Msg.MinimapDragged({newPixelScrollY})
-  | Msg.MinimapClicked({newPixelScrollY}) => (
+  | Msg.MinimapClicked({viewLine}) => (
+      Editor.scrollToLine(~line=viewLine, editor),
+      Nothing,
+    )
+  | Msg.MinimapDragged({newPixelScrollY}) => (
       Editor.scrollToPixelY(~pixelY=newPixelScrollY, editor),
       Nothing,
     )

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -118,8 +118,6 @@ let%component make =
 
   let scrollY = editor.minimapScrollY;
 
-  let onScroll = _ => prerr_endline("Scrolling...");
-
   let%hook (captureMouse, _state) =
     Hooks.mouseCapture(
       ~onMouseMove=

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -91,6 +91,7 @@ let getMinimapSize = (view: Editor.t) => {
 
 let%component make =
               (
+                ~dispatch: Msg.t => unit,
                 ~editor: Editor.t,
                 ~cursorPosition: Location.t,
                 ~width: int,
@@ -99,7 +100,6 @@ let%component make =
                 ~diagnostics,
                 ~getTokensForLine: int => list(BufferViewTokenizer.t),
                 ~selection: Hashtbl.t(Index.t, list(Range.t)),
-                ~onScroll: float => unit,
                 ~showSlider,
                 ~colors: Colors.t,
                 ~bufferHighlights,
@@ -118,6 +118,8 @@ let%component make =
 
   let scrollY = editor.minimapScrollY;
 
+  let onScroll = _ => prerr_endline("Scrolling...");
+
   let%hook (captureMouse, _state) =
     Hooks.mouseCapture(
       ~onMouseMove=
@@ -126,7 +128,11 @@ let%component make =
           let minimapLineSize =
             Constants.minimapLineSpacing + Constants.minimapCharacterHeight;
           let linesInMinimap = editor.pixelHeight / minimapLineSize;
-          onScroll(scrollTo -. float(linesInMinimap));
+          dispatch(
+            Msg.MinimapDragged({
+              newPixelScrollY: scrollTo -. float(linesInMinimap),
+            }),
+          );
           Some();
         },
       ~onMouseUp=(_, _) => None,
@@ -139,7 +145,11 @@ let%component make =
       Constants.minimapLineSpacing + Constants.minimapCharacterHeight;
     let linesInMinimap = editor.pixelHeight / minimapLineSize;
     if (evt.button == Revery.MouseButton.BUTTON_LEFT) {
-      onScroll(scrollTo -. editor.scrollY -. float(linesInMinimap));
+      dispatch(
+        Msg.MinimapClicked({
+          newPixelScrollY: scrollTo -. float(linesInMinimap),
+        }),
+      );
       captureMouse();
     };
   };

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -7,6 +7,6 @@ type t =
   | VerticalScrollbarMouseRelease
   | VerticalScrollbarMouseWheel({deltaWheel: float})
   | MinimapMouseWheel({deltaWheel: float})
-  | MinimapClicked({newPixelScrollY: float})
+  | MinimapClicked({viewLine: int})
   | MinimapDragged({newPixelScrollY: float})
   | EditorMouseWheel({deltaWheel: float});

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -5,4 +5,8 @@ type t =
   | VerticalScrollbarMouseDown
   | VerticalScrollbarMouseDrag({newPixelScrollY: float})
   | VerticalScrollbarMouseRelease
-  | VerticalScrollbarMouseWheel({deltaWheel: float});
+  | VerticalScrollbarMouseWheel({deltaWheel: float})
+  | MinimapMouseWheel({deltaWheel: float})
+  | MinimapClicked({newPixelScrollY: float})
+  | MinimapDragged({newPixelScrollY: float})
+  | EditorMouseWheel({deltaWheel: float});

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -42,10 +42,10 @@ let renderRulers = (~context, ~colors: Colors.t, rulers) =>
 
 let%component make =
               (
-                ~onScroll,
                 ~buffer,
                 ~editor,
                 ~colors,
+                ~dispatch,
                 ~topVisibleLine,
                 ~onCursorChange,
                 ~cursorPosition: Location.t,
@@ -76,7 +76,7 @@ let%component make =
     };
 
   let onMouseWheel = (wheelEvent: NodeEvents.mouseWheelEventParams) =>
-    onScroll(wheelEvent.deltaY *. (-50.));
+    dispatch(Msg.EditorMouseWheel({deltaWheel: wheelEvent.deltaY *. (-1.)}));
 
   let {scrollX, scrollY, _}: Editor.t = editor;
 

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -725,7 +725,8 @@ module Minimap = {
     );
   let warningHighlight =
     define("minimap.warningHighlight", all(ref(EditorWarning.foreground)));
-  let background = define("minimap.background", all(unspecified));
+  let background =
+    define("minimap.background", all(ref(Editor.background)));
 
   let defaults = [
     findMatchHighlight,

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -112,7 +112,6 @@ type t =
       pixelWidth: int,
       pixelHeight: int,
     })
-  | EditorScroll(Feature_Editor.EditorId.t, float)
   | EditorScrollToLine(Feature_Editor.EditorId.t, int)
   | EditorScrollToColumn(Feature_Editor.EditorId.t, int)
   | EditorTabClicked(int)

--- a/src/Model/EditorReducer.re
+++ b/src/Model/EditorReducer.re
@@ -14,8 +14,6 @@ let reduce = (view, action) =>
     }
   | EditorSetScroll(id, pixelY) when EditorId.equals(view.editorId, id) =>
     Editor.scrollToPixelY(~pixelY, view)
-  | EditorScroll(id, pixelY) when EditorId.equals(view.editorId, id) =>
-    Editor.scrollDeltaPixelY(~pixelY, view)
   | EditorScrollToLine(id, line) when EditorId.equals(view.editorId, id) =>
     Editor.scrollToLine(~line, view)
   | EditorScrollToColumn(id, column) when EditorId.equals(view.editorId, id) =>

--- a/src/UI/EditorGroupView.re
+++ b/src/UI/EditorGroupView.re
@@ -68,12 +68,6 @@ module Parts = {
         GlobalContext.current().dispatch(
           EditorSizeChanged({id: editorId, pixelWidth, pixelHeight}),
         );
-      let onScroll = deltaY =>
-        GlobalContext.current().editorScrollDelta(
-          ~editorId=editor.editorId,
-          ~deltaY,
-          (),
-        );
       let onCursorChange = cursor =>
         GlobalContext.current().dispatch(
           EditorCursorMove(editor.editorId, [cursor]),
@@ -94,7 +88,6 @@ module Parts = {
         buffer
         onCursorChange
         onEditorSizeChanged
-        onScroll
         theme
         mode={state.vimMode}
         bufferHighlights={state.bufferHighlights}

--- a/src/UI/GlobalContext.re
+++ b/src/UI/GlobalContext.re
@@ -10,13 +10,10 @@
 open Oni_Core;
 open Oni_Model;
 
-type editorScrollDelta =
-  (~editorId: Feature_Editor.EditorId.t, ~deltaY: float, unit) => unit;
 type editorSetScroll =
   (~editorId: Feature_Editor.EditorId.t, ~scrollY: float, unit) => unit;
 
 type t = {
-  editorScrollDelta,
   editorSetScroll,
   closeEditorById: int => unit,
   dispatch: Actions.t => unit,
@@ -26,7 +23,6 @@ let viewNoop: Views.viewOperation =
   (~path as _="", ~id as _=0, ~openMethod as _=Buffer, ()) => ();
 
 let default = {
-  editorScrollDelta: (~editorId as _, ~deltaY as _, ()) => (),
   editorSetScroll: (~editorId as _, ~scrollY as _, ()) => (),
   dispatch: _ => (),
   closeEditorById: _ => (),

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -323,8 +323,6 @@ switch (eff) {
 
       GlobalContext.set({
         closeEditorById: id => dispatch(Model.Actions.ViewCloseEditor(id)),
-        editorScrollDelta: (~editorId, ~deltaY, ()) =>
-          dispatch(Model.Actions.EditorScroll(editorId, deltaY)),
         editorSetScroll: (~editorId, ~scrollY, ()) =>
           dispatch(Model.Actions.EditorSetScroll(editorId, scrollY)),
         dispatch,


### PR DESCRIPTION
This implements several fixes for the minimap, described in #250 :

- Scrolling while dragging was unintuitive, because we were using relative-scroll when we should be setting the scroll to an absolute scroll position. This caused erratic and unpredictable scrolling.
- Mouse position was calculated relative to the window, which was problematic in the case where there were splits - it would not be possible to scroll from the top or bottom.
- Implements click-to-line behavior - clicking on a particular line would result in an unpredictable scroll, because it would move to a line as if it were a vertical scrollbar. However, this now moves to the particular line that was clicked. This is helpful when clicking on a line marked as having an error, for example.
- Refactor to use descriptive actions, which will make it easier to finish implementing features like smooth scroll - click-and-drag should not engage smooth scroll, but clicking to a line should.

(Also, the capture hook implemented by Glenn helped fix several issues!)

Fixes #250 