### PR TITLE
refactor(dependency): revery -> f2dce86

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "50523377bb7d08b6c3315ab45f94de88",
+  "checksum": "74d4c8b7dbbc51e0e75c52426f9f1ac1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#eec9bf9@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#12fb2dc@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+    "revery@github:revery-ui/revery#f2dce86@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#12fb2dc",
+      "version": "github:revery-ui/revery#f2dce86",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#12fb2dc" ]
+        "source": [ "github:revery-ui/revery#f2dce86" ]
       },
       "overrides": [],
       "dependencies": [
@@ -153,18 +153,17 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "flex@1.2.3@d41d8cd9",
+        "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-harfbuzz@1.9.1008@d41d8cd9",
         "esy-freetype2@2.9.1007@d41d8cd9",
-        "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.5@bb81afdc",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@aef1678b",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@b0227b2f", "@opam/bos@opam:0.2.0@df49e63f",
         "@glennsl/timber@1.2.0@d41d8cd9", "@esy-ocaml/reason@3.6.0@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
       ],
@@ -685,6 +684,41 @@
       ],
       "devDependencies": []
     },
+    "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-native-lwt",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-native-lwt/-/fetch-native-lwt-0.1.0-alpha.5.tgz#sha1:5a0a40149d5d10e233361bb40c42304f538090aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
+        "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "fetch-core@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-core@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-core",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-core/-/fetch-core-0.1.0-alpha.5.tgz#sha1:71a2420796743056f3efba8da19a540cc910db95"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "esy-tree-sitter@1.4.1@d41d8cd9": {
       "id": "esy-tree-sitter@1.4.1@d41d8cd9",
       "name": "esy-tree-sitter",
@@ -873,6 +907,20 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9": {
+      "id": "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+      "name": "esy-autoconf",
+      "version": "github:esy-packages/esy-autoconf#fb93edf",
+      "source": {
+        "type": "install",
+        "source": [ "github:esy-packages/esy-autoconf#fb93edf" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "editor-input@github:onivim/editor-input#c494950@d41d8cd9": {
       "id": "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
       "name": "editor-input",
@@ -1041,7 +1089,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#82db1eb@d41d8cd9",
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
@@ -1190,6 +1238,266 @@
       ],
       "devDependencies": []
     },
+    "@reason-native-web/ssl@0.5.9007@d41d8cd9": {
+      "id": "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+      "name": "@reason-native-web/ssl",
+      "version": "0.5.9007",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/ssl/-/ssl-0.5.9007.tgz#sha1:2eceef610fb593f10605dbde0cbcec153bf7b744"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/piaf@1.3.1000@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+      "name": "@reason-native-web/piaf",
+      "version": "1.3.1000",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.1000.tgz#sha1:e21820a3e0fe7ac1e2f0d41462c01bfc64d5ac0e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+        "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/uri@opam:3.1.0@faef85a4",
+        "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+        "@opam/magic-mime@opam:1.1.2@980f82fb",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9": {
+      "id": "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+      "name": "@reason-native-web/lwt_ssl",
+      "version": "1.1.3005",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/lwt_ssl/-/lwt_ssl-1.1.3005.tgz#sha1:6ac76e006175e3b320b8a1c690f50cebb5699050"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt-unix",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt-unix/-/h2-lwt-unix-0.6.1001.tgz#sha1:9f89181b5d2d244c9ee1d8a1e88fd258c4ab6d56"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/psq@opam:0.2.0@247756d4", "@opam/hpack@opam:0.2.0@9f3eae78",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/base64@opam:3.4.0@f5b9ad9b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt-unix",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt-unix/-/h1-lwt-unix-1.2.1001.tgz#sha1:ef6c7ab43bc717db58dc8af913f2b68b34de2c5f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt/-/h1-lwt-1.2.1001.tgz#sha1:e2fef4defebe735128c47484abcc12f55df6d43c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1/-/h1-1.2.1001.tgz#sha1:16f1cfeb43009f45e64e91a8aba9c62e80fb27fe"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt-unix",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt-unix/-/gluten-lwt-unix-0.2.1.tgz#sha1:e661685c6c72ef38b48318279ed16434824563f9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt/-/gluten-lwt-0.2.1.tgz#sha1:0d35a7de4abd2b55e4afc57d902c9f36a4d6e3e4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/gluten@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten/-/gluten-0.2.1.tgz#sha1:cbc732d5d238f845c54d466bb5da7380feb66b72"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9": {
+      "id": "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+      "name": "@reason-native-web/esy-openssl",
+      "version": "1.1.1006",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/esy-openssl/-/esy-openssl-1.1.1006.tgz#sha1:4154a9b17d9ebdc1c983a3075513b5cd276873ac"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/conf-autoconf@opam:0.1@27b3f7cf"
+      ],
+      "devDependencies": []
+    },
     "@opam/zed@opam:3.1.0@86c55416": {
       "id": "@opam/zed@opam:3.1.0@86c55416",
       "name": "@opam/zed",
@@ -1297,6 +1605,33 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/uri@opam:3.1.0@faef85a4": {
+      "id": "@opam/uri@opam:3.1.0@faef85a4",
+      "name": "@opam/uri",
+      "version": "opam:3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/c4/c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43",
+          "archive:https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+        ],
+        "opam": {
+          "name": "uri",
+          "version": "3.1.0",
+          "path": "bench.esy.lock/opam/uri.3.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/uchar@opam:0.0.2@c8218eea": {
       "id": "@opam/uchar@opam:0.0.2@c8218eea",
       "name": "@opam/uchar",
@@ -1399,6 +1734,33 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
+    "@opam/stringext@opam:1.6.0@104bc94b": {
+      "id": "@opam/stringext@opam:1.6.0@104bc94b",
+      "name": "@opam/stringext",
+      "version": "opam:1.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/db/db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea",
+          "archive:https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+        ],
+        "opam": {
+          "name": "stringext",
+          "version": "1.6.0",
+          "path": "bench.esy.lock/opam/stringext.1.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
     "@opam/stdlib-shims@opam:0.1.0@d957c903": {
       "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
       "name": "@opam/stdlib-shims",
@@ -1494,6 +1856,34 @@
         "ocaml@4.9.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
+    },
+    "@opam/rresult@opam:0.6.0@4b185e72": {
+      "id": "@opam/rresult@opam:0.6.0@4b185e72",
+      "name": "@opam/rresult",
+      "version": "opam:0.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ab/aba88cffa29081714468c2c7bcdf7fb1#md5:aba88cffa29081714468c2c7bcdf7fb1",
+          "archive:http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz#md5:aba88cffa29081714468c2c7bcdf7fb1"
+        ],
+        "opam": {
+          "name": "rresult",
+          "version": "0.6.0",
+          "path": "bench.esy.lock/opam/rresult.0.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/result@opam:1.5@6b753c82",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82"
+      ]
     },
     "@opam/result@opam:1.5@6b753c82": {
       "id": "@opam/result@opam:1.5@6b753c82",
@@ -2082,6 +2472,31 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa": {
+      "id": "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+      "name": "@opam/ocaml-syntax-shims",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/89/89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8",
+          "archive:https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+        ],
+        "opam": {
+          "name": "ocaml-syntax-shims",
+          "version": "1.0.0",
+          "path": "bench.esy.lock/opam/ocaml-syntax-shims.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47": {
       "id": "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
       "name": "@opam/ocaml-migrate-parsetree",
@@ -2379,6 +2794,31 @@
         "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/magic-mime@opam:1.1.2@980f82fb": {
+      "id": "@opam/magic-mime@opam:1.1.2@980f82fb",
+      "name": "@opam/magic-mime",
+      "version": "opam:1.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/0c/0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb",
+          "archive:https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+        ],
+        "opam": {
+          "name": "magic-mime",
+          "version": "1.1.2",
+          "path": "bench.esy.lock/opam/magic-mime.1.1.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {
       "id": "@opam/lwt_react@opam:1.1.3@72987fcf",
       "name": "@opam/lwt_react",
@@ -2662,6 +3102,35 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/hpack@opam:0.2.0@9f3eae78": {
+      "id": "@opam/hpack@opam:0.2.0@9f3eae78",
+      "name": "@opam/hpack",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c8/c883927ce8a9f3f7159ef7b20988f051#md5:c883927ce8a9f3f7159ef7b20988f051",
+          "archive:https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz#md5:c883927ce8a9f3f7159ef7b20988f051"
+        ],
+        "opam": {
+          "name": "hpack",
+          "version": "0.2.0",
+          "path": "bench.esy.lock/opam/hpack.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ]
+    },
     "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9": {
       "id": "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
       "name": "@opam/fs",
@@ -2784,6 +3253,91 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday-lwt-unix@opam:0.7.1@4854f547": {
+      "id": "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+      "name": "@opam/faraday-lwt-unix",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt-unix",
+          "version": "0.7.1",
+          "path": "bench.esy.lock/opam/faraday-lwt-unix.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ]
+    },
+    "@opam/faraday-lwt@opam:0.7.1@e28c97d1": {
+      "id": "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+      "name": "@opam/faraday-lwt",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt",
+          "version": "0.7.1",
+          "path": "bench.esy.lock/opam/faraday-lwt.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday@opam:0.7.1@19546ee5": {
+      "id": "@opam/faraday@opam:0.7.1@19546ee5",
+      "name": "@opam/faraday",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday",
+          "version": "0.7.1",
+          "path": "bench.esy.lock/opam/faraday.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -3068,6 +3622,31 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "@opam/conf-autoconf@opam:0.1@27b3f7cf": {
+      "id": "@opam/conf-autoconf@opam:0.1@27b3f7cf",
+      "name": "@opam/conf-autoconf",
+      "version": "opam:0.1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-autoconf",
+          "version": "0.1",
+          "path": "bench.esy.lock/opam/conf-autoconf.0.1"
+        }
+      },
+      "overrides": [
+        {
+          "opamoverride":
+            "bench.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override"
+        }
+      ],
+      "dependencies": [
+        "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "@opam/charInfo_width@opam:1.1.0@9d8d61b2": {
       "id": "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
       "name": "@opam/charInfo_width",
@@ -3122,6 +3701,42 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/bos@opam:0.2.0@df49e63f": {
+      "id": "@opam/bos@opam:0.2.0@df49e63f",
+      "name": "@opam/bos",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ae/aeae7447567db459c856ee41b5a66fd2#md5:aeae7447567db459c856ee41b5a66fd2",
+          "archive:http://erratique.ch/software/bos/releases/bos-0.2.0.tbz#md5:aeae7447567db459c856ee41b5a66fd2"
+        ],
+        "opam": {
+          "name": "bos",
+          "version": "0.2.0",
+          "path": "bench.esy.lock/opam/bos.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
     "@opam/biniou@opam:1.2.1@d7570399": {
       "id": "@opam/biniou@opam:1.2.1@d7570399",
       "name": "@opam/biniou",
@@ -3146,6 +3761,89 @@
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/bigstringaf@opam:0.6.1@35f5e6d1": {
+      "id": "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+      "name": "@opam/bigstringaf",
+      "version": "opam:0.6.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/dc/dccf639273b1eec0e0f142f21319268d#md5:dccf639273b1eec0e0f142f21319268d",
+          "archive:https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz#md5:dccf639273b1eec0e0f142f21319268d"
+        ],
+        "opam": {
+          "name": "bigstringaf",
+          "version": "0.6.1",
+          "path": "bench.esy.lock/opam/bigstringaf.0.6.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97"
+      ]
+    },
+    "@opam/bigarray-compat@opam:1.0.0@1faefa97": {
+      "id": "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+      "name": "@opam/bigarray-compat",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1c/1cc7c25382a8900bada34aadfd66632e#md5:1cc7c25382a8900bada34aadfd66632e",
+          "archive:https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz#md5:1cc7c25382a8900bada34aadfd66632e"
+        ],
+        "opam": {
+          "name": "bigarray-compat",
+          "version": "1.0.0",
+          "path": "bench.esy.lock/opam/bigarray-compat.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/base64@opam:3.4.0@f5b9ad9b": {
+      "id": "@opam/base64@opam:3.4.0@f5b9ad9b",
+      "name": "@opam/base64",
+      "version": "opam:3.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/1c/1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634",
+          "archive:https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+        ],
+        "opam": {
+          "name": "base64",
+          "version": "3.4.0",
+          "path": "bench.esy.lock/opam/base64.3.4.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -3368,6 +4066,35 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/angstrom@opam:0.14.1@07e286b0": {
+      "id": "@opam/angstrom@opam:0.14.1@07e286b0",
+      "name": "@opam/angstrom",
+      "version": "opam:0.14.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/91/915bbcc1adbd0debc1b0a54531c7601a#md5:915bbcc1adbd0debc1b0a54531c7601a",
+          "archive:https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz#md5:915bbcc1adbd0debc1b0a54531c7601a"
+        ],
+        "opam": {
+          "name": "angstrom",
+          "version": "0.14.1",
+          "path": "bench.esy.lock/opam/angstrom.0.14.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@glennsl/timber@1.2.0@d41d8cd9": {

--- a/bench.esy.lock/opam/angstrom.0.14.1/opam
+++ b/bench.esy.lock/opam/angstrom.0.14.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/angstrom"
+bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "bigstringaf"
+  "result"
+]
+synopsis: "Parser combinators built for speed and memory-efficiency"
+description: """
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
+default and support unbounded lookahead."""
+url {
+  src: "https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz"
+  checksum: "md5=915bbcc1adbd0debc1b0a54531c7601a"
+}

--- a/bench.esy.lock/opam/base64.3.4.0/opam
+++ b/bench.esy.lock/opam/base64.3.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>="4.03.0"}
+  "base-bytes"
+  "dune-configurator"
+  "dune" {>= "2.0"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz"
+  checksum: [
+    "sha256=1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+    "sha512=e66a67302a9eb136044bebf66a89a1d6e38a96c70622bb6cd27916fec36dcaf4b5b7e7d00c25608f0a2363f2ca4264a5fe765fe7747590958325dbce06311db9"
+  ]
+}

--- a/bench.esy.lock/opam/bigarray-compat.1.0.0/opam
+++ b/bench.esy.lock/opam/bigarray-compat.1.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Compatibility library to use Stdlib.Bigarray when possible"
+maintainer: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+authors: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/bigarray-compat"
+bug-reports: "https://github.com/mirage/bigarray-compat/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
+url {
+  src: "https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=1cc7c25382a8900bada34aadfd66632e"
+    "sha512=c365fee15582aca35d7b05268cde29e54774ad7df7be56762b4aad78ca1409d4326ad3b34af0f1cc2c7b872837290a9cd9ff43b47987c03bba7bba32fe8a030f"
+  ]
+}

--- a/bench.esy.lock/opam/bigstringaf.0.6.1/opam
+++ b/bench.esy.lock/opam/bigstringaf.0.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/bigstringaf"
+bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+  "bigarray-compat"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "js_of_ocaml" {< "3.5.0"}
+]
+synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"
+description: """
+Bigstring intrinsics and fast blits based on memcpy/memmove
+
+The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+widely-known, sometimes misused, and so programs that use Bigstrings are slower
+than they have to be. And even if a library got that part right and exposed the
+intrinsics properly, the compiler doesn't have any fast blits between
+Bigstrings and other string-like types.
+
+So here they are. Go crazy.
+"""
+url {
+  src: "https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz"
+  checksum: "md5=dccf639273b1eec0e0f142f21319268d"
+}

--- a/bench.esy.lock/opam/bos.0.2.0/opam
+++ b/bench.esy.lock/opam/bos.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/bos"
+doc: "http://erratique.ch/software/bos/doc"
+dev-repo: "git+http://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "base-unix"
+  "rresult" {>= "0.4.0"}
+  "astring"
+  "fpath"
+  "fmt" {>= "0.8.0"}
+  "logs"
+  "mtime" {with-test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Basic OS interaction for OCaml"
+description: """
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs"""
+url {
+  src: "http://erratique.ch/software/bos/releases/bos-0.2.0.tbz"
+  checksum: "md5=aeae7447567db459c856ee41b5a66fd2"
+}

--- a/bench.esy.lock/opam/conf-autoconf.0.1/opam
+++ b/bench.esy.lock/opam/conf-autoconf.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.gnu.org/software/autoconf"
+authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-3.0"
+build: [
+  ["which" "autoconf"]
+]
+depends: ["conf-which" {build}]
+depexts: [
+  ["autoconf"] {os-family = "debian"}
+  ["autoconf"] {os-distribution = "centos"}
+  ["autoconf"] {os-distribution = "fedora"}
+  ["autoconf"] {os-distribution = "arch"}
+  ["sys-devel/autoconf"] {os-distribution = "gentoo"}
+  ["autoconf"] {os-distribution = "nixos"}
+  ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["devel/autoconf"] {os = "openbsd"}
+  ["autoconf"] {os = "freebsd"}
+  ["autoconf"] {os = "netbsd"}
+  ["autoconf"] {os-distribution = "alpine"}
+  ["autoconf"] {os-distribution = "ol"}
+  ["autoconf"] {os-distribution = "rhel"}
+]
+synopsis: "Virtual package relying on autoconf installation"
+description: """
+This package can only install if the autoconf command
+is available on the system."""
+flags: conf

--- a/bench.esy.lock/opam/faraday-lwt-unix.0.7.1/opam
+++ b/bench.esy.lock/opam/faraday-lwt-unix.0.7.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday-lwt"
+  "lwt" {>= "2.7.0"}
+  "base-unix"
+]
+synopsis: "Lwt_unix support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/bench.esy.lock/opam/faraday-lwt.0.7.1/opam
+++ b/bench.esy.lock/opam/faraday-lwt.0.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday" {>= "0.5.0"}
+  "lwt"
+]
+synopsis: "Lwt support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/bench.esy.lock/opam/faraday.0.7.1/opam
+++ b/bench.esy.lock/opam/faraday.0.7.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.4.1"}
+  "bigstringaf"
+]
+synopsis: "A library for writing fast and memory-efficient serializers."
+description: """
+Faraday is a library for writing fast and memory-efficient serializers. Its
+core type and related operation gives the user fine-grained control over
+copying and allocation behavior while serializing user-defined types, and
+presents the output in a form that makes it possible to use vectorized write
+operations, such as the writev system call, or any other platform or
+application-specific output APIs."""
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/bench.esy.lock/opam/hpack.0.2.0/opam
+++ b/bench.esy.lock/opam/hpack.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+           "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-Clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune"
+  "yojson" {with-test}
+  "hex" {with-test}
+  "angstrom"
+  "faraday"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description: """
+hpack is an implementation of the HPACK: Header Compression for HTTP/2
+specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for
+parsing and serialization, respectively.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/bench.esy.lock/opam/magic-mime.1.1.2/opam
+++ b/bench.esy.lock/opam/magic-mime.1.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "magic-mime"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz"
+  checksum: [
+    "sha256=0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+    "sha512=8264db78adc2c75b8adabc23c26ad34eab98383bd3a8f2068f2236ff3425d653c0238fbd7361e55a3d70d843413ef8671b6e97293074b4d3a1e300628d5292ab"
+  ]
+}

--- a/bench.esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
+++ b/bench.esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Backport new syntax to older OCaml versions"
+description: """
+This packages backports new features of the language to older
+compilers, such as let+.
+"""
+maintainer: ["jeremie@dimino.org"]
+authors: ["Jérémie Dimino <jeremie@dimino.org>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocaml-syntax-shims"
+doc: "https://ocaml-ppx.github.io/ocaml-syntax-shims/"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-syntax-shims/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.02.3"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-syntax-shims.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz"
+  checksum: [
+    "sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+    "sha512=75c4c6b0bfa1267a8a49a82ba494d08cf0823fc8350863d6d3d4971528cb09e5a2a29e2981d04c75e76ad0f49360b05a432c9efeff9a4fbc1ec6b28960399852"
+  ]
+}

--- a/bench.esy.lock/opam/rresult.0.6.0/opam
+++ b/bench.esy.lock/opam/rresult.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "git+http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+   "ocaml" {>= "4.01.0"}
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]
+
+synopsis: """Result value combinators for OCaml"""
+description: """\
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz"
+checksum: "aba88cffa29081714468c2c7bcdf7fb1"
+}

--- a/bench.esy.lock/opam/stringext.1.6.0/opam
+++ b/bench.esy.lock/opam/stringext.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+license: "MIT"
+homepage: "https://github.com/rgrinberg/stringext"
+bug-reports: "https://github.com/rgrinberg/stringext/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "qtest" {with-test & >= "2.2"}
+  "base-bytes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/rgrinberg/stringext.git"
+synopsis: "Extra string functions for OCaml"
+description: """
+Extra string functions for OCaml. Mainly splitting. All functions are in the
+Stringext module.
+"""
+url {
+  src:
+    "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz"
+  checksum: [
+    "sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+    "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
+  ]
+}

--- a/bench.esy.lock/opam/uri.3.1.0/opam
+++ b/bench.esy.lock/opam/uri.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0" & < "v0.14"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz"
+  checksum: [
+    "sha256=c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+    "sha512=c015576bb077fd243022bcd8804e628d23a253dcd8bbdda8dc2a57e86cfeb9fd629087ec7d7e23dc71dd7cd137450ca2c5ecf8fb7d184ec9d1d4e41f6f83ee38"
+  ]
+}

--- a/bench.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
+++ b/bench.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
@@ -1,0 +1,6 @@
+{
+  "build": [ "true" ],
+  "dependencies": {
+    "esy-autoconf": "esy-packages/esy-autoconf#fb93edf"
+  }
+}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "50523377bb7d08b6c3315ab45f94de88",
+  "checksum": "74d4c8b7dbbc51e0e75c52426f9f1ac1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#eec9bf9@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#12fb2dc@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+    "revery@github:revery-ui/revery#f2dce86@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#12fb2dc",
+      "version": "github:revery-ui/revery#f2dce86",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#12fb2dc" ]
+        "source": [ "github:revery-ui/revery#f2dce86" ]
       },
       "overrides": [],
       "dependencies": [
@@ -153,18 +153,17 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "flex@1.2.3@d41d8cd9",
+        "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-harfbuzz@1.9.1008@d41d8cd9",
         "esy-freetype2@2.9.1007@d41d8cd9",
-        "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.5@bb81afdc",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@aef1678b",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@b0227b2f", "@opam/bos@opam:0.2.0@df49e63f",
         "@glennsl/timber@1.2.0@d41d8cd9", "@esy-ocaml/reason@3.6.0@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
       ],
@@ -685,6 +684,41 @@
       ],
       "devDependencies": []
     },
+    "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-native-lwt",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-native-lwt/-/fetch-native-lwt-0.1.0-alpha.5.tgz#sha1:5a0a40149d5d10e233361bb40c42304f538090aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
+        "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "fetch-core@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-core@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-core",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-core/-/fetch-core-0.1.0-alpha.5.tgz#sha1:71a2420796743056f3efba8da19a540cc910db95"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "esy-tree-sitter@1.4.1@d41d8cd9": {
       "id": "esy-tree-sitter@1.4.1@d41d8cd9",
       "name": "esy-tree-sitter",
@@ -873,6 +907,20 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9": {
+      "id": "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+      "name": "esy-autoconf",
+      "version": "github:esy-packages/esy-autoconf#fb93edf",
+      "source": {
+        "type": "install",
+        "source": [ "github:esy-packages/esy-autoconf#fb93edf" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "editor-input@github:onivim/editor-input#c494950@d41d8cd9": {
       "id": "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
       "name": "editor-input",
@@ -1041,7 +1089,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#82db1eb@d41d8cd9",
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
@@ -1189,6 +1237,266 @@
       ],
       "devDependencies": []
     },
+    "@reason-native-web/ssl@0.5.9007@d41d8cd9": {
+      "id": "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+      "name": "@reason-native-web/ssl",
+      "version": "0.5.9007",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/ssl/-/ssl-0.5.9007.tgz#sha1:2eceef610fb593f10605dbde0cbcec153bf7b744"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/piaf@1.3.1000@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+      "name": "@reason-native-web/piaf",
+      "version": "1.3.1000",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.1000.tgz#sha1:e21820a3e0fe7ac1e2f0d41462c01bfc64d5ac0e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+        "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/uri@opam:3.1.0@faef85a4",
+        "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+        "@opam/magic-mime@opam:1.1.2@980f82fb",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9": {
+      "id": "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+      "name": "@reason-native-web/lwt_ssl",
+      "version": "1.1.3005",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/lwt_ssl/-/lwt_ssl-1.1.3005.tgz#sha1:6ac76e006175e3b320b8a1c690f50cebb5699050"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt-unix",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt-unix/-/h2-lwt-unix-0.6.1001.tgz#sha1:9f89181b5d2d244c9ee1d8a1e88fd258c4ab6d56"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/psq@opam:0.2.0@247756d4", "@opam/hpack@opam:0.2.0@9f3eae78",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/base64@opam:3.4.0@f5b9ad9b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt-unix",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt-unix/-/h1-lwt-unix-1.2.1001.tgz#sha1:ef6c7ab43bc717db58dc8af913f2b68b34de2c5f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt/-/h1-lwt-1.2.1001.tgz#sha1:e2fef4defebe735128c47484abcc12f55df6d43c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1/-/h1-1.2.1001.tgz#sha1:16f1cfeb43009f45e64e91a8aba9c62e80fb27fe"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt-unix",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt-unix/-/gluten-lwt-unix-0.2.1.tgz#sha1:e661685c6c72ef38b48318279ed16434824563f9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt/-/gluten-lwt-0.2.1.tgz#sha1:0d35a7de4abd2b55e4afc57d902c9f36a4d6e3e4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/gluten@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten/-/gluten-0.2.1.tgz#sha1:cbc732d5d238f845c54d466bb5da7380feb66b72"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9": {
+      "id": "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+      "name": "@reason-native-web/esy-openssl",
+      "version": "1.1.1006",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/esy-openssl/-/esy-openssl-1.1.1006.tgz#sha1:4154a9b17d9ebdc1c983a3075513b5cd276873ac"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/conf-autoconf@opam:0.1@27b3f7cf"
+      ],
+      "devDependencies": []
+    },
     "@opam/zed@opam:3.1.0@86c55416": {
       "id": "@opam/zed@opam:3.1.0@86c55416",
       "name": "@opam/zed",
@@ -1296,6 +1604,33 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/uri@opam:3.1.0@faef85a4": {
+      "id": "@opam/uri@opam:3.1.0@faef85a4",
+      "name": "@opam/uri",
+      "version": "opam:3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/c4/c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43",
+          "archive:https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+        ],
+        "opam": {
+          "name": "uri",
+          "version": "3.1.0",
+          "path": "esy.lock/opam/uri.3.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/uchar@opam:0.0.2@c8218eea": {
       "id": "@opam/uchar@opam:0.0.2@c8218eea",
       "name": "@opam/uchar",
@@ -1398,6 +1733,33 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
+    "@opam/stringext@opam:1.6.0@104bc94b": {
+      "id": "@opam/stringext@opam:1.6.0@104bc94b",
+      "name": "@opam/stringext",
+      "version": "opam:1.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/db/db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea",
+          "archive:https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+        ],
+        "opam": {
+          "name": "stringext",
+          "version": "1.6.0",
+          "path": "esy.lock/opam/stringext.1.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
     "@opam/stdlib-shims@opam:0.1.0@d957c903": {
       "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
       "name": "@opam/stdlib-shims",
@@ -1493,6 +1855,34 @@
         "ocaml@4.9.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
+    },
+    "@opam/rresult@opam:0.6.0@4b185e72": {
+      "id": "@opam/rresult@opam:0.6.0@4b185e72",
+      "name": "@opam/rresult",
+      "version": "opam:0.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ab/aba88cffa29081714468c2c7bcdf7fb1#md5:aba88cffa29081714468c2c7bcdf7fb1",
+          "archive:http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz#md5:aba88cffa29081714468c2c7bcdf7fb1"
+        ],
+        "opam": {
+          "name": "rresult",
+          "version": "0.6.0",
+          "path": "esy.lock/opam/rresult.0.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/result@opam:1.5@6b753c82",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82"
+      ]
     },
     "@opam/result@opam:1.5@6b753c82": {
       "id": "@opam/result@opam:1.5@6b753c82",
@@ -2081,6 +2471,31 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa": {
+      "id": "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+      "name": "@opam/ocaml-syntax-shims",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/89/89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8",
+          "archive:https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+        ],
+        "opam": {
+          "name": "ocaml-syntax-shims",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/ocaml-syntax-shims.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47": {
       "id": "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
       "name": "@opam/ocaml-migrate-parsetree",
@@ -2378,6 +2793,31 @@
         "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/magic-mime@opam:1.1.2@980f82fb": {
+      "id": "@opam/magic-mime@opam:1.1.2@980f82fb",
+      "name": "@opam/magic-mime",
+      "version": "opam:1.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/0c/0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb",
+          "archive:https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+        ],
+        "opam": {
+          "name": "magic-mime",
+          "version": "1.1.2",
+          "path": "esy.lock/opam/magic-mime.1.1.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {
       "id": "@opam/lwt_react@opam:1.1.3@72987fcf",
       "name": "@opam/lwt_react",
@@ -2661,6 +3101,35 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/hpack@opam:0.2.0@9f3eae78": {
+      "id": "@opam/hpack@opam:0.2.0@9f3eae78",
+      "name": "@opam/hpack",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c8/c883927ce8a9f3f7159ef7b20988f051#md5:c883927ce8a9f3f7159ef7b20988f051",
+          "archive:https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz#md5:c883927ce8a9f3f7159ef7b20988f051"
+        ],
+        "opam": {
+          "name": "hpack",
+          "version": "0.2.0",
+          "path": "esy.lock/opam/hpack.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ]
+    },
     "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9": {
       "id": "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
       "name": "@opam/fs",
@@ -2783,6 +3252,91 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday-lwt-unix@opam:0.7.1@4854f547": {
+      "id": "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+      "name": "@opam/faraday-lwt-unix",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt-unix",
+          "version": "0.7.1",
+          "path": "esy.lock/opam/faraday-lwt-unix.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ]
+    },
+    "@opam/faraday-lwt@opam:0.7.1@e28c97d1": {
+      "id": "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+      "name": "@opam/faraday-lwt",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt",
+          "version": "0.7.1",
+          "path": "esy.lock/opam/faraday-lwt.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday@opam:0.7.1@19546ee5": {
+      "id": "@opam/faraday@opam:0.7.1@19546ee5",
+      "name": "@opam/faraday",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday",
+          "version": "0.7.1",
+          "path": "esy.lock/opam/faraday.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -3067,6 +3621,31 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "@opam/conf-autoconf@opam:0.1@27b3f7cf": {
+      "id": "@opam/conf-autoconf@opam:0.1@27b3f7cf",
+      "name": "@opam/conf-autoconf",
+      "version": "opam:0.1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-autoconf",
+          "version": "0.1",
+          "path": "esy.lock/opam/conf-autoconf.0.1"
+        }
+      },
+      "overrides": [
+        {
+          "opamoverride":
+            "esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override"
+        }
+      ],
+      "dependencies": [
+        "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "@opam/charInfo_width@opam:1.1.0@9d8d61b2": {
       "id": "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
       "name": "@opam/charInfo_width",
@@ -3121,6 +3700,42 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/bos@opam:0.2.0@df49e63f": {
+      "id": "@opam/bos@opam:0.2.0@df49e63f",
+      "name": "@opam/bos",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ae/aeae7447567db459c856ee41b5a66fd2#md5:aeae7447567db459c856ee41b5a66fd2",
+          "archive:http://erratique.ch/software/bos/releases/bos-0.2.0.tbz#md5:aeae7447567db459c856ee41b5a66fd2"
+        ],
+        "opam": {
+          "name": "bos",
+          "version": "0.2.0",
+          "path": "esy.lock/opam/bos.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
     "@opam/biniou@opam:1.2.1@d7570399": {
       "id": "@opam/biniou@opam:1.2.1@d7570399",
       "name": "@opam/biniou",
@@ -3145,6 +3760,89 @@
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/bigstringaf@opam:0.6.1@35f5e6d1": {
+      "id": "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+      "name": "@opam/bigstringaf",
+      "version": "opam:0.6.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/dc/dccf639273b1eec0e0f142f21319268d#md5:dccf639273b1eec0e0f142f21319268d",
+          "archive:https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz#md5:dccf639273b1eec0e0f142f21319268d"
+        ],
+        "opam": {
+          "name": "bigstringaf",
+          "version": "0.6.1",
+          "path": "esy.lock/opam/bigstringaf.0.6.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97"
+      ]
+    },
+    "@opam/bigarray-compat@opam:1.0.0@1faefa97": {
+      "id": "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+      "name": "@opam/bigarray-compat",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1c/1cc7c25382a8900bada34aadfd66632e#md5:1cc7c25382a8900bada34aadfd66632e",
+          "archive:https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz#md5:1cc7c25382a8900bada34aadfd66632e"
+        ],
+        "opam": {
+          "name": "bigarray-compat",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/bigarray-compat.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/base64@opam:3.4.0@f5b9ad9b": {
+      "id": "@opam/base64@opam:3.4.0@f5b9ad9b",
+      "name": "@opam/base64",
+      "version": "opam:3.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/1c/1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634",
+          "archive:https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+        ],
+        "opam": {
+          "name": "base64",
+          "version": "3.4.0",
+          "path": "esy.lock/opam/base64.3.4.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -3367,6 +4065,35 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/angstrom@opam:0.14.1@07e286b0": {
+      "id": "@opam/angstrom@opam:0.14.1@07e286b0",
+      "name": "@opam/angstrom",
+      "version": "opam:0.14.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/91/915bbcc1adbd0debc1b0a54531c7601a#md5:915bbcc1adbd0debc1b0a54531c7601a",
+          "archive:https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz#md5:915bbcc1adbd0debc1b0a54531c7601a"
+        ],
+        "opam": {
+          "name": "angstrom",
+          "version": "0.14.1",
+          "path": "esy.lock/opam/angstrom.0.14.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@glennsl/timber@1.2.0@d41d8cd9": {

--- a/esy.lock/opam/angstrom.0.14.1/opam
+++ b/esy.lock/opam/angstrom.0.14.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/angstrom"
+bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "bigstringaf"
+  "result"
+]
+synopsis: "Parser combinators built for speed and memory-efficiency"
+description: """
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
+default and support unbounded lookahead."""
+url {
+  src: "https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz"
+  checksum: "md5=915bbcc1adbd0debc1b0a54531c7601a"
+}

--- a/esy.lock/opam/base64.3.4.0/opam
+++ b/esy.lock/opam/base64.3.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>="4.03.0"}
+  "base-bytes"
+  "dune-configurator"
+  "dune" {>= "2.0"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz"
+  checksum: [
+    "sha256=1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+    "sha512=e66a67302a9eb136044bebf66a89a1d6e38a96c70622bb6cd27916fec36dcaf4b5b7e7d00c25608f0a2363f2ca4264a5fe765fe7747590958325dbce06311db9"
+  ]
+}

--- a/esy.lock/opam/bigarray-compat.1.0.0/opam
+++ b/esy.lock/opam/bigarray-compat.1.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Compatibility library to use Stdlib.Bigarray when possible"
+maintainer: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+authors: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/bigarray-compat"
+bug-reports: "https://github.com/mirage/bigarray-compat/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
+url {
+  src: "https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=1cc7c25382a8900bada34aadfd66632e"
+    "sha512=c365fee15582aca35d7b05268cde29e54774ad7df7be56762b4aad78ca1409d4326ad3b34af0f1cc2c7b872837290a9cd9ff43b47987c03bba7bba32fe8a030f"
+  ]
+}

--- a/esy.lock/opam/bigstringaf.0.6.1/opam
+++ b/esy.lock/opam/bigstringaf.0.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/bigstringaf"
+bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+  "bigarray-compat"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "js_of_ocaml" {< "3.5.0"}
+]
+synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"
+description: """
+Bigstring intrinsics and fast blits based on memcpy/memmove
+
+The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+widely-known, sometimes misused, and so programs that use Bigstrings are slower
+than they have to be. And even if a library got that part right and exposed the
+intrinsics properly, the compiler doesn't have any fast blits between
+Bigstrings and other string-like types.
+
+So here they are. Go crazy.
+"""
+url {
+  src: "https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz"
+  checksum: "md5=dccf639273b1eec0e0f142f21319268d"
+}

--- a/esy.lock/opam/bos.0.2.0/opam
+++ b/esy.lock/opam/bos.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/bos"
+doc: "http://erratique.ch/software/bos/doc"
+dev-repo: "git+http://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "base-unix"
+  "rresult" {>= "0.4.0"}
+  "astring"
+  "fpath"
+  "fmt" {>= "0.8.0"}
+  "logs"
+  "mtime" {with-test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Basic OS interaction for OCaml"
+description: """
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs"""
+url {
+  src: "http://erratique.ch/software/bos/releases/bos-0.2.0.tbz"
+  checksum: "md5=aeae7447567db459c856ee41b5a66fd2"
+}

--- a/esy.lock/opam/conf-autoconf.0.1/opam
+++ b/esy.lock/opam/conf-autoconf.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.gnu.org/software/autoconf"
+authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-3.0"
+build: [
+  ["which" "autoconf"]
+]
+depends: ["conf-which" {build}]
+depexts: [
+  ["autoconf"] {os-family = "debian"}
+  ["autoconf"] {os-distribution = "centos"}
+  ["autoconf"] {os-distribution = "fedora"}
+  ["autoconf"] {os-distribution = "arch"}
+  ["sys-devel/autoconf"] {os-distribution = "gentoo"}
+  ["autoconf"] {os-distribution = "nixos"}
+  ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["devel/autoconf"] {os = "openbsd"}
+  ["autoconf"] {os = "freebsd"}
+  ["autoconf"] {os = "netbsd"}
+  ["autoconf"] {os-distribution = "alpine"}
+  ["autoconf"] {os-distribution = "ol"}
+  ["autoconf"] {os-distribution = "rhel"}
+]
+synopsis: "Virtual package relying on autoconf installation"
+description: """
+This package can only install if the autoconf command
+is available on the system."""
+flags: conf

--- a/esy.lock/opam/faraday-lwt-unix.0.7.1/opam
+++ b/esy.lock/opam/faraday-lwt-unix.0.7.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday-lwt"
+  "lwt" {>= "2.7.0"}
+  "base-unix"
+]
+synopsis: "Lwt_unix support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/esy.lock/opam/faraday-lwt.0.7.1/opam
+++ b/esy.lock/opam/faraday-lwt.0.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday" {>= "0.5.0"}
+  "lwt"
+]
+synopsis: "Lwt support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/esy.lock/opam/faraday.0.7.1/opam
+++ b/esy.lock/opam/faraday.0.7.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.4.1"}
+  "bigstringaf"
+]
+synopsis: "A library for writing fast and memory-efficient serializers."
+description: """
+Faraday is a library for writing fast and memory-efficient serializers. Its
+core type and related operation gives the user fine-grained control over
+copying and allocation behavior while serializing user-defined types, and
+presents the output in a form that makes it possible to use vectorized write
+operations, such as the writev system call, or any other platform or
+application-specific output APIs."""
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/esy.lock/opam/hpack.0.2.0/opam
+++ b/esy.lock/opam/hpack.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+           "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-Clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune"
+  "yojson" {with-test}
+  "hex" {with-test}
+  "angstrom"
+  "faraday"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description: """
+hpack is an implementation of the HPACK: Header Compression for HTTP/2
+specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for
+parsing and serialization, respectively.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/esy.lock/opam/magic-mime.1.1.2/opam
+++ b/esy.lock/opam/magic-mime.1.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "magic-mime"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz"
+  checksum: [
+    "sha256=0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+    "sha512=8264db78adc2c75b8adabc23c26ad34eab98383bd3a8f2068f2236ff3425d653c0238fbd7361e55a3d70d843413ef8671b6e97293074b4d3a1e300628d5292ab"
+  ]
+}

--- a/esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
+++ b/esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Backport new syntax to older OCaml versions"
+description: """
+This packages backports new features of the language to older
+compilers, such as let+.
+"""
+maintainer: ["jeremie@dimino.org"]
+authors: ["Jérémie Dimino <jeremie@dimino.org>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocaml-syntax-shims"
+doc: "https://ocaml-ppx.github.io/ocaml-syntax-shims/"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-syntax-shims/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.02.3"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-syntax-shims.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz"
+  checksum: [
+    "sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+    "sha512=75c4c6b0bfa1267a8a49a82ba494d08cf0823fc8350863d6d3d4971528cb09e5a2a29e2981d04c75e76ad0f49360b05a432c9efeff9a4fbc1ec6b28960399852"
+  ]
+}

--- a/esy.lock/opam/rresult.0.6.0/opam
+++ b/esy.lock/opam/rresult.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "git+http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+   "ocaml" {>= "4.01.0"}
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]
+
+synopsis: """Result value combinators for OCaml"""
+description: """\
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz"
+checksum: "aba88cffa29081714468c2c7bcdf7fb1"
+}

--- a/esy.lock/opam/stringext.1.6.0/opam
+++ b/esy.lock/opam/stringext.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+license: "MIT"
+homepage: "https://github.com/rgrinberg/stringext"
+bug-reports: "https://github.com/rgrinberg/stringext/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "qtest" {with-test & >= "2.2"}
+  "base-bytes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/rgrinberg/stringext.git"
+synopsis: "Extra string functions for OCaml"
+description: """
+Extra string functions for OCaml. Mainly splitting. All functions are in the
+Stringext module.
+"""
+url {
+  src:
+    "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz"
+  checksum: [
+    "sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+    "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
+  ]
+}

--- a/esy.lock/opam/uri.3.1.0/opam
+++ b/esy.lock/opam/uri.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0" & < "v0.14"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz"
+  checksum: [
+    "sha256=c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+    "sha512=c015576bb077fd243022bcd8804e628d23a253dcd8bbdda8dc2a57e86cfeb9fd629087ec7d7e23dc71dd7cd137450ca2c5ecf8fb7d184ec9d1d4e41f6f83ee38"
+  ]
+}

--- a/esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
+++ b/esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
@@ -1,0 +1,6 @@
+{
+  "build": [ "true" ],
+  "dependencies": {
+    "esy-autoconf": "esy-packages/esy-autoconf#fb93edf"
+  }
+}

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "50523377bb7d08b6c3315ab45f94de88",
+  "checksum": "74d4c8b7dbbc51e0e75c52426f9f1ac1",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#eec9bf9@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#12fb2dc@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+    "revery@github:revery-ui/revery#f2dce86@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#12fb2dc",
+      "version": "github:revery-ui/revery#f2dce86",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#12fb2dc" ]
+        "source": [ "github:revery-ui/revery#f2dce86" ]
       },
       "overrides": [],
       "dependencies": [
@@ -153,18 +153,17 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "flex@1.2.3@d41d8cd9",
+        "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-harfbuzz@1.9.1008@d41d8cd9",
         "esy-freetype2@2.9.1007@d41d8cd9",
-        "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.5@bb81afdc",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@aef1678b",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@b0227b2f", "@opam/bos@opam:0.2.0@df49e63f",
         "@glennsl/timber@1.2.0@d41d8cd9", "@esy-ocaml/reason@3.6.0@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
       ],
@@ -685,6 +684,41 @@
       ],
       "devDependencies": []
     },
+    "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-native-lwt",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-native-lwt/-/fetch-native-lwt-0.1.0-alpha.5.tgz#sha1:5a0a40149d5d10e233361bb40c42304f538090aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
+        "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "fetch-core@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-core@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-core",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-core/-/fetch-core-0.1.0-alpha.5.tgz#sha1:71a2420796743056f3efba8da19a540cc910db95"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "esy-tree-sitter@1.4.1@d41d8cd9": {
       "id": "esy-tree-sitter@1.4.1@d41d8cd9",
       "name": "esy-tree-sitter",
@@ -873,6 +907,20 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9": {
+      "id": "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+      "name": "esy-autoconf",
+      "version": "github:esy-packages/esy-autoconf#fb93edf",
+      "source": {
+        "type": "install",
+        "source": [ "github:esy-packages/esy-autoconf#fb93edf" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "editor-input@github:onivim/editor-input#c494950@d41d8cd9": {
       "id": "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
       "name": "editor-input",
@@ -1041,7 +1089,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#82db1eb@d41d8cd9",
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
@@ -1189,6 +1237,266 @@
       ],
       "devDependencies": []
     },
+    "@reason-native-web/ssl@0.5.9007@d41d8cd9": {
+      "id": "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+      "name": "@reason-native-web/ssl",
+      "version": "0.5.9007",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/ssl/-/ssl-0.5.9007.tgz#sha1:2eceef610fb593f10605dbde0cbcec153bf7b744"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/piaf@1.3.1000@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+      "name": "@reason-native-web/piaf",
+      "version": "1.3.1000",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.1000.tgz#sha1:e21820a3e0fe7ac1e2f0d41462c01bfc64d5ac0e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+        "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/uri@opam:3.1.0@faef85a4",
+        "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+        "@opam/magic-mime@opam:1.1.2@980f82fb",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9": {
+      "id": "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+      "name": "@reason-native-web/lwt_ssl",
+      "version": "1.1.3005",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/lwt_ssl/-/lwt_ssl-1.1.3005.tgz#sha1:6ac76e006175e3b320b8a1c690f50cebb5699050"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt-unix",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt-unix/-/h2-lwt-unix-0.6.1001.tgz#sha1:9f89181b5d2d244c9ee1d8a1e88fd258c4ab6d56"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/psq@opam:0.2.0@247756d4", "@opam/hpack@opam:0.2.0@9f3eae78",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/base64@opam:3.4.0@f5b9ad9b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt-unix",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt-unix/-/h1-lwt-unix-1.2.1001.tgz#sha1:ef6c7ab43bc717db58dc8af913f2b68b34de2c5f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt/-/h1-lwt-1.2.1001.tgz#sha1:e2fef4defebe735128c47484abcc12f55df6d43c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1/-/h1-1.2.1001.tgz#sha1:16f1cfeb43009f45e64e91a8aba9c62e80fb27fe"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt-unix",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt-unix/-/gluten-lwt-unix-0.2.1.tgz#sha1:e661685c6c72ef38b48318279ed16434824563f9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt/-/gluten-lwt-0.2.1.tgz#sha1:0d35a7de4abd2b55e4afc57d902c9f36a4d6e3e4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/gluten@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten/-/gluten-0.2.1.tgz#sha1:cbc732d5d238f845c54d466bb5da7380feb66b72"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9": {
+      "id": "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+      "name": "@reason-native-web/esy-openssl",
+      "version": "1.1.1006",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/esy-openssl/-/esy-openssl-1.1.1006.tgz#sha1:4154a9b17d9ebdc1c983a3075513b5cd276873ac"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/conf-autoconf@opam:0.1@27b3f7cf"
+      ],
+      "devDependencies": []
+    },
     "@opam/zed@opam:3.1.0@86c55416": {
       "id": "@opam/zed@opam:3.1.0@86c55416",
       "name": "@opam/zed",
@@ -1296,6 +1604,33 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/uri@opam:3.1.0@faef85a4": {
+      "id": "@opam/uri@opam:3.1.0@faef85a4",
+      "name": "@opam/uri",
+      "version": "opam:3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/c4/c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43",
+          "archive:https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+        ],
+        "opam": {
+          "name": "uri",
+          "version": "3.1.0",
+          "path": "integrationtest.esy.lock/opam/uri.3.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/uchar@opam:0.0.2@c8218eea": {
       "id": "@opam/uchar@opam:0.0.2@c8218eea",
       "name": "@opam/uchar",
@@ -1398,6 +1733,33 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
+    "@opam/stringext@opam:1.6.0@104bc94b": {
+      "id": "@opam/stringext@opam:1.6.0@104bc94b",
+      "name": "@opam/stringext",
+      "version": "opam:1.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/db/db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea",
+          "archive:https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+        ],
+        "opam": {
+          "name": "stringext",
+          "version": "1.6.0",
+          "path": "integrationtest.esy.lock/opam/stringext.1.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
     "@opam/stdlib-shims@opam:0.1.0@d957c903": {
       "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
       "name": "@opam/stdlib-shims",
@@ -1493,6 +1855,34 @@
         "ocaml@4.9.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
+    },
+    "@opam/rresult@opam:0.6.0@4b185e72": {
+      "id": "@opam/rresult@opam:0.6.0@4b185e72",
+      "name": "@opam/rresult",
+      "version": "opam:0.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ab/aba88cffa29081714468c2c7bcdf7fb1#md5:aba88cffa29081714468c2c7bcdf7fb1",
+          "archive:http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz#md5:aba88cffa29081714468c2c7bcdf7fb1"
+        ],
+        "opam": {
+          "name": "rresult",
+          "version": "0.6.0",
+          "path": "integrationtest.esy.lock/opam/rresult.0.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/result@opam:1.5@6b753c82",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82"
+      ]
     },
     "@opam/result@opam:1.5@6b753c82": {
       "id": "@opam/result@opam:1.5@6b753c82",
@@ -2081,6 +2471,31 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa": {
+      "id": "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+      "name": "@opam/ocaml-syntax-shims",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/89/89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8",
+          "archive:https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+        ],
+        "opam": {
+          "name": "ocaml-syntax-shims",
+          "version": "1.0.0",
+          "path": "integrationtest.esy.lock/opam/ocaml-syntax-shims.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47": {
       "id": "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
       "name": "@opam/ocaml-migrate-parsetree",
@@ -2379,6 +2794,31 @@
         "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/magic-mime@opam:1.1.2@980f82fb": {
+      "id": "@opam/magic-mime@opam:1.1.2@980f82fb",
+      "name": "@opam/magic-mime",
+      "version": "opam:1.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/0c/0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb",
+          "archive:https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+        ],
+        "opam": {
+          "name": "magic-mime",
+          "version": "1.1.2",
+          "path": "integrationtest.esy.lock/opam/magic-mime.1.1.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {
       "id": "@opam/lwt_react@opam:1.1.3@72987fcf",
       "name": "@opam/lwt_react",
@@ -2662,6 +3102,35 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/hpack@opam:0.2.0@9f3eae78": {
+      "id": "@opam/hpack@opam:0.2.0@9f3eae78",
+      "name": "@opam/hpack",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c8/c883927ce8a9f3f7159ef7b20988f051#md5:c883927ce8a9f3f7159ef7b20988f051",
+          "archive:https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz#md5:c883927ce8a9f3f7159ef7b20988f051"
+        ],
+        "opam": {
+          "name": "hpack",
+          "version": "0.2.0",
+          "path": "integrationtest.esy.lock/opam/hpack.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ]
+    },
     "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9": {
       "id": "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
       "name": "@opam/fs",
@@ -2784,6 +3253,91 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday-lwt-unix@opam:0.7.1@4854f547": {
+      "id": "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+      "name": "@opam/faraday-lwt-unix",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt-unix",
+          "version": "0.7.1",
+          "path": "integrationtest.esy.lock/opam/faraday-lwt-unix.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ]
+    },
+    "@opam/faraday-lwt@opam:0.7.1@e28c97d1": {
+      "id": "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+      "name": "@opam/faraday-lwt",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt",
+          "version": "0.7.1",
+          "path": "integrationtest.esy.lock/opam/faraday-lwt.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday@opam:0.7.1@19546ee5": {
+      "id": "@opam/faraday@opam:0.7.1@19546ee5",
+      "name": "@opam/faraday",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday",
+          "version": "0.7.1",
+          "path": "integrationtest.esy.lock/opam/faraday.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -3068,6 +3622,31 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "@opam/conf-autoconf@opam:0.1@27b3f7cf": {
+      "id": "@opam/conf-autoconf@opam:0.1@27b3f7cf",
+      "name": "@opam/conf-autoconf",
+      "version": "opam:0.1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-autoconf",
+          "version": "0.1",
+          "path": "integrationtest.esy.lock/opam/conf-autoconf.0.1"
+        }
+      },
+      "overrides": [
+        {
+          "opamoverride":
+            "integrationtest.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override"
+        }
+      ],
+      "dependencies": [
+        "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "@opam/charInfo_width@opam:1.1.0@9d8d61b2": {
       "id": "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
       "name": "@opam/charInfo_width",
@@ -3122,6 +3701,42 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/bos@opam:0.2.0@df49e63f": {
+      "id": "@opam/bos@opam:0.2.0@df49e63f",
+      "name": "@opam/bos",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ae/aeae7447567db459c856ee41b5a66fd2#md5:aeae7447567db459c856ee41b5a66fd2",
+          "archive:http://erratique.ch/software/bos/releases/bos-0.2.0.tbz#md5:aeae7447567db459c856ee41b5a66fd2"
+        ],
+        "opam": {
+          "name": "bos",
+          "version": "0.2.0",
+          "path": "integrationtest.esy.lock/opam/bos.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
     "@opam/biniou@opam:1.2.1@d7570399": {
       "id": "@opam/biniou@opam:1.2.1@d7570399",
       "name": "@opam/biniou",
@@ -3146,6 +3761,89 @@
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/bigstringaf@opam:0.6.1@35f5e6d1": {
+      "id": "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+      "name": "@opam/bigstringaf",
+      "version": "opam:0.6.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/dc/dccf639273b1eec0e0f142f21319268d#md5:dccf639273b1eec0e0f142f21319268d",
+          "archive:https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz#md5:dccf639273b1eec0e0f142f21319268d"
+        ],
+        "opam": {
+          "name": "bigstringaf",
+          "version": "0.6.1",
+          "path": "integrationtest.esy.lock/opam/bigstringaf.0.6.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97"
+      ]
+    },
+    "@opam/bigarray-compat@opam:1.0.0@1faefa97": {
+      "id": "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+      "name": "@opam/bigarray-compat",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1c/1cc7c25382a8900bada34aadfd66632e#md5:1cc7c25382a8900bada34aadfd66632e",
+          "archive:https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz#md5:1cc7c25382a8900bada34aadfd66632e"
+        ],
+        "opam": {
+          "name": "bigarray-compat",
+          "version": "1.0.0",
+          "path": "integrationtest.esy.lock/opam/bigarray-compat.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/base64@opam:3.4.0@f5b9ad9b": {
+      "id": "@opam/base64@opam:3.4.0@f5b9ad9b",
+      "name": "@opam/base64",
+      "version": "opam:3.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/1c/1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634",
+          "archive:https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+        ],
+        "opam": {
+          "name": "base64",
+          "version": "3.4.0",
+          "path": "integrationtest.esy.lock/opam/base64.3.4.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -3368,6 +4066,35 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/angstrom@opam:0.14.1@07e286b0": {
+      "id": "@opam/angstrom@opam:0.14.1@07e286b0",
+      "name": "@opam/angstrom",
+      "version": "opam:0.14.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/91/915bbcc1adbd0debc1b0a54531c7601a#md5:915bbcc1adbd0debc1b0a54531c7601a",
+          "archive:https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz#md5:915bbcc1adbd0debc1b0a54531c7601a"
+        ],
+        "opam": {
+          "name": "angstrom",
+          "version": "0.14.1",
+          "path": "integrationtest.esy.lock/opam/angstrom.0.14.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@glennsl/timber@1.2.0@d41d8cd9": {

--- a/integrationtest.esy.lock/opam/angstrom.0.14.1/opam
+++ b/integrationtest.esy.lock/opam/angstrom.0.14.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/angstrom"
+bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "bigstringaf"
+  "result"
+]
+synopsis: "Parser combinators built for speed and memory-efficiency"
+description: """
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
+default and support unbounded lookahead."""
+url {
+  src: "https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz"
+  checksum: "md5=915bbcc1adbd0debc1b0a54531c7601a"
+}

--- a/integrationtest.esy.lock/opam/base64.3.4.0/opam
+++ b/integrationtest.esy.lock/opam/base64.3.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>="4.03.0"}
+  "base-bytes"
+  "dune-configurator"
+  "dune" {>= "2.0"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz"
+  checksum: [
+    "sha256=1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+    "sha512=e66a67302a9eb136044bebf66a89a1d6e38a96c70622bb6cd27916fec36dcaf4b5b7e7d00c25608f0a2363f2ca4264a5fe765fe7747590958325dbce06311db9"
+  ]
+}

--- a/integrationtest.esy.lock/opam/bigarray-compat.1.0.0/opam
+++ b/integrationtest.esy.lock/opam/bigarray-compat.1.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Compatibility library to use Stdlib.Bigarray when possible"
+maintainer: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+authors: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/bigarray-compat"
+bug-reports: "https://github.com/mirage/bigarray-compat/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
+url {
+  src: "https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=1cc7c25382a8900bada34aadfd66632e"
+    "sha512=c365fee15582aca35d7b05268cde29e54774ad7df7be56762b4aad78ca1409d4326ad3b34af0f1cc2c7b872837290a9cd9ff43b47987c03bba7bba32fe8a030f"
+  ]
+}

--- a/integrationtest.esy.lock/opam/bigstringaf.0.6.1/opam
+++ b/integrationtest.esy.lock/opam/bigstringaf.0.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/bigstringaf"
+bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+  "bigarray-compat"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "js_of_ocaml" {< "3.5.0"}
+]
+synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"
+description: """
+Bigstring intrinsics and fast blits based on memcpy/memmove
+
+The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+widely-known, sometimes misused, and so programs that use Bigstrings are slower
+than they have to be. And even if a library got that part right and exposed the
+intrinsics properly, the compiler doesn't have any fast blits between
+Bigstrings and other string-like types.
+
+So here they are. Go crazy.
+"""
+url {
+  src: "https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz"
+  checksum: "md5=dccf639273b1eec0e0f142f21319268d"
+}

--- a/integrationtest.esy.lock/opam/bos.0.2.0/opam
+++ b/integrationtest.esy.lock/opam/bos.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/bos"
+doc: "http://erratique.ch/software/bos/doc"
+dev-repo: "git+http://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "base-unix"
+  "rresult" {>= "0.4.0"}
+  "astring"
+  "fpath"
+  "fmt" {>= "0.8.0"}
+  "logs"
+  "mtime" {with-test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Basic OS interaction for OCaml"
+description: """
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs"""
+url {
+  src: "http://erratique.ch/software/bos/releases/bos-0.2.0.tbz"
+  checksum: "md5=aeae7447567db459c856ee41b5a66fd2"
+}

--- a/integrationtest.esy.lock/opam/conf-autoconf.0.1/opam
+++ b/integrationtest.esy.lock/opam/conf-autoconf.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.gnu.org/software/autoconf"
+authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-3.0"
+build: [
+  ["which" "autoconf"]
+]
+depends: ["conf-which" {build}]
+depexts: [
+  ["autoconf"] {os-family = "debian"}
+  ["autoconf"] {os-distribution = "centos"}
+  ["autoconf"] {os-distribution = "fedora"}
+  ["autoconf"] {os-distribution = "arch"}
+  ["sys-devel/autoconf"] {os-distribution = "gentoo"}
+  ["autoconf"] {os-distribution = "nixos"}
+  ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["devel/autoconf"] {os = "openbsd"}
+  ["autoconf"] {os = "freebsd"}
+  ["autoconf"] {os = "netbsd"}
+  ["autoconf"] {os-distribution = "alpine"}
+  ["autoconf"] {os-distribution = "ol"}
+  ["autoconf"] {os-distribution = "rhel"}
+]
+synopsis: "Virtual package relying on autoconf installation"
+description: """
+This package can only install if the autoconf command
+is available on the system."""
+flags: conf

--- a/integrationtest.esy.lock/opam/faraday-lwt-unix.0.7.1/opam
+++ b/integrationtest.esy.lock/opam/faraday-lwt-unix.0.7.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday-lwt"
+  "lwt" {>= "2.7.0"}
+  "base-unix"
+]
+synopsis: "Lwt_unix support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/integrationtest.esy.lock/opam/faraday-lwt.0.7.1/opam
+++ b/integrationtest.esy.lock/opam/faraday-lwt.0.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday" {>= "0.5.0"}
+  "lwt"
+]
+synopsis: "Lwt support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/integrationtest.esy.lock/opam/faraday.0.7.1/opam
+++ b/integrationtest.esy.lock/opam/faraday.0.7.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.4.1"}
+  "bigstringaf"
+]
+synopsis: "A library for writing fast and memory-efficient serializers."
+description: """
+Faraday is a library for writing fast and memory-efficient serializers. Its
+core type and related operation gives the user fine-grained control over
+copying and allocation behavior while serializing user-defined types, and
+presents the output in a form that makes it possible to use vectorized write
+operations, such as the writev system call, or any other platform or
+application-specific output APIs."""
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/integrationtest.esy.lock/opam/hpack.0.2.0/opam
+++ b/integrationtest.esy.lock/opam/hpack.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+           "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-Clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune"
+  "yojson" {with-test}
+  "hex" {with-test}
+  "angstrom"
+  "faraday"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description: """
+hpack is an implementation of the HPACK: Header Compression for HTTP/2
+specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for
+parsing and serialization, respectively.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/integrationtest.esy.lock/opam/magic-mime.1.1.2/opam
+++ b/integrationtest.esy.lock/opam/magic-mime.1.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "magic-mime"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz"
+  checksum: [
+    "sha256=0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+    "sha512=8264db78adc2c75b8adabc23c26ad34eab98383bd3a8f2068f2236ff3425d653c0238fbd7361e55a3d70d843413ef8671b6e97293074b4d3a1e300628d5292ab"
+  ]
+}

--- a/integrationtest.esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
+++ b/integrationtest.esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Backport new syntax to older OCaml versions"
+description: """
+This packages backports new features of the language to older
+compilers, such as let+.
+"""
+maintainer: ["jeremie@dimino.org"]
+authors: ["Jérémie Dimino <jeremie@dimino.org>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocaml-syntax-shims"
+doc: "https://ocaml-ppx.github.io/ocaml-syntax-shims/"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-syntax-shims/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.02.3"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-syntax-shims.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz"
+  checksum: [
+    "sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+    "sha512=75c4c6b0bfa1267a8a49a82ba494d08cf0823fc8350863d6d3d4971528cb09e5a2a29e2981d04c75e76ad0f49360b05a432c9efeff9a4fbc1ec6b28960399852"
+  ]
+}

--- a/integrationtest.esy.lock/opam/rresult.0.6.0/opam
+++ b/integrationtest.esy.lock/opam/rresult.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "git+http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+   "ocaml" {>= "4.01.0"}
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]
+
+synopsis: """Result value combinators for OCaml"""
+description: """\
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz"
+checksum: "aba88cffa29081714468c2c7bcdf7fb1"
+}

--- a/integrationtest.esy.lock/opam/stringext.1.6.0/opam
+++ b/integrationtest.esy.lock/opam/stringext.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+license: "MIT"
+homepage: "https://github.com/rgrinberg/stringext"
+bug-reports: "https://github.com/rgrinberg/stringext/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "qtest" {with-test & >= "2.2"}
+  "base-bytes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/rgrinberg/stringext.git"
+synopsis: "Extra string functions for OCaml"
+description: """
+Extra string functions for OCaml. Mainly splitting. All functions are in the
+Stringext module.
+"""
+url {
+  src:
+    "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz"
+  checksum: [
+    "sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+    "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
+  ]
+}

--- a/integrationtest.esy.lock/opam/uri.3.1.0/opam
+++ b/integrationtest.esy.lock/opam/uri.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0" & < "v0.14"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz"
+  checksum: [
+    "sha256=c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+    "sha512=c015576bb077fd243022bcd8804e628d23a253dcd8bbdda8dc2a57e86cfeb9fd629087ec7d7e23dc71dd7cd137450ca2c5ecf8fb7d184ec9d1d4e41f6f83ee38"
+  ]
+}

--- a/integrationtest.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
+++ b/integrationtest.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
@@ -1,0 +1,6 @@
+{
+  "build": [ "true" ],
+  "dependencies": {
+    "esy-autoconf": "esy-packages/esy-autoconf#fb93edf"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
   "resolutions": {
     "@esy-ocaml/libffi": "onivim/libffi#590b041",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "revery": "revery-ui/revery#12fb2dc",
+    "revery": "revery-ui/revery#f2dce86",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-skia": "revery-ui/esy-skia#d60e5fe",
     "rench": "bryphe/rench#a976fe5",

--- a/scripts/osx/codesign.sh
+++ b/scripts/osx/codesign.sh
@@ -33,12 +33,8 @@ else
    manual-codesign Contents/MacOS/node
    manual-codesign Contents/MacOS/Oni2_editor
    manual-codesign Contents/MacOS/Oni2
-   manual-codesign Contents/Frameworks/libonig.5.dylib
-   manual-codesign Contents/Frameworks/libpng16.16.dylib
-   manual-codesign Contents/Frameworks/libfreetype.6.dylib
-   manual-codesign Contents/Frameworks/libharfbuzz.0.dylib
-   manual-codesign Contents/Frameworks/libSDL2-2.0.0.dylib
-   manual-codesign Contents/Frameworks/libffi.6.dylib
+   manual-codesign Contents/Frameworks/libssl.1.1.dylib
+   manual-codesign Contents/Frameworks/libcrypto.1.1.dylib
    manual-codesign Contents/Resources/node/node_modules/node-pty/build/Release/pty.node
    manual-codesign Contents/Resources/node/node_modules/spdlog/build/Release/spdlog.node
    manual-codesign Contents/Resources/node/node_modules/native-watchdog/build/Release/watchdog.node

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -222,6 +222,11 @@ if (process.platform == "linux") {
       "com.apple.security.cs.allow-jit": true,
       "com.apple.security.cs.allow-unsigned-executable-memory": true,
       "com.apple.security.cs.disable-library-validation": true,
+// Allow dyld environment variables. Needed because Onivim 2 uses	
+//         dyld variables (such as @executable_path) to load libaries from	
+//         within the .app bundle.	
+// See: https://github.com/onivim/oni2/issues/1397	
+      "com.apple.security.cs.allow-dyld-environment-variables": true,
   };
   fs.writeFileSync(entitlementsPath, require("plist").build(entitlementsContents));
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -201,8 +201,18 @@ if (process.platform == "linux") {
 
   const frameworks = fs.readdirSync(frameworksDirectory);
 
-  if (frameworks.length > 0) {
-    console.error("Found a dynamic library: " + JSON.stringify(frameworks));
+  // Make sure these are codesigned as well in codesign.sh
+  // Must be kept in sync with:
+  // src/scripts/osx/codesign.sh
+  const frameworksWhiteList = [
+    "libcrypto.1.1.dylib",
+    "libssl.1.1.dylib"
+  ];
+
+  const disallowedFrameworks = frameworks.filter(framework => !frameworksWhiteList.some(allowedFramework => framework.indexOf(allowedFramework) >= 0));
+
+  if (disallowedFrameworks.length > 0) {
+    console.error("Found a dynamic library: " + JSON.stringify(disallowedFrameworks));
     console.error("There should be only static libraries to successfully package.");
     throw "FrameworkFound";
   }

--- a/src/UI/ExtensionListView.re
+++ b/src/UI/ExtensionListView.re
@@ -27,7 +27,7 @@ let make = (~model, ~theme, ~font: UiFont.t, ()) => {
     let icon =
       switch (extension.manifest.icon) {
       | None => <Container color=Revery.Colors.darkGray width=32 height=32 />
-      | Some(iconPath) => <Image src=`File(iconPath) width=32 height=32 />
+      | Some(iconPath) => <Image src={`File(iconPath)} width=32 height=32 />
       };
 
     <View

--- a/src/UI/ExtensionListView.re
+++ b/src/UI/ExtensionListView.re
@@ -27,7 +27,7 @@ let make = (~model, ~theme, ~font: UiFont.t, ()) => {
     let icon =
       switch (extension.manifest.icon) {
       | None => <Container color=Revery.Colors.darkGray width=32 height=32 />
-      | Some(iconPath) => <Image src=iconPath width=32 height=32 />
+      | Some(iconPath) => <Image src=`File(iconPath) width=32 height=32 />
       };
 
     <View

--- a/src/UI/Titlebar.re
+++ b/src/UI/Titlebar.re
@@ -231,7 +231,7 @@ module Windows = {
       mouseBehavior=Draggable
       style={Styles.Windows.container(~isFocused, ~theme)}>
       <View mouseBehavior=Draggable style=Styles.Windows.iconAndTitle>
-        <Image src="./logo-titlebar.png" width=18 height=18 />
+        <Image src=`File("./logo-titlebar.png") width=18 height=18 />
         <Text
           style={Styles.Windows.title(~isFocused, ~theme)}
           fontFamily={font.normal}

--- a/src/UI/Titlebar.re
+++ b/src/UI/Titlebar.re
@@ -231,7 +231,7 @@ module Windows = {
       mouseBehavior=Draggable
       style={Styles.Windows.container(~isFocused, ~theme)}>
       <View mouseBehavior=Draggable style=Styles.Windows.iconAndTitle>
-        <Image src=`File("./logo-titlebar.png") width=18 height=18 />
+        <Image src={`File("./logo-titlebar.png")} width=18 height=18 />
         <Text
           style={Styles.Windows.title(~isFocused, ~theme)}
           fontFamily={font.normal}

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -113,7 +113,7 @@ let%component make = (~theme, ~uiFont: UiFont.t, ~editorFont, ()) => {
     <Opacity opacity=transition>
       <View style=Styles.header>
         <Image
-          src=`File("./title-logo.png")
+          src={`File("./title-logo.png")}
           width=456
           height=250
           opacity=transition

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -113,7 +113,7 @@ let%component make = (~theme, ~uiFont: UiFont.t, ~editorFont, ()) => {
     <Opacity opacity=transition>
       <View style=Styles.header>
         <Image
-          src="./title-logo.png"
+          src=`File("./title-logo.png")
           width=456
           height=250
           opacity=transition

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2d3ae989364f347ec637f7b5da01a593",
+  "checksum": "c77516f26dc3fb9888139a4141091435",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -131,20 +131,20 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "reason-libvterm@github:revery-ui/reason-libvterm#eec9bf9@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#12fb2dc@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+    "revery@github:revery-ui/revery#f2dce86@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#12fb2dc",
+      "version": "github:revery-ui/revery#f2dce86",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#12fb2dc" ]
+        "source": [ "github:revery-ui/revery#f2dce86" ]
       },
       "overrides": [],
       "dependencies": [
@@ -153,18 +153,17 @@
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "flex@1.2.3@d41d8cd9",
+        "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-harfbuzz@1.9.1008@d41d8cd9",
         "esy-freetype2@2.9.1007@d41d8cd9",
-        "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.5@bb81afdc",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@aef1678b",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@b0227b2f", "@opam/bos@opam:0.2.0@df49e63f",
         "@glennsl/timber@1.2.0@d41d8cd9", "@esy-ocaml/reason@3.6.0@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
       ],
@@ -685,6 +684,41 @@
       ],
       "devDependencies": []
     },
+    "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-native-lwt",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-native-lwt/-/fetch-native-lwt-0.1.0-alpha.5.tgz#sha1:5a0a40149d5d10e233361bb40c42304f538090aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
+        "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "fetch-core@0.1.0-alpha.5@d41d8cd9": {
+      "id": "fetch-core@0.1.0-alpha.5@d41d8cd9",
+      "name": "fetch-core",
+      "version": "0.1.0-alpha.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fetch-core/-/fetch-core-0.1.0-alpha.5.tgz#sha1:71a2420796743056f3efba8da19a540cc910db95"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/reason@3.6.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "esy-tree-sitter@1.4.1@d41d8cd9": {
       "id": "esy-tree-sitter@1.4.1@d41d8cd9",
       "name": "esy-tree-sitter",
@@ -873,6 +907,20 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9": {
+      "id": "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+      "name": "esy-autoconf",
+      "version": "github:esy-packages/esy-autoconf#fb93edf",
+      "source": {
+        "type": "install",
+        "source": [ "github:esy-packages/esy-autoconf#fb93edf" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "editor-input@github:onivim/editor-input#c494950@d41d8cd9": {
       "id": "editor-input@github:onivim/editor-input#c494950@d41d8cd9",
       "name": "editor-input",
@@ -1041,7 +1089,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#82db1eb@d41d8cd9",
-        "revery@github:revery-ui/revery#12fb2dc@d41d8cd9",
+        "revery@github:revery-ui/revery#f2dce86@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
@@ -1058,7 +1106,7 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
         "@opam/reason@opam:3.6.0@2da53ff9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+        "@opam/ppxlib@opam:0.13.0@65a9c7cc",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_inline_test@opam:v0.13.1@45efd1b1",
         "@opam/ppx_deriving_yojson@opam:3.5.2@ca415fbe",
@@ -1189,6 +1237,266 @@
       ],
       "devDependencies": []
     },
+    "@reason-native-web/ssl@0.5.9007@d41d8cd9": {
+      "id": "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+      "name": "@reason-native-web/ssl",
+      "version": "0.5.9007",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/ssl/-/ssl-0.5.9007.tgz#sha1:2eceef610fb593f10605dbde0cbcec153bf7b744"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/piaf@1.3.1000@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.1000@d41d8cd9",
+      "name": "@reason-native-web/piaf",
+      "version": "1.3.1000",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.1000.tgz#sha1:e21820a3e0fe7ac1e2f0d41462c01bfc64d5ac0e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+        "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/uri@opam:3.1.0@faef85a4",
+        "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+        "@opam/magic-mime@opam:1.1.2@980f82fb",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9": {
+      "id": "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+      "name": "@reason-native-web/lwt_ssl",
+      "version": "1.1.3005",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/lwt_ssl/-/lwt_ssl-1.1.3005.tgz#sha1:6ac76e006175e3b320b8a1c690f50cebb5699050"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/ssl@0.5.9007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt-unix@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt-unix",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt-unix/-/h2-lwt-unix-0.6.1001.tgz#sha1:9f89181b5d2d244c9ee1d8a1e88fd258c4ab6d56"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2-lwt",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
+      "name": "@reason-native-web/h2",
+      "version": "0.6.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/psq@opam:0.2.0@247756d4", "@opam/hpack@opam:0.2.0@9f3eae78",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/base64@opam:3.4.0@f5b9ad9b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt-unix@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt-unix",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt-unix/-/h1-lwt-unix-1.2.1001.tgz#sha1:ef6c7ab43bc717db58dc8af913f2b68b34de2c5f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1-lwt@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1-lwt",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1-lwt/-/h1-lwt-1.2.1001.tgz#sha1:e2fef4defebe735128c47484abcc12f55df6d43c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/h1@1.2.1001@d41d8cd9": {
+      "id": "@reason-native-web/h1@1.2.1001@d41d8cd9",
+      "name": "@reason-native-web/h1",
+      "version": "1.2.1001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/h1/-/h1-1.2.1001.tgz#sha1:16f1cfeb43009f45e64e91a8aba9c62e80fb27fe"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt-unix",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt-unix/-/gluten-lwt-unix-0.2.1.tgz#sha1:e661685c6c72ef38b48318279ed16434824563f9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/lwt_ssl@1.1.3005@d41d8cd9",
+        "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten-lwt",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten-lwt/-/gluten-lwt-0.2.1.tgz#sha1:0d35a7de4abd2b55e4afc57d902c9f36a4d6e3e4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@reason-native-web/gluten@0.2.1@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/gluten@0.2.1@d41d8cd9": {
+      "id": "@reason-native-web/gluten@0.2.1@d41d8cd9",
+      "name": "@reason-native-web/gluten",
+      "version": "0.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/gluten/-/gluten-0.2.1.tgz#sha1:cbc732d5d238f845c54d466bb5da7380feb66b72"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@reason-native-web/h1@1.2.1001@d41d8cd9",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ],
+      "devDependencies": []
+    },
+    "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9": {
+      "id": "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
+      "name": "@reason-native-web/esy-openssl",
+      "version": "1.1.1006",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@reason-native-web/esy-openssl/-/esy-openssl-1.1.1006.tgz#sha1:4154a9b17d9ebdc1c983a3075513b5cd276873ac"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/conf-pkg-config@opam:1.2@d86c8f53",
+        "@opam/conf-autoconf@opam:0.1@27b3f7cf"
+      ],
+      "devDependencies": []
+    },
     "@opam/zed@opam:3.1.0@86c55416": {
       "id": "@opam/zed@opam:3.1.0@86c55416",
       "name": "@opam/zed",
@@ -1296,6 +1604,33 @@
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
     },
+    "@opam/uri@opam:3.1.0@faef85a4": {
+      "id": "@opam/uri@opam:3.1.0@faef85a4",
+      "name": "@opam/uri",
+      "version": "opam:3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/c4/c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43",
+          "archive:https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz#sha256:c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+        ],
+        "opam": {
+          "name": "uri",
+          "version": "3.1.0",
+          "path": "test.esy.lock/opam/uri.3.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/stringext@opam:1.6.0@104bc94b",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/uchar@opam:0.0.2@c8218eea": {
       "id": "@opam/uchar@opam:0.0.2@c8218eea",
       "name": "@opam/uchar",
@@ -1398,6 +1733,33 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
+    "@opam/stringext@opam:1.6.0@104bc94b": {
+      "id": "@opam/stringext@opam:1.6.0@104bc94b",
+      "name": "@opam/stringext",
+      "version": "opam:1.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/db/db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea",
+          "archive:https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz#sha256:db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+        ],
+        "opam": {
+          "name": "stringext",
+          "version": "1.6.0",
+          "path": "test.esy.lock/opam/stringext.1.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
     "@opam/stdlib-shims@opam:0.1.0@d957c903": {
       "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
       "name": "@opam/stdlib-shims",
@@ -1493,6 +1855,34 @@
         "ocaml@4.9.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
+    },
+    "@opam/rresult@opam:0.6.0@4b185e72": {
+      "id": "@opam/rresult@opam:0.6.0@4b185e72",
+      "name": "@opam/rresult",
+      "version": "opam:0.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ab/aba88cffa29081714468c2c7bcdf7fb1#md5:aba88cffa29081714468c2c7bcdf7fb1",
+          "archive:http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz#md5:aba88cffa29081714468c2c7bcdf7fb1"
+        ],
+        "opam": {
+          "name": "rresult",
+          "version": "0.6.0",
+          "path": "test.esy.lock/opam/rresult.0.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/result@opam:1.5@6b753c82",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82"
+      ]
     },
     "@opam/result@opam:1.5@6b753c82": {
       "id": "@opam/result@opam:1.5@6b753c82",
@@ -1687,20 +2077,20 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.12.0@fcf5cabc": {
-      "id": "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+    "@opam/ppxlib@opam:0.13.0@65a9c7cc": {
+      "id": "@opam/ppxlib@opam:0.13.0@65a9c7cc",
       "name": "@opam/ppxlib",
-      "version": "opam:0.12.0",
+      "version": "opam:0.13.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/6b/6b562c9b3b9350777318729921f890850b385c469db60769aafd9371998a2c42#sha256:6b562c9b3b9350777318729921f890850b385c469db60769aafd9371998a2c42",
-          "archive:https://github.com/ocaml-ppx/ppxlib/archive/0.12.0.tar.gz#sha256:6b562c9b3b9350777318729921f890850b385c469db60769aafd9371998a2c42"
+          "archive:https://opam.ocaml.org/cache/sha256/81/81e1f3d308500e0e7f6108d5b0dda2b879640a5c21ef3dc4a9bd90381cee39d9#sha256:81e1f3d308500e0e7f6108d5b0dda2b879640a5c21ef3dc4a9bd90381cee39d9",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.13.0/ppxlib-0.13.0.tbz#sha256:81e1f3d308500e0e7f6108d5b0dda2b879640a5c21ef3dc4a9bd90381cee39d9"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.12.0",
-          "path": "test.esy.lock/opam/ppxlib.0.12.0"
+          "version": "0.13.0",
+          "path": "test.esy.lock/opam/ppxlib.0.13.0"
         }
       },
       "overrides": [],
@@ -1847,12 +2237,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.13.0@65a9c7cc",
         "@opam/dune@opam:2.5.0@aef1678b", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.13.0@65a9c7cc",
         "@opam/dune@opam:2.5.0@aef1678b", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1874,12 +2264,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.13.0@65a9c7cc",
         "@opam/dune@opam:2.5.0@aef1678b", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.13.0@65a9c7cc",
         "@opam/dune@opam:2.5.0@aef1678b", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -2080,6 +2470,31 @@
         "ocaml@4.9.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]
+    },
+    "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa": {
+      "id": "@opam/ocaml-syntax-shims@opam:1.0.0@a9aa3bfa",
+      "name": "@opam/ocaml-syntax-shims",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/89/89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8",
+          "archive:https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz#sha256:89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+        ],
+        "opam": {
+          "name": "ocaml-syntax-shims",
+          "version": "1.0.0",
+          "path": "test.esy.lock/opam/ocaml-syntax-shims.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
     },
     "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47": {
       "id": "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -2378,6 +2793,31 @@
         "@opam/uchar@opam:0.0.2@c8218eea", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/magic-mime@opam:1.1.2@980f82fb": {
+      "id": "@opam/magic-mime@opam:1.1.2@980f82fb",
+      "name": "@opam/magic-mime",
+      "version": "opam:1.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/0c/0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb",
+          "archive:https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz#sha256:0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+        ],
+        "opam": {
+          "name": "magic-mime",
+          "version": "1.1.2",
+          "path": "test.esy.lock/opam/magic-mime.1.1.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
     "@opam/lwt_react@opam:1.1.3@72987fcf": {
       "id": "@opam/lwt_react@opam:1.1.3@72987fcf",
       "name": "@opam/lwt_react",
@@ -2661,6 +3101,35 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/hpack@opam:0.2.0@9f3eae78": {
+      "id": "@opam/hpack@opam:0.2.0@9f3eae78",
+      "name": "@opam/hpack",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c8/c883927ce8a9f3f7159ef7b20988f051#md5:c883927ce8a9f3f7159ef7b20988f051",
+          "archive:https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz#md5:c883927ce8a9f3f7159ef7b20988f051"
+        ],
+        "opam": {
+          "name": "hpack",
+          "version": "0.2.0",
+          "path": "test.esy.lock/opam/hpack.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/angstrom@opam:0.14.1@07e286b0"
+      ]
+    },
     "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9": {
       "id": "@opam/fs@github:bryphe/reason-native:fs.opam#fd0225c@d41d8cd9",
       "name": "@opam/fs",
@@ -2783,6 +3252,91 @@
       ],
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday-lwt-unix@opam:0.7.1@4854f547": {
+      "id": "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
+      "name": "@opam/faraday-lwt-unix",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt-unix",
+          "version": "0.7.1",
+          "path": "test.esy.lock/opam/faraday-lwt-unix.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-unix@opam:base@87d0b2eb"
+      ]
+    },
+    "@opam/faraday-lwt@opam:0.7.1@e28c97d1": {
+      "id": "@opam/faraday-lwt@opam:0.7.1@e28c97d1",
+      "name": "@opam/faraday-lwt",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday-lwt",
+          "version": "0.7.1",
+          "path": "test.esy.lock/opam/faraday-lwt.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/faraday@opam:0.7.1@19546ee5", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/faraday@opam:0.7.1@19546ee5": {
+      "id": "@opam/faraday@opam:0.7.1@19546ee5",
+      "name": "@opam/faraday",
+      "version": "opam:0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/09/09396dbb4a08323194e092b6bff4aaf6#md5:09396dbb4a08323194e092b6bff4aaf6",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz#md5:09396dbb4a08323194e092b6bff4aaf6"
+        ],
+        "opam": {
+          "name": "faraday",
+          "version": "0.7.1",
+          "path": "test.esy.lock/opam/faraday.0.7.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -3067,6 +3621,31 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "@opam/conf-autoconf@opam:0.1@27b3f7cf": {
+      "id": "@opam/conf-autoconf@opam:0.1@27b3f7cf",
+      "name": "@opam/conf-autoconf",
+      "version": "opam:0.1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-autoconf",
+          "version": "0.1",
+          "path": "test.esy.lock/opam/conf-autoconf.0.1"
+        }
+      },
+      "overrides": [
+        {
+          "opamoverride":
+            "test.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override"
+        }
+      ],
+      "dependencies": [
+        "esy-autoconf@github:esy-packages/esy-autoconf#fb93edf@d41d8cd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "@opam/charInfo_width@opam:1.1.0@9d8d61b2": {
       "id": "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
       "name": "@opam/charInfo_width",
@@ -3121,6 +3700,42 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/bos@opam:0.2.0@df49e63f": {
+      "id": "@opam/bos@opam:0.2.0@df49e63f",
+      "name": "@opam/bos",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ae/aeae7447567db459c856ee41b5a66fd2#md5:aeae7447567db459c856ee41b5a66fd2",
+          "archive:http://erratique.ch/software/bos/releases/bos-0.2.0.tbz#md5:aeae7447567db459c856ee41b5a66fd2"
+        ],
+        "opam": {
+          "name": "bos",
+          "version": "0.2.0",
+          "path": "test.esy.lock/opam/bos.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
     "@opam/biniou@opam:1.2.1@d7570399": {
       "id": "@opam/biniou@opam:1.2.1@d7570399",
       "name": "@opam/biniou",
@@ -3145,6 +3760,89 @@
       "devDependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/bigstringaf@opam:0.6.1@35f5e6d1": {
+      "id": "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+      "name": "@opam/bigstringaf",
+      "version": "opam:0.6.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/dc/dccf639273b1eec0e0f142f21319268d#md5:dccf639273b1eec0e0f142f21319268d",
+          "archive:https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz#md5:dccf639273b1eec0e0f142f21319268d"
+        ],
+        "opam": {
+          "name": "bigstringaf",
+          "version": "0.6.1",
+          "path": "test.esy.lock/opam/bigstringaf.0.6.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigarray-compat@opam:1.0.0@1faefa97"
+      ]
+    },
+    "@opam/bigarray-compat@opam:1.0.0@1faefa97": {
+      "id": "@opam/bigarray-compat@opam:1.0.0@1faefa97",
+      "name": "@opam/bigarray-compat",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1c/1cc7c25382a8900bada34aadfd66632e#md5:1cc7c25382a8900bada34aadfd66632e",
+          "archive:https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz#md5:1cc7c25382a8900bada34aadfd66632e"
+        ],
+        "opam": {
+          "name": "bigarray-compat",
+          "version": "1.0.0",
+          "path": "test.esy.lock/opam/bigarray-compat.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/base64@opam:3.4.0@f5b9ad9b": {
+      "id": "@opam/base64@opam:3.4.0@f5b9ad9b",
+      "name": "@opam/base64",
+      "version": "opam:3.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/1c/1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634",
+          "archive:https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz#sha256:1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+        ],
+        "opam": {
+          "name": "base64",
+          "version": "3.4.0",
+          "path": "test.esy.lock/opam/base64.3.4.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9",
+        "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -3369,6 +4067,35 @@
         "ocaml@4.9.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
+    "@opam/angstrom@opam:0.14.1@07e286b0": {
+      "id": "@opam/angstrom@opam:0.14.1@07e286b0",
+      "name": "@opam/angstrom",
+      "version": "opam:0.14.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/91/915bbcc1adbd0debc1b0a54531c7601a#md5:915bbcc1adbd0debc1b0a54531c7601a",
+          "archive:https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz#md5:915bbcc1adbd0debc1b0a54531c7601a"
+        ],
+        "opam": {
+          "name": "angstrom",
+          "version": "0.14.1",
+          "path": "test.esy.lock/opam/angstrom.0.14.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.9.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/dune@opam:2.5.0@aef1678b",
+        "@opam/bigstringaf@opam:0.6.1@35f5e6d1"
+      ]
+    },
     "@glennsl/timber@1.2.0@d41d8cd9": {
       "id": "@glennsl/timber@1.2.0@d41d8cd9",
       "name": "@glennsl/timber",
@@ -3459,7 +4186,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.12.0@fcf5cabc",
+        "ocaml@4.9.1000@d41d8cd9", "@opam/ppxlib@opam:0.13.0@65a9c7cc",
         "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.9.1000@d41d8cd9" ]

--- a/test.esy.lock/opam/angstrom.0.14.1/opam
+++ b/test.esy.lock/opam/angstrom.0.14.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/angstrom"
+bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "bigstringaf"
+  "result"
+]
+synopsis: "Parser combinators built for speed and memory-efficiency"
+description: """
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
+default and support unbounded lookahead."""
+url {
+  src: "https://github.com/inhabitedtype/angstrom/archive/0.14.1.tar.gz"
+  checksum: "md5=915bbcc1adbd0debc1b0a54531c7601a"
+}

--- a/test.esy.lock/opam/base64.3.4.0/opam
+++ b/test.esy.lock/opam/base64.3.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>="4.03.0"}
+  "base-bytes"
+  "dune-configurator"
+  "dune" {>= "2.0"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz"
+  checksum: [
+    "sha256=1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+    "sha512=e66a67302a9eb136044bebf66a89a1d6e38a96c70622bb6cd27916fec36dcaf4b5b7e7d00c25608f0a2363f2ca4264a5fe765fe7747590958325dbce06311db9"
+  ]
+}

--- a/test.esy.lock/opam/bigarray-compat.1.0.0/opam
+++ b/test.esy.lock/opam/bigarray-compat.1.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Compatibility library to use Stdlib.Bigarray when possible"
+maintainer: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+authors: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/bigarray-compat"
+bug-reports: "https://github.com/mirage/bigarray-compat/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
+url {
+  src: "https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=1cc7c25382a8900bada34aadfd66632e"
+    "sha512=c365fee15582aca35d7b05268cde29e54774ad7df7be56762b4aad78ca1409d4326ad3b34af0f1cc2c7b872837290a9cd9ff43b47987c03bba7bba32fe8a030f"
+  ]
+}

--- a/test.esy.lock/opam/bigstringaf.0.6.1/opam
+++ b/test.esy.lock/opam/bigstringaf.0.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/bigstringaf"
+bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+  "bigarray-compat"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "js_of_ocaml" {< "3.5.0"}
+]
+synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"
+description: """
+Bigstring intrinsics and fast blits based on memcpy/memmove
+
+The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+widely-known, sometimes misused, and so programs that use Bigstrings are slower
+than they have to be. And even if a library got that part right and exposed the
+intrinsics properly, the compiler doesn't have any fast blits between
+Bigstrings and other string-like types.
+
+So here they are. Go crazy.
+"""
+url {
+  src: "https://github.com/inhabitedtype/bigstringaf/archive/0.6.1.tar.gz"
+  checksum: "md5=dccf639273b1eec0e0f142f21319268d"
+}

--- a/test.esy.lock/opam/bos.0.2.0/opam
+++ b/test.esy.lock/opam/bos.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/bos"
+doc: "http://erratique.ch/software/bos/doc"
+dev-repo: "git+http://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "base-unix"
+  "rresult" {>= "0.4.0"}
+  "astring"
+  "fpath"
+  "fmt" {>= "0.8.0"}
+  "logs"
+  "mtime" {with-test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Basic OS interaction for OCaml"
+description: """
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs"""
+url {
+  src: "http://erratique.ch/software/bos/releases/bos-0.2.0.tbz"
+  checksum: "md5=aeae7447567db459c856ee41b5a66fd2"
+}

--- a/test.esy.lock/opam/conf-autoconf.0.1/opam
+++ b/test.esy.lock/opam/conf-autoconf.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.gnu.org/software/autoconf"
+authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-3.0"
+build: [
+  ["which" "autoconf"]
+]
+depends: ["conf-which" {build}]
+depexts: [
+  ["autoconf"] {os-family = "debian"}
+  ["autoconf"] {os-distribution = "centos"}
+  ["autoconf"] {os-distribution = "fedora"}
+  ["autoconf"] {os-distribution = "arch"}
+  ["sys-devel/autoconf"] {os-distribution = "gentoo"}
+  ["autoconf"] {os-distribution = "nixos"}
+  ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["devel/autoconf"] {os = "openbsd"}
+  ["autoconf"] {os = "freebsd"}
+  ["autoconf"] {os = "netbsd"}
+  ["autoconf"] {os-distribution = "alpine"}
+  ["autoconf"] {os-distribution = "ol"}
+  ["autoconf"] {os-distribution = "rhel"}
+]
+synopsis: "Virtual package relying on autoconf installation"
+description: """
+This package can only install if the autoconf command
+is available on the system."""
+flags: conf

--- a/test.esy.lock/opam/faraday-lwt-unix.0.7.1/opam
+++ b/test.esy.lock/opam/faraday-lwt-unix.0.7.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday-lwt"
+  "lwt" {>= "2.7.0"}
+  "base-unix"
+]
+synopsis: "Lwt_unix support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/test.esy.lock/opam/faraday-lwt.0.7.1/opam
+++ b/test.esy.lock/opam/faraday-lwt.0.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "faraday" {>= "0.5.0"}
+  "lwt"
+]
+synopsis: "Lwt support for Faraday"
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/test.esy.lock/opam/faraday.0.7.1/opam
+++ b/test.esy.lock/opam/faraday.0.7.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.4.1"}
+  "bigstringaf"
+]
+synopsis: "A library for writing fast and memory-efficient serializers."
+description: """
+Faraday is a library for writing fast and memory-efficient serializers. Its
+core type and related operation gives the user fine-grained control over
+copying and allocation behavior while serializing user-defined types, and
+presents the output in a form that makes it possible to use vectorized write
+operations, such as the writev system call, or any other platform or
+application-specific output APIs."""
+url {
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.1.tar.gz"
+  checksum: "md5=09396dbb4a08323194e092b6bff4aaf6"
+}

--- a/test.esy.lock/opam/hpack.0.2.0/opam
+++ b/test.esy.lock/opam/hpack.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+           "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-Clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune"
+  "yojson" {with-test}
+  "hex" {with-test}
+  "angstrom"
+  "faraday"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description: """
+hpack is an implementation of the HPACK: Header Compression for HTTP/2
+specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for
+parsing and serialization, respectively.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/test.esy.lock/opam/magic-mime.1.1.2/opam
+++ b/test.esy.lock/opam/magic-mime.1.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "magic-mime"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz"
+  checksum: [
+    "sha256=0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+    "sha512=8264db78adc2c75b8adabc23c26ad34eab98383bd3a8f2068f2236ff3425d653c0238fbd7361e55a3d70d843413ef8671b6e97293074b4d3a1e300628d5292ab"
+  ]
+}

--- a/test.esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
+++ b/test.esy.lock/opam/ocaml-syntax-shims.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Backport new syntax to older OCaml versions"
+description: """
+This packages backports new features of the language to older
+compilers, such as let+.
+"""
+maintainer: ["jeremie@dimino.org"]
+authors: ["Jérémie Dimino <jeremie@dimino.org>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocaml-syntax-shims"
+doc: "https://ocaml-ppx.github.io/ocaml-syntax-shims/"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-syntax-shims/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.02.3"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-syntax-shims.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz"
+  checksum: [
+    "sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+    "sha512=75c4c6b0bfa1267a8a49a82ba494d08cf0823fc8350863d6d3d4971528cb09e5a2a29e2981d04c75e76ad0f49360b05a432c9efeff9a4fbc1ec6b28960399852"
+  ]
+}

--- a/test.esy.lock/opam/ppxlib.0.13.0/opam
+++ b/test.esy.lock/opam/ppxlib.0.13.0/opam
@@ -14,9 +14,9 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1" & < "4.11.0"}
+  "ocaml"                   {>= "4.04.1"}
   "base"                    {>= "v0.11.0"}
-  "dune"                    {>= "1.11"}
+  "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.3.1"}
   "ppx_derivers"            {>= "1.0"}
@@ -38,9 +38,9 @@ A comprehensive toolbox for ppx development. It features:
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/archive/0.12.0.tar.gz"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.13.0/ppxlib-0.13.0.tbz"
   checksum: [
-    "sha256=6b562c9b3b9350777318729921f890850b385c469db60769aafd9371998a2c42"
-    "sha512=2372a7a53d857389978e617c95183289547d53caa5e83a7d867cab347b114b719667bd09eaf2e2334085ef92691a99b42871f6410ffb2977b0b8724014c80a70"
+    "sha256=81e1f3d308500e0e7f6108d5b0dda2b879640a5c21ef3dc4a9bd90381cee39d9"
+    "sha512=c94bab35affdbdd2562de7ad30eb97282568c2c7fe48229fab5d12d1fc73312a9ee398758d598d969318cc01e8f88df9958e91820785e39d8faf3dbd7bc2e606"
   ]
 }

--- a/test.esy.lock/opam/rresult.0.6.0/opam
+++ b/test.esy.lock/opam/rresult.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "git+http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+   "ocaml" {>= "4.01.0"}
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]
+
+synopsis: """Result value combinators for OCaml"""
+description: """\
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz"
+checksum: "aba88cffa29081714468c2c7bcdf7fb1"
+}

--- a/test.esy.lock/opam/stringext.1.6.0/opam
+++ b/test.esy.lock/opam/stringext.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+license: "MIT"
+homepage: "https://github.com/rgrinberg/stringext"
+bug-reports: "https://github.com/rgrinberg/stringext/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "qtest" {with-test & >= "2.2"}
+  "base-bytes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/rgrinberg/stringext.git"
+synopsis: "Extra string functions for OCaml"
+description: """
+Extra string functions for OCaml. Mainly splitting. All functions are in the
+Stringext module.
+"""
+url {
+  src:
+    "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz"
+  checksum: [
+    "sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+    "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
+  ]
+}

--- a/test.esy.lock/opam/uri.3.1.0/opam
+++ b/test.esy.lock/opam/uri.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0" & < "v0.14"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.1.0/uri-v3.1.0.tbz"
+  checksum: [
+    "sha256=c452823fd870cf7cffe51aef3e9ca646a382dc6f87282f2b16bfe30a7515ac43"
+    "sha512=c015576bb077fd243022bcd8804e628d23a253dcd8bbdda8dc2a57e86cfeb9fd629087ec7d7e23dc71dd7cd137450ca2c5ecf8fb7d184ec9d1d4e41f6f83ee38"
+  ]
+}

--- a/test.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
+++ b/test.esy.lock/overrides/opam__s__conf_autoconf_opam__c__0.1_opam_override/package.json
@@ -1,0 +1,6 @@
+{
+  "build": [ "true" ],
+  "dependencies": {
+    "esy-autoconf": "esy-packages/esy-autoconf#fb93edf"
+  }
+}


### PR DESCRIPTION
This brings in Revery with the `fetch` API to allow downloading - this requirements `libssl` and `libcrypto` to be bundled to handle SSL transport.

Unfortunately, we cannot statically link these libraries - so we must bundle them dynamically. I'm concerned about hitting another issue like https://github.com/onivim/oni2/issues/1397, but I've tested and ran AV to avoid a false positive (using Antivirus One) - and I don't see any issues. (OSX also runs AV as part of the notarization step, too, before we release)

Would be great if we could run on CI as well, though, in general....