### PR TITLE
refactor(libvim): AutoIndent - more context for indentation calculation

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a3d4a44f0a38e8fa30625e447f26fd28",
+  "checksum": "b49a0fb18af72a93b268047119dd5b3b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -471,14 +471,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.47@d41d8cd9": {
-      "id": "libvim@8.10869.47@d41d8cd9",
+    "libvim@8.10869.48@d41d8cd9": {
+      "id": "libvim@8.10869.48@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.47",
+      "version": "8.10869.48",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.47.tgz#sha1:6aaadf39d8823ed4667c600cee9dfbf630d2ac11"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.48.tgz#sha1:f726aa864f6fc34fb9d01311eeb346a3cd0da909"
         ]
       },
       "overrides": [],
@@ -1076,7 +1076,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.47@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.48@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a3d4a44f0a38e8fa30625e447f26fd28",
+  "checksum": "b49a0fb18af72a93b268047119dd5b3b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -471,14 +471,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.47@d41d8cd9": {
-      "id": "libvim@8.10869.47@d41d8cd9",
+    "libvim@8.10869.48@d41d8cd9": {
+      "id": "libvim@8.10869.48@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.47",
+      "version": "8.10869.48",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.47.tgz#sha1:6aaadf39d8823ed4667c600cee9dfbf630d2ac11"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.48.tgz#sha1:f726aa864f6fc34fb9d01311eeb346a3cd0da909"
         ]
       },
       "overrides": [],
@@ -1075,7 +1075,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.47@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.48@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a3d4a44f0a38e8fa30625e447f26fd28",
+  "checksum": "b49a0fb18af72a93b268047119dd5b3b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -471,14 +471,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.47@d41d8cd9": {
-      "id": "libvim@8.10869.47@d41d8cd9",
+    "libvim@8.10869.48@d41d8cd9": {
+      "id": "libvim@8.10869.48@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.47",
+      "version": "8.10869.48",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.47.tgz#sha1:6aaadf39d8823ed4667c600cee9dfbf630d2ac11"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.48.tgz#sha1:f726aa864f6fc34fb9d01311eeb346a3cd0da909"
         ]
       },
       "overrides": [],
@@ -1075,7 +1075,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.47@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.48@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
+    "libvim": "link:../libvim/src",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
     "revery": "revery-ui/revery#8fd2003",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "esy-sdl2": "*",
     "esy-skia": "*",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.47",
+    "libvim": "8.10869.48",
     "ocaml": "~4.7.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reason-tree-sitter": "^1.0.1001",
@@ -247,7 +247,6 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "libvim": "link:../libvim/src",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
     "revery": "revery-ui/revery#8fd2003",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",

--- a/src/Core/LanguageConfiguration.re
+++ b/src/Core/LanguageConfiguration.re
@@ -227,7 +227,11 @@ let toVimAutoClosingPairs = (syntaxScope: SyntaxScope.t, configuration: t) => {
 };
 
 let toAutoIndent =
