### PR TITLE
perf(colorizer): Remove array allocations from BufferLineColorizer

### DIFF
--- a/src/Feature/Editor/BufferLineColorizer.rei
+++ b/src/Feature/Editor/BufferLineColorizer.rei
@@ -31,7 +31,6 @@ type t = int => themedToken;
 let create:
   (
     ~startByte: int,
-    ~endByte: int,
     ~defaultBackgroundColor: Color.t,
     ~defaultForegroundColor: Color.t, // theme.editorForeground
     ~selectionHighlights: option(Range.t),

--- a/src/Feature/Editor/Helpers.re
+++ b/src/Feature/Editor/Helpers.re
@@ -69,12 +69,10 @@ let getTokensForLine =
         );
 
       let startByte = BufferLine.getByteFromIndex(~index=startIndex, line);
-      let endByte = BufferLine.getByteFromIndex(~index=endIndex, line);
 
       let colorizer =
         BufferLineColorizer.create(
           ~startByte,
-          ~endByte,
           ~defaultBackgroundColor=defaultBackground,
           ~defaultForegroundColor=colors.editorForeground,
           ~selectionHighlights=selection,

--- a/test/Feature/Editor/BufferLineColorizerTests.re
+++ b/test/Feature/Editor/BufferLineColorizerTests.re
@@ -44,7 +44,7 @@ let basicTokens = [
 
 describe("BufferLineColorizer", ({test, _}) => {
   test("base case - cover all tokens", ({expect, _}) => {
-    let colorize = basicColorizer(~startByte=0, ~endByte=11, basicTokens);
+    let colorize = basicColorizer(~startByte=0, basicTokens);
 
     let BufferLineColorizer.{color: color0, _} = colorize(0);
     let BufferLineColorizer.{color: color2, _} = colorize(2);
@@ -58,12 +58,12 @@ describe("BufferLineColorizer", ({test, _}) => {
   });
 
   test("out of bounds", ({expect, _}) => {
-    let colorize = basicColorizer(~startByte=4, ~endByte=6, basicTokens);
+    let colorize = basicColorizer(~startByte=4, basicTokens);
 
     let BufferLineColorizer.{color: color0, _} = colorize(0);
     let BufferLineColorizer.{color: color11, _} = colorize(11);
 
     expect.equal(color0, Colors.green);
-    expect.equal(color11, Colors.red);
+    expect.equal(color11, Colors.blue);
   });
 });


### PR DESCRIPTION
This removes a large array allocation, called for every line in the editor (and minimap) - which added GC pressure during the rendering critical path.