### PR TITLE
fix(layout/#2011): assert failure on GroupTabClicked

### DIFF
--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -108,8 +108,11 @@ let update = (~focus, model, msg) => {
 
   | DragComplete => (updateTree(Fun.id, model), Nothing)
 
-  | GroupTabClicked(id) => (
-      updateActiveGroup(Group.select(id), model),
+  | EditorTabClicked({groupId, editorId}) => (
+      updateActiveLayout(
+        updateGroup(groupId, Group.select(editorId)),
+        model,
+      ),
       Nothing,
     )
 

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -183,18 +183,17 @@ let updateTree = f =>
     {...layout, tree: f(activeTree(layout)), uncommittedTree: `None}
   );
 
+let updateGroup = (id, f, layout) => {
+  ...layout,
+  groups:
+    List.map(
+      (group: Group.t) => group.id == id ? f(group) : group,
+      layout.groups,
+    ),
+};
+
 let updateActiveGroup = f =>
-  updateActiveLayout(layout =>
-    {
-      ...layout,
-      groups:
-        List.map(
-          (group: Group.t) =>
-            group.id == layout.activeGroupId ? f(group) : group,
-          layout.groups,
-        ),
-    }
-  );
+  updateActiveLayout(layout => updateGroup(layout.activeGroupId, f, layout));
 
 let windows = model => Layout.windows(model |> activeLayout |> activeTree);
 

--- a/src/Feature/Layout/Msg.re
+++ b/src/Feature/Layout/Msg.re
@@ -35,7 +35,10 @@ type t =
       delta: float,
     })
   | DragComplete
-  | GroupTabClicked(int)
+  | EditorTabClicked({
+      groupId: int,
+      editorId: int,
+    })
   | GroupSelected(int)
   | EditorCloseButtonClicked(int)
   | LayoutTabClicked(int)

--- a/src/Feature/Layout/View.re
+++ b/src/Feature/Layout/View.re
@@ -301,7 +301,12 @@ module EditorGroupView = {
                 isModified={ContentModel.isModified(item)}
                 icon={ContentModel.icon(item)}
                 onClick={() =>
-                  dispatch(GroupTabClicked(ContentModel.id(item)))
+                  dispatch(
+                    EditorTabClicked({
+                      groupId: model.id,
+                      editorId: ContentModel.id(item),
+                    }),
+                  )
                 }
                 onClose={() =>
                   dispatch(EditorCloseButtonClicked(ContentModel.id(item)))


### PR DESCRIPTION
This adds `groupId` to `GroupTabClicked` instead of assuming the clicked tab is in the active group and crashing if it isn't.

Probably fixes #2011, but I can't be entirely sure since there' no repro. I can;t see what else it could be though, and this is a likely cause and sketchy assumption.