### PR TITLE
feature(textmate): CLI Tool to print scopes

### DIFF
--- a/test/reason-textmate/bin/TextmateCli.re
+++ b/test/reason-textmate/bin/TextmateCli.re
@@ -1,36 +1,69 @@
 //
 // TextmateCli.re
-// 
+//
 // Tool for testing the textmate grammars
 // Can be run via: `esy @test x TextmateCli --sourceFile=/path/to/source --grammarFile=/path/to/grammar --lineNumber=1 --scope=source.js`
 
-
-print_endline ("** Welcome to TextmateCli **");
+print_endline("** Welcome to TextmateCli **");
 
 module Cli = {
-	type t = {
-		sourceFile: string,
-		grammarFile: string,
-		scope: string,
-		lineNumber: int,
-	};
+  type t = {
+    sourceFile: string,
+    grammarFile: string,
+    scope: string,
+    lineNumber: int,
+  };
 
-	let parse = (args) => {
-		sourceFile: "source",
-		grammarFile: "grammar",
-		scope: "scope",
-		lineNumber: 1,
-	};
+  let parse = args => {
+    let sourceFile = ref(None);
+    let grammarFile = ref(None);
+    let scope = ref(None);
+    let lineNumber = ref(0);
+    let () = Arg.parse_argv(
+      ~current=ref(0),
+      args,
+      [
+         ("--file", String(s => sourceFile := Some(s)), "Source file to tokenize"),
+         ("--grammar", String(s => grammarFile := Some(s)), "Grammar file to use"),
+         ("--scope", String(s => scope := Some(s)), "Top-level scope (ie, 'source.js')"),
+         ("--line", Int(i => lineNumber := i), "Line number to show")
+      ],
+      _ => (),
+      ""
+    );
 
+    let getRequiredParameter = (name, maybeParam) => {
+      switch(maybeParam^) {
+      | None =>
+        prerr_endline ("ERROR: Missing required parameter: " ++ name)
+        failwith("Missing parameter: " ++ name);
+      | Some(v) => v
+      }
+    };
 
-	let toString = ({sourceFile, grammarFile, scope, lineNumber}) => Printf.sprintf({|
+    {
+    sourceFile: getRequiredParameter("file", sourceFile),
+    grammarFile: getRequiredParameter("grammar", grammarFile),
+    scope: getRequiredParameter("scope", scope),
+    lineNumber: lineNumber^
+    };
+  };
+
+  let toString = ({sourceFile, grammarFile, scope, lineNumber}) =>
+    Printf.sprintf(
+      {|
 Using arguments:
 - sourceFile: %s
 - grammarFile: %s
 - scope: %s
 - lineNumber: %d
-	|},  sourceFile, grammarFile, scope, lineNumber);
+	|},
+      sourceFile,
+      grammarFile,
+      scope,
+      lineNumber,
+    );
 };
 
 let args = Cli.parse(Sys.argv);
-print_endline (args |> Cli.toString);
+print_endline(args |> Cli.toString);

--- a/test/reason-textmate/bin/TextmateCli.re
+++ b/test/reason-textmate/bin/TextmateCli.re
@@ -1,0 +1,36 @@
+//
+// TextmateCli.re
+// 
+// Tool for testing the textmate grammars
+// Can be run via: `esy @test x TextmateCli --sourceFile=/path/to/source --grammarFile=/path/to/grammar --lineNumber=1 --scope=source.js`
+
+
+print_endline ("** Welcome to TextmateCli **");
+
+module Cli = {
+	type t = {
+		sourceFile: string,
+		grammarFile: string,
+		scope: string,
+		lineNumber: int,
+	};
+
+	let parse = (args) => {
+		sourceFile: "source",
+		grammarFile: "grammar",
+		scope: "scope",
+		lineNumber: 1,
+	};
+
+
+	let toString = ({sourceFile, grammarFile, scope, lineNumber}) => Printf.sprintf({|
+Using arguments:
+- sourceFile: %s
+- grammarFile: %s
+- scope: %s
+- lineNumber: %d
+	|},  sourceFile, grammarFile, scope, lineNumber);
+};
+
+let args = Cli.parse(Sys.argv);
+print_endline (args |> Cli.toString);

