### PR TITLE
feat(extensions): Add LaserWave Italic extension back

### DIFF
--- a/extensions/laserwave/package.json
+++ b/extensions/laserwave/package.json
@@ -25,6 +25,11 @@
 				"label": "LaserWave",
 				"uiTheme": "vs-dark",
 				"path": "./themes/LaserWave-color-theme.json"
+			},
+			{
+				"label": "LaserWave Italic",
+				"uiTheme": "vs-dark",
+				"path": "./themes/LaserWave-italic-color-theme.json"
 			}
 		]
 	},


### PR DESCRIPTION
Bring `LaserWave Italic` back in, since we now support the italics:

![image](https://user-images.githubusercontent.com/13532591/84680894-3bf85e80-aee8-11ea-8463-aa3cba3d5985.png)
