### PR TITLE
feat(layout/#592): layout tabs - part 3 - single tab mode

### DIFF
--- a/src/Feature/Layout/Configuration.re
+++ b/src/Feature/Layout/Configuration.re
@@ -58,4 +58,4 @@ let layoutTabPosition =
     ~default=`bottom,
   );
 
-let singleTabMode = setting("oni.layout.singleTabMode", bool, ~default=true);
+let singleTabMode = setting("oni.layout.singleTabMode", bool, ~default=false);

--- a/src/Feature/Layout/Configuration.re
+++ b/src/Feature/Layout/Configuration.re
@@ -57,3 +57,5 @@ let layoutTabPosition =
     Codec.layoutTabPosition,
     ~default=`bottom,
   );
+
+let singleTabMode = setting("oni.layout.singleTabMode", bool, ~default=true);

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -4,6 +4,13 @@ open Oni_Core.Utility;
 
 include Model;
 
+let openEditor = (~config, editor) =>
+  if (Local.Configuration.singleTabMode.get(config)) {
+    updateActiveGroup(Group.replaceAllWith(editor));
+  } else {
+    updateActiveGroup(Group.openEditor(editor));
+  };
+
 // UPDATE
 
 open Msg;

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -744,5 +744,9 @@ module Contributions = {
     ];
 
   let configuration =
-    Configuration.[showLayoutTabs.spec, layoutTabPosition.spec];
+    Configuration.[
+      showLayoutTabs.spec,
+      layoutTabPosition.spec,
+      singleTabMode.spec,
+    ];
 };

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -19,7 +19,7 @@ let split: ([ | `Horizontal | `Vertical], model) => model;
 
 let activeEditor: model => Editor.t;
 
-let openEditor: (Editor.t, model) => model;
+let openEditor: (~config: Config.resolver, Editor.t, model) => model;
 let closeBuffer: (~force: bool, Vim.Types.buffer, model) => option(model);
 
 let addLayoutTab: model => model;

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -1,3 +1,6 @@
+module Local = {
+  module Configuration = Configuration;
+};
 open Oni_Core;
 open Utility;
 open Feature_Editor;
@@ -18,6 +21,7 @@ module Group: {
   let nextEditor: t => t;
   let previousEditor: t => t;
   let openEditor: (Editor.t, t) => t;
+  let replaceAllWith: (Editor.t, t) => t;
   let removeEditor: (int, t) => option(t);
 
   let map: (Editor.t => Editor.t, t) => t;
@@ -90,6 +94,12 @@ module Group: {
         selectedId: Editor.getId(editor),
       }
     };
+  };
+
+  let replaceAllWith = (editor, group) => {
+    ...group,
+    editors: [editor],
+    selectedId: Editor.getId(editor),
   };
 
   let removeEditor = (editorId, group) => {
@@ -252,8 +262,6 @@ let moveDown = current => move(current, 0, 1);
 let nextEditor = updateActiveGroup(Group.nextEditor);
 
 let previousEditor = updateActiveGroup(Group.previousEditor);
-
-let openEditor = editor => updateActiveGroup(Group.openEditor(editor));
 
 let removeLayoutTab = (index, model) => {
   let left = Base.List.take(model.layouts, index);

--- a/src/Feature/Layout/View.re
+++ b/src/Feature/Layout/View.re
@@ -264,6 +264,7 @@ module EditorGroupView = {
   let make =
       (
         ~provider as module ContentModel: ContentModel,
+        ~config,
         ~showTabs,
         ~uiFont,
         ~theme,
@@ -280,7 +281,7 @@ module EditorGroupView = {
         | None => React.empty
         };
 
-      if (showTabs) {
+      if (showTabs && !Local.Configuration.singleTabMode.get(config)) {
         let editors = model.editors |> List.rev;
         let tabs =
           <Tabs
@@ -456,6 +457,7 @@ module Layout = {
       (
         ~provider,
         ~model as layout,
+        ~config,
         ~isZenMode,
         ~showTabs,
         ~uiFont,
@@ -489,6 +491,7 @@ module Layout = {
               <EditorGroupView
                 provider
                 uiFont
+                config
                 showTabs
                 isActive={group.id == layout.activeGroupId}
                 theme
@@ -548,6 +551,7 @@ let make =
     <Layout
       provider
       model={activeLayout(model)}
+      config
       isZenMode
       showTabs
       uiFont

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -128,6 +128,7 @@ let update =
         ...state,
         layout:
           Feature_Layout.openEditor(
+            ~config=Feature_Configuration.resolver(state.config),
             Feature_Editor.Editor.create(
               ~font=state.editorFont,
               ~buffer=editorBuffer,


### PR DESCRIPTION
This adds a "single tab mode" that hides the tab bar and restricts each group to a single tab. The effect of this is that `:q` will always close the split/group even if several buffers have been opened in it.

There is one caveat, however. If single tab mode is enabled when there are multiple tabs in a group, the extra tabs won't disappear immediately. Only when another buffer is opened will they be replaced. Any fix I can think of for this would be excessively complex for something that is designed to always be on or off, not toggled mid-session, so I doubt it's really worth it to fix it.

Addresses #592 - This should be the final piece of the puzzle for this, depending on how complete the support needs to be at this point.