### PR TITLE
fix(hover & signature help): check what editor the request was sent from

### DIFF
--- a/src/Feature/Hover/Feature_Hover.re
+++ b/src/Feature/Hover/Feature_Hover.re
@@ -23,6 +23,7 @@ type model = {
   triggeredFrom:
     option([ | `CommandPalette | `Mouse(EditorCoreTypes.Location.t)]),
   lastRequestID: option(int),
+  editor: option(Feature_Editor.Editor.t),
 };
 
 let initial = {
@@ -32,6 +33,7 @@ let initial = {
   range: None,
   triggeredFrom: None,
   lastRequestID: None,
+  editor: None,
 };
 
 module IDGenerator =
@@ -50,6 +52,7 @@ type msg =
       contents: list(Exthost.MarkdownString.t),
       range: option(EditorCoreTypes.Range.t),
       requestID: int,
+      editor: Feature_Editor.Editor.t,
     })
   | HoverRequestFailed(string)
   | MouseHovered(EditorCoreTypes.Location.t)
@@ -60,7 +63,7 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg));
 
 let getEffectsForLocation =
-    (~buffer, ~location, ~extHostClient, ~model, ~requestID) => {
+    (~buffer, ~location, ~extHostClient, ~model, ~requestID, ~editor) => {
   let filetype =
     buffer
     |> Oni_Core.Buffer.getFileType
@@ -86,6 +89,7 @@ let getEffectsForLocation =
              contents,
              range: Option.map(Exthost.OneBasedRange.toRange, range),
              requestID,
+             editor,
            })
          | Error(s) => HoverRequestFailed(s)
          }
@@ -107,6 +111,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
           ~extHostClient,
           ~model,
           ~requestID,
+          ~editor,
         );
       (
         {
@@ -122,7 +127,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
     }
   | MouseHovered(location) =>
     switch (maybeBuffer, maybeEditor) {
-    | (Some(buffer), Some(_)) =>
+    | (Some(buffer), Some(editor)) =>
       let requestID = IDGenerator.get();
       let effects =
         getEffectsForLocation(
@@ -131,6 +136,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
           ~extHostClient,
           ~model,
           ~requestID,
+          ~editor,
         );
       (
         {
@@ -182,10 +188,16 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
       {...model, providers: [provider, ...model.providers]},
       Nothing,
     )
-  | HoverInfoReceived({contents, range, requestID}) =>
+  | HoverInfoReceived({contents, range, requestID, editor}) =>
     switch (model.lastRequestID) {
     | Some(id) when requestID == id => (
-        {...model, contents, range, lastRequestID: None},
+        {
+          ...model,
+          contents,
+          range,
+          lastRequestID: None,
+          editor: Some(editor),
+        },
         Nothing,
       )
     | _ => (model, Nothing)
@@ -245,6 +257,7 @@ module View = {
         ~grammars,
         ~diagnostic,
         ~buffer,
+        ~editor,
         (),
       ) => {
     let defaultLanguage =
@@ -276,15 +289,18 @@ module View = {
         style={Styles.diagnostic(~theme=colorTheme)}
       />;
     };
-
-    <Oni_Components.HoverView x y theme=colorTheme>
-      {List.map(markdown => <hoverMarkdown markdown />, model.contents)
-       |> React.listToElement}
-      {model.contents != [] && diagnostic != []
-         ? <horizontalRule theme=colorTheme /> : React.empty}
-      {List.map(diag => <hoverDiagnostic diagnostic=diag />, diagnostic)
-       |> React.listToElement}
-    </Oni_Components.HoverView>;
+    switch (model.editor) {
+    | Some(editor') when editor' === editor =>
+      <Oni_Components.HoverView x y theme=colorTheme>
+        {List.map(markdown => <hoverMarkdown markdown />, model.contents)
+         |> React.listToElement}
+        {model.contents != [] && diagnostic != []
+           ? <horizontalRule theme=colorTheme /> : React.empty}
+        {List.map(diag => <hoverDiagnostic diagnostic=diag />, diagnostic)
+         |> React.listToElement}
+      </Oni_Components.HoverView>
+    | _ => React.empty
+    };
   };
 
   let make =
@@ -387,6 +403,7 @@ module View = {
         grammars
         diagnostic
         buffer
+        editor
       />
     | _ => React.empty
     };

--- a/src/Feature/Hover/Feature_Hover.rei
+++ b/src/Feature/Hover/Feature_Hover.rei
@@ -21,6 +21,7 @@ type msg =
       contents: list(Exthost.MarkdownString.t),
       range: option(EditorCoreTypes.Range.t),
       requestID: int,
+      editor: Feature_Editor.Editor.t,
     })
   | HoverRequestFailed(string)
   | MouseHovered(EditorCoreTypes.Location.t)

--- a/src/Feature/Hover/Feature_Hover.rei
+++ b/src/Feature/Hover/Feature_Hover.rei
@@ -21,7 +21,7 @@ type msg =
       contents: list(Exthost.MarkdownString.t),
       range: option(EditorCoreTypes.Range.t),
       requestID: int,
-      editor: Feature_Editor.Editor.t,
+      editorID: int,
     })
   | HoverRequestFailed(string)
   | MouseHovered(EditorCoreTypes.Location.t)

--- a/src/Feature/SignatureHelp/Feature_SignatureHelp.re
+++ b/src/Feature/SignatureHelp/Feature_SignatureHelp.re
@@ -23,6 +23,7 @@ type model = {
   signatures: list(Exthost.SignatureHelp.Signature.t),
   activeSignature: option(int),
   activeParameter: option(int),
+  editorID: option(int),
 };
 
 let initial = {
@@ -33,6 +34,7 @@ let initial = {
   signatures: [],
   activeSignature: None,
   activeParameter: None,
+  editorID: None,
 };
 
 [@deriving show({with_path: false})]
@@ -51,6 +53,7 @@ type msg =
       activeSignature: int,
       activeParameter: int,
       requestID: int,
+      editorID: int,
     })
   | EmptyInfoReceived(int)
   | RequestFailed(string)
