### PR TITLE
fix(formatting/#2052): Undo is not working consistently with formatting

### DIFF
--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -79,7 +79,7 @@ external vimSearchGetMatchingPair: unit => option((int, int)) =
 external vimSearchGetHighlights: (int, int) => array((int, int, int, int)) =
   "libvim_vimSearchGetHighlights";
 
-external vimUndoSaveRegion: (int, int) => unit = "libvim_vimUndoSaveRegion";
+external vimUndoSaveRegion: (int, int) => bool = "libvim_vimUndoSaveRegion";
 external vimUndoSync: int => unit = "libvim_vimUndoSync";
 
 external vimVisualGetRange: unit => (int, int, int, int) =

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -79,7 +79,6 @@ external vimSearchGetMatchingPair: unit => option((int, int)) =
 external vimSearchGetHighlights: (int, int) => array((int, int, int, int)) =
   "libvim_vimSearchGetHighlights";
 
-external vimUndoSaveCursor: unit => unit = "libvim_vimUndoSaveCursor";
 external vimUndoSaveRegion: (int, int) => unit = "libvim_vimUndoSaveRegion";
 external vimUndoSync: int => unit = "libvim_vimUndoSync";
 

--- a/src/reason-libvim/Undo.re
+++ b/src/reason-libvim/Undo.re
@@ -1,2 +1,10 @@
-let saveRegion = Native.vimUndoSaveRegion;
+let saveRegion = (start, stop) => {
+  let buf = Native.vimBufferGetCurrent();
+
+  let totalLines = Native.vimBufferGetLineCount(buf);
+  let start = max(0, start);
+  let stop = min(stop, totalLines + 1);
+  let _: bool = Native.vimUndoSaveRegion(start, stop);
+  ();
+};
 let sync = (~force: bool) => Native.vimUndoSync(force ? 1 : 0);

--- a/src/reason-libvim/Undo.re
+++ b/src/reason-libvim/Undo.re
@@ -1,3 +1,2 @@
-let saveCursor = Native.vimUndoSaveCursor;
 let saveRegion = Native.vimUndoSaveRegion;
 let sync = (~force: bool) => Native.vimUndoSync(force ? 1 : 0);

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -22,7 +22,9 @@ module Mode = Mode;
 module Options = Options;
 module Search = Search;
 module Types = Types;
-module Undo = Undo;
+module Testing = {
+  module Undo = Undo;
+};
 module Visual = Visual;
 module VisualRange = VisualRange;
 module Window = Window;

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -371,3 +371,5 @@ module Visual = Visual;
 module VisualRange = VisualRange;
 module Window = Window;
 module Yank = Yank;
+
+module Testing: {module Undo: {let saveRegion: (int, int) => unit;};};

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -940,14 +940,6 @@ CAMLprim value libvim_vimWindowSetTopLeft(value top, value left) {
   return Val_unit;
 }
 
-CAMLprim value libvim_vimUndoSaveCursor(value unit) {
-  CAMLparam0();
-
-  vimUndoSaveCursor();
-
-  CAMLreturn(Val_unit);
-}
-
 CAMLprim value libvim_vimUndoSync(value force) {
   CAMLparam0();
 

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -950,13 +950,14 @@ CAMLprim value libvim_vimUndoSync(value force) {
 
 CAMLprim value libvim_vimUndoSaveRegion(value startLine, value endLine) {
   CAMLparam2(startLine, endLine);
-
+  CAMLlocal1(ret);
+  
   int start = Int_val(startLine);
   int end = Int_val(endLine);
 
-  vimUndoSaveRegion(start, end);
+  int success = vimUndoSaveRegion(start, end);
 
-  CAMLreturn(Val_unit);
+  CAMLreturn(Val_bool(success != FAIL));
 }
 
 CAMLprim value libvim_vimVisualGetType(value unit) {

--- a/test/reason-libvim/Helpers.re
+++ b/test/reason-libvim/Helpers.re
@@ -4,6 +4,8 @@ let resetBuffer = filePath => {
   /* Reset clipboard provider */
   Clipboard.setProvider(_ => None);
 
+  let _ = Vim.command("clear-undo");
+
   let _ = input("<esc>");
   let _ = input("<esc>");
   let _context = command("e!");

--- a/test/reason-libvim/Helpers.re
+++ b/test/reason-libvim/Helpers.re
@@ -4,8 +4,6 @@ let resetBuffer = filePath => {
   /* Reset clipboard provider */
   Clipboard.setProvider(_ => None);
 
-  let _ = Vim.command("clear-undo");
-
   let _ = input("<esc>");
   let _ = input("<esc>");
   let _context = command("e!");

--- a/test/reason-libvim/UndoTest.re
+++ b/test/reason-libvim/UndoTest.re
@@ -1,0 +1,85 @@
+open EditorCoreTypes;
+open Vim;
+open TestFramework;
+
+let resetBuffer = () =>
+  Helpers.resetBuffer("test/reason-libvim/testfile.txt");
+let input = s => ignore(Vim.input(s));
+
+describe("Undo", ({describe, _}) => {
+  describe("saveRegion", ({test, _}) => {
+    test("undo whole buffer", ({expect, _}) => {
+      let buffer = resetBuffer();
+
+      Vim.Testing.Undo.saveRegion(0, 4);
+      Buffer.setLines(~lines=[|"a", "b", "c"|], buffer);
+
+      let index0 = Index.zero;
+      let index1 = Index.(zero + 1);
+      let index2 = Index.(zero + 2);
+
+      expect.equal(Buffer.getLine(buffer, index0), "a");
+      expect.equal(Buffer.getLine(buffer, index1), "b");
+      expect.equal(Buffer.getLine(buffer, index2), "c");
+
+      input("u");
+
+      expect.equal(
+        Buffer.getLine(buffer, index0),
+        "This is the first line of a test file",
+      );
+      expect.equal(
+        Buffer.getLine(buffer, index1),
+        "This is the second line of a test file",
+      );
+      expect.equal(
+        Buffer.getLine(buffer, index2),
+        "This is the third line of a test file",
+      );
+    });
+
+    test("undo is clamped to buffer size", ({expect, _}) => {
+      let buffer = resetBuffer();
+      Buffer.setLines(~lines=[|"d", "e", "f"|], buffer);
+
+      Vim.Testing.Undo.saveRegion(-1, 5);
+      Buffer.setLines(~lines=[|"a", "b", "c"|], buffer);
+
+      let index0 = Index.zero;
+      let index1 = Index.(zero + 1);
+      let index2 = Index.(zero + 2);
+
+      expect.equal(Buffer.getLine(buffer, index0), "a");
+      expect.equal(Buffer.getLine(buffer, index1), "b");
+      expect.equal(Buffer.getLine(buffer, index2), "c");
+
+      input("u");
+
+      expect.equal(Buffer.getLine(buffer, index0), "d");
+      expect.equal(Buffer.getLine(buffer, index1), "e");
+      expect.equal(Buffer.getLine(buffer, index2), "f");
+    });
+
+    test("undo partial buffer", ({expect, _}) => {
+      let buffer = resetBuffer();
+
+      Buffer.setLines(~lines=[|"0", "1", "2"|], buffer);
+      Vim.Testing.Undo.saveRegion(0, 2);
+      Buffer.setLines(~lines=[|"a", "b", "c"|], buffer);
+
+      let index0 = Index.zero;
+      let index1 = Index.(zero + 1);
+      let index2 = Index.(zero + 2);
+
+      expect.equal(Buffer.getLine(buffer, index0), "a");
+      expect.equal(Buffer.getLine(buffer, index1), "b");
+      expect.equal(Buffer.getLine(buffer, index2), "c");
+
+      input("u");
+
+      expect.equal(Buffer.getLine(buffer, index0), "0");
+      expect.equal(Buffer.getLine(buffer, index1), "b");
+      expect.equal(Buffer.getLine(buffer, index2), "c");
+    });
+  })
+});


### PR DESCRIPTION
__Issue:__ Sometimes, the formatting changes that would come from the extension host would not be un-doable.

__Defect:__ 

There were a couple of bugs here:

First, when making a format request, the format provider can sometimes send edits that are out of range. For example, when formatting a buffer that is 90 lines long, sometimes the edits will actually say they are editing up to line 94. This part is handled OK - we should handle this gracefully.

However, when we were communicating the undo region, prior to applying the edits, we would use the end line from the format request, that could be out of range.

We'd hit this logic:
```
  if (top >= bot || bot > curbuf->b_ml.ml_line_count + 1)
    return FAIL; // rely on caller to give an error message
```
- the `u_save` function would not create an undo if we exceeded the ranges for the buffer: https://github.com/onivim/libvim/blob/1ab7a7ecfbedc4c0b737273fe68f4b216f6acf0d/src/undo.c#L241

__Fix:__

We should validate the bounds of the undo request, and worst case, clamp them to the boundaries - this will be more resilient even if we get out-of-bounds edits.

This should fix #2052 