### PR TITLE
fix(ui): Scroll shadow is showing on line numbers

### DIFF
--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -242,6 +242,7 @@ let%component make =
   let (gutterWidth, gutterView) =
     <GutterView
       editor
+      showScrollShadow={Config.Experimental.scrollShadow.get(config)}
       showLineNumbers={Config.lineNumbers.get(config)}
       height={editor.pixelHeight}
       colors

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -84,6 +84,7 @@ let render =
     (
       ~editor,
       ~showLineNumbers,
+      ~showScrollShadow,
       ~lineNumberWidth,
       ~width,
       ~height,
@@ -133,12 +134,15 @@ let render =
     diffMarkers,
   );
 
-  ScrollShadow.renderVertical(~editor, ~width=float(width), ~context);
+  if (showScrollShadow) {
+    ScrollShadow.renderVertical(~editor, ~width=float(width), ~context);
+  };
 };
 
 let make =
     (
       ~editor,
+      ~showScrollShadow,
       ~showLineNumbers,
       ~height,
       ~colors,
@@ -175,6 +179,7 @@ let make =
   let render =
     render(
       ~editor,
+      ~showScrollShadow,
       ~showLineNumbers,
       ~lineNumberWidth,
       ~width=int_of_float(totalWidth),


### PR DESCRIPTION
__Issue:__ The experimental scroll shadow (https://github.com/onivim/oni2/pull/1907) is showing up over line numbers, even when the configuration is disabled (the default).

__Defect:__ We weren't gating the line-number rendering by the configuration.

__Fix:__ Add `showScrollShadow` parameter