### PR TITLE
fix(autoindent): Open-above

### DIFF
--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -323,7 +323,7 @@ let _onFormat = formatRequest => {
   );
 };
 
-let _onAutoIndent = (lnum: int, prevLine: string) => {
+let _onAutoIndent = (lnum: int, _prevLine: string) => {
   let buf = Buffer.getCurrent();
   let lineCount = Buffer.getLineCount(buf);
 
@@ -335,12 +335,12 @@ let _onAutoIndent = (lnum: int, prevLine: string) => {
       None;
     };
 
-  let beforeLine = 
+  let beforeLine =
     if (lnum >= 2 && lnum <= lineCount) {
       lnum - 1 |> Index.fromOneBased |> Buffer.getLine(buf);
     } else {
-      "" // This should never happen... but follow the Vim convention for empty lines.
-    }
+      ""; // This should never happen... but follow the Vim convention for empty lines.
+    };
 
   let indentAction =
     GlobalState.autoIndent^

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -335,9 +335,16 @@ let _onAutoIndent = (lnum: int, prevLine: string) => {
       None;
     };
 
+  let beforeLine = 
+    if (lnum >= 2 && lnum <= lineCount) {
+      lnum - 1 |> Index.fromOneBased |> Buffer.getLine(buf);
+    } else {
+      "" // This should never happen... but follow the Vim convention for empty lines.
+    }
+
   let indentAction =
     GlobalState.autoIndent^
-    |> Option.map(fn => fn(~previousLine=prevLine, ~beforePreviousLine))
+    |> Option.map(fn => fn(~previousLine=beforeLine, ~beforePreviousLine))
     |> Option.value(~default=AutoIndent.KeepIndent);
 
   switch (indentAction) {

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -117,4 +117,51 @@ describe("AutoIndent", ({test, _}) => {
       Some("This is the second line of a test file"),
     );
   });
+    
+  test(
+    "open before line",
+    ({expect, _}) => {
+    let _ = resetBuffer();
+
+    let prevRef = ref("");
+    let beforePrevRef = ref(Some(""));
+
+    let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
+      prevRef := previousLine;
+      beforePrevRef := beforePreviousLine;
+      AutoIndent.KeepIndent;
+    };
+
+    let input = input(~insertSpaces=true, ~autoIndent);
+    // Go to last line
+    input("j");
+    input("O");
+
+    expect.equal(prevRef^, "This is the first line of a test file");
+    expect.equal(
+      beforePrevRef^,
+      None,
+    );
+  });
+  test(
+    "auto-indent should not be called for first line",
+    ({expect, _}) => {
+    let _ = resetBuffer();
+
+    let prevRef = ref("");
+    let beforePrevRef = ref(Some(""));
+    let autoIndent = (~previousLine, ~beforePreviousLine) => {
+      prevRef := previousLine;
+      beforePrevRef := beforePreviousLine;
+      AutoIndent.KeepIndent;
+    };
+
+    let input = input(~insertSpaces=true, ~autoIndent);
+    // Open the very first line - auto-indent should not be called in this case
+    input("gg");
+    input("O");
+
+    expect.equal(prevRef^, "");
+    expect.equal(beforePrevRef^, None);
+  });
 });

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -117,10 +117,8 @@ describe("AutoIndent", ({test, _}) => {
       Some("This is the second line of a test file"),
     );
   });
-    
-  test(
-    "open before line",
-    ({expect, _}) => {
+
+  test("open before line", ({expect, _}) => {
     let _ = resetBuffer();
 
     let prevRef = ref("");
@@ -138,14 +136,9 @@ describe("AutoIndent", ({test, _}) => {
     input("O");
 
     expect.equal(prevRef^, "This is the first line of a test file");
-    expect.equal(
-      beforePrevRef^,
-      None,
-    );
+    expect.equal(beforePrevRef^, None);
   });
-  test(
-    "auto-indent should not be called for first line",
-    ({expect, _}) => {
+  test("auto-indent should not be called for first line", ({expect, _}) => {
     let _ = resetBuffer();
 
     let prevRef = ref("");


### PR DESCRIPTION
__Issue:__ When pressing `O` (open a new line above) on a line that increases indentation, the new line would be indented (even though it is _above_ the line).

__Defect:__ I assumed the comparison line coming from `libvim` is always the previous line, but it's actually the source line - our auto-indent callback assumes it's the previous line.

__Fix:__ Pass the previous line instead of the source line to the callback, to properly evaluate auto-indent.