### PR TITLE
feat(extensions/#1018): Implement CLI extension query

### DIFF
--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -25,6 +25,7 @@ type eff =
   | CheckHealth
   | ListExtensions
   | InstallExtension(string)
+  | QueryExtension(string)
   | UninstallExtension(string)
   | StartSyntaxServer({
       parentPid: string,
@@ -113,6 +114,7 @@ let parse = args => {
       ("--checkhealth", setEffect(CheckHealth), ""),
       ("--list-extensions", setEffect(ListExtensions), ""),
       ("--install-extension", setStringEffect(s => InstallExtension(s)), ""),
+      ("--query-extension", setStringEffect(s => QueryExtension(s)), ""),
       (
         "--uninstall-extension",
         setStringEffect(s => UninstallExtension(s)),

--- a/src/CLI/Oni_CLI.rei
+++ b/src/CLI/Oni_CLI.rei
@@ -14,6 +14,7 @@ type eff =
   | CheckHealth
   | ListExtensions
   | InstallExtension(string)
+  | QueryExtension(string)
   | UninstallExtension(string)
   | StartSyntaxServer({
       parentPid: string,

--- a/src/Service/Extensions/Service_Extensions.re
+++ b/src/Service/Extensions/Service_Extensions.re
@@ -1,0 +1,84 @@
+open Oni_Core;
+module Constants = {
+  let baseUrl = "https://open-vsx.org/api"
+};
+
+module Url = {
+
+  let extensionInfo = (publisher, id) => {
+    Printf.sprintf("%s/%s/%s", Constants.baseUrl, publisher, id);
+  };
+  
+};
+
+module Catalog = {
+  module VersionInfo = {
+    type t = {
+      version: string,
+      url: string,
+    };
+  };
+
+  module Entry = {
+    type t = {
+      downloadUrl: string,
+//      repositoryUrl: string,
+//      homepageUrl: string,
+//      manifestUrl: string,
+//      iconUrl: string,
+//      readmeUrl: string,
+//      licenseName: string,
+//      licenseUrl: string,
+//      name: string,
+//      namespace: string,
+//      downloadCount: int,
+//      displayName: string,
+//      descrption: string,
+//      categories: list(string),
+//      versions: list(VersionInfo.t),
+    };
+
+    let toString = ({
+      downloadUrl,
+      }) => {
+      Printf.sprintf({|Extension %s:
+      - Download Url: %s
+      |}, "derp", downloadUrl);
+    };
+
+    module Decode = {
+      open Json.Decode;
+
+      let versions = key_value_pairs(string);
+
+      let files = field("files");
+      let downloadUrl = files(field("download", string));
+      let manifestUrl = files(field("manifest", string));
+
+      let decode = obj(({whatever, _}) => {
+        downloadUrl: whatever(downloadUrl),
+        //manifestUrl: whatever(manifestUrl),
+      });
+      
+      
+    };
+    
+  };
+
+  let query = (
+    ~setup,
+    ~publisher,
+    name
+  ) => {
+
+    let url = Url.extensionInfo(publisher, name);
+
+    Service_Net.Request.json(
+      ~setup,
+      ~decoder=Entry.Decode.decode,
+      url
+    )
+  };
+  
+};
+

--- a/src/Service/Extensions/Service_Extensions.re
+++ b/src/Service/Extensions/Service_Extensions.re
@@ -1,14 +1,12 @@
 open Oni_Core;
 module Constants = {
-  let baseUrl = "https://open-vsx.org/api"
+  let baseUrl = "https://open-vsx.org/api";
 };
 
 module Url = {
-
   let extensionInfo = (publisher, id) => {
     Printf.sprintf("%s/%s/%s", Constants.baseUrl, publisher, id);
   };
-  
 };
 
 module Catalog = {
@@ -17,68 +15,100 @@ module Catalog = {
       version: string,
       url: string,
     };
+
+    let decode =
+      Json.Decode.(
+        key_value_pairs(string)
+        |> map(List.map(((version, url)) => {version, url}))
+      );
+
+    let toString = ({version, url}) =>
+      Printf.sprintf(" - Version %s: %s", version, url);
   };
 
   module Entry = {
     type t = {
       downloadUrl: string,
-//      repositoryUrl: string,
-//      homepageUrl: string,
-//      manifestUrl: string,
-//      iconUrl: string,
-//      readmeUrl: string,
-//      licenseName: string,
-//      licenseUrl: string,
-//      name: string,
-//      namespace: string,
-//      downloadCount: int,
-//      displayName: string,
-//      descrption: string,
-//      categories: list(string),
-//      versions: list(VersionInfo.t),
+      repositoryUrl: string,
+      homepageUrl: string,
+      manifestUrl: string,
+      iconUrl: string,
+      readmeUrl: string,
+      licenseName: string,
+      //      licenseUrl: string,
+      //      name: string,
+      //      namespace: string,
+      //      downloadCount: int,
+      displayName: string,
+      description: string,
+      //      categories: list(string),
+      versions: list(VersionInfo.t),
     };
 
-    let toString = ({
-      downloadUrl,
-      }) => {
-      Printf.sprintf({|Extension %s:
-      - Download Url: %s
-      |}, "derp", downloadUrl);
+    let toString =
+        ({downloadUrl, displayName, description, homepageUrl, versions, _}) => {
+      let versions =
+        versions |> List.map(VersionInfo.toString) |> String.concat("\n");
+      Printf.sprintf(
+        {|Extension %s:
+- Description: %s
+- Homepage: %s
+- Download Url: %s
+- Versions:
+%s
+      |},
+        displayName,
+        description,
+        homepageUrl,
+        downloadUrl,
+        versions,
+      );
     };
 
     module Decode = {
       open Json.Decode;
 
-      let versions = key_value_pairs(string);
+      let files = (name, decoder) => field("files", field(name, decoder));
+      let downloadUrl = files("download", string);
+      let manifestUrl = files("manifest", string);
+      let iconUrl = files("icon", string);
+      let readmeUrl = files("readme", string);
+      let homepageUrl = field("publishedBy", field("homepage", string));
 
-      let files = field("files");
-      let downloadUrl = files(field("download", string));
-      let manifestUrl = files(field("manifest", string));
-
-      let decode = obj(({whatever, _}) => {
-        downloadUrl: whatever(downloadUrl),
-        //manifestUrl: whatever(manifestUrl),
-      });
-      
-      
+      let decode =
+        obj(({field, whatever, _}) =>
+          {
+            downloadUrl: whatever(downloadUrl),
+            manifestUrl: whatever(manifestUrl),
+            iconUrl: whatever(iconUrl),
+            readmeUrl: whatever(readmeUrl),
+            repositoryUrl: field.required("repository", string),
+            homepageUrl: whatever(homepageUrl),
+            licenseName: field.required("license", string),
+            displayName: field.required("displayName", string),
+            description: field.required("description", string),
+            versions:
+              field.withDefault("allVersions", [], VersionInfo.decode),
+          }
+        );
     };
-    
   };
 
-  let query = (
-    ~setup,
-    ~publisher,
-    name
-  ) => {
-
-    let url = Url.extensionInfo(publisher, name);
-
-    Service_Net.Request.json(
-      ~setup,
-      ~decoder=Entry.Decode.decode,
-      url
-    )
+  let toPublisherName = str => {
+    let items = String.split_on_char('.', str);
+    switch (items) {
+    | [publisher, id] => Some((publisher, id))
+    | _ => None
+    };
   };
-  
+
+  let query = (~setup, id) => {
+    switch (toPublisherName(id)) {
+    | None => Lwt.fail_with("Invalid id: " ++ id)
+    | Some((publisher, name)) =>
+      let url = Url.extensionInfo(publisher, name);
+
+      Service_Net.Request.json(~setup, ~decoder=Entry.Decode.decode, url);
+    };
+  };
 };
-

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -1,0 +1,32 @@
+open Oni_Core;
+module Catalog: {
+  module VersionInfo: {
+    type t = {
+      version: string,
+      url: string,
+    };
+  };
+
+  module Entry: {
+    type t = {
+      downloadUrl: string,
+//      name: string,
+//      namespace: string,
+//      downloadCount: int,
+//      displayName: string,
+//      descrption: string,
+//      categories: list(string),
+//      license: string,
+//      repositoryUrl: string,
+//      versions: list(VersionInfo.t),
+    }
+
+    let toString: t => string;
+  };
+
+  let query: (
+    ~setup: Setup.t,
+    ~publisher: string,
+    string) => Lwt.t(Entry.t);
+
+};

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -10,23 +10,24 @@ module Catalog: {
   module Entry: {
     type t = {
       downloadUrl: string,
-//      name: string,
-//      namespace: string,
-//      downloadCount: int,
-//      displayName: string,
-//      descrption: string,
-//      categories: list(string),
-//      license: string,
-//      repositoryUrl: string,
-//      versions: list(VersionInfo.t),
-    }
+      repositoryUrl: string,
+      homepageUrl: string,
+      manifestUrl: string,
+      iconUrl: string,
+      readmeUrl: string,
+      licenseName: string,
+      //      licenseUrl: string,
+      //      name: string,
+      //      namespace: string,
+      //      downloadCount: int,
+      displayName: string,
+      description: string,
+      //      categories: list(string),
+      versions: list(VersionInfo.t),
+    };
 
     let toString: t => string;
   };
 
-  let query: (
-    ~setup: Setup.t,
-    ~publisher: string,
-    string) => Lwt.t(Entry.t);
-
+  let query: (~setup: Setup.t, string) => Lwt.t(Entry.t);
 };

--- a/src/Service/Extensions/dune
+++ b/src/Service/Extensions/dune
@@ -1,0 +1,12 @@
+(library
+    (name Service_Extensions)
+    (public_name Oni2.service.extensions)
+    (libraries 
+      editor-core-types
+      Oni2.core
+      Oni2.service.net
+      Revery
+      isolinear
+      base
+    )
+    (preprocess (pps ppx_let ppx_deriving.show)))

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -50,6 +50,11 @@ let printVersion = () => {
   0;
 };
 
+let queryExtension = (_extension, _cli) => {
+  prerr_endline ("not implemented");
+  1;
+};
+
 let listExtensions = ({overriddenExtensionsDir, _}) => {
   let extensions = Store.Utility.getUserExtensions(~overriddenExtensionsDir);
   let printExtension = (ext: Exthost.Extension.Scanner.ScanResult.t) => {
@@ -65,6 +70,7 @@ let (cliOptions, eff) = Oni_CLI.parse(Sys.argv);
 switch (eff) {
 | PrintVersion => printVersion() |> exit
 | InstallExtension(name) => installExtension(name, cliOptions) |> exit
+| QueryExtension(name) => queryExtension(name, cliOptions) |> exit
 | UninstallExtension(name) => uninstallExtension(name, cliOptions) |> exit
 | CheckHealth => HealthCheck.run(~checks=All, cliOptions) |> exit
 | ListExtensions => listExtensions(cliOptions) |> exit

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -50,9 +50,21 @@ let printVersion = () => {
   0;
 };
 
-let queryExtension = (_extension, _cli) => {
-  prerr_endline ("not implemented");
-  1;
+let queryExtension = (extension, _cli) => {
+  let setup = Core.Setup.init();
+  Service_Extensions.Catalog.query(~setup, extension)
+  |> LwtEx.sync
+  |> (
+    fun
+    | Ok(ext) => {
+        ext |> Service_Extensions.Catalog.Entry.toString |> print_endline;
+        0;
+      }
+    | Error(msg) => {
+        prerr_endline(Printexc.to_string(msg));
+        1;
+      }
+  );
 };
 
 let listExtensions = ({overriddenExtensionsDir, _}) => {

--- a/src/bin_editor/dune
+++ b/src/bin_editor/dune
@@ -14,6 +14,7 @@
         Oni2.extensionManagement
         Oni2.extensions
         Oni2.model
+        Oni2.service.extensions
         Oni2.service.net
         Oni2.store
         Oni2.syntax_client

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -54,6 +54,11 @@ let spec =
       " Install extension by specifying a path to the .vsix file",
     ),
     (
+      "--query-extension",
+      passthroughStringAndStayAttached,
+      " Query extension info by specifying an extension id.",
+    ),
+    (
       "--uninstall-extension",
       passthroughStringAndStayAttached,
       " Uninstall extension by specifying an extension id.",

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -26,6 +26,16 @@ describe("CLI Integration Tests", ({describe, _}) => {
       )
     });
   });
+  describe("--query-extension", ({test, _}) => {
+    test("Query for Java extension", _ => {
+      TestRunner.(
+        startEditorWithArgs(["--query-extension", "redhat.java"])
+        |> validateOutputContains("Language Support for Java")
+        |> validateExitStatus(WEXITED(0))
+        |> finish
+      )
+    })
+  });
   describe("editor", ({test, _}) => {
     test("rogue -psn argument shouldn't cause a failure", _ => {
       TestRunner.(


### PR DESCRIPTION
This adds a `--query-extension` CLI parameter, like: `oni2 --query-extension redhat.java`, which queries the open-vsx.org catalog and returns some info, like:

```
Extension Language Support for Java(TM) by Red Hat:
- Description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
- Homepage: https://github.com/fbricon
- Download Url: https://open-vsx.org/api/redhat/java/0.63.0/file/redhat.java-0.63.0.vsix
- Versions:
 - Version latest: https://open-vsx.org/api/redhat/java/latest
 - Version preview: https://open-vsx.org/api/redhat/java/preview
 - Version 0.63.0: https://open-vsx.org/api/redhat/java/0.63.0
 - Version 0.62.0: https://open-vsx.org/api/redhat/java/0.62.0
 - Version 0.61.0: https://open-vsx.org/api/redhat/java/0.61.0
 - Version 0.60.0: https://open-vsx.org/api/redhat/java/0.60.0
 - Version 0.59.1: https://open-vsx.org/api/redhat/java/0.59.1
 - Version 0.59.0: https://open-vsx.org/api/redhat/java/0.59.0
```

This is setting up the plumbing to have in-editor search / query extension functionality.