### PR TITLE
feat(formatting): Hook up '=' operator to exthost formatting strategy

### DIFF
--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -171,7 +171,8 @@ let start =
   let _: unit => unit =
     Vim.onEffect(
       fun
-      | Goto(gotoType) => handleGoto(gotoType),
+      | Goto(gotoType) => handleGoto(gotoType)
+      | Format(_) => Log.debug("Format provider not hooked up yet"),
     );
 
   let _: unit => unit =

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -1,2 +1,12 @@
 type t =
-  | Goto(Goto.t);
+  | Goto(Goto.effect)
+  | FormatBuffer({
+    bufferId: int,
+    adjustCursor: bool,
+  })
+  | FormatRange({
+    bufferId: int,
+    startLine: Index.t,
+    endLine: Index.t,
+    adjustCursor: bool,
+  });

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -1,12 +1,3 @@
 type t =
   | Goto(Goto.effect)
-  | FormatBuffer({
-      bufferId: int,
-      adjustCursor: bool,
-    })
-  | FormatRange({
-      bufferId: int,
-      startLine: Index.t,
-      endLine: Index.t,
-      adjustCursor: bool,
-    });
+  | Format(Format.effect);

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -1,12 +1,12 @@
 type t =
   | Goto(Goto.effect)
   | FormatBuffer({
-    bufferId: int,
-    adjustCursor: bool,
-  })
+      bufferId: int,
+      adjustCursor: bool,
+    })
   | FormatRange({
-    bufferId: int,
-    startLine: Index.t,
-    endLine: Index.t,
-    adjustCursor: bool,
-  });
+      bufferId: int,
+      startLine: Index.t,
+      endLine: Index.t,
+      adjustCursor: bool,
+    });

--- a/src/reason-libvim/Format.re
+++ b/src/reason-libvim/Format.re
@@ -1,4 +1,11 @@
-
 type effect =
-| Buffer({bufferId: int, adjustCursor: bool})
-| Range({bufferId: int, startLine: Index.t, endLine: Index.t, adjustCursor: bool})
+  | Buffer({
+      bufferId: int,
+      adjustCursor: bool,
+    })
+  | Range({
+      bufferId: int,
+      startLine: Index.t,
+      endLine: Index.t,
+      adjustCursor: bool,
+    });

--- a/src/reason-libvim/Format.re
+++ b/src/reason-libvim/Format.re
@@ -1,9 +1,17 @@
+open EditorCoreTypes;
+
+type formatType =
+  | Indentation
+  | Formatting;
+
 type effect =
   | Buffer({
+      formatType,
       bufferId: int,
       adjustCursor: bool,
     })
   | Range({
+      requestType: formatType,
       bufferId: int,
       startLine: Index.t,
       endLine: Index.t,

--- a/src/reason-libvim/Format.re
+++ b/src/reason-libvim/Format.re
@@ -11,9 +11,11 @@ type effect =
       adjustCursor: bool,
     })
   | Range({
-      requestType: formatType,
+      formatType,
       bufferId: int,
+      // The inclusive startline of the format
       startLine: Index.t,
+      // The inclusive endline of the format
       endLine: Index.t,
       adjustCursor: bool,
     });

--- a/src/reason-libvim/Format.re
+++ b/src/reason-libvim/Format.re
@@ -1,0 +1,4 @@
+
+type effect =
+| Buffer({bufferId: int, adjustCursor: bool})
+| Range({bufferId: int, startLine: Index.t, endLine: Index.t, adjustCursor: bool})

--- a/src/reason-libvim/Goto.re
+++ b/src/reason-libvim/Goto.re
@@ -1,4 +1,4 @@
-type t =
+type effect =
   | Definition
   | Declaration
   | Hover;

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -1,6 +1,13 @@
 type buffer = Types.buffer;
 type lineEnding = Types.lineEnding;
 
+type formatRequest = {
+  bufferId: int,
+  startLine: int,
+  endLine: int,
+  returnCursor: int,
+};
+
 external vimInit: unit => unit = "libvim_vimInit";
 external vimInput: string => unit = "libvim_vimInput";
 external vimCommand: string => unit = "libvim_vimCommand";

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -11,6 +11,7 @@ type formatRequest = {
   bufferId: int,
   returnCursor: int,
   formatType,
+  lineCount: int,
 };
 
 external vimInit: unit => unit = "libvim_vimInit";

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -1,11 +1,16 @@
 type buffer = Types.buffer;
 type lineEnding = Types.lineEnding;
 
+type formatType =
+  | Indentation
+  | Formatting;
+
 type formatRequest = {
-  bufferId: int,
   startLine: int,
   endLine: int,
+  bufferId: int,
   returnCursor: int,
+  formatType,
 };
 
 external vimInit: unit => unit = "libvim_vimInit";

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -248,13 +248,27 @@ let _clipboardGet = (regname: int) => {
   };
 };
 
