### PR TITLE
refactor(sidebar): switch arrow-icon and use sidebar-color for it

### DIFF
--- a/src/UI/FileTreeView.re
+++ b/src/UI/FileTreeView.re
@@ -169,7 +169,7 @@ let make =
       tree
       itemHeight=22
       onClick=onNodeClick
-      arrowColor={Colors.foreground.from(theme)}>
+      arrowColor={Colors.SideBar.foreground.from(theme)}>
       ...{node => {
         let decorations = StringMap.find_opt(node.path, decorations);
 

--- a/src/UI/TreeView.re
+++ b/src/UI/TreeView.re
@@ -6,7 +6,7 @@ open Oni_Core;
 open Utility;
 
 module FontAwesome = Oni_Components.FontAwesome;
-module FontIcon = Oni_Components.FontIcon;
+module Codicon = Oni_Components.Codicon;
 module Sneakable = Feature_Sneak.View.Sneakable;
 
 module Log = (val Log.withNamespace("Oni2.UI.TreeView"));
@@ -69,16 +69,21 @@ module Styles = {
   let children = [transform(Transform.[TranslateX(Constants.indentSize)])];
 
   // Margin applied to center vertically
-  let arrow = size => [width(size), height(size), marginTop(4)];
+  let arrow = size => [
+    width(size),
+    height(size),
+    marginTop(4),
+    marginRight(4),
+  ];
 };
 
 module Make = (Model: TreeModel) => {
   let arrow = (~isOpen, ~color, ()) =>
     <View style={Styles.arrow(int_of_float(Constants.arrowSize))}>
-      <FontIcon
-        fontSize=Constants.arrowSize
+      <Codicon
+        icon={isOpen ? Codicon.chevronDown : Codicon.chevronRight}
         color
-        icon={isOpen ? FontAwesome.angleDown : FontAwesome.angleRight}
+        fontSize=Constants.arrowSize
       />
     </View>;
 


### PR DESCRIPTION
Switches the icon to a thinner variant, uses the icon-color from the sidebar of the theme instead of its foreground-color.

**Before:**
<img width="957" alt="before" src="https://user-images.githubusercontent.com/17602389/84131556-fd285b80-aa44-11ea-821d-cd937a3d6546.png">

**After:**
<img width="957" alt="after" src="https://user-images.githubusercontent.com/17602389/84132413-24cbf380-aa46-11ea-8144-3e55ef893c54.png">
