### PR TITLE
fix(QuickMenu): contract to only the number of available items

### DIFF
--- a/src/UI/QuickmenuView.re
+++ b/src/UI/QuickmenuView.re
@@ -9,6 +9,7 @@ module Colors = Feature_Theme.Colors;
 module Constants = {
   let menuWidth = 400;
   let menuHeight = 320;
+  let rowHeight = 40;
 };
 
 module Styles = {
@@ -22,7 +23,13 @@ module Styles = {
 
   let inputContainer = [padding(5)];
 
-  let dropdown = [height(Constants.menuHeight), overflow(`Hidden)];
+  let dropdown = (~numItems) => [
+    height(
+      Constants.rowHeight * numItems > Constants.menuHeight
+        ? Constants.menuHeight : Constants.rowHeight * numItems,
+    ),
+    overflow(`Hidden),
+  ];
 
   let menuItem = [cursor(Revery.MouseCursors.pointer)];
 
@@ -172,8 +179,12 @@ let make =
     </View>;
 
   let dropdown = () =>
-    <View style=Styles.dropdown>
-      <FlatList rowHeight=40 count={Array.length(items)} focused theme>
+    <View style={Styles.dropdown(~numItems=Array.length(items))}>
+      <FlatList
+        rowHeight=Constants.rowHeight
+        count={Array.length(items)}
+        focused
+        theme>
         ...renderItem
       </FlatList>
       {switch (progress) {


### PR DESCRIPTION
This was noted by user papasmurf on Discord. As of now, the command palette/other quick menus don't contract to the size of the number of items. This PR adds a `numItems` param to the `dropdown` style and a `rowHeight` value to `Constants` to calculate the appropriate height of the quickmenu.

GIF:
![Jun-21-2020 18-26-13](https://user-images.githubusercontent.com/4527949/85236537-c52dfa80-b3ec-11ea-828e-d95812930678.gif)
