### PR TITLE
refactor(editor): Pull view lines from Editor instead of external buffer

### DIFF
--- a/src/Feature/Editor/ContentView.re
+++ b/src/Feature/Editor/ContentView.re
@@ -95,7 +95,7 @@ let renderDefinition =
       ~context,
       ~leftVisibleColumn,
       ~cursorPosition: Location.t,
-      ~buffer,
+      ~editor,
       ~bufferHighlights,
       ~colors,
       ~matchingPairs,
@@ -103,7 +103,7 @@ let renderDefinition =
       ~bufferWidthInCharacters,
     ) =>
   getTokenAtPosition(
-    ~buffer,
+    ~editor,
     ~bufferHighlights,
     ~cursorLine=Index.toZeroBased(cursorPosition.line),
     ~colors,
@@ -135,7 +135,7 @@ let renderText =
       ~context,
       ~count,
       ~selectionRanges,
-      ~buffer,
+      ~editor,
       ~bufferHighlights,
       ~cursorLine,
       ~colors,
@@ -161,7 +161,7 @@ let renderText =
         };
       let tokens =
         getTokensForLine(
-          ~buffer,
+          ~editor,
           ~bufferHighlights,
           ~cursorLine,
           ~colors,
@@ -188,6 +188,7 @@ let render =
       ~context,
       ~count,
       ~buffer,
+      ~editor,
       ~leftVisibleColumn,
       ~colors,
       ~diagnosticsMap,
@@ -218,9 +219,9 @@ let render =
       )) {
     renderDefinition(
       ~context,
+      ~editor,
       ~leftVisibleColumn,
       ~cursorPosition,
-      ~buffer,
       ~bufferHighlights,
       ~colors,
       ~matchingPairs,
@@ -233,7 +234,7 @@ let render =
     ~context,
     ~count,
     ~selectionRanges,
-    ~buffer,
+    ~editor,
     ~bufferHighlights,
     ~cursorLine=Index.toZeroBased(cursorPosition.line),
     ~colors,

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -8,6 +8,12 @@ type pixelPosition = {
   pixelY: float,
 };
 
+type viewLine = {
+  contents: BufferLine.t,
+  byteOffset: int,
+  characterOffset: int,
+};
+
 [@deriving show]
 // TODO: This type needs to be private, so we can maintain invariants with the `EditorBuffer.t` and computed properties
 type t = {
@@ -60,6 +66,12 @@ let bufferLineByteToPixel =
 
     ({pixelX, pixelY}, float(width) *. font.measuredWidth);
   };
+};
+
+let viewLine = (editor, lineNumber) => {
+  let contents = editor.buffer |> EditorBuffer.line(lineNumber);
+
+  {contents, byteOffset: 0, characterOffset: 0};
 };
 
 let bufferLineCharacterToPixel =

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -15,6 +15,12 @@ type scrollbarMetrics = {
   thumbOffset: int,
 };
 
+type viewLine = {
+  contents: BufferLine.t,
+  byteOffset: int,
+  characterOffset: int,
+};
+
 let create: (~font: Service_Font.font, ~buffer: EditorBuffer.t, unit) => t;
 
 let getId: t => int;
@@ -44,6 +50,8 @@ let visiblePixelWidth: t => int;
 let visiblePixelHeight: t => int;
 
 let font: t => Service_Font.font;
+
+let viewLine: (t, int) => viewLine;
 
 let scrollX: t => float;
 let scrollY: t => float;

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -57,7 +57,6 @@ module Styles = {
 
 let minimap =
     (
-      ~buffer,
       ~bufferHighlights,
       ~cursorPosition: Location.t,
       ~colors,
@@ -100,7 +99,7 @@ let minimap =
       count
       diagnostics=diagnosticsMap
       getTokensForLine={getTokensForLine(
-        ~buffer,
+        ~editor,
         ~bufferHighlights,
         ~cursorLine=Index.toZeroBased(cursorPosition.line),
         ~colors,
@@ -186,7 +185,7 @@ let%component make =
     |> Option.map(editorForeground => {...colors, editorForeground})
     |> Option.value(~default=colors);
 
-  let lineCount = Buffer.getNumberOfLines(buffer);
+  let lineCount = editor |> Editor.totalViewLines;
 
   let editorFont = Editor.font(editor);
 
@@ -288,7 +287,6 @@ let%component make =
        ? <minimap
            editor
            diagnosticsMap
-           buffer
            bufferHighlights
            cursorPosition
            colors

--- a/src/Feature/Editor/Helpers.re
+++ b/src/Feature/Editor/Helpers.re
@@ -5,7 +5,7 @@ module BufferHighlights = Oni_Syntax.BufferHighlights;
 
 let getTokensForLine =
     (
-      ~buffer,
+      ~editor,
       ~bufferHighlights,
       ~cursorLine,
       ~colors: Colors.t,
@@ -17,20 +17,23 @@ let getTokensForLine =
       endIndex,
       i,
     ) =>
-  if (i >= Buffer.getNumberOfLines(buffer)) {
+  if (i >= Editor.totalViewLines(editor)) {
     [];
   } else {
-    let line = Buffer.getLine(i, buffer);
+    let viewLine = Editor.viewLine(editor, i);
+    let line = viewLine.contents;
     let length = BufferLine.lengthInBytes(line);
     let startIndex = max(0, startIndex);
     let endIndex = max(0, endIndex);
+    let bufferId = Editor.getBufferId(editor);
+
     if (length == 0) {
       [];
     } else {
       let idx = Index.fromZeroBased(i);
       let highlights =
         BufferHighlights.getHighlightsByLine(
-          ~bufferId=Buffer.getId(buffer),
+          ~bufferId,
           ~line=idx,
           bufferHighlights,
         );
@@ -57,7 +60,7 @@ let getTokensForLine =
 
       let tokenColors =
         Feature_Syntax.getTokens(
-          ~bufferId=Buffer.getId(buffer),
+          ~bufferId,
           ~line=Index.fromZeroBased(i),
           bufferSyntaxHighlights,
         );
@@ -83,7 +86,7 @@ let getTokensForLine =
 
 let getTokenAtPosition =
     (
-      ~buffer,
+      ~editor,
       ~bufferHighlights,
       ~cursorLine,
       ~colors,
@@ -97,7 +100,7 @@ let getTokenAtPosition =
   let index = position.column |> Index.toZeroBased;
 
   getTokensForLine(
-    ~buffer,
+    ~editor,
     ~bufferHighlights,
     ~cursorLine,
     ~colors,

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -69,7 +69,7 @@ let%component make =
   let%hook (hoverTimer, resetHoverTimer) =
     Hooks.timer(~active=hoverTimerActive^, ());
 
-  let lineCount = Buffer.getNumberOfLines(buffer);
+  let lineCount = editor |> Editor.totalViewLines;
   let indentation =
     switch (Buffer.getIndentation(buffer)) {
     | Some(v) => v
@@ -206,6 +206,7 @@ let%component make =
           ~context,
           ~count=lineCount,
           ~buffer,
+          ~editor,
           ~leftVisibleColumn,
           ~colors,
           ~diagnosticsMap,


### PR DESCRIPTION
Another refactoring in preparation for word-wrap (#1969 ) - pull the lines for rendering from the editor (which is aware of wrapping), rather than the buffer directly (which is not aware of the view / wrapping).