### PR TITLE
fix(file-explorer): focus issues

### DIFF
--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -34,7 +34,18 @@ let setOpen = (isOpen, state) =>
 let setActive = (maybePath, state) =>
   updateFileExplorer(s => {...s, active: maybePath}, state);
 let setFocus = (maybePath, state) =>
-  updateFileExplorer(s => {...s, focus: maybePath}, state);
+  updateFileExplorer(
+    s =>
+      switch (maybePath, s.tree) {
+      | (Some(path), Some(tree)) =>
+        switch (FsTreeNode.findByPath(path, tree)) {
+        | Some(_) => {...s, focus: Some(path)}
+        | None => s
+        }
+      | _ => {...s, focus: None}
+      },
+    state,
+  );
 let setScrollOffset = (scrollOffset, state) =>
   updateFileExplorer(s => {...s, scrollOffset}, state);
 

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -49,7 +49,7 @@ let setFocus = (maybePath, state) =>
 let setScrollOffset = (scrollOffset, state) =>
   updateFileExplorer(s => {...s, scrollOffset}, state);
 
-let revealPath = (path, state: State.t) => {
+let revealAndFocusPath = (path, state: State.t) => {
   switch (state.fileExplorer.tree) {
   | Some(tree) =>
     switch (FsTreeNode.findNodesByPath(path, tree)) {
@@ -80,7 +80,10 @@ let revealPath = (path, state: State.t) => {
         };
 
       (
-        state |> setTree(tree) |> setScrollOffset(offset),
+        state
+        |> setFocus(Some(path))
+        |> setTree(tree)
+        |> setScrollOffset(offset),
         Isolinear.Effect.none,
       );
     }
@@ -148,7 +151,7 @@ let start = () => {
     | FocusNodeLoaded(node) =>
       switch (state.fileExplorer.active) {
       | Some(activePath) =>
-        state |> replaceNode(node) |> revealPath(activePath)
+        state |> replaceNode(node) |> revealAndFocusPath(activePath)
 
       | None => (state, Isolinear.Effect.none)
       }
@@ -221,7 +224,7 @@ let start = () => {
       | {active, _} when active != filePath =>
         let state = setActive(filePath, state);
         switch (filePath) {
-        | Some(path) => revealPath(path, state)
+        | Some(path) => revealAndFocusPath(path, state)
         | None => (state, Isolinear.Effect.none)
         };
 


### PR DESCRIPTION
**Issue:** The file explorer would not initially set the focus to a file opened from outside of the file explorer. Additionally, the focus would be set to invalid paths, or paths that do not exist in the tree, in certain conditions such as initially when the welcome screen is shown and the focus would be set to `oni://Welcome`

**Defect:** When setting the focus, the path was not checked against the tree. Additionally, the focus was set before the nodes in the path had been loaded.

**Fix:** Validate that the path exists on the tree when settings focus, and set the focus only after loading and revealing the path.