--- a/test/reason-textmate/bin/TextmateCli.re
+++ b/test/reason-textmate/bin/TextmateCli.re
@@ -2,68 +2,133 @@
 // TextmateCli.re
 //
 // Tool for testing the textmate grammars
-// Can be run via: `esy @test x TextmateCli --sourceFile=/path/to/source --grammarFile=/path/to/grammar --lineNumber=1 --scope=source.js`
+//
+// Can be run via:
+// `esy @test x TextmateCli --file=package.json --grammar=test/reason-textmate/json.json --line=25
 
-print_endline("** Welcome to TextmateCli **");
+open Textmate;
 
 module Cli = {
   type t = {
     sourceFile: string,
     grammarFile: string,
-    scope: string,
     lineNumber: int,
   };
 
   let parse = args => {
     let sourceFile = ref(None);
     let grammarFile = ref(None);
-    let scope = ref(None);
     let lineNumber = ref(0);
-    let () = Arg.parse_argv(
-      ~current=ref(0),
-      args,
-      [
-         ("--file", String(s => sourceFile := Some(s)), "Source file to tokenize"),
-         ("--grammar", String(s => grammarFile := Some(s)), "Grammar file to use"),
-         ("--scope", String(s => scope := Some(s)), "Top-level scope (ie, 'source.js')"),
-         ("--line", Int(i => lineNumber := i), "Line number to show")
-      ],
-      _ => (),
-      ""
-    );
+    let () =
+      Arg.parse_argv(
+        ~current=ref(0),
+        args,
+        [
+          (
+            "--file",
+            String(s => sourceFile := Some(s)),
+            "Source file to tokenize",
+          ),
+          (
+            "--grammar",
+            String(s => grammarFile := Some(s)),
+            "Grammar file to use",
+          ),
+          ("--line", Int(i => lineNumber := i), "Line number to show"),
+        ],
+        _ => (),
+        "",
+      );
 
     let getRequiredParameter = (name, maybeParam) => {
-      switch(maybeParam^) {
+      switch (maybeParam^) {
       | None =>
-        prerr_endline ("ERROR: Missing required parameter: " ++ name)
+        prerr_endline("ERROR: Missing required parameter: " ++ name);
         failwith("Missing parameter: " ++ name);
       | Some(v) => v
-      }
+      };
     };
 
     {
-    sourceFile: getRequiredParameter("file", sourceFile),
-    grammarFile: getRequiredParameter("grammar", grammarFile),
-    scope: getRequiredParameter("scope", scope),
-    lineNumber: lineNumber^
+      sourceFile: getRequiredParameter("file", sourceFile),
+      grammarFile: getRequiredParameter("grammar", grammarFile),
+      lineNumber: lineNumber^,
     };
   };
 
-  let toString = ({sourceFile, grammarFile, scope, lineNumber}) =>
+  let toString = ({sourceFile, grammarFile, lineNumber}) =>
     Printf.sprintf(
       {|
 Using arguments:
 - sourceFile: %s
 - grammarFile: %s
-- scope: %s
 - lineNumber: %d
 	|},
       sourceFile,
       grammarFile,
-      scope,
       lineNumber,
     );
 };
 
