### PR TITLE
fix(completion): Positioning regression

### DIFF
--- a/src/Feature/Editor/OverlaysView.re
+++ b/src/Feature/Editor/OverlaysView.re
@@ -69,8 +69,8 @@ let make =
       editor,
     );
 
-  let cursorPixelY = pixelY +. gutterWidth |> int_of_float;
-  let cursorPixelX = pixelX |> int_of_float;
+  let cursorPixelY = pixelY |> int_of_float;
+  let cursorPixelX = pixelX +. gutterWidth |> int_of_float;
 
   isActiveSplit
     ? <View style=Styles.bufferViewOverlay>


### PR DESCRIPTION
There was a regression in the completion-overlay positioning from https://github.com/onivim/oni2/pull/1953 - we were incorrectly adding the `gutterWidth` to the `y` (vertical) position as opposed to the `x` (horizontal) position.