### PR TITLE
fix(keybindings/#2019): Add <C-W>V/<C-W>S default bindings

### DIFF
--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -367,6 +367,26 @@ let start = maybeKeyBindingsFilePath => {
         condition: windowCommandCondition,
       },
       {
+        key: "<C-W><C-S>",
+        command: Feature_Layout.Commands.splitHorizontal.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>S",
+        command: Feature_Layout.Commands.splitHorizontal.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-V>",
+        command: Feature_Layout.Commands.splitVertical.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>V",
+        command: Feature_Layout.Commands.splitVertical.id,
+        condition: windowCommandCondition,
+      },
+      {
         key: "<C-W><RIGHT>",
         command: Feature_Layout.Commands.moveRight.id,
         condition: windowCommandCondition,


### PR DESCRIPTION
__Issue:__ Some of the `Control+W` window commands aren't working:
- `Control+W, V` to open a vertical split
- `Control+W, S` to open a horizontal split

__Defect:__ These used to be handled by `libvim`, and forwarded up to us - but we need first-class bindings for it now that we're handling all of the window commands (and management) in the Onivim layer.

__Fix:__ Add default bindings for these.

Fixes #2019 