### PR TITLE
fix(markdown): add default language parameter to Markdown component

### DIFF
--- a/src/Components/Markdown.re
+++ b/src/Components/Markdown.re
@@ -18,6 +18,7 @@ open {
              ~languageInfo,
              ~grammars,
              ~language,
+             ~defaultLanguage,
              lines,
            ) => {
          let grammarRepository =
@@ -26,10 +27,19 @@ open {
            );
 
          let scope =
-           Oni_Extensions.LanguageInfo.getScopeFromLanguage(
-             languageInfo,
-             language,
-           );
+           switch (
+             Oni_Extensions.LanguageInfo.getScopeFromLanguage(
+               languageInfo,
+               language,
+             )
+           ) {
+           | Some(scope) as s => s
+           | None =>
+             Oni_Extensions.LanguageInfo.getScopeFromLanguage(
+               languageInfo,
+               defaultLanguage,
+             )
+           };
 
          switch (scope) {
          | Some(scope) =>
@@ -101,6 +111,7 @@ let make =
       ~codeFontFamily,
       ~baseFontSize=16.,
       ~codeBlockStyle=?,
+      ~defaultLanguage="",
       (),
     ) => {
   let textStyle = Styles.text(~theme=colorTheme);
@@ -110,6 +121,7 @@ let make =
       ~colorTheme,
       ~languageInfo,
       ~grammars,
+      ~defaultLanguage,
     )}
     markdown
     fontFamily

--- a/src/Components/Markdown.re
+++ b/src/Components/Markdown.re
@@ -27,19 +27,16 @@ open {
            );
 
          let scope =
-           switch (
-             Oni_Extensions.LanguageInfo.getScopeFromLanguage(
-               languageInfo,
-               language,
-             )
-           ) {
-           | Some(scope) as s => s
-           | None =>
-             Oni_Extensions.LanguageInfo.getScopeFromLanguage(
-               languageInfo,
-               defaultLanguage,
-             )
-           };
+           Oni_Extensions.LanguageInfo.getScopeFromLanguage(
+             languageInfo,
+             language,
+           )
+           |> Utility.OptionEx.or_(
+                Oni_Extensions.LanguageInfo.getScopeFromLanguage(
+                  languageInfo,
+                  defaultLanguage,
+                ),
+              );
 
          switch (scope) {
          | Some(scope) =>
@@ -71,7 +68,6 @@ open {
              },
            );
          | None =>
-           // TODO: Replace this with SyntaxHighlight.default when revery#906 is merged
            List.init(List.length(lines), _ =>
              [
                Markdown.SyntaxHighlight.makeHighlight(

--- a/src/Feature/Hover/Feature_Hover.re
+++ b/src/Feature/Hover/Feature_Hover.re
@@ -306,6 +306,7 @@ module View = {
                   ~model,
                   ~grammars,
                   ~diagnostic,
+                  ~buffer,
                   (),
                 ) => {
     let reducer = (action, state) =>
@@ -324,11 +325,15 @@ module View = {
         },
       );
 
+    let defaultLanguage =
+      Oni_Extensions.LanguageInfo.getLanguageFromBuffer(languageInfo, buffer);
+
     let hoverMarkdown = (~markdown) =>
       Oni_Components.Markdown.make(
         ~colorTheme,
         ~tokenTheme,
         ~languageInfo,
+        ~defaultLanguage,
         ~fontFamily={
           uiFont.family;
         },
@@ -528,6 +533,7 @@ module View = {
         model
         grammars
         diagnostic
+        buffer
       />
     | _ => React.empty
     };


### PR DESCRIPTION
This is to address the second half of #1947. If there isn't/an invalid language, we fallback to this default.

In use with the RLS
<img width="965" alt="image" src="https://user-images.githubusercontent.com/4527949/84969146-18026c00-b0e6-11ea-8d24-86ed6652dbaf.png">
