### PR TITLE
fix(editor): Exception in BufferLine.getByteFromIndex

### DIFF
--- a/src/Core/BufferLine.re
+++ b/src/Core/BufferLine.re
@@ -171,7 +171,10 @@ let getByteFromIndex = (~index, bufferLine) => {
   Internal.resolveTo(~index, bufferLine);
   let rawLength = String.length(bufferLine.raw);
   let characters = bufferLine.characters;
-  if (index >= Array.length(characters)) {
+  let len = Array.length(characters);
+  if (index < 0) {
+    0;
+  } else if (index >= len) {
     rawLength;
   } else {
     switch (characters[index]) {

--- a/test/Core/BufferLineTests.re
+++ b/test/Core/BufferLineTests.re
@@ -86,6 +86,13 @@ describe("BufferLine", ({describe, _}) => {
       expect.int(len).toBe(3);
     });
   });
+  describe("getByteFromIndex", ({test, _}) => {
+    test("clamps to byte 0", ({expect, _}) => {
+      let bufferLine = makeLine("abc");
+      let byte = bufferLine |> BufferLine.getByteFromIndex(~index=-1);
+      expect.int(byte).toBe(0);
+    })
+  });
   describe("getPositionAndWidth", ({test, _}) => {
     test("UTF-8: Hiragana あ", ({expect, _}) => {
       let str = "あa";


### PR DESCRIPTION
Fix a crash exposed by the word wrap work in #1969 