### PR TITLE
fix(hover/#1947): RLS - turn module path off by default

### DIFF
--- a/extensions/reason-vscode/package.json
+++ b/extensions/reason-vscode/package.json
@@ -108,7 +108,7 @@
 				},
 				"reason_language_server.show_module_path_on_hover": {
 					"type": "boolean",
-					"default": true,
+					"default": false,
 					"description": "Show the module path on hover"
 				},
 				"reason_language_server.reloadOnChange": {


### PR DESCRIPTION
__Issue:__ Our bundled `rls` was showing the module path by default, which is a bit unexpected.

__Defect:__ We were defaulting the setting to `true`.

__Fix:__ Change to `false` by default.

Related to #1947 