### PR TITLE
feat(autoindent): On-Type auto-indent

### DIFF
--- a/src/Core/LanguageConfiguration.re
+++ b/src/Core/LanguageConfiguration.re
@@ -290,7 +290,7 @@ let toTypeAutoIndent = ({decreaseIndentPattern, brackets, _}, str) => {
              bracket => BracketPair.isJustClosingPair(bracket, str),
              brackets,
            ),
-         );
+         )
        })
     |> Option.value(~default=false);
 

--- a/src/Core/LanguageConfiguration.re
+++ b/src/Core/LanguageConfiguration.re
@@ -92,6 +92,34 @@ module BracketPair = {
   let endsWithOpenPair = ({openPair, _}, str) => {
     StringEx.endsWith(~postfix=openPair, str);
   };
+
+  let isJustClosingPair = ({closePair, _}, str) => {
+    let len = String.length(str);
+
+    let rec loop = (foundPair, idx) =>
+      if (idx >= len) {
+        foundPair;
+      } else if (foundPair) {
+        false;
+             // We found the closing pair... but there's other stuff after
+      } else {
+        let c = str.[idx];
+
+        if (c == ' ' || c == '\t') {
+          loop(foundPair, idx + 1);
+        } else if (c == closePair.[0]) {
+          loop(true, idx + 1);
+        } else {
+          false;
+        };
+      };
+
+    if (String.length(closePair) == 1) {
+      loop(false, 0);
+    } else {
+      false;
+    };
+  };
 };
 
 let defaultBrackets: list(BracketPair.t) =
@@ -226,9 +254,9 @@ let toVimAutoClosingPairs = (syntaxScope: SyntaxScope.t, configuration: t) => {
   );
 };
 
-let toAutoIndent =
+let toOpenAutoIndent =
     (
-      {increaseIndentPattern, decreaseIndentPattern, brackets, _},
+      {increaseIndentPattern, brackets, _},
       ~previousLine as str,
       ~beforePreviousLine as _,
     ) => {
@@ -246,16 +274,27 @@ let toAutoIndent =
        )
     |> Option.value(~default=false);
 
