### PR TITLE
fix(explorer): Focused file not switching reliably

### DIFF
--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -14,6 +14,7 @@ type t = {
 
 [@deriving show({with_path: false})]
 type action =
+  | ActiveFilePathChanged(option(string))
   | TreeLoaded(FsTreeNode.t)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -12,6 +12,7 @@ type t = {
 
 [@deriving show]
 type action =
+  | ActiveFilePathChanged(option(string))
   | TreeLoaded(FsTreeNode.t)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)

--- a/src/Model/Oni_Model.re
+++ b/src/Model/Oni_Model.re
@@ -32,6 +32,7 @@ module References = References;
 module Selectors = Selectors;
 module SideBar = SideBar;
 module State = State;
+module Sub = Sub;
 module ThemeInfo = ThemeInfo;
 module Title = Title;
 module Workspace = Workspace;

--- a/src/Model/Sub.re
+++ b/src/Model/Sub.re
@@ -1,0 +1,56 @@
+open Oni_Core.Utility;
+
+module type Config = {type computedValue;};
+
+type params('a) = {
+  id: string,
+  selector: State.t => 'a,
+  state: State.t,
+  toMsg: 'a => Actions.t,
+};
+
+module Make = (ConfigInstance: Config) =>
+  Isolinear.Sub.Make({
+    type nonrec msg = Actions.t;
+
+    type nonrec params = params(ConfigInstance.computedValue);
+
+    type state = {lastValue: ConfigInstance.computedValue};
+
+    let name = "Oni_Model.StateDeltaSub";
+    let id = ({id, _}) => id;
+
+    let init = (~params, ~dispatch) => {
+      let lastValue = params.selector(params.state);
+      dispatch(params.toMsg(lastValue));
+      {lastValue: lastValue};
+    };
+
+    let update = (~params, ~state, ~dispatch) => {
+      let newValue = params.selector(params.state);
+      if (newValue != state.lastValue) {
+        dispatch(params.toMsg(newValue));
+      };
+
+      {lastValue: newValue};
+    };
+
+    let dispose = (~params as _, ~state as _) => {
+      ();
+    };
+  });
+
+module ActiveFilePathSub =
+  Make({
+    type computedValue = option(string);
+  });
+
+let activeFile = (~id, ~state: State.t, ~toMsg) => {
+  let selector = state =>
+    state
+    |> Selectors.getActiveBuffer
+    |> OptionEx.flatMap(Oni_Core.Buffer.getFilePath);
+  ActiveFilePathSub.create(
+    {state, selector, id, toMsg}: ActiveFilePathSub.params,
+  );
+};

--- a/src/Model/Sub.rei
+++ b/src/Model/Sub.rei
@@ -1,0 +1,3 @@
+let activeFile:
+  (~id: string, ~state: State.t, ~toMsg: option(string) => Actions.t) =>
+  Isolinear.Sub.t(Actions.t);

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -144,7 +144,7 @@ let start = () => {
 
   let updater = (state: State.t, action: FileExplorer.action) => {
     switch (action) {
-    | ActiveFilePathChanged(maybeFilePath) => 
+    | ActiveFilePathChanged(maybeFilePath) =>
       switch (state.fileExplorer) {
       | {active, _} when active != maybeFilePath =>
         let state = setActive(maybeFilePath, state);
@@ -229,8 +229,7 @@ let start = () => {
         ]),
       )
 
-    | FileExplorer(action) =>
-      updater(state, action);
+    | FileExplorer(action) => updater(state, action)
     | _ => (state, Isolinear.Effect.none)
     };
   };

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -144,6 +144,16 @@ let start = () => {
 
   let updater = (state: State.t, action: FileExplorer.action) => {
     switch (action) {
+    | ActiveFilePathChanged(maybeFilePath) => 
+      switch (state.fileExplorer) {
+      | {active, _} when active != maybeFilePath =>
+        let state = setActive(maybeFilePath, state);
+        switch (maybeFilePath) {
+        | Some(path) => revealAndFocusPath(path, state)
+        | None => (state, Isolinear.Effect.none)
+        };
+      | _ => (state, Isolinear.Effect.none)
+      }
     | TreeLoaded(tree) => (setTree(tree, state), Isolinear.Effect.none)
 
     | NodeLoaded(node) => (replaceNode(node, state), Isolinear.Effect.none)
@@ -201,7 +211,7 @@ let start = () => {
     };
   };
 
-  (state: State.t, action: Actions.t) =>
+  (state: State.t, action: Actions.t) => {
     switch (action) {
     // TODO: Should be handled by a more general init mechanism
     | Init => (
@@ -219,19 +229,9 @@ let start = () => {
         ]),
       )
 
-    | BufferEnter({filePath, _}) =>
-      switch (state.fileExplorer) {
-      | {active, _} when active != filePath =>
-        let state = setActive(filePath, state);
-        switch (filePath) {
-        | Some(path) => revealAndFocusPath(path, state)
-        | None => (state, Isolinear.Effect.none)
-        };
-
-      | _ => (state, Isolinear.Effect.none)
-      }
-
-    | FileExplorer(action) => updater(state, action)
+    | FileExplorer(action) =>
+      updater(state, action);
     | _ => (state, Isolinear.Effect.none)
     };
+  };
 };

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -299,6 +299,12 @@ let start =
       )
       |> Isolinear.Sub.map(() => Model.Actions.Noop);
 
+    let fileExplorerActiveFileSub =
+      Model.Sub.activeFile(
+        ~id="activeFile.fileExplorer", ~state, ~toMsg=maybeFilePath =>
+        Model.Actions.FileExplorer(ActiveFilePathChanged(maybeFilePath))
+      );
+
     [
       syntaxSubscription,
       terminalSubscription,
@@ -306,6 +312,7 @@ let start =
       terminalFontSubscription,
       extHostSubscription,
       Isolinear.Sub.batch(VimStoreConnector.subscriptions(state)),
+      fileExplorerActiveFileSub,
     ]
     |> Isolinear.Sub.batch;
   };


### PR DESCRIPTION
__Issue:__ The focused file in the explorer is not switching reliably. If you open multiple files, and then click the tab of a file to focus it, the explorer won't auto-scroll to the file until the key is pressed.

__Defect:__ The `BufferEnter` event was used to detect when the focused file is changed, but it's not reliable (ie, it's in the process of being phased out). Previously, we always kept the Vim state in sync with the editor state at all times - so `BufferEnter` would be dispatched from Vim during this synchronization.

However, we switched to a 'push' model - where we push the state on a keypress or other API calls. This means that our state can be the 'source of truth', but it also means that this event - like `BufferEnter` isn't necessarily reliable to use, since libvim's view of when the buffer entered won't be until a key is pressed.

__Fix:__ Use the state as the source of truth - create a subscription that dispatches an action when the active file is changed, and use a scoped event for the FileExplorer to handle this.

Future work:
- The `FileExplorer` should be moved to a feature project, so we can further encapsulate the state
- Some of the `FileExplorer` effects could be factored into a subscription, which would mean we no longer require the `Init` action
- We need to remove the remainder of the `BufferEnter` events, and remove the concept from `libvim`.