### PR TITLE
fix(editor): Completion showing up in multiple windows

### DIFF
--- a/src/Feature/Layout/EditorGroupView.re
+++ b/src/Feature/Layout/EditorGroupView.re
@@ -31,7 +31,7 @@ module type ContentModel = {
   let icon: t => option(IconTheme.IconDefinition.t);
   let isModified: t => bool;
 
-  let render: t => element;
+  let render: (~isActive: bool, t) => element;
 };
 
 let make =
@@ -49,7 +49,7 @@ let make =
   let children = {
     let editorContainer =
       switch (List.find_opt(isSelected, model.editors)) {
-      | Some(item) => ContentModel.render(item)
+      | Some(item) => ContentModel.render(~isActive, item)
       | None => React.empty
       };
 

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -346,7 +346,7 @@ module type ContentModel = {
   let icon: t => option(Oni_Core.IconTheme.IconDefinition.t);
   let isModified: t => bool;
 
-  let render: t => Revery.UI.element;
+  let render: (~isActive: bool, t) => Revery.UI.element;
 };
 
 module View = {

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -47,7 +47,7 @@ module type ContentModel = {
   let icon: t => option(IconTheme.IconDefinition.t);
   let isModified: t => bool;
 
-  let render: t => Revery.UI.element;
+  let render: (~isActive: bool, t) => Revery.UI.element;
 };
 
 module View: {

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -244,8 +244,8 @@ let make =
       IconTheme.getIconForFile(state.iconTheme, filePath, language);
     };
 
-    let render = editor =>
-      <Parts.EditorContainer editor state theme isActive=true dispatch />;
+    let render = (~isActive, editor) =>
+      <Parts.EditorContainer editor state theme isActive dispatch />;
   };
 
   <View onFileDropped style={Styles.container(theme)}>


### PR DESCRIPTION
__Issue:__ Our completion UI would show up in all visible editor windows, like:

![image](https://user-images.githubusercontent.com/13532591/85487205-00f9c900-b581-11ea-9250-2869bd78be8d.png)

__Defect:__ This looks like a regression from #1977 - the `isActive` field is hardcoded to `true`, and the completion rendering uses that flag to decide which split to render on. 

__Fix:__ Wire up the `isActive` property - which is being set elsewhere, but just not plumbed through.

Future work:
- The completion should be its own feature project, and keep track of the editor we make the request (like we're doing for hover and signature help).