+  if (increase) {Vim.AutoIndent.IncreaseIndent} else {
+    Vim.AutoIndent.KeepIndent
+  };
+};
+
+let toTypeAutoIndent = ({decreaseIndentPattern, brackets, _}, str) => {
   let decrease =
     decreaseIndentPattern
     |> Option.map(regex => OnigRegExp.test(str, regex))
+    // If no indentation pattern, fall-back to bracket pair
+    |> OptionEx.or_lazy(() => {
+         Some(
+           List.exists(
+             bracket => BracketPair.isJustClosingPair(bracket, str),
+             brackets,
+           ),
+         );
+       })
     |> Option.value(~default=false);
 
-  if (increase) {
-    Vim.AutoIndent.IncreaseIndent;
-  } else if (decrease) {
-    Vim.AutoIndent.DecreaseIndent;
-  } else {
-    Vim.AutoIndent.KeepIndent;
+  if (decrease) {Vim.AutoIndent.DecreaseIndent} else {
+    Vim.AutoIndent.KeepIndent
   };
 };

--- a/src/Core/LanguageConfiguration.rei
+++ b/src/Core/LanguageConfiguration.rei
@@ -44,6 +44,8 @@ let decode: Json.decoder(t);
 
 let toVimAutoClosingPairs: (SyntaxScope.t, t) => Vim.AutoClosingPairs.t;
 
-let toAutoIndent:
+let toOpenAutoIndent:
   (t, ~previousLine: string, ~beforePreviousLine: option(string)) =>
   Vim.AutoIndent.action;
+
+let toTypeAutoIndent: (t, string) => Vim.AutoIndent.action;

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -81,7 +81,7 @@ let current = (state: State.t) => {
     };
 
   // TODO: Hook up to Vim context
-  let autoIndent =
+  let onOpenAutoIndent =
     maybeLanguageConfig
     |> Option.map(LanguageConfiguration.toAutoIndent)
     |> Option.value(~default=(~previousLine as _, ~beforePreviousLine as _) =>
@@ -116,7 +116,8 @@ let current = (state: State.t) => {
   let insertSpaces = indentation.mode == Spaces;
 
   Vim.Context.{
-    autoIndent,
+    onOpenAutoIndent,
+    onTypeAutoIndent:(_) => Vim.AutoIndent.KeepIndent,
     bufferId,
     leftColumn,
     topLine,

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -117,7 +117,7 @@ let current = (state: State.t) => {
 
   Vim.Context.{
     onOpenAutoIndent,
-    onTypeAutoIndent:(_) => Vim.AutoIndent.KeepIndent,
+    onTypeAutoIndent: _ => Vim.AutoIndent.KeepIndent,
     bufferId,
     leftColumn,
     topLine,

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -1,8 +1,9 @@
 type t = {
   autoClosingPairs: AutoClosingPairs.t,
-  autoIndent:
+  onOpenAutoIndent:
     (~previousLine: string, ~beforePreviousLine: option(string)) =>
     AutoIndent.action,
+  onTypeAutoIndent: string => AutoIndent.action,
   bufferId: int,
   width: int,
   height: int,
@@ -16,7 +17,8 @@ type t = {
 
 let current = () => {
   autoClosingPairs: AutoClosingPairs.empty,
-  autoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
+  onOpenAutoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
+  onTypeAutoIndent: _ => AutoIndent.KeepIndent,
   bufferId: Buffer.getCurrent() |> Buffer.getId,
   width: Window.getWidth(),
   height: Window.getHeight(),

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -36,8 +36,6 @@ module GlobalState = {
       ),
     ) =
     ref(None);
-  let onTypeAutoIndent: ref(option(string => AutoIndent.action)) =
-    ref(None);
   let queuedFunctions: ref(list(unit => unit)) = ref([]);
 };
 

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -44,7 +44,7 @@ module Context: {
       (~previousLine: string, ~beforePreviousLine: option(string)) =>
       AutoIndent.action,
     // Auto-indentation engaged when the user is typing.
-    onTypeAutoIndent: (string) => AutoIndent.action,
+    onTypeAutoIndent: string => AutoIndent.action,
     bufferId: int,
     width: int,
     height: int,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -38,9 +38,13 @@ module AutoIndent: {
 module Context: {
   type t = {
     autoClosingPairs: AutoClosingPairs.t,
-    autoIndent:
+    // Auto-indentation engaged when a new line is entered,
+    // via `o`, `O`, `<CR>`, etc.
+    onOpenAutoIndent:
       (~previousLine: string, ~beforePreviousLine: option(string)) =>
       AutoIndent.action,
+    // Auto-indentation engaged when the user is typing.
+    onTypeAutoIndent: (string) => AutoIndent.action,
     bufferId: int,
     width: int,
     height: int,

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -11,7 +11,7 @@ let resetBufferIndent2Spaces = () =>
 let input = (~insertSpaces=false, ~tabSize=3, ~autoIndent, s) => {
   ignore(
     Vim.input(
-      ~context={...Context.current(), insertSpaces, tabSize, autoIndent},
+      ~context={...Context.current(), insertSpaces, tabSize, onOpenAutoIndent:autoIndent},
       s,
     ): Context.t,
   );

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -8,196 +8,237 @@ let resetBuffer = () =>
 let resetBufferIndent2Spaces = () =>
   Helpers.resetBuffer("test/reason-libvim/indent-two-spaces.txt");
 
-let input = (~insertSpaces=false, ~tabSize=3, ~autoIndent, s) => {
-  ignore(
-    Vim.input(
-      ~context={...Context.current(), insertSpaces, tabSize, onOpenAutoIndent:autoIndent},
-      s,
-    ): Context.t,
-  );
-};
-
-describe("AutoIndent", ({test, _}) => {
-  let keepIndent = (~previousLine as _, ~beforePreviousLine: option(string)) => {
-    ignore(beforePreviousLine);
-    Vim.AutoIndent.KeepIndent;
-  };
-  let increaseIndent =
-      (~previousLine as _, ~beforePreviousLine: option(string)) => {
-    ignore(beforePreviousLine);
-    Vim.AutoIndent.IncreaseIndent;
-  };
-  let decreaseIndent =
-      (~previousLine as _, ~beforePreviousLine: option(string)) => {
-    ignore(beforePreviousLine);
-    Vim.AutoIndent.DecreaseIndent;
-  };
-
-  test("keep indent (open line)", ({expect, _}) => {
-    let buffer = resetBuffer();
-    input(~autoIndent=keepIndent, "o");
-    input(~autoIndent=keepIndent, "a");
-
-    let line = Buffer.getLine(buffer, Index.(zero + 1));
-    expect.string(line).toEqual("a");
-  });
-
-  test("increase indent (open line)", ({expect, _}) => {
-    let buffer = resetBuffer();
-    input(~autoIndent=increaseIndent, "o");
-    input(~autoIndent=increaseIndent, "a");
-
-    let line = Buffer.getLine(buffer, Index.(zero + 1));
-    expect.string(line).toEqual("\ta");
-  });
-
-  test("increase indent (open line, insert spaces)", ({expect, _}) => {
-    let buffer = resetBuffer();
-
-    let input = input(~insertSpaces=true, ~autoIndent=increaseIndent);
-    input("o");
-    input("a");
-
-    let line = Buffer.getLine(buffer, Index.(zero + 1));
-    expect.string(line).toEqual("   a");
-  });
-
-  test("decrease indent (open line, insert spaces)", ({expect, _}) => {
-    let buffer = resetBuffer();
-
-    let input = input(~insertSpaces=true, ~autoIndent=decreaseIndent);
-    input("o");
-    input("\t");
-    input("a");
-    input("<CR>");
-    input("b");
-
-    let line = Buffer.getLine(buffer, Index.(zero + 2));
-    expect.string(line).toEqual("b");
-  });
-  test(
-    "previous line is set, before previous line is None for first line",
-    ({expect, _}) => {
-    let _ = resetBuffer();
-
-    let prevRef = ref("");
-    let beforePrevRef = ref(Some(""));
-
-    let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
-      prevRef := previousLine;
-      beforePrevRef := beforePreviousLine;
-      AutoIndent.KeepIndent;
+describe("AutoIndent", ({describe, _}) => {
+  describe("onTypeAutoIndent", ({test, _}) => {
+    let decreaseIndentWithCharacter = (c, str) => {
+      String.index_opt(str, c) == None
+        ? Vim.AutoIndent.KeepIndent : Vim.AutoIndent.DecreaseIndent;
+    };
+    let input = (~insertSpaces=true, ~tabSize=3, ~onTypeAutoIndent, s) => {
+      ignore(
+        Vim.input(
+          ~context={
+            ...Context.current(),
+            insertSpaces,
+            tabSize,
+            onTypeAutoIndent,
+          },
+          s,
+        ): Context.t,
+      );
     };
 
-    let input = input(~insertSpaces=true, ~autoIndent);
-    input("o");
+    test("decrease indent on type, conditionally", ({expect, _}) => {
+      let buffer = resetBuffer();
+      let input = input(~onTypeAutoIndent=decreaseIndentWithCharacter('}'));
 
-    expect.equal(prevRef^, "This is the first line of a test file");
-    expect.equal(beforePrevRef^, None);
+      input("O");
+      input("   a");
+
+      let line = Buffer.getLine(buffer, Index.(zero));
+      expect.string(line).toEqual("   a");
+
+      input("}");
+      let line = Buffer.getLine(buffer, Index.(zero));
+      expect.string(line).toEqual("a}");
+    });
   });
-  test(
-    "previous line is set, before previous line is set for last line",
-    ({expect, _}) => {
-    let _ = resetBuffer();
-
-    let prevRef = ref("");
-    let beforePrevRef = ref(Some(""));
-
-    let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
-      prevRef := previousLine;
-      beforePrevRef := beforePreviousLine;
-      AutoIndent.KeepIndent;
+  describe("onOpenAutoIndent", ({test, _}) => {
+    let input = (~insertSpaces=false, ~tabSize=3, ~autoIndent, s) => {
+      ignore(
+        Vim.input(
+          ~context={
+            ...Context.current(),
+            insertSpaces,
+            tabSize,
+            onOpenAutoIndent: autoIndent,
+          },
+          s,
+        ): Context.t,
+      );
+    };
+    let keepIndent =
+        (~previousLine as _, ~beforePreviousLine: option(string)) => {
+      ignore(beforePreviousLine);
+      Vim.AutoIndent.KeepIndent;
+    };
+    let increaseIndent =
+        (~previousLine as _, ~beforePreviousLine: option(string)) => {
+      ignore(beforePreviousLine);
+      Vim.AutoIndent.IncreaseIndent;
+    };
+    let decreaseIndent =
+        (~previousLine as _, ~beforePreviousLine: option(string)) => {
+      ignore(beforePreviousLine);
+      Vim.AutoIndent.DecreaseIndent;
     };
 
-    let input = input(~insertSpaces=true, ~autoIndent);
-    // Go to last line
-    input("G");
-    input("o");
+    test("keep indent (open line)", ({expect, _}) => {
+      let buffer = resetBuffer();
+      input(~autoIndent=keepIndent, "o");
+      input(~autoIndent=keepIndent, "a");
 
-    expect.equal(prevRef^, "This is the third line of a test file");
-    expect.equal(
-      beforePrevRef^,
-      Some("This is the second line of a test file"),
-    );
-  });
+      let line = Buffer.getLine(buffer, Index.(zero + 1));
+      expect.string(line).toEqual("a");
+    });
 
-  test("open before indented line, keep indent", ({expect, _}) => {
-    let buffer = resetBufferIndent2Spaces();
+    test("increase indent (open line)", ({expect, _}) => {
+      let buffer = resetBuffer();
+      input(~autoIndent=increaseIndent, "o");
+      input(~autoIndent=increaseIndent, "a");
 
-    let input = input(~insertSpaces=true, ~autoIndent=keepIndent);
-    // Go to second line
-    input("j");
-    input("O");
-    input("a");
+      let line = Buffer.getLine(buffer, Index.(zero + 1));
+      expect.string(line).toEqual("\ta");
+    });
 
-    let line = Buffer.getLine(buffer, Index.(zero + 1));
-    expect.string(line).toEqual("a");
-  });
+    test("increase indent (open line, insert spaces)", ({expect, _}) => {
+      let buffer = resetBuffer();
 
-  test("open before indented line, indent", ({expect, _}) => {
-    let buffer = resetBufferIndent2Spaces();
+      let input = input(~insertSpaces=true, ~autoIndent=increaseIndent);
+      input("o");
+      input("a");
 
-    let input = input(~insertSpaces=true, ~autoIndent=increaseIndent);
-    // Go to second line
-    input("j");
-    input("O");
-    input("a");
+      let line = Buffer.getLine(buffer, Index.(zero + 1));
+      expect.string(line).toEqual("   a");
+    });
 
-    let line = Buffer.getLine(buffer, Index.(zero + 1));
-    expect.string(line).toEqual("  a");
-  });
+    test("decrease indent (open line, insert spaces)", ({expect, _}) => {
+      let buffer = resetBuffer();
 
-  test("open before indented line, un-indent", ({expect, _}) => {
-    let buffer = resetBufferIndent2Spaces();
+      let input = input(~insertSpaces=true, ~autoIndent=decreaseIndent);
+      input("o");
+      input("\t");
+      input("a");
+      input("<CR>");
+      input("b");
 
-    let input = input(~insertSpaces=true, ~autoIndent=decreaseIndent);
-    // Go to second line
-    input("j");
-    input("j");
-    input("O");
-    input("a");
+      let line = Buffer.getLine(buffer, Index.(zero + 2));
+      expect.string(line).toEqual("b");
+    });
+    test(
+      "previous line is set, before previous line is None for first line",
+      ({expect, _}) => {
+      let _ = resetBuffer();
 
-    let line = Buffer.getLine(buffer, Index.(zero + 2));
-    expect.string(line).toEqual("a");
-  });
+      let prevRef = ref("");
+      let beforePrevRef = ref(Some(""));
 
-  test("open before line", ({expect, _}) => {
-    let _ = resetBuffer();
+      let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
+        prevRef := previousLine;
+        beforePrevRef := beforePreviousLine;
+        AutoIndent.KeepIndent;
+      };
 
-    let prevRef = ref("");
-    let beforePrevRef = ref(Some(""));
+      let input = input(~insertSpaces=true, ~autoIndent);
+      input("o");
 
-    let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
-      prevRef := previousLine;
-      beforePrevRef := beforePreviousLine;
-      AutoIndent.KeepIndent;
-    };
+      expect.equal(prevRef^, "This is the first line of a test file");
+      expect.equal(beforePrevRef^, None);
+    });
+    test(
+      "previous line is set, before previous line is set for last line",
+      ({expect, _}) => {
+      let _ = resetBuffer();
 
-    let input = input(~insertSpaces=true, ~autoIndent);
-    // Go to last line
-    input("j");
-    input("O");
+      let prevRef = ref("");
+      let beforePrevRef = ref(Some(""));
 
-    expect.equal(prevRef^, "This is the first line of a test file");
-    expect.equal(beforePrevRef^, None);
-  });
-  test("auto-indent should not be called for first line", ({expect, _}) => {
-    let _ = resetBuffer();
+      let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
+        prevRef := previousLine;
+        beforePrevRef := beforePreviousLine;
+        AutoIndent.KeepIndent;
+      };
 
-    let prevRef = ref("");
-    let beforePrevRef = ref(Some(""));
-    let autoIndent = (~previousLine, ~beforePreviousLine) => {
-      prevRef := previousLine;
-      beforePrevRef := beforePreviousLine;
-      AutoIndent.KeepIndent;
-    };
+      let input = input(~insertSpaces=true, ~autoIndent);
+      // Go to last line
+      input("G");
+      input("o");
 
-    let input = input(~insertSpaces=true, ~autoIndent);
-    // Open the very first line - auto-indent should not be called in this case
-    input("gg");
-    input("O");
+      expect.equal(prevRef^, "This is the third line of a test file");
+      expect.equal(
+        beforePrevRef^,
+        Some("This is the second line of a test file"),
+      );
+    });
 
-    expect.equal(prevRef^, "");
-    expect.equal(beforePrevRef^, None);
+    test("open before indented line, keep indent", ({expect, _}) => {
+      let buffer = resetBufferIndent2Spaces();
+
+      let input = input(~insertSpaces=true, ~autoIndent=keepIndent);
+      // Go to second line
+      input("j");
+      input("O");
+      input("a");
+
+      let line = Buffer.getLine(buffer, Index.(zero + 1));
+      expect.string(line).toEqual("a");
+    });
+
+    test("open before indented line, indent", ({expect, _}) => {
+      let buffer = resetBufferIndent2Spaces();
+
+      let input = input(~insertSpaces=true, ~autoIndent=increaseIndent);
+      // Go to second line
+      input("j");
+      input("O");
+      input("a");
+
+      let line = Buffer.getLine(buffer, Index.(zero + 1));
+      expect.string(line).toEqual("  a");
+    });
+
+    test("open before indented line, un-indent", ({expect, _}) => {
+      let buffer = resetBufferIndent2Spaces();
+
+      let input = input(~insertSpaces=true, ~autoIndent=decreaseIndent);
+      // Go to second line
+      input("j");
+      input("j");
+      input("O");
+      input("a");
+
+      let line = Buffer.getLine(buffer, Index.(zero + 2));
+      expect.string(line).toEqual("a");
+    });
+
+    test("open before line", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let prevRef = ref("");
+      let beforePrevRef = ref(Some(""));
+
+      let autoIndent = (~previousLine, ~beforePreviousLine: option(string)) => {
+        prevRef := previousLine;
+        beforePrevRef := beforePreviousLine;
+        AutoIndent.KeepIndent;
+      };
+
+      let input = input(~insertSpaces=true, ~autoIndent);
+      // Go to last line
+      input("j");
+      input("O");
+
+      expect.equal(prevRef^, "This is the first line of a test file");
+      expect.equal(beforePrevRef^, None);
+    });
+    test("auto-indent should not be called for first line", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let prevRef = ref("");
+      let beforePrevRef = ref(Some(""));
+      let autoIndent = (~previousLine, ~beforePreviousLine) => {
+        prevRef := previousLine;
+        beforePrevRef := beforePreviousLine;
+        AutoIndent.KeepIndent;
+      };
+
+      let input = input(~insertSpaces=true, ~autoIndent);
+      // Open the very first line - auto-indent should not be called in this case
+      input("gg");
+      input("O");
+
+      expect.equal(prevRef^, "");
+      expect.equal(beforePrevRef^, None);
+    });
   });
 });


### PR DESCRIPTION
__Issue:__ The way we were modelling `decreaseIndent` was incorrect - it's done on-type (on return, in some editors)

__Fix:__ Implement an on-type auto-indent provider that we can hook in our `decreaseIndent` pattern / closing bracket patterns.