-let args = Cli.parse(Sys.argv);
-print_endline(args |> Cli.toString);
+let getOkOrFail = (~msg, res) => {
+  switch (res) {
+  | Ok(v) => v
+  | Error(errMsg) =>
+    let err = Printf.sprintf("%s: %s", msg, errMsg);
+    prerr_endline(err);
+    failwith(err);
+  };
+};
+
+let run = () => {
+  print_endline("** Welcome to TextmateCli **");
+
+  let Cli.{sourceFile, grammarFile, lineNumber} as args =
+    Cli.parse(Sys.argv);
+  print_endline(args |> Cli.toString);
+
+  print_endline("Loading grammar: " ++ grammarFile);
+
+  let grammar =
+    grammarFile
+    |> Grammar.Json.of_file
+    |> getOkOrFail(~msg="Unable to load grammar " ++ grammarFile);
+
+  let grammarRepository = _ => None;
+
+  let scopeName = Grammar.getScopeName(grammar);
+  print_endline("Grammar loaded - using scope: " ++ scopeName);
+
+  print_endline("Trying to read file: " ++ sourceFile);
+  let lines =
+    sourceFile |> Oni_Core.Utility.File.readAllLines |> Array.of_list;
+  print_endline(Printf.sprintf("Read %d lines.", Array.length(lines)));
+
+  let currentScopeStack = ref(None);
+  let latestTokens = ref([]);
+  let latestLine = ref("");
+
+  for (i in 0 to lineNumber) {
+    let line = lines[i];
+    let (tokens, scopeStack) =
+      Grammar.tokenize(
+        ~scopes=currentScopeStack^,
+        ~grammarRepository,
+        ~grammar,
+        lines[i],
+      );
+
+    currentScopeStack := Some(scopeStack);
+    latestLine := line;
+    latestTokens := tokens;
+  };
+
+  print_endline(Printf.sprintf("Line %d: %s", lineNumber, latestLine^));
+  print_endline("** Tokens: **");
+
+  latestTokens^ |> List.map(Token.show) |> List.iter(print_endline);
+
+  print_endline("Done!");
+};
+
+run();

--- a/test/reason-textmate/bin/dune
+++ b/test/reason-textmate/bin/dune
@@ -3,5 +3,7 @@
     (package OniUnitTestRunner)
     (public_names TextmateCli)
     (libraries
+        Oni2.core
+        Oni2.core.utility
         textmate)
 )

--- a/test/reason-textmate/bin/dune
+++ b/test/reason-textmate/bin/dune
@@ -1,0 +1,7 @@
+(executables
+    (names TextmateCli)
+    (package OniUnitTestRunner)
+    (public_names TextmateCli)
+    (libraries
+        textmate)
+)


### PR DESCRIPTION
@CrossR  - here's the CLI tool I promised, to compliment the work you're doing here: https://github.com/onivim/reason-tree-sitter/pulls

This adds a CLI tool that takes a textmate grammar, a source file, and a line number, and outputs the textmate tokens we parse from it.

An example invocation is:
```
esy '@test' x TextmateCli --file=package.json --grammar=test/reason-textmate/json.json --line=2
```

with output:
```
** Welcome to TextmateCli **

Using arguments:
- sourceFile: package.json
- grammarFile: test/reason-textmate/json.json
- lineNumber: 2
	
Loading grammar: test/reason-textmate/json.json
Grammar loaded - using scope: source.json
Trying to read file: package.json
Read 274 lines.
Line 2:   "version": "0.4.0",
** Tokens: **
Token(0,2:, meta.structure.dictionary.json, source.json)
Token(2,3:, punctuation.definition.string.begin.json, string.quoted.double.json, meta.structure.dictionary.json, source.json)
Token(3,10:, string.quoted.double.json, meta.structure.dictionary.json, source.json)
Token(10,11:, punctuation.definition.string.end.json, string.quoted.double.json, meta.structure.dictionary.json, source.json)
Token(11,12:, punctuation.separator.dictionary.key-value.json, meta.structure.dictionary.value.json, meta.structure.dictionary.json, source.json)
Token(12,13:, meta.structure.dictionary.value.json, meta.structure.dictionary.json, source.json)
Token(13,14:, punctuation.definition.string.begin.json, string.quoted.double.json, meta.structure.dictionary.value.json, meta.structure.dictionary.json, source.json)
Token(14,19:, string.quoted.double.json, meta.structure.dictionary.value.json, meta.structure.dictionary.json, source.json)
Token(19,20:, punctuation.definition.string.end.json, string.quoted.double.json, meta.structure.dictionary.value.json, meta.structure.dictionary.json, source.json)
Token(20,21:, punctuation.separator.dictionary.pair.json, meta.structure.dictionary.value.json, meta.structure.dictionary.json, source.json)
Done!
```