### PR TITLE
fix(exthost): Signature Help - hook up documentation of parameters / signature

### DIFF
--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -83,7 +83,11 @@ module Location: {
 };
 
 module MarkdownString: {
-  type t = string;
+  [@deriving show]
+  type t;
+
+  let fromString: string => t;
+  let toString: t => string;
 
   let decode: Json.decoder(t);
 };
@@ -298,8 +302,7 @@ module SignatureHelp: {
     [@deriving show]
     type t = {
       label: string,
-      // TODO
-      //documentation: option(string),
+      documentation: option(MarkdownString.t),
     };
     let decode: Json.decoder(t);
   };
@@ -308,8 +311,7 @@ module SignatureHelp: {
     [@deriving show]
     type t = {
       label: string,
-      // TODO:
-      //documentation: options(MarkdownString.t),
+      documentation: option(MarkdownString.t),
       parameters: list(ParameterInformation.t),
     };
 

--- a/src/Exthost/MarkdownString.re
+++ b/src/Exthost/MarkdownString.re
@@ -8,7 +8,16 @@
 //}
 open Oni_Core;
 
+[@deriving show]
 type t = string;
 
 let decode =
-  Json.Decode.(obj(({field, _}) => {field.required("value", string)}));
+  Json.Decode.(
+    one_of([
+      ("markdown", obj(({field, _}) => {field.required("value", string)})),
+      ("string", string),
+    ])
+  );
+
+let toString = str => str;
+let fromString = str => str;

--- a/src/Exthost/SignatureHelp.re
+++ b/src/Exthost/SignatureHelp.re
@@ -66,8 +66,7 @@ module ParameterInformation = {
   [@deriving show]
   type t = {
     label: string,
-    // TODO:
-    //documentation: option(MarkdownString.t),
+    documentation: option(MarkdownString.t),
   };
 
   let decode =
@@ -75,7 +74,8 @@ module ParameterInformation = {
       obj(({field, _}) =>
         {
           label: field.required("label", string),
-          //documentation: field.optional("documentation", string),
+          documentation:
+            field.optional("documentation", MarkdownString.decode),
         }
       )
     );
@@ -85,8 +85,7 @@ module Signature = {
   [@deriving show]
   type t = {
     label: string,
-    // TODO:
-    //documentation: options(MarkdownString.t),
+    documentation: option(MarkdownString.t),
     parameters: list(ParameterInformation.t),
   };
 
@@ -101,6 +100,8 @@ module Signature = {
               [],
               list(ParameterInformation.decode),
             ),
+          documentation:
+            field.optional("documentation", MarkdownString.decode),
         }
       )
     );

--- a/src/Feature/Hover/Feature_Hover.re
+++ b/src/Feature/Hover/Feature_Hover.re
@@ -18,7 +18,7 @@ type provider = {
 type model = {
   shown: bool,
   providers: list(provider),
-  contents: list(string),
+  contents: list(Exthost.MarkdownString.t),
   range: option(EditorCoreTypes.Range.t),
   triggeredFrom:
     option([ | `CommandPalette | `Mouse(EditorCoreTypes.Location.t)]),
@@ -54,7 +54,7 @@ type msg =
   | KeyPressed(string)
   | ProviderRegistered(provider)
   | HoverInfoReceived({
-      contents: list(string),
+      contents: list(Exthost.MarkdownString.t),
       range: option(EditorCoreTypes.Range.t),
       requestID: int,
     })
@@ -336,7 +336,7 @@ module View = {
           editorFont.fontFamily;
         },
         ~grammars,
-        ~markdown,
+        ~markdown=Exthost.MarkdownString.toString(markdown),
         ~baseFontSize=14.,
         ~codeBlockStyle=Style.[flexGrow(1)],
       );

--- a/src/Feature/Hover/Feature_Hover.rei
+++ b/src/Feature/Hover/Feature_Hover.rei
@@ -18,7 +18,7 @@ type msg =
   | KeyPressed(string)
   | ProviderRegistered(provider)
   | HoverInfoReceived({
-      contents: list(string),
+      contents: list(Exthost.MarkdownString.t),
       range: option(EditorCoreTypes.Range.t),
       requestID: int,
     })

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -384,13 +384,13 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
            ),
          )
       |> Test.withClientRequest(
-           ~name="Get symbols",
+           ~name="Get hover",
            ~validate=
              (maybeHover: option(Exthost.Hover.t)) => {
                expect.equal(
                  maybeHover,
                  Some({
-                   contents: ["Hover Content"],
+                   contents: [MarkdownString.fromString("Hover Content")],
                    range:
                      Some(
                        OneBasedRange.{
@@ -463,8 +463,22 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
                    signatures: [
                      Signature.{
                        label: "signature 1",
+                       documentation:
+                         Some(
+                           MarkdownString.fromString(
+                             "signature 1 documentation",
+                           ),
+                         ),
                        parameters: [
-                         ParameterInformation.{label: "parameter 1"},
+                         ParameterInformation.{
+                           label: "parameter 1",
+                           documentation:
+                             Some(
+                               MarkdownString.fromString(
+                                 "parameter 1 documentation",
+                               ),
+                             ),
+                         },
                        ],
                      },
                    ],

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -62,9 +62,9 @@ function activate(context) {
 
 	const signatureHelpProvider = {
 		provideSignatureHelp: (_document, _position, _token, _context) => {
-			const signature1 = new vscode.SignatureInformation("signature 1", null);
+			const signature1 = new vscode.SignatureInformation("signature 1", "signature 1 documentation");
 			signature1.parameters = [
-				new vscode.ParameterInformation("parameter 1", null)
+				new vscode.ParameterInformation("parameter 1", "parameter 1 documentation")
 			];
 
 			// Signature Help


### PR DESCRIPTION
This change wires up the `documentation` properties for the `ParameterInformation` and `Signature` information coming from the extension host, and updates the test case so that we're actually sending some signature info and validating it comes through.