### PR TITLE
refactor(editor): Config subscription, internalize minimap state

### DIFF
--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -6,6 +6,8 @@ open Feature_Editor;
 
 Vim.init();
 
+let config = _ => None;
+
 /* Create a state with some editor size */
 let simpleState = {
   let initialBuffer = {
@@ -53,7 +55,7 @@ let defaultEditorBuffer =
   defaultBuffer |> Feature_Editor.EditorBuffer.ofBuffer;
 
 let simpleEditor =
-  Editor.create(~font=defaultFont, ~buffer=defaultEditorBuffer, ())
+  Editor.create(~config, ~font=defaultFont, ~buffer=defaultEditorBuffer, ())
   |> Editor.setSize(~pixelWidth=3440, ~pixelHeight=1440);
 
 let createUpdateAction = (oldBuffer: Buffer.t, update: BufferUpdate.t) => {

--- a/src/Core/Config.re
+++ b/src/Core/Config.re
@@ -165,3 +165,51 @@ module Schema = {
 
   include DSL;
 };
+
+module Sub = {
+  module type Config = {
+    type configValue;
+    let schema: Schema.setting(configValue);
+    type msg; 
+  };
+  module Make = (C: Config) => {
+   type params = {
+        config: resolver,
+        name: string,
+        toMsg: C.configValue => C.msg,
+   };
+   module InnerSub = Isolinear.Sub.Make({
+      type nonrec msg = C.msg;
+      type nonrec params = params;
+      type state = {lastValue: C.configValue};
+
+      let name = "Config.Subscription";
+      let id = params => {
+        params.name
+      };
+
+      let init = (~params, ~dispatch) => {
+        let lastValue = C.schema.get(params.config);
+        dispatch(params.toMsg(lastValue));
+        {lastValue: lastValue}
+      };
+
+      let update = (~params, ~state, ~dispatch) => {
+        let newValue = C.schema.get(params.config);
+        if (newValue != state.lastValue) {
+          dispatch(params.toMsg(newValue));
+        };
+
+        {lastValue: newValue};
+      };
+
+      let dispose = (~params, ~state) => {
+        ();
+      }
+    });
+
+    let create = (~config, ~name, ~toMsg) => {
+      InnerSub.create({config, name, toMsg });
+    }
+  };
+}

--- a/src/Core/Config.rei
+++ b/src/Core/Config.rei
@@ -73,3 +73,24 @@ module Schema: {
 
   let setting: (string, codec('a), ~default: 'a) => setting('a);
 };
+
+module Sub: {
+  module type Config = {
+    type configValue;
+    let schema: Schema.setting(configValue);
+    type msg;
+  };
+
+  module type S = {
+    type configValue;
+    type msg;
+
+    let create:
+      (~config: resolver, ~name: string, ~toMsg: configValue => msg) =>
+      Isolinear.Sub.t(msg);
+  };
+
+  module Make:
+    (Config: Config) =>
+     S with type msg = Config.msg and type configValue = Config.configValue;
+};

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -11,6 +11,7 @@
         Oni2.core.kernel
         Oni2.core.utility
         Oni2.core.whenExpr
+        isolinear
         Rench
         Revery
         yojson

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -21,7 +21,14 @@ type viewLine = {
   characterOffset: int,
 };
 
-let create: (~font: Service_Font.font, ~buffer: EditorBuffer.t, unit) => t;
+let create:
+  (
+    ~config: Config.resolver,
+    ~font: Service_Font.font,
+    ~buffer: EditorBuffer.t,
+    unit
+  ) =>
+  t;
 let copy: t => t;
 
 let getId: t => int;
@@ -30,13 +37,7 @@ let getTopVisibleLine: t => int;
 let getBottomVisibleLine: t => int;
 let getLeftVisibleColumn: t => int;
 let getLayout:
-  (
-    ~showLineNumbers: bool,
-    ~isMinimapShown: bool,
-    ~maxMinimapCharacters: int,
-    t
-  ) =>
-  EditorLayout.t;
+  (~showLineNumbers: bool, ~maxMinimapCharacters: int, t) => EditorLayout.t;
 let getCharacterUnderCursor: t => option(Uchar.t);
 let getCharacterBehindCursor: t => option(Uchar.t);
 let getCharacterAtPosition: (~line: int, ~index: int, t) => option(Uchar.t);
@@ -48,6 +49,9 @@ let getVerticalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getVimCursors: t => list(Vim.Cursor.t);
 let setVimCursors: (~cursors: list(Vim.Cursor.t), t) => t;
+
+let isMinimapEnabled: t => bool;
+let setMinimapEnabled: (~enabled: bool, t) => t;
 
 let getNearestMatchingPair:
   (

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -200,7 +200,6 @@ let%component make =
     Editor.getLayout(
       ~showLineNumbers=Config.lineNumbers.get(config) != `Off,
       ~maxMinimapCharacters=Config.Minimap.maxColumn.get(config),
-      ~isMinimapShown=Config.Minimap.enabled.get(config),
       editor,
     );
 
@@ -293,7 +292,7 @@ let%component make =
       windowIsFocused
       config
     />
-    {Config.Minimap.enabled.get(config)
+    {Editor.isMinimapEnabled(editor)
        ? <minimap
            editor
            diagnosticsMap

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -105,21 +105,24 @@ let update = (editor, msg) => {
       Editor.scrollToColumn(~column, editor),
       Nothing,
     )
-  | MinimapEnabledChanged(_) => (editor, Nothing);
+  | MinimapEnabledConfigChanged(enabled) => (
+      Editor.setMinimapEnabled(~enabled, editor),
+      Nothing,
+    )
   };
 };
 
 module Sub = {
-  module MinimapEnabledSub = Oni_Core.Config.Sub.Make({
-    type configValue = bool;
-    let schema = EditorConfiguration.Minimap.enabled;
-    type msg = Msg.t;
-  });
+  module MinimapEnabledSub =
+    Oni_Core.Config.Sub.Make({
+      type configValue = bool;
+      let schema = EditorConfiguration.Minimap.enabled;
+      type msg = Msg.t;
+    });
   let global = (~config) => {
     MinimapEnabledSub.create(
-      ~config,
-      ~name="Feature_Editor.Config.minimapEnabled",
-      ~toMsg=enabled=>MinimapEnabledChanged(enabled)
+      ~config, ~name="Feature_Editor.Config.minimapEnabled", ~toMsg=enabled =>
+      MinimapEnabledConfigChanged(enabled)
     );
   };
 };

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -105,5 +105,21 @@ let update = (editor, msg) => {
       Editor.scrollToColumn(~column, editor),
       Nothing,
     )
+  | MinimapEnabledChanged(_) => (editor, Nothing);
+  };
+};
+
+module Sub = {
+  module MinimapEnabledSub = Oni_Core.Config.Sub.Make({
+    type configValue = bool;
+    let schema = EditorConfiguration.Minimap.enabled;
+    type msg = Msg.t;
+  });
+  let global = (~config) => {
+    MinimapEnabledSub.create(
+      ~config,
+      ~name="Feature_Editor.Config.minimapEnabled",
+      ~toMsg=enabled=>MinimapEnabledChanged(enabled)
+    );
   };
 };

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -28,4 +28,4 @@ type t =
   | CursorsChanged([@opaque] list(Vim.Cursor.t))
   | ScrollToLine(int)
   | ScrollToColumn(int)
-  | MinimapEnabledChanged(bool);
+  | MinimapEnabledConfigChanged(bool);

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -27,4 +27,5 @@ type t =
   | SelectionChanged([@opaque] VisualRange.t)
   | CursorsChanged([@opaque] list(Vim.Cursor.t))
   | ScrollToLine(int)
-  | ScrollToColumn(int);
+  | ScrollToColumn(int)
+  | MinimapEnabledChanged(bool);

--- a/src/Feature/Formatting/Feature_Formatting.re
+++ b/src/Feature/Formatting/Feature_Formatting.re
@@ -115,8 +115,6 @@ module Internal = {
         && stopLine < Array.length(lines)) {
       let lines = Array.sub(lines, startLine, stopLine - startLine + 1);
 
-      lines |> Array.iter(prerr_endline);
-
       let edits =
         DefaultFormatter.format(
           ~indentation,

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -35,7 +35,7 @@ let moveActiveLayoutTabTo: (int, model) => model;
 let moveActiveLayoutTabRelative: (int, model) => model;
 
 let map: (Editor.t => Editor.t, model) => model;
-let fold: ((Editor.t, 'acc) => 'acc, 'acc, model) => 'acc;
+let fold: (('acc, Editor.t) => 'acc, 'acc, model) => 'acc;
 
 // UPDATE
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -35,6 +35,7 @@ let moveActiveLayoutTabTo: (int, model) => model;
 let moveActiveLayoutTabRelative: (int, model) => model;
 
 let map: (Editor.t => Editor.t, model) => model;
+let fold: ((Editor.t, 'acc) => 'acc, 'acc, model) => 'acc;
 
 // UPDATE
 

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -25,7 +25,7 @@ module Group: {
   let removeEditor: (int, t) => option(t);
 
   let map: (Editor.t => Editor.t, t) => t;
-  let fold: ((Editor.t, 'acc) => 'acc, 'acc, model) => 'acc;
+  let fold: (('acc, Editor.t) => 'acc, 'acc, t) => 'acc;
 } = {
   type t = {
     id: int,
@@ -430,9 +430,15 @@ let map = (f, model) => {
 };
 
 let fold = (f, initial, model) => {
-  List.fold_left((layout, acc) => {
-    List.fold_left((group, acc) => {
-      Group.fold(f, acc, group);
-    }, acc, layout.groups);
-  }, initial, model.layouts);
+  List.fold_left(
+    (initial', layout) => {
+      List.fold_left(
+        (acc, group) => {Group.fold(f, acc, group)},
+        initial',
+        layout.groups,
+      )
+    },
+    initial,
+    model.layouts,
+  );
 };

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -25,11 +25,16 @@ module Group: {
   let removeEditor: (int, t) => option(t);
 
   let map: (Editor.t => Editor.t, t) => t;
+  let fold: ((Editor.t, 'acc) => 'acc, 'acc, model) => 'acc;
 } = {
   type t = {
     id: int,
     editors: list(Editor.t),
     selectedId: int,
+  };
+
+  let fold = (f, initial, group) => {
+    List.fold_left(f, initial, group.editors);
   };
 
   let create = {
@@ -422,4 +427,12 @@ let map = (f, model) => {
       layout => {...layout, groups: List.map(Group.map(f), layout.groups)},
       model.layouts,
     ),
+};
+
+let fold = (f, initial, model) => {
+  List.fold_left((layout, acc) => {
+    List.fold_left((group, acc) => {
+      Group.fold(f, acc, group);
+    }, acc, layout.groups);
+  }, initial, model.layouts);
 };

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -118,7 +118,7 @@ type t =
       extensionId: option(string),
     })
   | Editor({
-      editorId: int,
+      scope: EditorScope.t,
       msg: Feature_Editor.msg,
     })
   | FilesDropped({paths: list(string)})

--- a/src/Model/EditorScope.re
+++ b/src/Model/EditorScope.re
@@ -1,0 +1,11 @@
+[@deriving show]
+type t =
+  | All
+  | Editor(int);
+
+let matches = (editor, scope) => {
+  switch (scope) {
+  | All => true
+  | Editor(id) => id == Feature_Editor.Editor.getId(editor)
+  };
+};

--- a/src/Model/EditorVisibleRanges.re
+++ b/src/Model/EditorVisibleRanges.re
@@ -16,12 +16,7 @@ let getVisibleRangesForEditor = (editor: Editor.t) => {
   let leftVisibleColumn = Editor.getLeftVisibleColumn(editor);
 
   let {bufferWidthInCharacters, minimapWidthInCharacters, _}: EditorLayout.t =
-    Editor.getLayout(
-      ~isMinimapShown=false,
-      ~showLineNumbers=false,
-      ~maxMinimapCharacters=0,
-      editor,
-    );
+    Editor.getLayout(~showLineNumbers=false, ~maxMinimapCharacters=0, editor);
 
   let i = ref(max(topVisibleLine - 1, 0));
   let eRanges = ref([]);

--- a/src/Model/Oni_Model.re
+++ b/src/Model/Oni_Model.re
@@ -13,6 +13,7 @@ module BufferRenderer = BufferRenderer;
 module BufferRenderers = BufferRenderers;
 module ContextKeys = ContextKeys;
 module DecorationProvider = DecorationProvider;
+module EditorScope = EditorScope;
 module EditorVisibleRanges = EditorVisibleRanges;
 module Extensions = Extensions;
 module FileExplorer = FileExplorer;

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -86,10 +86,26 @@ let initial =
       ~contributedCommands,
       ~workingDirectory,
     ) => {
+  let config =
+    Feature_Configuration.initial(
+      ~getUserSettings,
+      [
+        Feature_Editor.Contributions.configuration,
+        Feature_Syntax.Contributions.configuration,
+        Feature_Terminal.Contributions.configuration,
+        Feature_Layout.Contributions.configuration,
+      ],
+    );
   let initialEditor = {
     open Feature_Editor;
     let editorBuffer = initialBuffer |> EditorBuffer.ofBuffer;
-    Editor.create(~font=Service_Font.default, ~buffer=editorBuffer, ());
+    let config = Feature_Configuration.resolver(config);
+    Editor.create(
+      ~config,
+      ~font=Service_Font.default,
+      ~buffer=editorBuffer,
+      (),
+    );
   };
 
   {
@@ -106,16 +122,7 @@ let initial =
     commands: Feature_Commands.initial(contributedCommands),
     contextMenu: Feature_ContextMenu.initial,
     completions: Completions.initial,
-    config:
-      Feature_Configuration.initial(
-        ~getUserSettings,
-        [
-          Feature_Editor.Contributions.configuration,
-          Feature_Syntax.Contributions.configuration,
-          Feature_Terminal.Contributions.configuration,
-          Feature_Layout.Contributions.configuration,
-        ],
-      ),
+    config,
     configuration: Configuration.default,
     decorationProviders: [],
     definition: Definition.empty,

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -98,12 +98,7 @@ let current = (state: State.t) => {
         _,
       } =
     // TODO: Fix this
-    Editor.getLayout(
-      ~isMinimapShown=true,
-      ~showLineNumbers=true,
-      ~maxMinimapCharacters=0,
-      editor,
-    );
+    Editor.getLayout(~showLineNumbers=true, ~maxMinimapCharacters=0, editor);
 
   let leftColumn = Editor.getLeftVisibleColumn(editor);
   let topLine = Editor.getTopVisibleLine(editor);

--- a/src/Store/CompletionStoreConnector.re
+++ b/src/Store/CompletionStoreConnector.re
@@ -38,9 +38,10 @@ module Effects = {
       let _: Vim.Context.t = VimEx.repeatInput(delta, "<BS>");
       let {cursors, _}: Vim.Context.t = VimEx.inputString(completion.label);
 
+      let editorId = editor |> Editor.getId;
       dispatch(
         Editor({
-          editorId: Editor.getId(editor),
+          scope: EditorScope.Editor(editorId),
           msg: CursorsChanged(cursors),
         }),
       );

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -28,6 +28,60 @@ module Internal = {
     Isolinear.Effect.createWithDispatch(~name="quit", dispatch =>
       dispatch(Actions.Quit(true))
     );
+
+  let updateEditor = (~editorId, ~msg, layout) => {
+    switch (Feature_Layout.editorById(editorId, layout)) {
+    | Some(editor) =>
+      open Feature_Editor;
+
+      let (updatedEditor, outmsg) = update(editor, msg);
+      let layout =
+        Feature_Layout.map(
+          editor => Editor.getId(editor) == editorId ? updatedEditor : editor,
+          layout,
+        );
+
+      let effect =
+        switch (outmsg) {
+        | Nothing => Effect.none
+        | MouseHovered(location) =>
+          Effect.createWithDispatch(~name="editor.mousehovered", dispatch => {
+            dispatch(Hover(Feature_Hover.MouseHovered(location)))
+          })
+        | MouseMoved(location) =>
+          Effect.createWithDispatch(~name="editor.mousemoved", dispatch => {
+            dispatch(Hover(Feature_Hover.MouseMoved(location)))
+          })
+        };
+
+      (layout, effect);
+    | None => (layout, Effect.none)
+    };
+  };
+
+  let updateEditors =
+      (
+        ~scope: EditorScope.t,
+        ~msg: Feature_Editor.msg,
+        layout: Feature_Layout.model,
+      ) => {
+    switch (scope) {
+    | All =>
+      let (layout', effects) =
+        Feature_Layout.fold(
+          (prev, editor) => {
+            let (layout, effects) = prev;
+            let editorId = Feature_Editor.Editor.getId(editor);
+            let (layout', effect') = updateEditor(~editorId, ~msg, layout);
+            (layout', [effect', ...effects]);
+          },
+          (layout, []),
+          layout,
+        );
+      (layout', Isolinear.Effect.batch(effects));
+    | Editor(editorId) => updateEditor(~editorId, ~msg, layout)
+    };
+  };
 };
 
 // UPDATE
@@ -136,13 +190,15 @@ let update =
   | BufferEnter({buffer, _}) =>
     let editorBuffer = buffer |> Feature_Editor.EditorBuffer.ofBuffer;
 
+    let config = Feature_Configuration.resolver(state.config);
     (
       {
         ...state,
         layout:
           Feature_Layout.openEditor(
-            ~config=Feature_Configuration.resolver(state.config),
+            ~config,
             Feature_Editor.Editor.create(
+              ~config,
               ~font=state.editorFont,
               ~buffer=editorBuffer,
               (),
@@ -392,40 +448,11 @@ let update =
       );
     (state, eff);
 
-  | Editor({editorId, msg}) =>
-    switch (Feature_Layout.editorById(editorId, state.layout)) {
-    | Some(editor) =>
-      open Feature_Editor;
-
-      let (updatedEditor, outmsg) = update(editor, msg);
-
-      let state = {
-        ...state,
-        layout:
-          Feature_Layout.map(
-            editor =>
-              Editor.getId(editor) == editorId ? updatedEditor : editor,
-            state.layout,
-          ),
-      };
-
-      let effect =
-        switch (outmsg) {
-        | Nothing => Effect.none
-        | MouseHovered(location) =>
-          Effect.createWithDispatch(~name="editor.mousehovered", dispatch => {
-            dispatch(Hover(Feature_Hover.MouseHovered(location)))
-          })
-        | MouseMoved(location) =>
-          Effect.createWithDispatch(~name="editor.mousemoved", dispatch => {
-            dispatch(Hover(Feature_Hover.MouseMoved(location)))
-          })
-        };
-
-      (state, effect);
-
-    | None => (state, Effect.none)
-    }
+  | Editor({scope, msg}) =>
+    let (layout, effect) =
+      Internal.updateEditors(~scope, ~msg, state.layout);
+    let state = {...state, layout};
+    (state, effect);
 
   | Changelog(msg) =>
     let (model, eff) = Feature_Changelog.update(state.changelog, msg);

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -302,6 +302,12 @@ let start =
         Model.Actions.FileExplorer(ActiveFilePathChanged(maybeFilePath))
       );
 
+    let editorGlobalSub =
+      Feature_Editor.Sub.global(~config)
+      |> Isolinear.Sub.map(msg =>
+           Model.Actions.Editor({scope: Model.EditorScope.All, msg})
+         );
+
     [
       syntaxSubscription,
       terminalSubscription,
@@ -310,6 +316,7 @@ let start =
       extHostSubscription,
       Isolinear.Sub.batch(VimStoreConnector.subscriptions(state)),
       fileExplorerActiveFileSub,
+      editorGlobalSub,
     ]
     |> Isolinear.Sub.batch;
   };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -264,7 +264,12 @@ let start =
 
       let editorId =
         Feature_Layout.activeEditor(getState().layout) |> Editor.getId;
-      dispatch(Editor({editorId, msg: SelectionChanged(vr)}));
+      dispatch(
+        Editor({
+          scope: Oni_Model.EditorScope.Editor(editorId),
+          msg: SelectionChanged(vr),
+        }),
+      );
     });
 
   let _: unit => unit =
@@ -493,7 +498,12 @@ let start =
     let editorId =
       Feature_Layout.activeEditor(getState().layout) |> Editor.getId;
 
-    dispatch(Actions.Editor({editorId, msg: CursorsChanged(cursors)}));
+    dispatch(
+      Actions.Editor({
+        scope: EditorScope.Editor(editorId),
+        msg: CursorsChanged(cursors),
+      }),
+    );
   };
 
   let isVimKey = key => {
@@ -531,12 +541,23 @@ let start =
           Vim.input(~context, key);
         currentTriggerKey := None;
 
-        dispatch(Actions.Editor({editorId, msg: CursorsChanged(cursors)}));
         dispatch(
-          Actions.Editor({editorId, msg: ScrollToLine(newTopLine - 1)}),
+          Actions.Editor({
+            scope: EditorScope.Editor(editorId),
+            msg: CursorsChanged(cursors),
+          }),
         );
         dispatch(
-          Actions.Editor({editorId, msg: ScrollToColumn(newLeftColumn)}),
+          Actions.Editor({
+            scope: EditorScope.Editor(editorId),
+            msg: ScrollToLine(newTopLine - 1),
+          }),
+        );
+        dispatch(
+          Actions.Editor({
+            scope: EditorScope.Editor(editorId),
+            msg: ScrollToColumn(newLeftColumn),
+          }),
         );
 
         Log.debug("handled key: " ++ key);
@@ -558,7 +579,12 @@ let start =
 
       let topLine: int = max(Index.toZeroBased(location.line) - 10, 0);
 
-      dispatch(Actions.Editor({editorId, msg: ScrollToLine(topLine)}));
+      dispatch(
+        Actions.Editor({
+          scope: EditorScope.Editor(editorId),
+          msg: ScrollToLine(topLine),
+        }),
+      );
     });
 
   let addBufferRendererEffect = (bufferId, renderer) =>
@@ -725,13 +751,10 @@ let start =
         Vim.input("$");
 
       // Update the editor, which is the source of truth for cursor position
-      dispatch(Actions.Editor({editorId, msg: CursorsChanged(cursors)}));
-      dispatch(
-        Actions.Editor({editorId, msg: ScrollToLine(newTopLine - 1)}),
-      );
-      dispatch(
-        Actions.Editor({editorId, msg: ScrollToColumn(newLeftColumn)}),
-      );
+      let scope = EditorScope.Editor(editorId);
+      dispatch(Actions.Editor({scope, msg: CursorsChanged(cursors)}));
+      dispatch(Actions.Editor({scope, msg: ScrollToLine(newTopLine - 1)}));
+      dispatch(Actions.Editor({scope, msg: ScrollToColumn(newLeftColumn)}));
     });
   };
 

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -44,7 +44,9 @@ module Parts = {
         |> Option.value(~default=LanguageConfiguration.default);
 
       let editorDispatch = msg =>
-        dispatch(Editor({editorId: Editor.getId(editor), msg}));
+        dispatch(
+          Editor({scope: EditorScope.Editor(Editor.getId(editor)), msg}),
+        );
       let onEditorSizeChanged = (editorId, pixelWidth, pixelHeight) =>
         dispatch(EditorSizeChanged({id: editorId, pixelWidth, pixelHeight}));
       let onCursorChange = cursor =>


### PR DESCRIPTION
For word-wrap - we need to know whether the minimap is enabled. Previously, we only kept track of this at render time, but it needs to around for the wrapping logic to know about the available buffer space. This change adds an editor subscription to track the minimap setting, and update editors if necessary.