### PR TITLE
refactor(exthost): Add msg for buffer update queued + trigger key

### DIFF
--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -55,7 +55,7 @@ let editorGroup =
 
 let createUpdateAction = (oldBuffer: Buffer.t, update: BufferUpdate.t) => {
   let newBuffer = Buffer.update(oldBuffer, update);
-  Actions.BufferUpdate({update, oldBuffer, newBuffer});
+  Actions.BufferUpdate({update, oldBuffer, newBuffer, triggerKey: None});
 };
 
 let thousandLineBuffer = Buffer.ofLines(thousandLines);

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -79,9 +79,7 @@ type t =
   | EditorFont(Service_Font.msg)
   | TerminalFont(Service_Font.msg)
   | Extension(Extensions.action)
-  | ExtensionBufferUpdateQueued({
-      triggerKey: option(string),
-  })
+  | ExtensionBufferUpdateQueued({triggerKey: option(string)})
   | FileChanged(Service_FileWatcher.event)
   | References(References.actions)
   | KeyBindingsSet([@opaque] Keybindings.t)

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -45,6 +45,7 @@ type t =
       update: [@opaque] BufferUpdate.t,
       oldBuffer: [@opaque] Buffer.t,
       newBuffer: [@opaque] Buffer.t,
+      triggerKey: option(string),
     })
   | BufferLineEndingsChanged({
       id: int,
@@ -78,6 +79,9 @@ type t =
   | EditorFont(Service_Font.msg)
   | TerminalFont(Service_Font.msg)
   | Extension(Extensions.action)
+  | ExtensionBufferUpdateQueued({
+      triggerKey: option(string),
+  })
   | FileChanged(Service_FileWatcher.event)
   | References(References.actions)
   | KeyBindingsSet([@opaque] Keybindings.t)

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -6,9 +6,10 @@ module Log = (val Log.withNamespace("Service_Exthost"));
 
 module Effects = {
   module Documents = {
-  let modelChanged = (~buffer: Buffer.t, ~update: BufferUpdate.t,
-  client, toMsg) =>
-    Isolinear.Effect.createWithDispatch(~name="exthost.bufferUpdate", dispatch =>
+    let modelChanged =
+        (~buffer: Buffer.t, ~update: BufferUpdate.t, client, toMsg) =>
+      Isolinear.Effect.createWithDispatch(
+        ~name="exthost.bufferUpdate", dispatch =>
         Oni_Core.Log.perf("exthost.bufferUpdate", () => {
           let modelContentChange =
             Exthost.ModelContentChange.ofBufferUpdate(
@@ -30,7 +31,7 @@ module Effects = {
           );
           dispatch(toMsg());
         })
-    );
+      );
   };
   module SCM = {
     let provideOriginalResource = (~handles, extHostClient, path, toMsg) =>

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -5,6 +5,33 @@ module Log = (val Log.withNamespace("Service_Exthost"));
 // EFFECTS
 
 module Effects = {
+  module Documents = {
+  let modelChanged = (~buffer: Buffer.t, ~update: BufferUpdate.t,
+  client, toMsg) =>
+    Isolinear.Effect.createWithDispatch(~name="exthost.bufferUpdate", dispatch =>
+        Oni_Core.Log.perf("exthost.bufferUpdate", () => {
+          let modelContentChange =
+            Exthost.ModelContentChange.ofBufferUpdate(
+              update,
+              Exthost.Eol.default,
+            );
+          let modelChangedEvent =
+            Exthost.ModelChangedEvent.{
+              changes: [modelContentChange],
+              eol: Exthost.Eol.default,
+              versionId: update.version,
+            };
+
+          Exthost.Request.Documents.acceptModelChanged(
+            ~uri=Buffer.getUri(buffer),
+            ~modelChangedEvent,
+            ~isDirty=Buffer.isModified(buffer),
+            client,
+          );
+          dispatch(toMsg());
+        })
+    );
+  };
   module SCM = {
     let provideOriginalResource = (~handles, extHostClient, path, toMsg) =>
       Isolinear.Effect.createWithDispatch(~name="scm.getOriginalUri", dispatch => {

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -1,5 +1,15 @@
 // EFFECTS
 module Effects: {
+
+  module Documents: {
+    let modelChanged: (
+      ~buffer: Oni_Core.Buffer.t,
+      ~update: Oni_Core.BufferUpdate.t,
+      Exthost.Client.t,
+      unit => 'msg
+    ) => Isolinear.Effect.t('msg);
+  };
+
   module SCM: {
     let provideOriginalResource:
       (

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -1,13 +1,14 @@
 // EFFECTS
 module Effects: {
-
   module Documents: {
-    let modelChanged: (
-      ~buffer: Oni_Core.Buffer.t,
-      ~update: Oni_Core.BufferUpdate.t,
-      Exthost.Client.t,
-      unit => 'msg
-    ) => Isolinear.Effect.t('msg);
+    let modelChanged:
+      (
+        ~buffer: Oni_Core.Buffer.t,
+        ~update: Oni_Core.BufferUpdate.t,
+        Exthost.Client.t,
+        unit => 'msg
+      ) =>
+      Isolinear.Effect.t('msg);
   };
 
   module SCM: {

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -162,11 +162,9 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
     | BufferUpdate({update, newBuffer, triggerKey, _}) => (
         state,
         Service_Exthost.Effects.Documents.modelChanged(
-          ~buffer=newBuffer,
-          ~update,
-          extHostClient,
-          () => Actions.ExtensionBufferUpdateQueued({triggerKey: triggerKey})
-        )
+          ~buffer=newBuffer, ~update, extHostClient, () =>
+          Actions.ExtensionBufferUpdateQueued({triggerKey: triggerKey})
+        ),
       )
 
     | BufferSaved(_) => (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -399,6 +399,10 @@ let update =
         Effect.map(msg => Actions.Hover(msg), eff)
       };
     ({...state, hover: model'}, effect);
+  | ExtensionBufferUpdateQueued(_) /* {triggerKey}*/ =>
+    // TODO: Engage features that require trigger characters
+    // (completion, signature help) here:
+    (state, Effect.none)
   | Vim(msg) => (
       {...state, vim: Feature_Vim.update(msg, state.vim)},
       Effect.none,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -435,8 +435,12 @@ let start =
         |> Option.iter(oldBuffer => {
              let newBuffer = Core.Buffer.update(oldBuffer, bu);
              dispatch(
-               Actions.BufferUpdate({update: bu, newBuffer, oldBuffer,
-               triggerKey: currentTriggerKey^}),
+               Actions.BufferUpdate({
+                 update: bu,
+                 newBuffer,
+                 oldBuffer,
+                 triggerKey: currentTriggerKey^,
+               }),
              );
            });
       } else {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -61,6 +61,7 @@ let start =
     ) => {
   let (stream, dispatch) = Isolinear.Stream.create();
   let libvimHasInitialized = ref(false);
+  let currentTriggerKey = ref(None);
 
   let languageConfigLoader =
     Ext.LanguageConfigurationLoader.create(languageInfo);
@@ -434,7 +435,8 @@ let start =
         |> Option.iter(oldBuffer => {
              let newBuffer = Core.Buffer.update(oldBuffer, bu);
              dispatch(
-               Actions.BufferUpdate({update: bu, newBuffer, oldBuffer}),
+               Actions.BufferUpdate({update: bu, newBuffer, oldBuffer,
+               triggerKey: currentTriggerKey^}),
              );
            });
       } else {
@@ -577,8 +579,10 @@ let start =
         let context =
           Oni_Model.VimContext.current(~languageConfigLoader, state);
 
+        currentTriggerKey := Some(key);
         let {cursors, topLine: newTopLine, leftColumn: newLeftColumn, _}: Vim.Context.t =
           Vim.input(~context, key);
+        currentTriggerKey := None;
 
         let () =
           editor


### PR DESCRIPTION
__Issue:__ Several of the extension host APIs - like signature help and completion - need a reliable way to request with a trigger key, _after_ a buffer update has been processed. We have some complicated interplay to handle this with completion, but it's not really maintainable.

__Fix:__ Add some additional context around buffer updates, specifically, what, if any, character triggered the update. In addition, add a message to report once a buffer update has been queued, along with the trigger character - we can use this context to then trigger features that require the trigger character (ie, signature help / completion).

This could be improved further by moving more of the state / effects from `ExtensionClientStoreConnector` to `Service_Exthost` and `Feature_Exthost` - the `modelChanged` effect was migrated.