-    ({increaseIndentPattern, decreaseIndentPattern, brackets, _}, str) => {
+    (
+      {increaseIndentPattern, decreaseIndentPattern, brackets, _},
+      ~previousLine as str,
+      ~beforePreviousLine as _,
+    ) => {
   let increase =
     increaseIndentPattern
     |> Option.map(regex => OnigRegExp.test(str, regex))

--- a/src/Core/LanguageConfiguration.rei
+++ b/src/Core/LanguageConfiguration.rei
@@ -44,4 +44,6 @@ let decode: Json.decoder(t);
 
 let toVimAutoClosingPairs: (SyntaxScope.t, t) => Vim.AutoClosingPairs.t;
 
-let toAutoIndent: (t, string) => Vim.AutoIndent.action;
+let toAutoIndent:
+  (t, ~previousLine: string, ~beforePreviousLine: option(string)) =>
+  Vim.AutoIndent.action;

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -90,7 +90,10 @@ let current:
          let autoIndent =
            maybeLanguageConfig
            |> Option.map(LanguageConfiguration.toAutoIndent)
-           |> Option.value(~default=_ => Vim.AutoIndent.KeepIndent);
+           |> Option.value(
+                ~default=(~previousLine as _, ~beforePreviousLine as _) =>
+                Vim.AutoIndent.KeepIndent
+              );
 
          let syntaxScope = Internal.syntaxScope(~cursor=maybeCursor, state);
          let autoClosingPairs =

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -1,6 +1,8 @@
 type t = {
   autoClosingPairs: AutoClosingPairs.t,
-  autoIndent: string => AutoIndent.action,
+  autoIndent:
+    (~previousLine: string, ~beforePreviousLine: option(string)) =>
+    AutoIndent.action,
   bufferId: int,
   width: int,
   height: int,
@@ -14,7 +16,7 @@ type t = {
 
 let current = () => {
   autoClosingPairs: AutoClosingPairs.empty,
-  autoIndent: _ => AutoIndent.KeepIndent,
+  autoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
   bufferId: Buffer.getCurrent() |> Buffer.getId,
   width: Window.getWidth(),
   height: Window.getHeight(),

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -38,7 +38,9 @@ module AutoIndent: {
 module Context: {
   type t = {
     autoClosingPairs: AutoClosingPairs.t,
-    autoIndent: string => AutoIndent.action,
+    autoIndent:
+      (~previousLine: string, ~beforePreviousLine: option(string)) =>
+      AutoIndent.action,
     bufferId: int,
     width: int,
     height: int,

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -47,7 +47,7 @@ void onBufferChanged(bufferUpdate_T bu) {
   free(pArgs);
 }
 
-int onAutoIndent(buf_T *buf, char_u *prevLine, char_u *newLine) {
+int onAutoIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *newLine) {
   CAMLparam0();
   CAMLlocal2(vPrevLine, vNewLine);
   static const value *lv_onAutoIndent = NULL;
@@ -58,7 +58,7 @@ int onAutoIndent(buf_T *buf, char_u *prevLine, char_u *newLine) {
 
   vPrevLine = caml_copy_string(prevLine);
 
-  value vIndent = caml_callback(*lv_onAutoIndent, vPrevLine);
+  value vIndent = caml_callback2(*lv_onAutoIndent, Val_int(lnum), vPrevLine);
 
   int ret = Int_val(vIndent);
 

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9806eb844076ea87e8d1f52815e87a5c",
+  "checksum": "fe16eaac7bb7c609f863d29f5e8c9c16",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -471,14 +471,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.47@d41d8cd9": {
-      "id": "libvim@8.10869.47@d41d8cd9",
+    "libvim@8.10869.48@d41d8cd9": {
+      "id": "libvim@8.10869.48@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.47",
+      "version": "8.10869.48",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.47.tgz#sha1:6aaadf39d8823ed4667c600cee9dfbf630d2ac11"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.48.tgz#sha1:f726aa864f6fc34fb9d01311eeb346a3cd0da909"
         ]
       },
       "overrides": [],
@@ -1075,7 +1075,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.47@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.48@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/test/Core/LanguageConfigurationTest.re
+++ b/test/Core/LanguageConfigurationTest.re
@@ -144,12 +144,20 @@ describe("LanguageConfiguration", ({describe, test, _}) => {
         Result.get_ok(parsedLangConfig);
 
       expect.equal(
-        LanguageConfiguration.toAutoIndent(langConfig, "abc")
+        LanguageConfiguration.toAutoIndent(
+          langConfig,
+          ~previousLine="abc",
+          ~beforePreviousLine=None,
+        )
         == Vim.AutoIndent.IncreaseIndent,
         true,
       );
       expect.equal(
-        LanguageConfiguration.toAutoIndent(langConfig, "def")
+        LanguageConfiguration.toAutoIndent(
+          langConfig,
+          ~previousLine="def",
+          ~beforePreviousLine=None,
+        )
         == Vim.AutoIndent.DecreaseIndent,
         true,
       );
@@ -166,7 +174,11 @@ describe("LanguageConfiguration", ({describe, test, _}) => {
         Result.get_ok(parsedLangConfig);
 
       expect.equal(
-        LanguageConfiguration.toAutoIndent(langConfig, "   {")
+        LanguageConfiguration.toAutoIndent(
+          langConfig,
+          ~previousLine="   {",
+          ~beforePreviousLine=None,
+        )
         == Vim.AutoIndent.IncreaseIndent,
         true,
       );


### PR DESCRIPTION
For auto-indent, we were basing our calculation purely off the previous line. However, this is not sufficient to handle some of the rules that show up in the indentationRules, like `indentNextLinePattern`. 

The rules that VSCode extensions follow are the same as textmate, defined here: https://macromates.com/manual/en/appendix

To be able to handle the `indentNextLinePattern`, which has some non-local effects, we need additional context to the auto-indent handler.