### PR TITLE
refactor(theme/#1933): Theme name / file path is not logged

### DIFF
--- a/src/Store/ThemeStoreConnector.re
+++ b/src/Store/ThemeStoreConnector.re
@@ -51,6 +51,8 @@ let start = (themeInfo: ThemeInfo.t) => {
       Oni_Core.Log.perf("theme.load", () => {
         let dark = uiTheme == "vs-dark" || uiTheme == "hc-black";
 
+        Log.infof(m => m("Loading theme: %s", themePath));
+
         themePath
         |> Textmate.Theme.from_file(~isDark=dark)
         |> Utility.ResultEx.tapError(err => {
@@ -78,6 +80,7 @@ let start = (themeInfo: ThemeInfo.t) => {
     });
 
   let loadThemeByNameEffect = themeName => {
+    Log.infof(m => m("Loading theme by name: %s", themeName));
     let themeInfo = ThemeInfo.getThemeByName(themeInfo, themeName);
 
     switch (themeInfo) {


### PR DESCRIPTION
Investigating #1933 - we weren't actually logging out the theme name / file being loaded (which would've been useful information to diagnose the bug). This does not address the root cause of #1933, but means it'll be easier to investigate from the log in the future.