@@ -97,7 +100,15 @@ module Contributions = {
 };
 
 let getEffectsForLocation =
-    (~buffer, ~location, ~extHostClient, ~model, ~context, ~requestID) => {
+    (
+      ~buffer,
+      ~location,
+      ~extHostClient,
+      ~model,
+      ~context,
+      ~requestID,
+      ~editor,
+    ) => {
   let filetype =
     buffer |> Buffer.getFileType |> Option.value(~default="plaintext");
 
@@ -123,6 +134,7 @@ let getEffectsForLocation =
              activeSignature,
              activeParameter,
              requestID,
+             editorID: Feature_Editor.Editor.getId(editor),
            })
          | Ok(None) => EmptyInfoReceived(requestID)
          | Error(s) => RequestFailed(s)
@@ -148,6 +160,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
       let effects =
         getEffectsForLocation(
           ~buffer,
+          ~editor,
           ~location=Feature_Editor.Editor.getPrimaryCursor(editor),
           ~extHostClient,
           ~model,
@@ -170,7 +183,13 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
       {...model, providers: [provider, ...model.providers]},
       Nothing,
     )
-  | InfoReceived({signatures, activeSignature, activeParameter, requestID}) =>
+  | InfoReceived({
+      signatures,
+      activeSignature,
+      activeParameter,
+      requestID,
+      editorID,
+    }) =>
     switch (model.lastRequestID) {
     | Some(reqID) when reqID == requestID => (
         {
@@ -178,6 +197,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
           signatures,
           activeSignature: Some(activeSignature),
           activeParameter: Some(activeParameter),
+          editorID: Some(editorID),
         },
         Nothing,
       )
@@ -243,6 +263,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
         let effects =
           getEffectsForLocation(
             ~buffer,
+            ~editor,
             ~location,
             ~extHostClient,
             ~model,
@@ -265,6 +286,7 @@ let update = (~maybeBuffer, ~maybeEditor, ~extHostClient, model, msg) =>
         let effects =
           getEffectsForLocation(
             ~buffer,
+            ~editor,
             ~location,
             ~extHostClient,
             ~model,
@@ -377,6 +399,7 @@ module View = {
         ~uiFont: UiFont.t,
         ~editorFont: Service_Font.font,
         ~model,
+        ~editor,
         ~grammars,
         ~signatureIndex,
         ~parameterIndex,
@@ -454,56 +477,60 @@ module View = {
         |> React.listToElement;
       };
     };
-    <HoverView x y displayAt=`Top theme=colorTheme>
-      <View style=Styles.signatureLine> {renderLabel()} </View>
-      <UI.Components.Row>
-        <View
-          style=Styles.button
-          onMouseUp={_ => dispatch(SignatureDecrementClicked)}>
-          <Codicon
-            icon=Codicon.chevronLeft
-            color={Feature_Theme.Colors.foreground.from(colorTheme)}
-            fontSize={uiFont.size *. 0.9}
+    switch (model.editorID) {
+    | Some(editorID) when editorID == Feature_Editor.Editor.getId(editor) =>
+      <HoverView x y displayAt=`Top theme=colorTheme>
+        <View style=Styles.signatureLine> {renderLabel()} </View>
+        <UI.Components.Row>
+          <View
+            style=Styles.button
+            onMouseUp={_ => dispatch(SignatureDecrementClicked)}>
+            <Codicon
+              icon=Codicon.chevronLeft
+              color={Feature_Theme.Colors.foreground.from(colorTheme)}
+              fontSize={uiFont.size *. 0.9}
+            />
+          </View>
+          <Text
+            text={Printf.sprintf(
+              "%d/%d",
+              signatureIndex + 1,
+              List.length(model.signatures),
+            )}
+            fontFamily={uiFont.family}
+            fontSize={uiFont.size *. 0.8}
           />
-        </View>
-        <Text
-          text={Printf.sprintf(
-            "%d/%d",
-            signatureIndex + 1,
-            List.length(model.signatures),
-          )}
-          fontFamily={uiFont.family}
-          fontSize={uiFont.size *. 0.8}
-        />
-        <View
-          style=Styles.button
-          onMouseUp={_ => dispatch(SignatureIncrementClicked)}>
-          <Codicon
-            icon=Codicon.chevronRight
-            color={Feature_Theme.Colors.foreground.from(colorTheme)}
-            fontSize={uiFont.size *. 0.9}
-          />
-        </View>
-      </UI.Components.Row>
-      {switch (parameter.documentation) {
-       | Some(docs) when Exthost.MarkdownString.toString(docs) != "" =>
-         [
-           <horizontalRule theme=colorTheme />,
-           <signatureHelpMarkdown markdown=docs />,
-         ]
-         |> React.listToElement
-       | _ => React.empty
-       }}
-      {switch (signature.documentation) {
-       | Some(docs) when Exthost.MarkdownString.toString(docs) != "" =>
-         [
-           <horizontalRule theme=colorTheme />,
-           <signatureHelpMarkdown markdown=docs />,
-         ]
-         |> React.listToElement
-       | _ => React.empty
-       }}
-    </HoverView>;
+          <View
+            style=Styles.button
+            onMouseUp={_ => dispatch(SignatureIncrementClicked)}>
+            <Codicon
+              icon=Codicon.chevronRight
+              color={Feature_Theme.Colors.foreground.from(colorTheme)}
+              fontSize={uiFont.size *. 0.9}
+            />
+          </View>
+        </UI.Components.Row>
+        {switch (parameter.documentation) {
+         | Some(docs) when Exthost.MarkdownString.toString(docs) != "" =>
+           [
+             <horizontalRule theme=colorTheme />,
+             <signatureHelpMarkdown markdown=docs />,
+           ]
+           |> React.listToElement
+         | _ => React.empty
+         }}
+        {switch (signature.documentation) {
+         | Some(docs) when Exthost.MarkdownString.toString(docs) != "" =>
+           [
+             <horizontalRule theme=colorTheme />,
+             <signatureHelpMarkdown markdown=docs />,
+           ]
+           |> React.listToElement
+         | _ => React.empty
+         }}
+      </HoverView>
+    | _ => React.empty
+    };
   };
 
   let make =
@@ -549,6 +576,7 @@ module View = {
         uiFont
         editorFont
         model
+        editor
         grammars
         signatureIndex
         parameterIndex

--- a/src/Feature/SignatureHelp/Feature_SignatureHelp.rei
+++ b/src/Feature/SignatureHelp/Feature_SignatureHelp.rei
@@ -27,6 +27,7 @@ type msg =
       activeSignature: int,
       activeParameter: int,
       requestID: int,
+      editorID: int,
     })
   | EmptyInfoReceived(int)
   | RequestFailed(string)


### PR DESCRIPTION
This fixes the multiple hovers issue @bryphe noted in #1973. The request now takes an editor, and the view checks that it is the same when displaying.

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/4527949/85236099-bf361a80-b3e8-11ea-8265-5da32dac78cb.png">
