### PR TITLE
fix(editor): add horizontal scrolling to tabs and editor

### DIFF
--- a/src/Components/Tabs.re
+++ b/src/Components/Tabs.re
@@ -95,7 +95,8 @@ let make =
 
       setScrollLeft(actualScrollLeft => {
         let newScrollLeft =
-          actualScrollLeft - int_of_float(wheelEvent.deltaY *. 25.);
+          actualScrollLeft
+          - int_of_float((wheelEvent.deltaX +. wheelEvent.deltaY) *. 25.);
 
         newScrollLeft |> max(0) |> min(maxOffset);
       });

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -339,6 +339,21 @@ let scrollDeltaPixelY = (~pixelY, view) => {
   scrollToPixelY(~pixelY, view);
 };
 
+let scrollToPixelXY = (~pixelX as newScrollX, ~pixelY as newScrollY, view) => {
+  let {scrollX, _} = scrollToPixelX(~pixelX=newScrollX, view);
+  let {scrollY, minimapScrollY, _} =
+    scrollToPixelY(~pixelY=newScrollY, view);
+
+  {...view, scrollX, scrollY, minimapScrollY};
+};
+
+let scrollDeltaPixelXY = (~pixelX, ~pixelY, view) => {
+  let {scrollX, _} = scrollDeltaPixelX(~pixelX, view);
+  let {scrollY, minimapScrollY, _} = scrollDeltaPixelY(~pixelY, view);
+
+  {...view, scrollX, scrollY, minimapScrollY};
+};
+
 // PROJECTION
 
 let project = (~line, ~column: int, ~pixelWidth: int, ~pixelHeight, editor) => {

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -75,6 +75,9 @@ let scrollToLine: (~line: int, t) => t;
 let scrollToPixelY: (~pixelY: float, t) => t;
 let scrollDeltaPixelY: (~pixelY: float, t) => t;
 
+let scrollToPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
+let scrollDeltaPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
+
 let getCharacterWidth: t => float;
 let getLineHeight: t => float;
 

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -57,9 +57,10 @@ let update = (editor, msg) => {
       Editor.scrollToPixelY(~pixelY=newPixelScrollY, editor),
       Nothing,
     )
-  | EditorMouseWheel({deltaWheel}) => (
-      Editor.scrollDeltaPixelY(
-        ~pixelY=deltaWheel *. Constants.editorWheelMultiplier,
+  | EditorMouseWheel({deltaX, deltaY}) => (
+      Editor.scrollDeltaPixelXY(
+        ~pixelX=deltaX *. Constants.editorWheelMultiplier,
+        ~pixelY=deltaY *. Constants.editorWheelMultiplier,
         editor,
       ),
       Nothing,

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -18,7 +18,10 @@ type t =
   | MinimapMouseWheel({deltaWheel: float})
   | MinimapClicked({viewLine: int})
   | MinimapDragged({newPixelScrollY: float})
-  | EditorMouseWheel({deltaWheel: float})
+  | EditorMouseWheel({
+      deltaX: float,
+      deltaY: float,
+    })
   | MouseHovered({location: Location.t})
   | MouseMoved({location: Location.t})
   | SelectionChanged([@opaque] VisualRange.t)

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -77,7 +77,12 @@ let%component make =
     };
 
   let onMouseWheel = (wheelEvent: NodeEvents.mouseWheelEventParams) =>
-    dispatch(Msg.EditorMouseWheel({deltaWheel: wheelEvent.deltaY *. (-1.)}));
+    dispatch(
+      Msg.EditorMouseWheel({
+        deltaY: wheelEvent.deltaY *. (-1.),
+        deltaX: wheelEvent.deltaX,
+      }),
+    );
 
   let getMaybeLocationFromMousePosition = (mouseX, mouseY) => {
     maybeBbox^


### PR DESCRIPTION
This fixes #1994. I tested it on multiple directions/settings on my MacBook Pro's trackpad, and it all followed the system config.