### PR TITLE
chore(ci): Fix failing unit test

### DIFF
--- a/test/Feature/Editor/BufferLineColorizerTests.re
+++ b/test/Feature/Editor/BufferLineColorizerTests.re
@@ -46,10 +46,10 @@ describe("BufferLineColorizer", ({test, _}) => {
   test("base case - cover all tokens", ({expect, _}) => {
     let colorize = basicColorizer(~startByte=0, ~endByte=11, basicTokens);
 
-    let BufferLineColorizer.{backgroundColor: color0, _} = colorize(0);
-    let BufferLineColorizer.{backgroundColor: color2, _} = colorize(2);
-    let BufferLineColorizer.{backgroundColor: color6, _} = colorize(6);
-    let BufferLineColorizer.{backgroundColor: color11, _} = colorize(11);
+    let BufferLineColorizer.{color: color0, _} = colorize(0);
+    let BufferLineColorizer.{color: color2, _} = colorize(2);
+    let BufferLineColorizer.{color: color6, _} = colorize(6);
+    let BufferLineColorizer.{color: color11, _} = colorize(11);
 
     expect.equal(color0, Colors.white);
     expect.equal(color2, Colors.green);
@@ -60,8 +60,8 @@ describe("BufferLineColorizer", ({test, _}) => {
   test("out of bounds", ({expect, _}) => {
     let colorize = basicColorizer(~startByte=4, ~endByte=6, basicTokens);
 
-    let BufferLineColorizer.{backgroundColor: color0, _} = colorize(0);
-    let BufferLineColorizer.{backgroundColor: color11, _} = colorize(11);
+    let BufferLineColorizer.{color: color0, _} = colorize(0);
+    let BufferLineColorizer.{color: color11, _} = colorize(11);
 
     expect.equal(color0, Colors.green);
     expect.equal(color11, Colors.red);

--- a/test/OniUnitTestRunnerCI.re
+++ b/test/OniUnitTestRunnerCI.re
@@ -54,6 +54,19 @@ Oni_Components_Test.TestFramework.run(
   ),
 );
 
+Feature_Editor_Test.TestFramework.run(
+  Rely.RunConfig.withReporters(
+    [Default, JUnit("./junit.xml")],
+    Rely.RunConfig.initialize(),
+  ),
+);
+Feature_LanguageSupport_Test.TestFramework.run(
+  Rely.RunConfig.withReporters(
+    [Default, JUnit("./junit.xml")],
+    Rely.RunConfig.initialize(),
+  ),
+);
+
 Exthost_Transport_Test.TestFramework.run(
   Rely.RunConfig.withReporters(
     [Default, JUnit("./junit.xml")],

--- a/test/dune
+++ b/test/dune
@@ -121,6 +121,8 @@
         Oni_Input_Test
         Oni_Syntax_Test
         Oni_Model_Test
+        Feature_Editor_Test
+        Feature_LanguageSupport_Test
         Exthost_Transport_Test
         Exthost_Test
         Libvim_Test


### PR DESCRIPTION
A unit test failure snuck in - there was a suite we weren't running as part of `esy '@test' run-ci` - this brings in the missing suites and a fix for the test failure.