### PR TITLE
feat(layout): keyboard navigation between sidebar, pane and editors

### DIFF
--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -1,5 +1,10 @@
 // MODEL
 
+type panel =
+  | Left
+  | Center(int)
+  | Bottom;
+
 type model = {
   tree: Layout.t(int),
   uncommittedTree: [
@@ -77,7 +82,7 @@ type msg =
 
 type outmsg =
   | Nothing
-  | Focus(int);
+  | Focus(panel);
 
 let rotate = (direction, focus, model) => {
   ...model,
@@ -134,143 +139,227 @@ let update = (~focus, model, msg) => {
 
   | Command(MoveLeft) =>
     switch (focus) {
-    | Some(focus) => (model, Focus(moveLeft(focus, activeTree(model))))
+    | Some(Center(focus)) =>
+      let newFocus = model |> activeTree |> moveLeft(focus);
+      if (newFocus == focus) {
+        (model, Focus(Left));
+      } else {
+        (model, Focus(Center(focus)));
+      };
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(MoveRight) =>
     switch (focus) {
-    | Some(focus) => (model, Focus(moveRight(focus, activeTree(model))))
+    | Some(Center(focus)) =>
+      let newFocus = model |> activeTree |> moveRight(focus);
+      (model, Focus(Center(newFocus)));
+
+    | Some(Left) =>
+      let focus = model |> activeTree |> Layout.leftmost;
+      (model, Focus(Center(focus)));
+
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(MoveUp) =>
     switch (focus) {
-    | Some(focus) => (model, Focus(moveUp(focus, activeTree(model))))
+    | Some(Center(focus)) =>
+      let newFocus = model |> activeTree |> moveUp(focus);
+      (model, Focus(Center(newFocus)));
+
+    | Some(Bottom) =>
+      let focus = model |> activeTree |> Layout.bottommost;
+      (model, Focus(Center(focus)));
+
+    | Some(Left)
     | None => (model, Nothing)
     }
 
   | Command(MoveDown) =>
     switch (focus) {
-    | Some(focus) => (model, Focus(moveDown(focus, activeTree(model))))
+    | Some(Center(focus)) =>
+      let newFocus = model |> activeTree |> moveDown(focus);
+      if (newFocus == focus) {
+        (model, Focus(Bottom));
+      } else {
+        (model, Focus(Center(newFocus)));
+      };
+
+    | Some(Left) => (model, Focus(Bottom))
+
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(RotateForward) =>
     switch (focus) {
-    | Some(focus) => (rotate(`Forward, focus, model), Nothing)
+    | Some(Center(focus)) => (rotate(`Forward, focus, model), Nothing)
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(RotateBackward) =>
     switch (focus) {
-    | Some(focus) => (rotate(`Backward, focus, model), Nothing)
+    | Some(Center(focus)) => (rotate(`Backward, focus, model), Nothing)
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(DecreaseSize) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model
         |> resizeWindowByAxis(`Horizontal, focus, 0.95)
         |> resizeWindowByAxis(`Vertical, focus, 0.95),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(IncreaseSize) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model
         |> resizeWindowByAxis(`Horizontal, focus, 1.05)
         |> resizeWindowByAxis(`Vertical, focus, 1.05),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(DecreaseHorizontalSize) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model |> resizeWindowByAxis(`Horizontal, focus, 0.95),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(IncreaseHorizontalSize) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model |> resizeWindowByAxis(`Horizontal, focus, 1.05),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(DecreaseVerticalSize) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model |> resizeWindowByAxis(`Vertical, focus, 0.95),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(IncreaseVerticalSize) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model |> resizeWindowByAxis(`Vertical, focus, 1.05),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(IncreaseWindowSize(direction)) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model |> resizeWindowByDirection(direction, focus, 1.05),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(DecreaseWindowSize(direction)) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         model |> resizeWindowByDirection(direction, focus, 0.95),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(Maximize) =>
     switch (focus) {
-    | Some(focus) => (maximize(focus, model), Nothing)
+    | Some(Center(focus)) => (maximize(focus, model), Nothing)
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(MaximizeHorizontal) =>
     switch (focus) {
-    | Some(focus) => (
+    | Some(Center(focus)) => (
         maximize(~direction=`Horizontal, focus, model),
         Nothing,
       )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(MaximizeVertical) =>
     switch (focus) {
-    | Some(focus) => (maximize(~direction=`Vertical, focus, model), Nothing)
+    | Some(Center(focus)) => (
+        maximize(~direction=`Vertical, focus, model),
+        Nothing,
+      )
+
+    | Some(Left)
+    | Some(Bottom)
     | None => (model, Nothing)
     }
 
   | Command(ToggleMaximize) =>
     let model =
-      switch (focus, model.uncommittedTree) {
-      | (_, `Maximized(_)) => {...model, uncommittedTree: `None}
-      | (Some(focus), _) => maximize(focus, model)
-      | (None, _) => model
+      switch (model.uncommittedTree) {
+      | `Maximized(_) => {...model, uncommittedTree: `None}
+
+      | _ =>
+        switch (focus) {
+        | Some(Center(focus)) => maximize(focus, model)
+
+        | Some(Left)
+        | Some(Bottom)
+        | None => model
+        }
       };
     (model, Nothing);
 

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -144,7 +144,7 @@ let update = (~focus, model, msg) => {
       if (newFocus == focus) {
         (model, Focus(Left));
       } else {
-        (model, Focus(Center(focus)));
+        (model, Focus(Center(newFocus)));
       };
 
     | Some(Left)

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -2,6 +2,11 @@ open Oni_Core;
 
 // MODEL
 
+type panel =
+  | Left
+  | Center(int)
+  | Bottom;
+
 type model;
 
 let initial: int => model;
@@ -25,9 +30,9 @@ type msg;
 
 type outmsg =
   | Nothing
-  | Focus(int);
+  | Focus(panel);
 
-let update: (~focus: option(int), model, msg) => (model, outmsg);
+let update: (~focus: option(panel), model, msg) => (model, outmsg);
 
 // VIEW
 

--- a/src/Feature/Layout/Layout.re
+++ b/src/Feature/Layout/Layout.re
@@ -1300,3 +1300,34 @@ let%test_module "maximize" =
           ]);
      };
    });
+
+let rec topmost = node =>
+  switch (node.kind) {
+  | `Window(id) => id
+  | `Split(_, [first, ..._]) => topmost(first)
+  | `Split(_, []) => failwith("encountered empty split")
+  };
+
+let rec bottommost = node =>
+  switch (node.kind) {
+  | `Window(id) => id
+  | `Split(`Horizontal, children) =>
+    children |> Base.List.last_exn |> bottommost
+  | `Split(`Vertical, [first, ..._]) => bottommost(first)
+  | `Split(_, []) => failwith("encountered empty split")
+  };
+
+let rec leftmost = node =>
+  switch (node.kind) {
+  | `Window(id) => id
+  | `Split(_, [first, ..._]) => leftmost(first)
+  | `Split(_, []) => failwith("encountered empty split")
+  };
+
+let rec rightmost = node =>
+  switch (node.kind) {
+  | `Window(id) => id
+  | `Split(`Vertical, children) => children |> Base.List.last_exn |> rightmost
+  | `Split(`Horizontal, [first, ..._]) => rightmost(first)
+  | `Split(_, []) => failwith("encountered empty split")
+  };

--- a/src/Store/PaneStore.re
+++ b/src/Store/PaneStore.re
@@ -5,6 +5,13 @@
 open Oni_Model;
 open Actions;
 
+let focus = (state: State.t) =>
+  if (state.pane.isOpen && state.pane.selected == Search) {
+    FocusManager.push(Search, state);
+  } else {
+    state;
+  };
+
 let showSearchPane = (state: State.t) =>
   {
     ...state,

--- a/src/Store/SideBarReducer.re
+++ b/src/Store/SideBarReducer.re
@@ -6,6 +6,17 @@ open Oni_Core;
 open Oni_Model;
 open Actions;
 
+let focus = (state: State.t) =>
+  if (state.sideBar.isOpen) {
+    switch (state.sideBar.selected) {
+    | FileExplorer => FocusManager.push(FileExplorer, state)
+    | SCM => FocusManager.push(SCM, state)
+    | _ => state
+    };
+  } else {
+    state;
+  };
+
 let reduce = (~zenMode, state: SideBar.t, action: Actions.t) => {
   switch (action) {
   // When we're in Zen mode, we ignore toggling, and exit zen mode


### PR DESCRIPTION
This adds keyboard navigation between editors, the sidebar and the bottom pane as an extension of the existing window movement keybindings. We lack good visual indication of where the keyboard focus actually is, but otherwise it works great!

Adding proper indication of focus will require some design work and is too big to in scope for this PR I think, but let me know if you think it should be added before merging.