### PR TITLE
fix(editor): Fix mouse interactions with smooth scroll

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -29,6 +29,7 @@ type t = {
   editorId: EditorId.t,
   scrollX: float,
   scrollY: float,
+  isScrollAnimated: bool,
   isMinimapEnabled: bool,
   minimapMaxColumnWidth: int,
   minimapScrollY: float,
@@ -63,6 +64,7 @@ let setMinimapEnabled = (~enabled, editor) => {
 };
 
 let isMinimapEnabled = ({isMinimapEnabled, _}) => isMinimapEnabled;
+let isScrollAnimated = ({isScrollAnimated, _}) => isScrollAnimated;
 
 let bufferLineByteToPixel =
     (~line, ~byteIndex, {scrollX, scrollY, buffer, font, _}) => {
@@ -117,6 +119,7 @@ let create = (~config, ~font, ~buffer, ()) => {
   {
     editorId: id,
     isMinimapEnabled,
+    isScrollAnimated: false,
     buffer,
     scrollX: 0.,
     scrollY: 0.,
@@ -383,12 +386,17 @@ let scrollToPixelY = (~pixelY as newScrollY, view) => {
   let newMinimapScroll =
     scrollPercentage *. float_of_int(availableMinimapScroll);
 
-  {...view, minimapScrollY: newMinimapScroll, scrollY: newScrollY};
+  {
+    ...view,
+    isScrollAnimated: false,
+    minimapScrollY: newMinimapScroll,
+    scrollY: newScrollY,
+  };
 };
 
 let scrollToLine = (~line, view) => {
   let pixelY = float_of_int(line) *. getLineHeight(view);
-  scrollToPixelY(~pixelY, view);
+  {...scrollToPixelY(~pixelY, view), isScrollAnimated: true};
 };
 
 let scrollToPixelX = (~pixelX as newScrollX, view) => {
@@ -398,7 +406,7 @@ let scrollToPixelX = (~pixelX as newScrollX, view) => {
     max(0., float_of_int(view.maxLineLength) *. getCharacterWidth(view));
   let scrollX = min(newScrollX, availableScroll);
 
-  {...view, scrollX};
+  {...view, isScrollAnimated: false, scrollX};
 };
 
 let scrollDeltaPixelX = (~pixelX, editor) => {
@@ -408,7 +416,7 @@ let scrollDeltaPixelX = (~pixelX, editor) => {
 
 let scrollToColumn = (~column, view) => {
   let pixelX = float_of_int(column) *. getCharacterWidth(view);
-  scrollToPixelX(~pixelX, view);
+  {...scrollToPixelX(~pixelX, view), isScrollAnimated: true};
 };
 
 let scrollDeltaPixelY = (~pixelY, view) => {

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -81,6 +81,7 @@ let selectionOrCursorRange: t => Range.t;
 
 let totalViewLines: t => int;
 
+let isScrollAnimated: t => bool;
 let scrollToColumn: (~column: int, t) => t;
 let scrollToPixelX: (~pixelX: float, t) => t;
 let scrollDeltaPixelX: (~pixelX: float, t) => t;

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -229,19 +229,20 @@ let%component make =
       ? EditorDiffMarkers.generate(buffer) : None;
 
   let smoothScroll = Config.Experimental.smoothScroll.get(config);
+  let isScrollAnimated = Editor.isScrollAnimated(editor);
 
   let%hook (scrollY, _setScrollYImmediately) =
     Hooks.spring(
       ~target=Editor.scrollY(editor),
       ~restThreshold=10.,
-      ~enabled=smoothScroll,
+      ~enabled=smoothScroll && isScrollAnimated,
       scrollSpringOptions,
     );
   let%hook (scrollX, _setScrollXImmediately) =
     Hooks.spring(
       ~target=Editor.scrollX(editor),
       ~restThreshold=10.,
-      ~enabled=smoothScroll,
+      ~enabled=smoothScroll && isScrollAnimated,
       scrollSpringOptions,
     );
 


### PR DESCRIPTION
__Issue:__ When `experimental.editor.smoothScroll` is enabled, the mouse interactions would feel fuzzy or laggy

__Defect:__ Smooth scroll was being initiated in mouse gestures, but for mouse input, we shouldn't delay or animate.

__Fix:__ For the mouse-driven gestures - we set an `isScrollAnimated` flag to `false` - and when the scrolling happens another way (ie, via cursor movement) - we set it to `true`.