### PR TITLE
docs(installation): OSX - Remove note on 10.12 support

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -12,8 +12,6 @@ While we're developing Onivim 2, the latest builds are available at our [early a
 
 - Requires OSX 10.13+
 
-> NOTE: We're [working on 10.12 support](https://github.com/onivim/oni2/issues/902), but it is not currently available.
-
 ### Windows
 
 - x64 Only


### PR DESCRIPTION
Since OSX 10.12 is EOL by Apple (and we don't have a good way to test it at the moment, since Azure CI machines don't have 10.12 VM images) - remove the note in the docs about 10.12 support.

Closes #902 