### PR TITLE
docs(installation): Update esy version in docs

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -10,7 +10,7 @@ sidebar_label: Building from Source
 
 - Install [Git](https://git-scm.com/)
 - Install [Node](https://nodejs.org/en)
-- Install [Esy](https://esy.sh) (__0.6.2__ is required `npm install -g esy@0.6.2`)
+- Install [Esy](https://esy.sh) (__0.6.2__ or above is required, but the latest version is recommened: `npm install -g esy@latest`)
 - __Windows-only__: Run `npm install -g windows-build-tools` (this installs some build tools that aren't included by default on Windows)
 - Install any other system packages required by Oni2 dependencies, as outlined below.
 


### PR DESCRIPTION
Tiny change to recommend the latest version of `esy` in the docs, rather than specifically `0.6.2` since there was some issues that were fixed in the later version and aligns the docs with the CI (#1869, #1866).

This seems like the best way to prevent us having to change every update, or alternatively we could stick a link in to the CI config to recommend using what we use in the CI.