### PR TITLE
fix(autoindent): Open above with empty previous line

### DIFF
--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -89,6 +89,26 @@ module Internal = {
     String.sub(str, 0, lastWhitespaceIndex);
   };
 
+  let isEmpty = (~max: int, str) => {
+    let len = String.length(str);
+
+    let rec loop = idx =>
+      if (idx >= max) {
+        false;
+      } else if (idx >= len) {
+        true;
+      } else {
+        let c = str.[idx];
+        if (c == ' ' || c == '\t') {
+          loop(idx + 1);
+        } else {
+          false;
+        };
+      };
+
+    loop(0);
+  };
+
   let getPrecedingWhitespaceCount = (~max: int, str) => {
     let len = String.length(str);
 
@@ -375,12 +395,14 @@ let _onAutoIndent = (lnum: int, sourceLine: string) => {
   let afterWhitespace =
     Internal.getPrecedingWhitespaceCount(~max=100, sourceLine);
 
+  let isPreviousLineEmpty = Internal.isEmpty(~max=100, beforeLine);
+
   // The [indentOffset] is computed to offset the difference between the previous line and source line,
   // to normalize the indentation provided by the callback function.
   let indentOffset =
-    if (aboveWhitespace > afterWhitespace) {
+    if (!isPreviousLineEmpty && aboveWhitespace > afterWhitespace) {
       1;
-    } else if (aboveWhitespace < afterWhitespace) {
+    } else if (!isPreviousLineEmpty && aboveWhitespace < afterWhitespace) {
       (-1);
     } else {
       0;

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -120,17 +120,20 @@ describe("AutoIndent", ({test, _}) => {
       Some("This is the second line of a test file"),
     );
   });
-  
-  test("open before indented line, after empty line, keep indent", ({expect, _}) => {
+
+  test(
+    "open before indented line, after empty line, keep indent", ({expect, _}) => {
     let buffer = resetBufferIndent2Spaces();
 
     buffer
-    |> Vim.Buffer.setLines(~lines=[|
-    "line 1",
-    "", // Add a line with spaces
-    "  line2",
-    "    line3"
-    |]);
+    |> Vim.Buffer.setLines(
+         ~lines=[|
+           "line 1",
+           "", // Add a line with spaces
+           "  line2",
+           "    line3",
+         |],
+       );
 
     let input = input(~insertSpaces=true, ~autoIndent=keepIndent);
     // Go to third line

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -120,6 +120,29 @@ describe("AutoIndent", ({test, _}) => {
       Some("This is the second line of a test file"),
     );
   });
+  
+  test("open before indented line, after empty line, keep indent", ({expect, _}) => {
+    let buffer = resetBufferIndent2Spaces();
+
+    buffer
+    |> Vim.Buffer.setLines(~lines=[|
+    "line 1",
+    "", // Add a line with spaces
+    "  line2",
+    "    line3"
+    |]);
+
+    let input = input(~insertSpaces=true, ~autoIndent=keepIndent);
+    // Go to third line
+    input("gg");
+    input("j");
+    input("j");
+    input("O");
+    input("a");
+
+    let line = Buffer.getLine(buffer, Index.(zero + 2));
+    expect.string(line).toEqual("  a");
+  });
 
   test("open before indented line, keep indent", ({expect, _}) => {
     let buffer = resetBufferIndent2Spaces();


### PR DESCRIPTION
__Issue:__ The fix in #1976 missed a case - opening-above when the previous line is an empty line. In that case, we would erroneously think we needed to correct for indentation, when in reality we did not.

__Fix:__ Implement test case covering this case; don't correct when the previous line is empty.