### PR TITLE
feat(extensions): Add Service_Net + JSON requests

### DIFF
--- a/node/request.js
+++ b/node/request.js
@@ -22,4 +22,4 @@ const req = requestFn(url, (res) => {
             req.end()
         })
     }
-});
+})

--- a/node/request.js
+++ b/node/request.js
@@ -1,0 +1,25 @@
+const http = require("http")
+const https = require("https")
+
+const url = new URL(process.argv[2])
+
+let requestFn = null
+
+if (url.protocol == "http:") {
+    requestFn = http.get
+} else if (url.protocol == "https:") {
+    requestFn = https.get
+} else {
+    throw "Unrecognized protocol: " + url.protocol
+}
+
+const req = requestFn(url, (res) => {
+    if (res.statusCode == 200) {
+        res.on("data", (d) => {
+            process.stdout.write(d)
+        })
+        res.on("end", () => {
+            req.end()
+        })
+    }
+});

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -2,10 +2,9 @@
  * NodeTask.re
  */
 
-open Oni_Core;
-open Oni_Core.Utility;
+open Utility;
 exception TaskFailed;
-module Log = (val Log.withNamespace("Oni2.Extensions.NodeTask"));
+module Log = (val Kernel.Log.withNamespace("Oni2.Core.NodeTask"));
 
 let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
   Log.info("Starting task: " ++ name);

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -13,55 +13,80 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
   let scriptPath = Setup.getNodeScriptPath(~script, setup);
   Log.info("Using node path: " ++ scriptPath);
 
