### PR TITLE
fix(editor/#1937): non mono font resolution

### DIFF
--- a/src/Feature/Editor/CursorView.re
+++ b/src/Feature/Editor/CursorView.re
@@ -173,6 +173,7 @@ let%component make =
               ~y=y -. fontMetrics.ascent -. 0.5,
               ~bold=false,
               ~italic=false,
+              ~mono=false,
               ~color=background |> Revery.Color.multiplyAlpha(textOpacity),
               text,
             );

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -89,10 +89,11 @@ let drawShapedText = {
 
   Skia.Paint.setLcdRenderText(paint, true);
 
-  (~context, ~x, ~y, ~color, ~bold, ~italic, text) => {
+  (~context, ~x, ~y, ~color, ~bold, ~italic, ~mono, text) => {
     let font =
       Service_Font.resolveWithFallback(
         ~italic,
+        ~mono,
         bold ? Revery.Font.Weight.Bold : Revery.Font.Weight.Normal,
         context.fontFamily,
       );
@@ -114,10 +115,11 @@ let drawUtf8Text = {
 
   Skia.Paint.setLcdRenderText(paint, true);
 
-  (~context, ~x, ~y, ~color, ~bold, ~italic, text) => {
+  (~context, ~x, ~y, ~color, ~bold, ~italic, ~mono, text) => {
     let font =
       Service_Font.resolveWithFallback(
         ~italic,
+        ~mono,
         bold ? Revery.Font.Weight.Bold : Revery.Font.Weight.Normal,
         context.fontFamily,
       );
@@ -220,6 +222,7 @@ let token =
   let font =
     Service_Font.resolveWithFallback(
       ~italic=token.italic,
+      ~mono=true,
       token.bold ? Revery.Font.Weight.Bold : Revery.Font.Weight.Normal,
       context.fontFamily,
     );
@@ -236,6 +239,7 @@ let token =
       ~color=token.color,
       ~bold=token.bold,
       ~italic=token.italic,
+      ~mono=true,
       token.text,
     )
 

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -59,6 +59,7 @@ let renderLineNumber =
     ~color,
     ~bold=false,
     ~italic=false,
+    ~mono=false,
     lineNumber,
   );
 };

--- a/src/Service/Font/FontLoader.re
+++ b/src/Service/Font/FontLoader.re
@@ -73,6 +73,7 @@ let loadAndValidateEditorFont =
                   isMonospace(~smoothing, ~fontSize, ~font=f);
                 if (isMono) {
                   Revery_Font.Family.toPath(
+                    ~mono=true,
                     Revery_Font.Weight.Bold,
                     fontFamily,
                   );
@@ -104,6 +105,7 @@ let loadAndValidateEditorFont =
                   isMonospace(~smoothing, ~fontSize, ~font=f);
                 if (isMono) {
                   Revery_Font.Family.toPath(
+                    ~mono=true,
                     ~italic=true,
                     Revery_Font.Weight.Normal,
                     fontFamily,

--- a/src/Service/Font/FontLoader.re
+++ b/src/Service/Font/FontLoader.re
@@ -63,6 +63,7 @@ let loadAndValidateEditorFont =
             let boldPath =
               switch (
                 Revery_Font.Family.resolve(
+                  ~mono=true,
                   Revery_Font.Weight.Bold,
                   fontFamily,
                 )
@@ -92,6 +93,7 @@ let loadAndValidateEditorFont =
             let italicPath =
               switch (
                 Revery_Font.Family.resolve(
+                  ~mono=true,
                   ~italic=true,
                   Revery_Font.Weight.Normal,
                   fontFamily,

--- a/src/Service/Font/FontLoader.re
+++ b/src/Service/Font/FontLoader.re
@@ -51,7 +51,7 @@ let loadAndValidateEditorFont =
       Stdlib.Result.bind(
         r,
         font => {
-          let (isMono, c1width, c2width) =
+          let (isMono, c1width, _) =
             isMonospace(~font, ~smoothing, ~fontSize);
           if (!isMono) {
             Error("Not a monospace font");

--- a/src/Service/Font/FontLoader.re
+++ b/src/Service/Font/FontLoader.re
@@ -76,6 +76,9 @@ let loadAndValidateEditorFont =
                     fontFamily,
                   );
                 } else {
+                  Log.warnf(m =>
+                    m("Unable to load monospace bold variant of %s", fullPath)
+                  );
                   fullPath;
                 };
               | Error(_) => fullPath
@@ -99,6 +102,12 @@ let loadAndValidateEditorFont =
                     fontFamily,
                   );
                 } else {
+                  Log.warnf(m =>
+                    m(
+                      "Unable to load monospace italic variant of %s",
+                      fullPath,
+                    )
+                  );
                   fullPath;
                 };
               | Error(_) => fullPath

--- a/src/Service/Font/FontLoader.re
+++ b/src/Service/Font/FontLoader.re
@@ -68,7 +68,7 @@ let loadAndValidateEditorFont =
                 )
               ) {
               | Ok(f) =>
-                let (isMono, _, _) =
+                let (isMono, c1w, c2w) =
                   isMonospace(~smoothing, ~fontSize, ~font=f);
                 if (isMono) {
                   Revery_Font.Family.toPath(
@@ -77,7 +77,12 @@ let loadAndValidateEditorFont =
                   );
                 } else {
                   Log.warnf(m =>
-                    m("Unable to load monospace bold variant of %s", fullPath)
+                    m(
+                      "Unable to load monospace italic variant of %s: c1 width : %f c2 width : %f",
+                      fullPath,
+                      c1w,
+                      c2w,
+                    )
                   );
                   fullPath;
                 };
@@ -93,7 +98,7 @@ let loadAndValidateEditorFont =
                 )
               ) {
               | Ok(f) =>
-                let (isMono, _, _) =
+                let (isMono, c1w, c2w) =
                   isMonospace(~smoothing, ~fontSize, ~font=f);
                 if (isMono) {
                   Revery_Font.Family.toPath(
@@ -104,8 +109,10 @@ let loadAndValidateEditorFont =
                 } else {
                   Log.warnf(m =>
                     m(
-                      "Unable to load monospace italic variant of %s",
+                      "Unable to load monospace italic variant of %s: c1 width : %f c2 width : %f",
                       fullPath,
+                      c1w,
+                      c2w,
                     )
                   );
                   fullPath;


### PR DESCRIPTION
This fixes #1937 by ensuring monospace fonts in resolutions and prefetching the monospaced variants.