### PR TITLE
feat(layout/#592): layout tabs - part 2 - `:tab*` commands and `gt/gT`

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "15c9f6cfa320083ff95d8f68805ddc3b",
+  "checksum": "af791fb3c1541cc903720a015127e59a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -472,14 +472,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.50@d41d8cd9": {
-      "id": "libvim@8.10869.50@d41d8cd9",
+    "libvim@8.10869.51@d41d8cd9": {
+      "id": "libvim@8.10869.51@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.50",
+      "version": "8.10869.51",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.50.tgz#sha1:f0a641b8cf868217656a86eae130b6c901e75ae9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.51.tgz#sha1:ad9bc8926cc654a74dd5eac0d1886f052b44c302"
         ]
       },
       "overrides": [],
@@ -1077,7 +1077,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.50@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.51@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "15c9f6cfa320083ff95d8f68805ddc3b",
+  "checksum": "af791fb3c1541cc903720a015127e59a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -472,14 +472,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.50@d41d8cd9": {
-      "id": "libvim@8.10869.50@d41d8cd9",
+    "libvim@8.10869.51@d41d8cd9": {
+      "id": "libvim@8.10869.51@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.50",
+      "version": "8.10869.51",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.50.tgz#sha1:f0a641b8cf868217656a86eae130b6c901e75ae9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.51.tgz#sha1:ad9bc8926cc654a74dd5eac0d1886f052b44c302"
         ]
       },
       "overrides": [],
@@ -1076,7 +1076,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.50@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.51@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "15c9f6cfa320083ff95d8f68805ddc3b",
+  "checksum": "af791fb3c1541cc903720a015127e59a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -472,14 +472,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.50@d41d8cd9": {
-      "id": "libvim@8.10869.50@d41d8cd9",
+    "libvim@8.10869.51@d41d8cd9": {
+      "id": "libvim@8.10869.51@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.50",
+      "version": "8.10869.51",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.50.tgz#sha1:f0a641b8cf868217656a86eae130b6c901e75ae9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.51.tgz#sha1:ad9bc8926cc654a74dd5eac0d1886f052b44c302"
         ]
       },
       "overrides": [],
@@ -1076,7 +1076,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.50@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.51@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "esy-sdl2": "*",
     "esy-skia": "*",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.50",
+    "libvim": "8.10869.51",
     "ocaml": "~4.7.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reason-tree-sitter": "^1.0.1001",

--- a/src/Core/Utility/ListEx.re
+++ b/src/Core/Utility/ListEx.re
@@ -77,3 +77,75 @@ let findIndex = (predicate, list) => {
     | [_, ...tail] => loop(i + 1, tail);
   loop(0, list);
 };
+
+/**
+ * removeAt
+ */
+let removeAt = (index, list) => {
+  let left = Base.List.take(list, index);
+  let right = Base.List.drop(list, index + 1);
+  left @ right;
+};
+
+let%test_module "removeAt" =
+  (module
+   {
+     let%test "0" = removeAt(0, [1, 2, 3]) == [2, 3];
+     let%test "1" = removeAt(1, [1, 2, 3]) == [1, 3];
+     let%test "2" = removeAt(2, [1, 2, 3]) == [1, 2];
+     let%test "-10 (out of bounds)" = removeAt(-10, [1, 2, 3]) == [1, 2, 3];
+     let%test "10 (out of bounds)" = removeAt(10, [1, 2, 3]) == [1, 2, 3];
+   });
+
+/**
+ * insertAt
+ */
+let insertAt = (index, element, list) => {
+  let (left, right) = Base.List.split_n(list, index);
+  left @ [element] @ right;
+};
+
+let%test_module "removeAt" =
+  (module
+   {
+     let%test "0" = insertAt(0, 42, [1, 2, 3]) == [42, 1, 2, 3];
+     let%test "1" = insertAt(1, 42, [1, 2, 3]) == [1, 42, 2, 3];
+     let%test "2" = insertAt(2, 42, [1, 2, 3]) == [1, 2, 42, 3];
+     let%test "3" = insertAt(3, 42, [1, 2, 3]) == [1, 2, 3, 42];
+     let%test "-10 (out of bounds)" =
+       insertAt(-10, 42, [1, 2, 3]) == [42, 1, 2, 3];
+     let%test "10 (out of bounds)" =
+       insertAt(10, 42, [1, 2, 3]) == [1, 2, 3, 42];
+   });
+
+/**
+ * move
+ */
+let move = (~fromi, ~toi, list) => {
+  let element = List.nth(list, fromi);
+  list |> removeAt(fromi) |> insertAt(toi, element);
+};
+
+let%test_module "move" =
+  (module
+   {
+     let%test "0 -> 0" = move(~fromi=0, ~toi=0, [1, 2, 3]) == [1, 2, 3];
+     let%test "0 -> 1" = move(~fromi=0, ~toi=1, [1, 2, 3]) == [2, 1, 3];
+     let%test "0 -> 2" = move(~fromi=0, ~toi=2, [1, 2, 3]) == [2, 3, 1];
+     let%test "1 -> 0" = move(~fromi=1, ~toi=0, [1, 2, 3]) == [2, 1, 3];
+     let%test "1 -> 1" = move(~fromi=1, ~toi=1, [1, 2, 3]) == [1, 2, 3];
+     let%test "1 -> 2" = move(~fromi=1, ~toi=2, [1, 2, 3]) == [1, 3, 2];
+     let%test "2 -> 0" = move(~fromi=2, ~toi=0, [1, 2, 3]) == [3, 1, 2];
+     let%test "2 -> 1" = move(~fromi=2, ~toi=1, [1, 2, 3]) == [1, 3, 2];
+     let%test "2 -> 2" = move(~fromi=2, ~toi=2, [1, 2, 3]) == [1, 2, 3];
+     let%test "-10 -> 1 (out of bounds)" =
+       switch (move(~fromi=-10, ~toi=1, [1, 2, 3])) {
+       | exception (Invalid_argument(_)) => true
+       | _ => false
+       };
+     let%test "10 -> 1 (out of bounds)" =
+       switch (move(~fromi=10, ~toi=1, [1, 2, 3])) {
+       | exception (Failure(_)) => true
+       | _ => false
+       };
+   });

--- a/src/Core/Utility/ListEx.re
+++ b/src/Core/Utility/ListEx.re
@@ -105,7 +105,7 @@ let insertAt = (index, element, list) => {
   left @ [element] @ right;
 };
 
-let%test_module "removeAt" =
+let%test_module "insertAt" =
   (module
    {
      let%test "0" = insertAt(0, 42, [1, 2, 3]) == [42, 1, 2, 3];

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -29,6 +29,7 @@ let nextLayoutTab: (~count: int=?, model) => model;
 let removeLayoutTab: (int, model) => option(model);
 let removeActiveLayoutTab: model => option(model);
 let removeOtherLayoutTabs: model => model;
+let moveActiveLayoutTabTo: (int, model) => model;
 
 let map: (Editor.t => Editor.t, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -28,6 +28,7 @@ let previousLayoutTab: (~count: int=?, model) => model;
 let nextLayoutTab: (~count: int=?, model) => model;
 let removeLayoutTab: (int, model) => option(model);
 let removeActiveLayoutTab: model => option(model);
+let removeOtherLayoutTabs: model => model;
 
 let map: (Editor.t => Editor.t, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -30,6 +30,7 @@ let removeLayoutTab: (int, model) => option(model);
 let removeActiveLayoutTab: model => option(model);
 let removeOtherLayoutTabs: model => model;
 let moveActiveLayoutTabTo: (int, model) => model;
+let moveActiveLayoutTabRelative: (int, model) => model;
 
 let map: (Editor.t => Editor.t, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -26,6 +26,7 @@ let addLayoutTab: model => model;
 let gotoLayoutTab: (int, model) => model;
 let previousLayoutTab: (~count: int=?, model) => model;
 let nextLayoutTab: (~count: int=?, model) => model;
+let removeActiveLayoutTab: model => option(model);
 
 let map: (Editor.t => Editor.t, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -23,7 +23,9 @@ let openEditor: (~config: Config.resolver, Editor.t, model) => model;
 let closeBuffer: (~force: bool, Vim.Types.buffer, model) => option(model);
 
 let addLayoutTab: model => model;
-let gotoLayoutTab: (~delta: int, model) => model;
+let gotoLayoutTab: (int, model) => model;
+let previousLayoutTab: (~count: int=?, model) => model;
+let nextLayoutTab: (~count: int=?, model) => model;
 
 let map: (Editor.t => Editor.t, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -30,6 +30,7 @@ let removeLayoutTab: (int, model) => option(model);
 let removeLayoutTabRelative: (~delta: int, model) => option(model);
 let removeActiveLayoutTab: model => option(model);
 let removeOtherLayoutTabs: model => model;
+let removeOtherLayoutTabsRelative: (~count: int, model) => model;
 let moveActiveLayoutTabTo: (int, model) => model;
 let moveActiveLayoutTabRelative: (int, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -26,6 +26,7 @@ let addLayoutTab: model => model;
 let gotoLayoutTab: (int, model) => model;
 let previousLayoutTab: (~count: int=?, model) => model;
 let nextLayoutTab: (~count: int=?, model) => model;
+let removeLayoutTab: (int, model) => option(model);
 let removeActiveLayoutTab: model => option(model);
 
 let map: (Editor.t => Editor.t, model) => model;

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -23,6 +23,7 @@ let openEditor: (~config: Config.resolver, Editor.t, model) => model;
 let closeBuffer: (~force: bool, Vim.Types.buffer, model) => option(model);
 
 let addLayoutTab: model => model;
+let gotoLayoutTab: (~delta: int, model) => model;
 
 let map: (Editor.t => Editor.t, model) => model;
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -27,6 +27,7 @@ let gotoLayoutTab: (int, model) => model;
 let previousLayoutTab: (~count: int=?, model) => model;
 let nextLayoutTab: (~count: int=?, model) => model;
 let removeLayoutTab: (int, model) => option(model);
+let removeLayoutTabRelative: (~delta: int, model) => option(model);
 let removeActiveLayoutTab: model => option(model);
 let removeOtherLayoutTabs: model => model;
 let moveActiveLayoutTabTo: (int, model) => model;

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -285,7 +285,19 @@ let removeActiveLayoutTab = model =>
   removeLayoutTab(model.activeLayoutIndex, model);
 
 let removeOtherLayoutTabs = model => {
-  {layouts: [activeLayout(model)], activeLayoutIndex: 0};
+  layouts: [activeLayout(model)],
+  activeLayoutIndex: 0,
+};
+
+let removeOtherLayoutTabsRelative = (~count, model) => {
+  let (start, stop) =
+    count < 0
+      ? (model.activeLayoutIndex + count, model.activeLayoutIndex - 1)
+      : (model.activeLayoutIndex + 1, model.activeLayoutIndex + count);
+  {
+    layouts: ListEx.sublist(start, stop, model.layouts),
+    activeLayoutIndex: 0,
+  };
 };
 
 let removeEditor = (editorId, model) => {

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -278,6 +278,9 @@ let removeLayoutTab = (index, model) => {
   };
 };
 
+let removeActiveLayoutTab = model =>
+  removeLayoutTab(model.activeLayoutIndex, model);
+
 let removeEditor = (editorId, model) => {
   let removeFromLayout = layout => {
     let groups =

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -367,13 +367,17 @@ let addLayoutTab = model => {
   };
 };
 
-let gotoLayoutTab = (~delta, model) => {
+let gotoLayoutTab = (index, model) => {
   ...model,
   activeLayoutIndex:
-    model.activeLayoutIndex
-    + delta
-    |> IntEx.clamp(~lo=0, ~hi=List.length(model.layouts) - 1),
+    IntEx.clamp(index, ~lo=0, ~hi=List.length(model.layouts) - 1),
 };
+
+let previousLayoutTab = (~count=1, model) =>
+  gotoLayoutTab(model.activeLayoutIndex - count, model);
+
+let nextLayoutTab = (~count=1, model) =>
+  gotoLayoutTab(model.activeLayoutIndex + count, model);
 
 let map = (f, model) => {
   ...model,

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -367,6 +367,14 @@ let addLayoutTab = model => {
   };
 };
 
+let gotoLayoutTab = (~delta, model) => {
+  ...model,
+  activeLayoutIndex:
+    model.activeLayoutIndex
+    + delta
+    |> IntEx.clamp(~lo=0, ~hi=List.length(model.layouts) - 1),
+};
+
 let map = (f, model) => {
   ...model,
   layouts:

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -281,6 +281,10 @@ let removeLayoutTab = (index, model) => {
 let removeActiveLayoutTab = model =>
   removeLayoutTab(model.activeLayoutIndex, model);
 
+let removeOtherLayoutTabs = model => {
+  {layouts: [activeLayout(model)], activeLayoutIndex: 0};
+};
+
 let removeEditor = (editorId, model) => {
   let removeFromLayout = layout => {
     let groups =

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -386,6 +386,17 @@ let previousLayoutTab = (~count=1, model) =>
 let nextLayoutTab = (~count=1, model) =>
   gotoLayoutTab(model.activeLayoutIndex + count, model);
 
+let moveActiveLayoutTabTo = (index, model) => {
+  let newLayouts =
+    ListEx.move(~fromi=model.activeLayoutIndex, ~toi=index, model.layouts);
+
+  {
+    layouts: newLayouts,
+    activeLayoutIndex:
+      IntEx.clamp(index, ~lo=0, ~hi=List.length(newLayouts) - 1),
+  };
+};
+
 let map = (f, model) => {
   ...model,
   layouts:

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -397,6 +397,9 @@ let moveActiveLayoutTabTo = (index, model) => {
   };
 };
 
+let moveActiveLayoutTabRelative = (delta, model) =>
+  moveActiveLayoutTabTo(model.activeLayoutIndex + delta, model);
+
 let map = (f, model) => {
   ...model,
   layouts:

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -278,6 +278,9 @@ let removeLayoutTab = (index, model) => {
   };
 };
 
+let removeLayoutTabRelative = (~delta, model) =>
+  removeLayoutTab(model.activeLayoutIndex + delta, model);
+
 let removeActiveLayoutTab = model =>
   removeLayoutTab(model.activeLayoutIndex, model);
 

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -227,7 +227,8 @@ type t =
   | TabPagePrevious(int)
   | TabPageNext
   | TabPageMove(int)
-  | TabPageClose
+  | TabPageClose(int)
+  | TabPageCloseActive
   | Noop
 and command = {
   commandCategory: option(string),

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -223,13 +223,7 @@ type t =
       decorations: list(Decoration.t),
     })
   | Vim(Feature_Vim.msg)
-  | TabPageGoto(int)
-  | TabPagePrevious(int)
-  | TabPageNext
-  | TabPageMove(int)
-  | TabPageClose(int)
-  | TabPageCloseActive
-  | TabPageCloseOther(int)
+  | TabPage(Vim.TabPage.effect)
   | Noop
 and command = {
   commandCategory: option(string),

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -229,6 +229,7 @@ type t =
   | TabPageMove(int)
   | TabPageClose(int)
   | TabPageCloseActive
+  | TabPageCloseOther(int)
   | Noop
 and command = {
   commandCategory: option(string),

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -223,6 +223,7 @@ type t =
       decorations: list(Decoration.t),
     })
   | Vim(Feature_Vim.msg)
+  | GotoTabPage(int)
   | Noop
 and command = {
   commandCategory: option(string),

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -223,7 +223,11 @@ type t =
       decorations: list(Decoration.t),
     })
   | Vim(Feature_Vim.msg)
-  | GotoTabPage(int)
+  | TabPageGoto(int)
+  | TabPagePrevious(int)
+  | TabPageNext
+  | TabPageMove(int)
+  | TabPageClose
   | Noop
 and command = {
   commandCategory: option(string),

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1024,6 +1024,12 @@ let start =
       | None => (state, Isolinear.Effect.none)
       }
 
+    | TabPage(CloseRelative(delta)) =>
+      switch (Feature_Layout.removeLayoutTabRelative(~delta, state.layout)) {
+      | Some(layout) => ({...state, layout}, Isolinear.Effect.none)
+      | None => (state, Isolinear.Effect.none)
+      }
+
     | TabPage(Only(0)) => (
         {
           ...state,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1049,6 +1049,16 @@ let start =
         Isolinear.Effect.none,
       )
 
+    | TabPage(OnlyRelative(count)) => (
+        {
+          ...state,
+          layout:
+            state.layout
+            |> Feature_Layout.removeOtherLayoutTabsRelative(~count),
+        },
+        Isolinear.Effect.none,
+      )
+
     | _ => (state, Isolinear.Effect.none)
     };
   };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1005,6 +1005,14 @@ let start =
         Isolinear.Effect.none,
       )
 
+    | TabPageMove(index) => (
+        {
+          ...state,
+          layout: Feature_Layout.moveActiveLayoutTabTo(index, state.layout),
+        },
+        Isolinear.Effect.none,
+      )
+
     | TabPageClose(index) =>
       switch (Feature_Layout.removeLayoutTab(index, state.layout)) {
       | Some(layout) => ({...state, layout}, Isolinear.Effect.none)

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -998,6 +998,12 @@ let start =
         Isolinear.Effect.none,
       )
 
+    | TabPageClose =>
+      switch (Feature_Layout.removeActiveLayoutTab(state.layout)) {
+      | Some(layout) => ({...state, layout}, Isolinear.Effect.none)
+      | None => (state, Isolinear.Effect.none)
+      }
+
     | _ => (state, Isolinear.Effect.none)
     };
   };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -977,19 +977,19 @@ let start =
         Isolinear.Effect.none,
       )
 
-    | TabPage(GotoRelative(count)) when count < 0 => (
+    | TabPage(GotoRelative(delta)) when delta < 0 => (
         {
           ...state,
           layout:
-            Feature_Layout.previousLayoutTab(~count=- count, state.layout),
+            Feature_Layout.previousLayoutTab(~count=- delta, state.layout),
         },
         Isolinear.Effect.none,
       )
 
-    | TabPage(GotoRelative(count)) => (
+    | TabPage(GotoRelative(delta)) => (
         {
           ...state,
-          layout: Feature_Layout.nextLayoutTab(~count, state.layout),
+          layout: Feature_Layout.nextLayoutTab(~count=delta, state.layout),
         },
         Isolinear.Effect.none,
       )
@@ -999,6 +999,15 @@ let start =
           ...state,
           layout:
             Feature_Layout.moveActiveLayoutTabTo(index - 1, state.layout),
+        },
+        Isolinear.Effect.none,
+      )
+
+    | TabPage(MoveRelative(delta)) => (
+        {
+          ...state,
+          layout:
+            Feature_Layout.moveActiveLayoutTabRelative(delta, state.layout),
         },
         Isolinear.Effect.none,
       )

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -129,7 +129,9 @@ let start =
         dispatch(TabPageCloseActive);
       } else {
         dispatch(TabPageClose(index - 1));
-      };
+      }
+    | Vim.TabPage.CloseOther(index) =>
+      dispatch(TabPageCloseOther(index - 1));
 
   let _: unit => unit =
     Vim.onEffect(
@@ -1014,6 +1016,17 @@ let start =
       | Some(layout) => ({...state, layout}, Isolinear.Effect.none)
       | None => (state, Isolinear.Effect.none)
       }
+
+    | TabPageCloseOther(index) => (
+        {
+          ...state,
+          layout:
+            state.layout
+            |> Feature_Layout.gotoLayoutTab(index)
+            |> Feature_Layout.removeOtherLayoutTabs,
+        },
+        Isolinear.Effect.none,
+      )
 
     | _ => (state, Isolinear.Effect.none)
     };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -89,6 +89,7 @@ let start =
   let handleGoto = gotoType => {
     switch (gotoType) {
     | Vim.Goto.Hover => dispatch(Actions.Hover(Feature_Hover.Command(Show)))
+
     | Vim.Goto.Definition
     | Vim.Goto.Declaration =>
       Log.debug("Goto definition requested");
@@ -114,6 +115,10 @@ let start =
       Option.map(getDefinition, maybeBuffer)
       |> Option.join
       |> Option.iter(action => dispatch(action));
+
+    | Vim.Goto.TabPage(count) =>
+      let delta = count == 0 ? 1 : count;
+      dispatch(GotoTabPage(delta));
     };
   };
 
@@ -737,6 +742,7 @@ let start =
         state,
         synchronizeViml(configuration),
       )
+
     | Command("editor.action.clipboardPasteAction") => (
         state,
         pasteIntoEditorAction,
@@ -751,6 +757,7 @@ let start =
     | Command("vim.esc") => (state, escapeEffect)
     | Command("vim.tutor") => (state, openTutorEffect)
     | VimExecuteCommand(cmd) => (state, commandEffect(cmd))
+
     | ListFocusUp
     | ListFocusDown
     | ListFocus(_) =>
@@ -905,6 +912,7 @@ let start =
       (state, effect);
 
     | KeyboardInput(s) => (state, inputEffect(s))
+
     | CopyActiveFilepathToClipboard => (
         state,
         copyActiveFilepathToClipboardEffect,
@@ -963,6 +971,14 @@ let start =
         )
       | _ => (state, Isolinear.Effect.none)
       }
+
+    | GotoTabPage(delta) => (
+        {
+          ...state,
+          layout: Feature_Layout.gotoLayoutTab(~delta, state.layout),
+        },
+        Isolinear.Effect.none,
+      )
 
     | _ => (state, Isolinear.Effect.none)
     };

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -1,3 +1,4 @@
 type t =
   | Goto(Goto.effect)
+  | TabPage(TabPage.effect)
   | Format(Format.effect);

--- a/src/reason-libvim/Goto.re
+++ b/src/reason-libvim/Goto.re
@@ -1,4 +1,5 @@
 type effect =
   | Definition
   | Declaration
-  | Hover;
+  | Hover
+  | TabPage(int);

--- a/src/reason-libvim/Goto.re
+++ b/src/reason-libvim/Goto.re
@@ -1,5 +1,4 @@
 type effect =
   | Definition
   | Declaration
-  | Hover
-  | TabPage(int);
+  | Hover;

--- a/src/reason-libvim/TabPage.re
+++ b/src/reason-libvim/TabPage.re
@@ -3,4 +3,4 @@ type effect =
   | Previous(int)
   | Next
   | Move(int)
-  | Close;
+  | Close(int);

--- a/src/reason-libvim/TabPage.re
+++ b/src/reason-libvim/TabPage.re
@@ -1,7 +1,10 @@
+[@deriving show({with_path: false})]
 type effect =
   | Goto(int)
-  | Previous(int)
-  | Next
+  | GotoRelative(int)
   | Move(int)
+  | MoveRelative(int)
   | Close(int)
-  | CloseOther(int);
+  | CloseRelative(int)
+  | Only(int)
+  | OnlyRelative(int);

--- a/src/reason-libvim/TabPage.re
+++ b/src/reason-libvim/TabPage.re
@@ -3,4 +3,5 @@ type effect =
   | Previous(int)
   | Next
   | Move(int)
-  | Close(int);
+  | Close(int)
+  | CloseOther(int);

--- a/src/reason-libvim/TabPage.re
+++ b/src/reason-libvim/TabPage.re
@@ -1,0 +1,6 @@
+type effect =
+  | Goto(int)
+  | Previous(int)
+  | Next
+  | Move(int)
+  | Close;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -17,6 +17,7 @@ module Effect = Effect;
 module Event = Event;
 module Format = Format;
 module Goto = Goto;
+module TabPage = TabPage;
 module Mode = Mode;
 module Options = Options;
 module Search = Search;
@@ -419,6 +420,10 @@ let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
 };
 
+let _onTabPage = (msg: TabPage.effect) => {
+  queue(() => Event.dispatch(Effect.TabPage(msg), Listeners.effect));
+};
+
 let _onTerminal = terminalRequest => {
   queue(() => Event.dispatch(terminalRequest, Listeners.terminalRequested));
 };
@@ -435,6 +440,7 @@ let init = () => {
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);
   Callback.register("lv_onFormat", _onFormat);
   Callback.register("lv_onGoto", _onGoto);
+  Callback.register("lv_onTabPage", _onTabPage);
   Callback.register("lv_onIntro", _onIntro);
   Callback.register("lv_onMessage", _onMessage);
   Callback.register("lv_onQuit", _onQuit);

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -218,8 +218,16 @@ module Goto: {
   type effect =
     | Definition
     | Declaration
-    | Hover
-    | TabPage(int);
+    | Hover;
+};
+
+module TabPage: {
+  type effect =
+    | Goto(int)
+    | Previous(int)
+    | Next
+    | Move(int)
+    | Close;
 };
 
 module Format: {
@@ -245,6 +253,7 @@ module Format: {
 module Effect: {
   type t =
     | Goto(Goto.effect)
+    | TabPage(TabPage.effect)
     | Format(Format.effect);
 };
 

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -227,7 +227,7 @@ module TabPage: {
     | Previous(int)
     | Next
     | Move(int)
-    | Close;
+    | Close(int);
 };
 
 module Format: {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -227,7 +227,8 @@ module TabPage: {
     | Previous(int)
     | Next
     | Move(int)
-    | Close(int);
+    | Close(int)
+    | CloseOther(int);
 };
 
 module Format: {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -218,7 +218,8 @@ module Goto: {
   type effect =
     | Definition
     | Declaration
-    | Hover;
+    | Hover
+    | TabPage(int);
 };
 
 module Format: {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -222,13 +222,16 @@ module Goto: {
 };
 
 module TabPage: {
+  [@deriving show]
   type effect =
     | Goto(int)
-    | Previous(int)
-    | Next
+    | GotoRelative(int)
     | Move(int)
+    | MoveRelative(int)
     | Close(int)
-    | CloseOther(int);
+    | CloseRelative(int)
+    | Only(int)
+    | OnlyRelative(int);
 };
 
 module Format: {

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -103,32 +103,44 @@ int onTabPage(tabPageRequest_T request) {
 
   switch (request.kind) {
   case GOTO:
-    msg = caml_alloc(1, 0);
-    Store_field(msg, 0, Val_int(request.arg));
-    break;
-    
-  case PREVIOUS:
-    msg = caml_alloc(1, 1);
-    Store_field(msg, 0, Val_int(request.arg));
-    break;
-    
-  case NEXT:
-    msg = Val_int(0);
+    if (request.relative == 0) {
+      msg = caml_alloc(1, 0);
+      Store_field(msg, 0, Val_int(request.arg));
+    } else {
+      msg = caml_alloc(1, 1);
+      Store_field(msg, 0, Val_int(request.arg * request.relative));
+    }
     break;
     
   case MOVE:
-    msg = caml_alloc(1, 2);
-    Store_field(msg, 0, Val_int(request.arg));
+    if (request.relative == 0) {
+      msg = caml_alloc(1, 2);
+      Store_field(msg, 0, Val_int(request.arg));
+    } else {
+      msg = caml_alloc(1, 3);
+      Store_field(msg, 0, Val_int(request.arg * request.relative));
+    }
     break;
   
   case CLOSE:
-    msg = caml_alloc(1, 3);
-    Store_field(msg, 0, Val_int(request.arg));
+    if (request.relative == 0) {
+      msg = caml_alloc(1, 4);
+      Store_field(msg, 0, Val_int(request.arg));
+    } else {
+      msg = caml_alloc(1, 5);
+      Store_field(msg, 0, Val_int(request.arg * request.relative));
+    }
     break;
 
-  case CLOSE_OTHER:
-    msg = caml_alloc(1, 4);
-    Store_field(msg, 0, Val_int(request.arg));
+  case ONLY:
+    if (request.relative == 0) {
+      
+      msg = caml_alloc(1, 6);
+      Store_field(msg, 0, Val_int(request.arg));
+    } else {
+      msg = caml_alloc(1, 7);
+      Store_field(msg, 0, Val_int(request.arg * request.relative));
+    }
     break;
   }
 

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -122,7 +122,8 @@ int onTabPage(tabPageRequest_T request) {
     break;
   
   case CLOSE:
-    msg = Val_int(1);
+    msg = caml_alloc(1, 3);
+    Store_field(msg, 0, Val_int(request.arg));
     break;
   }
 

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -66,6 +66,8 @@ int onAutoIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *newLine) {
 };
 
 int onGoto(gotoRequest_T gotoInfo) {
+  CAMLparam0();
+  CAMLlocal1(target);
   static const value *lv_onGoto = NULL;
 
   if (lv_onGoto == NULL) {
@@ -74,22 +76,26 @@ int onGoto(gotoRequest_T gotoInfo) {
 
   int line = gotoInfo.location.lnum;
   int col = gotoInfo.location.col;
-  int target = 0;
   switch (gotoInfo.target) {
   case DEFINITION:
-    target = 0;
+    target = Val_int(0);
     break;
   case DECLARATION:
-    target = 1;
+    target = Val_int(1);
     break;
   case HOVER:
-    target = 2;
+    target = Val_int(2);
+    break;
+  case TABPAGE:
+    target = caml_alloc(1, 0);
+    Store_field(target, 0, Val_int(gotoInfo.count));
     break;
   default:
-    target = 0;
+    target = Val_int(0);
   }
 
-  caml_callback3(*lv_onGoto, Val_int(line), Val_int(col), Val_int(target));
+  caml_callback3(*lv_onGoto, Val_int(line), Val_int(col), target);
+  CAMLreturn(0);
 }
 
 void onAutocommand(event_T event, buf_T *buf) {

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -125,6 +125,11 @@ int onTabPage(tabPageRequest_T request) {
     msg = caml_alloc(1, 3);
     Store_field(msg, 0, Val_int(request.arg));
     break;
+
+  case CLOSE_OTHER:
+    msg = caml_alloc(1, 4);
+    Store_field(msg, 0, Val_int(request.arg));
+    break;
   }
 
   caml_callback(*tabPageCallback, msg);

--- a/src/reason-libvim/dune
+++ b/src/reason-libvim/dune
@@ -5,7 +5,14 @@
     (c_flags (:include c_flags.sexp))
     (c_names bindings)
     (cxx_flags (:include cxx_flags.sexp))
-    (libraries base editor-core-types timber zed_oni))
+    (preprocess (pps ppx_deriving.show))
+    (libraries
+        base
+        editor-core-types
+        timber
+        zed_oni
+        ppx_deriving.runtime
+))
 
 (rule
     (targets c_flags.sexp cxx_flags.sexp flags.sexp)

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bde1703e8d6e1691b9ff8d7b421ea409",
+  "checksum": "33657278a343994729c9aa4a31b5934b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -472,14 +472,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.50@d41d8cd9": {
-      "id": "libvim@8.10869.50@d41d8cd9",
+    "libvim@8.10869.51@d41d8cd9": {
+      "id": "libvim@8.10869.51@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.50",
+      "version": "8.10869.51",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.50.tgz#sha1:f0a641b8cf868217656a86eae130b6c901e75ae9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.51.tgz#sha1:ad9bc8926cc654a74dd5eac0d1886f052b44c302"
         ]
       },
       "overrides": [],
@@ -1076,7 +1076,7 @@
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-tree-sitter@1.0.1001@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.50@d41d8cd9",
+        "ocaml@4.9.1000@d41d8cd9", "libvim@8.10869.51@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#d60e5fe@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",


### PR DESCRIPTION
This wires up the `:tab*` commands and `gt/gT`.

Depends on https://github.com/onivim/libvim/pull/211
Addresses #592