### PR TITLE
feat(layout): minimum window sizes and cascading

### DIFF
--- a/src/Feature/Layout/AbstractTree.re
+++ b/src/Feature/Layout/AbstractTree.re
@@ -17,6 +17,11 @@ module DSL = {
   let window = (meta, id) => {meta, kind: `Window(id)};
 
   let withMetadata = (meta, node) => {...node, meta};
+  let withChildren = (children, node) =>
+    switch (node.kind) {
+    | `Split(direction, _) => {...node, kind: `Split((direction, children))}
+    | `Window(_) => node
+    };
 };
 
 let rec fold = (f, acc, node) =>

--- a/src/Feature/Layout/AbstractTree.re
+++ b/src/Feature/Layout/AbstractTree.re
@@ -37,6 +37,23 @@ let rec map = (f, node) =>
     f({...node, kind: `Split((direction, List.map(map(f), children)))})
   };
 
+let path = (targetId, node) => {
+  exception Found(list(int));
+
+  let rec traverse = (path, node) =>
+    switch (node.kind) {
+    | `Split(_, children) =>
+      List.iteri(i => traverse([i, ...path]), children)
+    | `Window(id) when id == targetId => raise(Found(List.rev(path)))
+    | `Window(_) => ()
+    };
+
+  switch (traverse([], node)) {
+  | () => None
+  | exception (Found(path)) => Some(path)
+  };
+};
+
 let rec windowNodes = node =>
   switch (node.kind) {
   | `Window(_) => [node]

--- a/src/Feature/Layout/AbstractTree.re
+++ b/src/Feature/Layout/AbstractTree.re
@@ -8,13 +8,13 @@ type node('id, 'meta) = {
 };
 
 module DSL = {
-  let split = (~meta, direction, children) => {
+  let split = (meta, direction, children) => {
     meta,
     kind: `Split((direction, children)),
   };
-  let vsplit = (~meta, children) => split(~meta, `Vertical, children);
-  let hsplit = (~meta, children) => split(~meta, `Horizontal, children);
-  let window = (~meta, id) => {meta, kind: `Window(id)};
+  let vsplit = (meta, children) => split(meta, `Vertical, children);
+  let hsplit = (meta, children) => split(meta, `Horizontal, children);
+  let window = (meta, id) => {meta, kind: `Window(id)};
 
   let withMetadata = (meta, node) => {...node, meta};
 };
