### PR TITLE
fix(cli): OSX - 'oni2' command is not forking by default

### DIFF
--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -13,4 +13,4 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 export ONI2_BUNDLED=1
 
-"$DIR"/../MacOS/Oni2_editor --working-directory "$CWD" "$@"
+"$DIR"/../MacOS/Oni2 --working-directory "$CWD" "$@"


### PR DESCRIPTION
__Issue:__ When running `oni2` with the latest builds, on OSX, it is staying attached to the terminal process. The expected behavior is it should detach, unless `-f` or `--nofork` are passed - in which case it should stay attached.

__Fix:__ Run `Oni2` instead of `Oni2_editor`.

Looks like this is a regression from https://github.com/onivim/oni2/pull/1927 - I still see the `ONI2_BUNDLED` environment variable get passed, so I think this is OK. @zbaylin - is there anything else I should check here?
