### PR TITLE
refactor(explorer): new arrow icon, v alignments

### DIFF
--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -29,6 +29,9 @@ module Styles = {
     height(Constants.tabHeight),
   ];
 
+  // Minor adjustment to align with text
+  let folder = [marginTop(4)];
+
   let item = (~isFocus, ~isActive, ~theme) => [
     flexDirection(`Row),
     flexGrow(1),
@@ -39,13 +42,14 @@ module Styles = {
       } else if (isFocus) {
         Colors.List.focusBackground.from(theme);
       } else {
+        // NOTE: Could use, `Colors.SideBar.background.from(theme)`
         Revery.Colors.transparentWhite;
       },
     ),
   ];
 
   let text = (~isFocus, ~isActive, ~decoration, ~theme, ~font: UiFont.t) => [
-    fontSize(11.),
+    fontSize(12.),
     fontFamily(font.fontFile),
     color(
       switch (
@@ -60,12 +64,13 @@ module Styles = {
         } else if (isFocus) {
           Colors.List.focusForeground.from(theme);
         } else {
-          Colors.foreground.from(theme);
+          Colors.SideBar.foreground.from(theme);
         }
       },
     ),
     marginLeft(10),
-    marginVertical(2),
+    // Minor adjustment to align with seti-icon
+    marginTop(4),
     textWrap(TextWrapping.NoWrap),
   ];
 };
@@ -80,6 +85,8 @@ let setiIcon = (~icon, ~fontSize as size, ~fg, ()) => {
       width(int_of_float(size *. 1.5)),
       height(int_of_float(size *. 1.75)),
       textWrap(TextWrapping.NoWrap),
+      // Minor adjustment to center vertically
+      marginTop(-2),
       marginLeft(-4),
     ]
   />;
@@ -111,10 +118,12 @@ let nodeView =
   let icon = () =>
     switch (node.kind) {
     | Directory({isOpen, _}) =>
-      <FontIcon
-        color={Colors.SideBar.foreground.from(theme)}
-        icon={isOpen ? FontAwesome.folderOpen : FontAwesome.folder}
-      />
+      <View style=Styles.folder>
+        <FontIcon
+          color={Colors.SideBar.foreground.from(theme)}
+          icon={isOpen ? FontAwesome.folderOpen : FontAwesome.folder}
+        />
+      </View>
     | _ => <icon />
     };
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -74,7 +74,8 @@ module Styles = {
     color(Colors.white),
   ];
 
-  let arrow = size => [width(size), height(size)];
+  // Margin applied to center vertically
+  let arrow = size => [width(size), height(size), marginTop(4)];
 };
 
 module Make = (Model: TreeModel) => {
@@ -83,7 +84,7 @@ module Make = (Model: TreeModel) => {
       <FontIcon
         fontSize=Constants.arrowSize
         color
-        icon={isOpen ? FontAwesome.caretDown : FontAwesome.caretRight}
+        icon={isOpen ? FontAwesome.angleDown : FontAwesome.angleRight}
       />
     </View>;
 


### PR DESCRIPTION
This is a minor one, but:
- Switches to use the foreground-color `SideBar` provided by the theme
- Switches icon to the `angle`-one
- Adjusts some margins in order to align things vertically (see `CODE_OF_CONDUCT.md`)
- Increases the font-size by 1pt 

**Before:**
<img width="1290" alt="Screenshot 2020-06-05 at 14 35 01" src="https://user-images.githubusercontent.com/17602389/83876864-d236c280-a739-11ea-86b1-0328e4859bc3.png">
**After:**
<img width="1126" alt="Screenshot 2020-06-05 at 14 32 33" src="https://user-images.githubusercontent.com/17602389/83876875-d662e000-a739-11ea-8eae-21aad5c830ea.png">