+let nativeFormatRequestToEffect: Native.formatRequest => Format.effect =
+  ({bufferId, startLine, endLine, returnCursor, formatType}) => {
+    let adjustCursor = returnCursor == 0 ? false : true;
+    let formatType =
+      switch (formatType) {
+      | Native.Indentation => Format.Indentation
+      | Native.Formatting => Format.Formatting
+      };
+    Format.Buffer({formatType, bufferId, adjustCursor});
+  };
+
 let _onFormat = formatRequest => {
   queue(() =>
-    Event.dispatch(Effect.Format(formatRequest), Listeners.effect)
+    Event.dispatch(
+      Effect.Format(formatRequest |> nativeFormatRequestToEffect),
+      Listeners.effect,
+    )
   );
 };
 
-let _onGoto = (_line: int, _column: int, gotoType: Goto.t) => {
+let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
 };
 

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -25,6 +25,30 @@ module VisualRange = VisualRange;
 module Window = Window;
 module Yank = Yank;
 
+module Internal = {
+  let nativeFormatRequestToEffect: Native.formatRequest => Format.effect =
+    ({bufferId, startLine, endLine, returnCursor, formatType, lineCount}) => {
+      let adjustCursor = returnCursor == 0 ? false : true;
+      let formatType =
+        switch (formatType) {
+        | Native.Indentation => Format.Indentation
+        | Native.Formatting => Format.Formatting
+        };
+
+      if (startLine <= 1 && endLine >= lineCount) {
+        Format.Buffer({formatType, bufferId, adjustCursor});
+      } else {
+        Format.Range({
+          formatType,
+          bufferId,
+          adjustCursor,
+          startLine: Index.fromOneBased(startLine),
+          endLine: Index.fromOneBased(endLine),
+        });
+      };
+    };
+};
+
 type fn = unit => unit;
 
 let queuedFunctions: ref(list(fn)) = ref([]);
@@ -248,21 +272,10 @@ let _clipboardGet = (regname: int) => {
   };
 };
 
-let nativeFormatRequestToEffect: Native.formatRequest => Format.effect =
-  ({bufferId, startLine, endLine, returnCursor, formatType}) => {
-    let adjustCursor = returnCursor == 0 ? false : true;
-    let formatType =
-      switch (formatType) {
-      | Native.Indentation => Format.Indentation
-      | Native.Formatting => Format.Formatting
-      };
-    Format.Buffer({formatType, bufferId, adjustCursor});
-  };
-
 let _onFormat = formatRequest => {
   queue(() =>
     Event.dispatch(
-      Effect.Format(formatRequest |> nativeFormatRequestToEffect),
+      Effect.Format(formatRequest |> Internal.nativeFormatRequestToEffect),
       Listeners.effect,
     )
   );

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -13,6 +13,7 @@ module Context = Context;
 module Cursor = Cursor;
 module Effect = Effect;
 module Event = Event;
+module Format = Format;
 module Goto = Goto;
 module Mode = Mode;
 module Options = Options;
@@ -247,6 +248,10 @@ let _clipboardGet = (regname: int) => {
   };
 };
 
+let _onFormat = formatRequest => {
+    queue(() => Event.dispatch(Effect.Format(formatRequest), Listeners.effect));
+};
+
 let _onGoto = (_line: int, _column: int, gotoType: Goto.t) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
 };
