### PR TITLE
refactor(editor): Add getCharacterAtLocation function, use with CursorView

### DIFF
--- a/src/Feature/Editor/BufferViewTokenizer.re
+++ b/src/Feature/Editor/BufferViewTokenizer.re
@@ -38,7 +38,6 @@ let isWhitespace = c => {
 let filterRuns = (r: Tokenizer.TextRun.t) => ZedBundled.length(r.text) != 0;
 
 let textRunToToken = (colorizer, r: Tokenizer.TextRun.t) => {
-  //let startIndex = Index.toZeroBased(r.startIndex);
   let {color, backgroundColor, bold, italic}: BufferLineColorizer.themedToken =
     colorizer(r.startByte);
 
@@ -63,19 +62,6 @@ let textRunToToken = (colorizer, r: Tokenizer.TextRun.t) => {
     bold,
     italic,
   };
-};
-
-let getCharacterPositionAndWidth = (~viewOffset: int=0, line: BufferLine.t, i) => {
-  let (totalOffset, width) = BufferLine.getPositionAndWidth(~index=i, line);
-
-  let actualOffset =
-    if (viewOffset > 0) {
-      totalOffset - viewOffset;
-    } else {
-      totalOffset;
-    };
-
-  (actualOffset, width);
 };
 
 let tokenize =

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -174,6 +174,19 @@ let mapCursor = (~position: Vim.Cursor.t, editor) => {
   };
 };
 
+let getCharacterAtPosition = (~line, ~index, {buffer, _}) => {
+  let bufferLineCount = EditorBuffer.numberOfLines(buffer);
+
+  if (line < bufferLineCount) {
+    let bufferLine = EditorBuffer.line(line, buffer);
+    try(Some(BufferLine.getUcharExn(~index, bufferLine))) {
+    | _exn => None
+    };
+  } else {
+    None;
+  };
+};
+
 let getCharacterBehindCursor = ({cursors, buffer, _}) => {
   switch (cursors) {
   | [] => None

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -39,6 +39,7 @@ let getLayout:
   EditorLayout.t;
 let getCharacterUnderCursor: t => option(Uchar.t);
 let getCharacterBehindCursor: t => option(Uchar.t);
+let getCharacterAtPosition: (~line: int, ~index: int, t) => option(Uchar.t);
 let getPrimaryCursor: t => Location.t;
 let getVisibleView: t => int;
 let getTotalHeightInPixels: t => int;

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -259,7 +259,6 @@ let%component make =
       config
       editor
       editorFont
-      buffer
       mode
       cursorPosition
       isActiveSplit


### PR DESCRIPTION
Refactoring to remove parts of the editor from going directly against a raw buffer line, in support of implementing word wrap in #1969 