-  let processResult =
-    Luv.Pipe.init()
-    |> ResultEx.flatMap(parent_pipe => {
-         let on_exit = (_, ~exit_status, ~term_signal as _) =>
-           if (exit_status == 0L) {
-             Log.info("Task completed successfully: " ++ name);
-             Lwt.wakeup(resolver, ());
-           } else {
-             Lwt.wakeup_exn(resolver, TaskFailed);
-           };
+  let result = {
+    open Base.Result.Let_syntax;
 
-         let process =
-           LuvEx.Process.spawn(
-             ~on_exit,
-             ~detached=true,
-             ~redirect=[
-               Luv.Process.to_parent_pipe(
-                 ~fd=Luv.Process.stdout,
-                 ~parent_pipe,
-                 (),
-               ),
-             ],
-             setup.nodePath,
-             [setup.nodePath, scriptPath, ...args],
-           );
+    let%bind stdoutPipe = Luv.Pipe.init();
+    let%bind stderrPipe = Luv.Pipe.init();
 
-         // If process was created successfully, we'll read from stdout
-         process
-         |> Result.iter(_ => {
-              Luv.Stream.read_start(
-                parent_pipe,
-                fun
-                | Error(`EOF) => {
-                    Log.info("Done!");
-                    Luv.Handle.close(parent_pipe, ignore);
-                  }
-                | Error(msg) => Log.error(Luv.Error.strerror(msg))
-                | Ok(buffer) => Log.info(Luv.Buffer.to_string(buffer)),
-              )
-            });
-         process;
-       })
-    |> Result.map_error(Luv.Error.strerror);
+    let on_exit = (_, ~exit_status, ~term_signal as _) =>
+      if (exit_status == 0L) {
+        Log.info("Task completed successfully: " ++ name);
+      } else {
+        Lwt.wakeup_exn(resolver, TaskFailed);
+      };
 
-  processResult
-  |> Result.iter_error(err => {
-       Log.error(err);
-       Lwt.wakeup_exn(resolver, TaskFailed);
-     });
+    let%bind _: Luv.Process.t =
+      LuvEx.Process.spawn(
+        ~on_exit,
+        ~detached=true,
+        ~redirect=[
+          Luv.Process.to_parent_pipe(
+            ~fd=Luv.Process.stdout,
+            ~parent_pipe=stdoutPipe,
+            (),
+          ),
+          Luv.Process.to_parent_pipe(
+            ~fd=Luv.Process.stderr,
+            ~parent_pipe=stderrPipe,
+            (),
+          ),
+        ],
+        setup.nodePath,
+        [setup.nodePath, scriptPath, ...args],
+      );
 
+    let buffers = ref([]);
+
+    // If process was created successfully, we'll read from stdout
+    let () =
+      Luv.Stream.read_start(
+        stdoutPipe,
+        fun
+        | Error(`EOF) => {
+            Log.info("Got EOF on stdout");
+            Luv.Handle.close(stdoutPipe, ignore);
+            let allOutput =
+              buffers^
+              |> List.rev
+              |> List.map(Luv.Buffer.to_string)
+              |> String.concat("");
+            Log.infof(m => m("Got output: %s", allOutput));
+            Lwt.wakeup(resolver, allOutput);
+          }
+        | Error(msg) => Log.error(Luv.Error.strerror(msg))
+        | Ok(buffer) => buffers := [buffer, ...buffers^],
+      );
+
+    let () =
+      Luv.Stream.read_start(
+        stderrPipe,
+        fun
+        | Error(`EOF) => {
+            Log.info("Got EOF on stderr");
+            Luv.Handle.close(stderrPipe, ignore);
+          }
+        | Error(msg) => Log.error(Luv.Error.strerror(msg))
+        | Ok(buffer) => Log.error(Luv.Buffer.to_string(buffer)),
+      );
+    Ok();
+  };
+
+  switch (result) {
+  | Ok(_) => ()
+  | Error(err) =>
+    Log.error(Luv.Error.strerror(err));
+    Lwt.wakeup_exn(resolver, TaskFailed);
+  };
   promise;
 };

--- a/src/Core/NodeTask.rei
+++ b/src/Core/NodeTask.rei
@@ -6,4 +6,4 @@ exception TaskFailed;
 
 let run:
   (~name: string=?, ~args: list(string)=?, ~setup: Setup.t, string) =>
-  Lwt.t(unit);
+  Lwt.t(string);

--- a/src/Core/NodeTask.rei
+++ b/src/Core/NodeTask.rei
@@ -2,8 +2,6 @@
  * NodeTask.rei
  */
 
-open Oni_Core;
-
 exception TaskFailed;
 
 let run:

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -35,6 +35,7 @@ module LineNumber = LineNumber;
 module Log = Kernel.Log;
 module Menu = Menu;
 module Mode = Mode;
+module NodeTask = NodeTask;
 module Ripgrep = Ripgrep;
 module Scheduler = Scheduler;
 module Decoration = Decoration;

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -22,4 +22,4 @@
         ReasonFuzz
         decoders-yojson
     )
-    (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))
+    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show)))

--- a/src/ExtensionManagement/Oni_ExtensionManagement.re
+++ b/src/ExtensionManagement/Oni_ExtensionManagement.re
@@ -17,7 +17,7 @@ let install = (~extensionsFolder, ~path) => {
 
   Log.debugf(m => m("Installing extension %s to %s", name, extensionsFolder));
 
-  let promise: Lwt.t(unit) =
+  let promise: Lwt.t(string) =
     NodeTask.run(
       ~name="Install",
       ~setup,
@@ -25,7 +25,7 @@ let install = (~extensionsFolder, ~path) => {
       "install-extension.js",
     );
 
-  Lwt.on_success(promise, () => {
+  Lwt.on_success(promise, _ => {
     Log.debugf(m => m("Successfully installed extension: %s", name))
   });
 

--- a/src/ExtensionManagement/Oni_ExtensionManagement.re
+++ b/src/ExtensionManagement/Oni_ExtensionManagement.re
@@ -1,6 +1,6 @@
 open Oni_Core;
 
-module NodeTask = Oni_Extensions.NodeTask;
+module NodeTask = Oni_Core.NodeTask;
 
 module Log = (val Log.withNamespace("Oni2.Extensions.ExtensionManagement"));
 

--- a/src/ExtensionManagement/Oni_ExtensionManagement.rei
+++ b/src/ExtensionManagement/Oni_ExtensionManagement.rei
@@ -1,3 +1,3 @@
-let install: (~extensionsFolder: string, ~path: string) => Lwt.t(unit);
+let install: (~extensionsFolder: string, ~path: string) => Lwt.t(string);
 
 let uninstall: (~extensionsFolder: string, ~id: string) => Lwt.t(unit);

--- a/src/Extensions/Oni_Extensions.re
+++ b/src/Extensions/Oni_Extensions.re
@@ -5,5 +5,4 @@
  */
 
 module LanguageInfo = LanguageInfo;
-module NodeTask = NodeTask;
 module ProviderUtility = ProviderUtility;

--- a/src/Service/Net/Service_Net.re
+++ b/src/Service/Net/Service_Net.re
@@ -1,0 +1,8 @@
+module Request = {
+	let json = (
+		~decoder,
+		url
+	) => {
+		Lwt.fail_with("Error");
+	}
+}

--- a/src/Service/Net/Service_Net.re
+++ b/src/Service/Net/Service_Net.re
@@ -1,8 +1,22 @@
+open Oni_Core;
+
 module Request = {
-	let json = (
-		~decoder,
-		url
-	) => {
-		Lwt.fail_with("Error");
-	}
-}
+  let json = (~setup, ~decoder: Json.decoder('a), url) => {
+    let promise = NodeTask.run(~args=[url], ~setup, "request.js");
+    Lwt.bind(
+      promise,
+      (output: string) => {
+        let result: result('a, string) =
+          output
+          |> Yojson.Safe.from_string
+          |> Json.Decode.decode_value(decoder)
+          |> Result.map_error(Json.Decode.string_of_error);
+
+        switch (result) {
+        | Ok(v) => Lwt.return(v)
+        | Error(msg) => Lwt.fail_with(msg)
+        };
+      },
+    );
+  };
+};

--- a/src/Service/Net/Service_Net.rei
+++ b/src/Service/Net/Service_Net.rei
@@ -1,7 +1,6 @@
 open Oni_Core;
-module Request : {
-	let json: (
-		~decoder: Json.decoder('a),
-		string
-	) => Lwt.t(result('a, string));
-}
+module Request: {
+  let json:
+    (~setup: Oni_Core.Setup.t, ~decoder: Json.decoder('a), string) =>
+    Lwt.t('a);
+};

--- a/src/Service/Net/Service_Net.rei
+++ b/src/Service/Net/Service_Net.rei
@@ -1,0 +1,7 @@
+open Oni_Core;
+module Request : {
+	let json: (
+		~decoder: Json.decoder('a),
+		string
+	) => Lwt.t(result('a, string));
+}

--- a/src/Service/Net/dune
+++ b/src/Service/Net/dune
@@ -1,6 +1,7 @@
 (library
     (name Service_Net)
     (public_name Oni2.service.net)
+    (inline_tests)
     (libraries 
       editor-core-types
       Oni2.core
@@ -8,4 +9,4 @@
       isolinear
       base
     )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+    (preprocess (pps ppx_let ppx_deriving.show ppx_inline_test)))

--- a/src/Service/Net/dune
+++ b/src/Service/Net/dune
@@ -1,0 +1,11 @@
+(library
+    (name Service_Net)
+    (public_name Oni2.service.net)
+    (libraries 
+      editor-core-types
+      Oni2.core
+      Revery
+      isolinear
+      base
+    )
+    (preprocess (pps ppx_let ppx_deriving.show)))

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -18,7 +18,7 @@ let start = () => {
       ~name,
       () => {
         let _ =
-          Oni_Extensions.NodeTask.run(
+          Oni_Core.NodeTask.run(
             ~setup=Oni_Core.Setup.init(),
             "add-to-path.js",
           );

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -91,6 +91,18 @@ let mainChecks = [
     },
   ),
   (
+    "Verify simple request",
+    (setup: Setup.t) => {
+      Service_Net.Request.json(
+        ~setup,
+        ~decoder=Json.Decode.value,
+        "https://httpbin.org/json",
+      )
+      |> LwtEx.sync
+      |> Result.is_ok;
+    },
+  ),
+  (
     "Verify ripgrep (rg) executable",
     (setup: Setup.t) => Sys.file_exists(setup.rgPath),
   ),

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -81,7 +81,7 @@ let mainChecks = [
   (
     "Verify node dependencies",
     (setup: Setup.t) => {
-      Oni_Extensions.NodeTask.run(~setup, "check-health.js")
+      NodeTask.run(~setup, "check-health.js")
       |> LwtEx.sync
       |> (
         fun

--- a/src/bin_editor/dune
+++ b/src/bin_editor/dune
@@ -14,6 +14,7 @@
         Oni2.extensionManagement
         Oni2.extensions
         Oni2.model
+        Oni2.service.net
         Oni2.store
         Oni2.syntax_client
         Oni2.syntax_server

--- a/test.json
+++ b/test.json
@@ -9,6 +9,7 @@
     "model": "esy '@test' x OniUnitTestRunnerModel",
     "exthost": "esy '@test' x OniUnitTestRunnerExtHost",
     "textmate": "esy '@test' x OniUnitTestRunnerTextmate",
+    "service_net": "esy '@test' x OniUnitTestRunnerServiceNet",
     "watch": "esy '@test' dune build --watch --root . -j4",
     "inline": "esy b dune runtest",
     "watch:inline": "esy b dune runtest --watch"

--- a/test/ExtensionManagement/InstallerTests.re
+++ b/test/ExtensionManagement/InstallerTests.re
@@ -25,7 +25,7 @@ describe("Installer", ({test, _}) => {
     let result =
       ExtM.install(~extensionsFolder, ~path=markdownExtension) |> LwtEx.sync;
 
-    expect.equal(result, Ok());
+    expect.equal(Result.is_ok(result), true);
 
     let afterInstallExtensions =
       Scanner.scan(~category=Development, extensionsFolder);

--- a/test/OniUnitTestRunner.re
+++ b/test/OniUnitTestRunner.re
@@ -13,6 +13,8 @@ Feature_Editor_Test.TestFramework.cli();
 Feature_LanguageSupport_Test.TestFramework.cli();
 Oni_Components_Test.TestFramework.cli();
 
+Service_Net_Test.TestFramework.cli();
+
 Vim.init();
 Libvim_Test.TestFramework.cli();
 

--- a/test/OniUnitTestRunnerCI.re
+++ b/test/OniUnitTestRunnerCI.re
@@ -96,6 +96,12 @@ Oniguruma_Test.TestFramework.run(
   ),
 );
 
+Service_Net_Test.TestFramework.run(
+  Rely.RunConfig.withReporters(
+    [Default, JUnit("./junit.xml")],
+    Rely.RunConfig.initialize(),
+  ),
+);
 Textmate_Test.TestFramework.run(
   Rely.RunConfig.withReporters(
     [Default, JUnit("./junit.xml")],

--- a/test/OniUnitTestRunnerServiceNet.re
+++ b/test/OniUnitTestRunnerServiceNet.re
@@ -1,0 +1,3 @@
+Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
+
+Service_Net_Test.TestFramework.cli();

--- a/test/Service/Net/RequestTests.re
+++ b/test/Service/Net/RequestTests.re
@@ -1,0 +1,45 @@
+open Oni_Core;
+open Oni_Core.Utility;
+open TestFramework;
+
+open Service_Net;
+
+let setup = Oni_Core.Setup.init();
+
+describe("Request", ({test, _}) => {
+  test("success", ({expect, _}) => {
+    let response =
+      Request.json(
+        ~setup,
+        ~decoder=Json.Decode.value,
+        "https://httpbin.org/json",
+      )
+      |> LwtEx.sync;
+
+    expect.equal(Result.is_ok(response), true);
+  });
+
+  test("fail: 400", ({expect, _}) => {
+    let response =
+      Request.json(
+        ~setup,
+        ~decoder=Json.Decode.value,
+        "https://httpbin.org/status/404",
+      )
+      |> LwtEx.sync;
+
+    expect.equal(Result.is_error(response), true);
+  });
+
+  test("fail: 500", ({expect, _}) => {
+    let response =
+      Request.json(
+        ~setup,
+        ~decoder=Json.Decode.value,
+        "https://httpbin.org/status/500",
+      )
+      |> LwtEx.sync;
+
+    expect.equal(Result.is_error(response), true);
+  });
+});

--- a/test/Service/Net/TestFramework.re
+++ b/test/Service/Net/TestFramework.re
@@ -1,0 +1,7 @@
+include Rely.Make({
+  let config =
+    Rely.TestFrameworkConfig.initialize({
+      snapshotDir: "__snapshots__",
+      projectDir: "",
+    });
+});

--- a/test/Service/Net/dune
+++ b/test/Service/Net/dune
@@ -1,0 +1,5 @@
+(library
+    (name Service_Net_Test)
+    (library_flags (-linkall -g))
+    (modules (:standard))
+    (libraries Oni2.core Oni2.service.net Oni_Core_Test rely.lib editor-core-types))

--- a/test/dune
+++ b/test/dune
@@ -16,12 +16,23 @@
         Oni_Syntax_Test
         Feature_Editor_Test
         Feature_LanguageSupport_Test
+        Service_Net_Test
         Exthost_Transport_Test
         Exthost_Test
         Libvim_Test
         Oniguruma_Test
         Textmate_Test
         reason-native-crash-utils.asan
+            ))
+    
+(executable
+    (name OniUnitTestRunnerServiceNet)
+    (public_name OniUnitTestRunnerServiceNet)
+    (modules OniUnitTestRunnerServiceNet)
+    (package OniUnitTestRunner)
+    (libraries
+        yojson
+        Service_Net_Test
             ))
 
 (executable
@@ -124,6 +135,7 @@
         Oni_Model_Test
         Feature_Editor_Test
         Feature_LanguageSupport_Test
+        Service_Net_Test
         Exthost_Transport_Test
         Exthost_Test
         Libvim_Test


### PR DESCRIPTION
For extension management, we need a way to query the `open-vsx.org` directory - this adds a `Service_Net` service project with a `Request.json` function, to help with this. Also adds some test infra and a health-check for making a `json` request.

Unfortunately, there isn't a Luv-based JSON request OCaml module at the moment - we have `fetch`, but it uses `Lwt`, and we need `Lwt.main_run` to execute it - which I'm not sure we can parallelize with our app execution (`Lwt.main_run`) is blocking. So for now - I defer the work of making a request to our bundled `node`. Hopefully, in the future, we can switch to a pure OCaml+Luv-based solution for making requests.