@@ -75,9 +75,9 @@ let%test_module "rotate" =
    {
      module DSL = {
        include DSL;
-       let hsplit = hsplit(~meta=());
-       let vsplit = vsplit(~meta=());
-       let window = window(~meta=());
+       let hsplit = hsplit();
+       let vsplit = vsplit();
+       let window = window();
      };
      open DSL;
 

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -12,10 +12,10 @@ module DSL = {
   open AbstractTree.DSL;
 
   let split = (~size=1., direction, children) =>
-    split(~meta={size: size}, direction, children);
+    split({size: size}, direction, children);
   let vsplit = (~size=1., children) => split(~size, `Vertical, children);
   let hsplit = (~size=1., children) => split(~size, `Horizontal, children);
-  let window = (~size=1., id) => window(~meta={size: size}, id);
+  let window = (~size=1., id) => window({size: size}, id);
 
   let withSize = (size, node) => node |> withMetadata({size: size});
 };

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -57,8 +57,8 @@ open {
                let delta =
                  if (node.meta.size +. delta < minimumWeight) {
                    min(0., -. (node.meta.size -. minimumWeight));
-                 } else if (next.meta.size +. delta < minimumWeight) {
-                   min(0., -. (next.meta.size -. minimumWeight));
+                 } else if (next.meta.size -. delta < minimumWeight) {
+                   max(0., next.meta.size -. minimumWeight);
                  } else {
                    delta;
                  };

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -63,6 +63,15 @@ open {
          loop(start, 0.);
        };
 
+       let reclaimLeft = (~limit, index, nodes) =>
+         reclaim(
+           ~limit,
+           ~start=index - 1,
+           ~next=pred,
+           ~stopWhen=i => i < 0,
+           nodes,
+         );
+
        let reclaimRight = (~limit, index, nodes) =>
          reclaim(
            ~limit,

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -79,6 +79,7 @@ open {
          (module
           {
             let weights = List.map(node => node.meta.weight);
+            let weights_int = List.map(node => int_of_float(node.meta.weight *. 100.));
 
             let%test "sanity check: weights - even" =
               weights([window(1), window(2), window(3)]) == [1., 1., 1.];
@@ -120,6 +121,14 @@ open {
               let actual = initial |> shiftWeightRight(~delta=-0.05, 1);
 
               weights(actual) == weights(initial);
+            };
+            
+            let%test "delta too large" = {
+              let initial = [window(1), window(2), window(3)];
+
+              let actual = initial |> shiftWeightRight(~delta=-4., 1);
+
+              weights_int(actual) == [100, 30, 170]
             };
           });
      };

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -242,7 +242,7 @@ open {
 
               let reclaimed = reclaimRight(~limit=0.5, 0, nodes);
 
-              (reclaimed, nodes) == (0.5, [|1., 0.5, 1.0|]);
+              (reclaimed, nodes) == (0.5, [|1., 0.5, 1.|]);
             };
 
             let%test "available > limit && single node, target == 0" = {
@@ -253,18 +253,19 @@ open {
               (reclaimed, nodes) == (1., [|1., 0.3, 0.7|]);
             };
 
-            let%test "target == -1 (out of bounds)" = {
+            let%test "target == -3 (out of bounds)" = {
               let nodes = [|window(1), window(2), window(3)|];
 
-              let reclaimed = reclaimRight(~limit=10., -1, nodes);
-
-              (reclaimed, nodes) == (2.09, [|0.3, 0.3, 0.3|]);
+              switch (reclaimRight(~limit=10., -3, nodes)) {
+              | _ => false
+              | exception (Invalid_argument(_)) => true
+              };
             };
 
-            let%test "target == 3 (out of bounds)" = {
+            let%test "target == 6 (out of bounds)" = {
               let nodes = [|window(1), window(2), window(3)|];
 
-              let reclaimed = reclaimRight(~limit=10., 3, nodes);
+              let reclaimed = reclaimRight(~limit=10., 6, nodes);
 
               (reclaimed, nodes) == (0., [|1., 1., 1.|]);
             };

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -18,6 +18,7 @@ module DSL = {
   let window = (~size=1., id) => window({size: size}, id);
 
   let withSize = (size, node) => node |> withMetadata({size: size});
+  let withChildren = withChildren;
 };
 
 include DSL;

--- a/src/Feature/Layout/Positioned.re
+++ b/src/Feature/Layout/Positioned.re
@@ -89,11 +89,11 @@ let%test_module "move" =
         {
           let initial =
             hsplit(
-              ~meta={x: 0, y: 0, width: 300, height: 300},
+              {x: 0, y: 0, width: 300, height: 300},
               [
-                window(3, ~meta={x: 0, y: 0, width: 300, height: 100}),
-                window(2, ~meta={x: 0, y: 100, width: 300, height: 100}),
-                window(1, ~meta={x: 0, y: 200, width: 300, height: 100}),
+                window({x: 0, y: 0, width: 300, height: 100}, 3),
+                window({x: 0, y: 100, width: 300, height: 100}, 2),
+                window({x: 0, y: 200, width: 300, height: 100}, 1),
               ],
             );
 
@@ -149,11 +149,10 @@ let rec fromLayout = (x, y, width, height, node) => {
         |> List.rev;
 
       AbstractTree.DSL.(
-        split(~meta={x, y, width, height}, direction, sizedChildren)
+        split({x, y, width, height}, direction, sizedChildren)
       );
 
-    | `Window(id) =>
-      AbstractTree.DSL.(window(~meta={x, y, width, height}, id))
+    | `Window(id) => AbstractTree.DSL.(window({x, y, width, height}, id))
     }
   );
 };
@@ -170,10 +169,10 @@ let%test_module "fromLayout" =
 
        actual
        == vsplit(
-            ~meta={x: 0, y: 0, width: 200, height: 200},
+            {x: 0, y: 0, width: 200, height: 200},
             [
-              window(2, ~meta={x: 0, y: 0, width: 100, height: 200}),
-              window(1, ~meta={x: 100, y: 0, width: 100, height: 200}),
+              window({x: 0, y: 0, width: 100, height: 200}, 2),
+              window({x: 100, y: 0, width: 100, height: 200}, 1),
             ],
           );
      };
@@ -185,10 +184,10 @@ let%test_module "fromLayout" =
 
        actual
        == hsplit(
-            ~meta={x: 0, y: 0, width: 200, height: 200},
+            {x: 0, y: 0, width: 200, height: 200},
             [
-              window(2, ~meta={x: 0, y: 0, width: 200, height: 100}),
-              window(1, ~meta={x: 0, y: 100, width: 200, height: 100}),
+              window({x: 0, y: 0, width: 200, height: 100}, 2),
+              window({x: 0, y: 100, width: 200, height: 100}, 1),
             ],
           );
      };
@@ -201,14 +200,14 @@ let%test_module "fromLayout" =
 
        actual
        == hsplit(
-            ~meta={x: 0, y: 0, width: 200, height: 200},
+            {x: 0, y: 0, width: 200, height: 200},
             [
-              window(2, ~meta={x: 0, y: 0, width: 200, height: 100}),
+              window({x: 0, y: 0, width: 200, height: 100}, 2),
               vsplit(
-                ~meta={x: 0, y: 100, width: 200, height: 100},
+                {x: 0, y: 100, width: 200, height: 100},
                 [
-                  window(3, ~meta={x: 0, y: 100, width: 100, height: 100}),
-                  window(1, ~meta={x: 100, y: 100, width: 100, height: 100}),
+                  window({x: 0, y: 100, width: 100, height: 100}, 3),
+                  window({x: 100, y: 100, width: 100, height: 100}, 1),
                 ],
               ),
             ],

--- a/src/Feature/Layout/Positioned.re
+++ b/src/Feature/Layout/Positioned.re
@@ -113,7 +113,7 @@ let rec fromLayout = (x, y, width, height, node) => {
     | `Split(direction, children) =>
       let totalWeight =
         children
-        |> List.map(child => child.meta.size)
+        |> List.map(child => child.meta.weight)
         |> List.fold_left((+.), 0.)
         |> max(1.);
 
@@ -124,7 +124,7 @@ let rec fromLayout = (x, y, width, height, node) => {
             let unitHeight = float(height) /. totalWeight;
             List.fold_left(
               ((y, acc), child) => {
-                let height = int_of_float(unitHeight *. child.meta.size);
+                let height = int_of_float(unitHeight *. child.meta.weight);
                 let sized = fromLayout(x, y, width, height, child);
                 (y + height, [sized, ...acc]);
               },
@@ -136,7 +136,7 @@ let rec fromLayout = (x, y, width, height, node) => {
             let unitWidth = float(width) /. totalWeight;
             List.fold_left(
               ((x, acc), child) => {
-                let width = int_of_float(unitWidth *. child.meta.size);
+                let width = int_of_float(unitWidth *. child.meta.weight);
                 let sized = fromLayout(x, y, width, height, child);
                 (x + width, [sized, ...acc]);
               },


### PR DESCRIPTION
![cascading](https://user-images.githubusercontent.com/5207036/84314180-e890b400-ab67-11ea-99fc-ec55ba39a795.gif)

Implements minimum sizes and "cascading", fixes the tracking of the handle relative to the mouse pointer, and remembers the window state before dragging a handle so that moving the handle back reverts it. It also lays the groundwork for implementing maximization and directional resizing.