@@ -264,6 +269,7 @@ let init = () => {
   Callback.register("lv_onBufferChanged", _onBufferChanged);
   Callback.register("lv_onAutocommand", _onAutocommand);
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);
+  Callback.register("lv_onFormat", _onFormat);
   Callback.register("lv_onGoto", _onGoto);
   Callback.register("lv_onIntro", _onIntro);
   Callback.register("lv_onMessage", _onMessage);

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -249,7 +249,9 @@ let _clipboardGet = (regname: int) => {
 };
 
 let _onFormat = formatRequest => {
-    queue(() => Event.dispatch(Effect.Format(formatRequest), Listeners.effect));
+  queue(() =>
+    Event.dispatch(Effect.Format(formatRequest), Listeners.effect)
+  );
 };
 
 let _onGoto = (_line: int, _column: int, gotoType: Goto.t) => {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -200,7 +200,7 @@ module Format: {
         adjustCursor: bool,
       })
     | Range({
-        requestType: formatType,
+        formatType,
         bufferId: int,
         startLine: Index.t,
         endLine: Index.t,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -182,15 +182,21 @@ module Buffer: {
 };
 
 module Goto: {
-  type t =
+  type effect =
     | Definition
     | Declaration
     | Hover;
 };
 
+module Format: {
+  type effect =
+  | Buffer({ bufferId: int, adjustCursor: bool})
+}
+
 module Effect: {
   type t =
-    | Goto(Goto.t);
+    | Goto(Goto.effect)
+    | Format(Format.effect);
 };
 
 /**

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -189,9 +189,21 @@ module Goto: {
 };
 
 module Format: {
+  type formatType =
+    | Indentation
+    | Formatting;
+
   type effect =
     | Buffer({
+        formatType,
         bufferId: int,
+        adjustCursor: bool,
+      })
+    | Range({
+        requestType: formatType,
+        bufferId: int,
+        startLine: Index.t,
+        endLine: Index.t,
         adjustCursor: bool,
       });
 };

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -190,8 +190,11 @@ module Goto: {
 
 module Format: {
   type effect =
-  | Buffer({ bufferId: int, adjustCursor: bool})
-}
+    | Buffer({
+        bufferId: int,
+        adjustCursor: bool,
+      });
+};
 
 module Effect: {
   type t =

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -115,13 +115,20 @@ void onFormat(formatRequest_T *pRequest) {
   }
 
   int id = vimBufferGetId(pRequest->buf);
+  int formatType = 0;
 
-  ret = caml_alloc(4, 0);
+  if (pRequest->formatType == FORMATTING) {
+    formatType = 1;
+  }
+
+  ret = caml_alloc(5, 0);
   Store_field(ret, 0, Val_int(pRequest->start.lnum));
-  Store_field(ret, 1, Val_int(pRequest->end.lnum))
-  Store_field(ret, 2, Val_int(id))
+  Store_field(ret, 1, Val_int(pRequest->end.lnum));
+  Store_field(ret, 2, Val_int(id));
   Store_field(ret, 3, Val_int(pRequest->returnCursor));
+  Store_field(ret, 4, Val_int(formatType));
 
+  caml_callback(*lv_onFormat, ret);
   CAMLreturn0;
 }
 

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -98,6 +98,33 @@ void onDirectoryChanged(char_u *path) {
   CAMLreturn0;
 }
 
+void onFormat(formatRequest_T *pRequest) {
+  CAMLparam0();
+  CAMLlocal3(ret, commandString, commandOpt);
+
+  static const value *lv_onFormat = NULL;
+  if (lv_onFormat == NULL) {
+    lv_onFormat = caml_named_value("lv_onFormat");
+  }
+
+  if (pRequest->cmd != NULL) {
+    commandString = caml_copy_string(pRequest->cmd);
+    commandOpt = Val_some(commandString);
+  } else {
+    commandOpt = Val_none;
+  }
+
+  int id = vimBufferGetId(pRequest->buf);
+
+  ret = caml_alloc(4, 0);
+  Store_field(ret, 0, Val_int(pRequest->start.lnum));
+  Store_field(ret, 1, Val_int(pRequest->end.lnum))
+  Store_field(ret, 2, Val_int(id))
+  Store_field(ret, 3, Val_int(pRequest->returnCursor));
+
+  CAMLreturn0;
+}
+
 void onMessage(char_u *title, char_u *contents, msgPriority_T priority) {
   CAMLparam0();
   CAMLlocal2(titleString, contentsString);
@@ -344,6 +371,7 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetDirectoryChangedCallback(&onDirectoryChanged);
   vimSetDisplayIntroCallback(&onIntro);
   vimSetDisplayVersionCallback(&onVersion);
+  vimSetFormatCallback(&onFormat);
   vimSetGotoCallback(&onGoto);
   vimSetMessageCallback(&onMessage);
   vimSetQuitCallback(&onQuit);

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -115,18 +115,20 @@ void onFormat(formatRequest_T *pRequest) {
   }
 
   int id = vimBufferGetId(pRequest->buf);
+  int lineCount = vimBufferGetLineCount(pRequest->buf);
   int formatType = 0;
 
   if (pRequest->formatType == FORMATTING) {
     formatType = 1;
   }
 
-  ret = caml_alloc(5, 0);
+  ret = caml_alloc(6, 0);
   Store_field(ret, 0, Val_int(pRequest->start.lnum));
   Store_field(ret, 1, Val_int(pRequest->end.lnum));
   Store_field(ret, 2, Val_int(id));
   Store_field(ret, 3, Val_int(pRequest->returnCursor));
   Store_field(ret, 4, Val_int(formatType));
+  Store_field(ret, 5, Val_int(lineCount));
 
   caml_callback(*lv_onFormat, ret);
   CAMLreturn0;

--- a/test/reason-libvim/FormatTest.re
+++ b/test/reason-libvim/FormatTest.re
@@ -12,16 +12,76 @@ describe("Format", ({test, _}) => {
 
     let effects = ref([]);
 
-    let dispose = onEffect(gotoType => updates := [gotoType, ...updates^]);
+    let dispose = onEffect(eff => effects := [eff, ...effects^]);
 
-    input("gg=G");
-    let formatEffect = List.hd(updates^);
+    input("gg");
+    input("=");
+    input("G");
+    let formatEffect = List.hd(effects^);
 
     expect.int(List.length(effects^)).toBe(1);
-    expect.equal(formateffect, Effect.Format(Buffer({
-      bufferId,
-      returnCursor: false,
-    });
+    expect.equal(
+      formatEffect,
+      Effect.Format(
+        Buffer({
+          formatType: Format.Indentation,
+          bufferId,
+          adjustCursor: false,
+        }),
+      ),
+    );
+
+    dispose();
+  });
+  test("gggqG", ({expect, _}) => {
+    let _ = resetBuffer();
+
+    let bufferId = Vim.Buffer.(getCurrent() |> getId);
+
+    let effects = ref([]);
+
+    let dispose = onEffect(eff => effects := [eff, ...effects^]);
+
+    input("gg");
+    input("gq");
+    input("G");
+    let formatEffect = List.hd(effects^);
+
+    expect.int(List.length(effects^)).toBe(1);
+    expect.equal(
+      formatEffect,
+      Effect.Format(
+        Buffer({
+          formatType: Format.Formatting,
+          bufferId,
+          adjustCursor: false,
+        }),
+      ),
+    );
+
+    dispose();
+  });
+  test("gggwG", ({expect, _}) => {
+    let _ = resetBuffer();
+
+    let bufferId = Vim.Buffer.(getCurrent() |> getId);
+
+    let effects = ref([]);
+
+    let dispose = onEffect(eff => effects := [eff, ...effects^]);
+
+    input("gg");
+    input("gw");
+    input("G");
+    let formatEffect = List.hd(effects^);
+
+    expect.int(List.length(effects^)).toBe(1);
+    expect.equal(
+      formatEffect,
+      Effect.Format(
+        Buffer({formatType: Format.Formatting, bufferId, adjustCursor: true}),
+      ),
+    );
 
     dispose();
   });

--- a/test/reason-libvim/FormatTest.re
+++ b/test/reason-libvim/FormatTest.re
@@ -1,7 +1,9 @@
+open EditorCoreTypes;
 open TestFramework;
 open Vim;
 
-let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
+let resetBuffer = () =>
+  Helpers.resetBuffer("test/reason-libvim/testfile.txt");
 let input = s => ignore(Vim.input(s): Context.t);
 
 describe("Format", ({test, _}) => {
@@ -27,6 +29,34 @@ describe("Format", ({test, _}) => {
           formatType: Format.Indentation,
           bufferId,
           adjustCursor: false,
+        }),
+      ),
+    );
+
+    dispose();
+  });
+  test("==", ({expect, _}) => {
+    let _ = resetBuffer();
+
+    let bufferId = Vim.Buffer.(getCurrent() |> getId);
+
+    let effects = ref([]);
+
+    let dispose = onEffect(eff => effects := [eff, ...effects^]);
+
+    input("==");
+    let formatEffect = List.hd(effects^);
+
+    expect.int(List.length(effects^)).toBe(1);
+    expect.equal(
+      formatEffect,
+      Effect.Format(
+        Format.Range({
+          formatType: Format.Indentation,
+          bufferId,
+          adjustCursor: false,
+          startLine: Index.zero,
+          endLine: Index.zero,
         }),
       ),
     );

--- a/test/reason-libvim/FormatTest.re
+++ b/test/reason-libvim/FormatTest.re
@@ -1,0 +1,28 @@
+open TestFramework;
+open Vim;
+
+let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
+let input = s => ignore(Vim.input(s): Context.t);
+
+describe("Format", ({test, _}) => {
+  test("gg=G", ({expect, _}) => {
+    let _ = resetBuffer();
+
+    let bufferId = Vim.Buffer.(getCurrent() |> getId);
+
+    let effects = ref([]);
+
+    let dispose = onEffect(gotoType => updates := [gotoType, ...updates^]);
+
+    input("gg=G");
+    let formatEffect = List.hd(updates^);
+
+    expect.int(List.length(effects^)).toBe(1);
+    expect.equal(formateffect, Effect.Format(Buffer({
+      bufferId,
+      returnCursor: false,
+    });
+
+    dispose();
+  });
+});


### PR DESCRIPTION
This hooks up the externalization of the indentation and formatting operators in `libvim` (https://github.com/onivim/libvim/pull/204) such that they can be used as the interface for triggering format operations from the VSCode exthost format providers.