### PR TITLE
feat(extensions): Add search API to query open-vsx store

### DIFF
--- a/src/Service/Extensions/Service_Extensions.re
+++ b/src/Service/Extensions/Service_Extensions.re
@@ -7,9 +7,35 @@ module Url = {
   let extensionInfo = (publisher, id) => {
     Printf.sprintf("%s/%s/%s", Constants.baseUrl, publisher, id);
   };
+
+  let search = (~offset, ~query) => {
+    Printf.sprintf(
+      "%s/-/search?query=%s&offset=%d",
+      Constants.baseUrl,
+      query,
+      offset,
+    );
+  };
 };
 
 module Catalog = {
+  module Identifier = {
+    type t = {
+      publisher: string,
+      name: string,
+    };
+
+    let fromString = str => {
+      let items = String.split_on_char('.', str);
+      switch (items) {
+      | [publisher, name] => Some({publisher, name})
+      | _ => None
+      };
+    };
+
+    let toString = ({publisher, name}) =>
+      String.concat("", [publisher, ".", name]);
+  };
   module VersionInfo = {
     type t = {
       version: string,
@@ -26,7 +52,7 @@ module Catalog = {
       Printf.sprintf(" - Version %s: %s", version, url);
   };
 
-  module Entry = {
+  module Details = {
     type t = {
       downloadUrl: string,
       repositoryUrl: string,
@@ -94,21 +120,99 @@ module Catalog = {
     };
   };
 
-  let toPublisherName = str => {
-    let items = String.split_on_char('.', str);
-    switch (items) {
-    | [publisher, id] => Some((publisher, id))
-    | _ => None
+  let details = (~setup, {publisher, name}: Identifier.t) => {
+    let url = Url.extensionInfo(publisher, name);
+    Service_Net.Request.json(~setup, ~decoder=Details.Decode.decode, url);
+  };
+
+  module Summary = {
+    type t = {
+      url: string,
+      downloadUrl: string,
+      iconUrl: option(string),
+      version: string,
+      name: string,
+      namespace: string,
+      displayName: string,
+      description: string,
+    };
+
+    let decode = {
+      open Json.Decode;
+
+      let downloadUrl = field("files", field("download", string));
+      let iconUrl = field("files", field("icon", nullable(string)));
+
+      obj(({field, whatever, _}) =>
+        {
+          url: field.required("url", string),
+          downloadUrl: whatever(downloadUrl),
+          iconUrl: whatever(iconUrl),
+          version: field.required("version", string),
+          name: field.required("name", string),
+          namespace: field.required("namespace", string),
+          displayName: field.required("displayName", string),
+          description: field.required("description", string),
+        }
+      );
+    };
+
+    let toString =
+        ({displayName, description, version, url, namespace, name, _}) => {
+      Printf.sprintf(
+        {|%s.%s:
+- Name: %s
+- Description: %s
+- Url: %s
+- Version: %s
+      |},
+        namespace,
+        name,
+        displayName,
+        description,
+        url,
+        version,
+      );
     };
   };
 
-  let query = (~setup, id) => {
-    switch (toPublisherName(id)) {
-    | None => Lwt.fail_with("Invalid id: " ++ id)
-    | Some((publisher, name)) =>
-      let url = Url.extensionInfo(publisher, name);
-
-      Service_Net.Request.json(~setup, ~decoder=Entry.Decode.decode, url);
+  module SearchResponse = {
+    type t = {
+      offset: int,
+      totalSize: int,
+      extensions: list(Summary.t),
     };
+
+    let decode = {
+      Json.Decode.(
+        obj(({field, _}) =>
+          {
+            offset: field.required("offset", int),
+            totalSize: field.required("totalSize", int),
+            extensions:
+              field.withDefault("extensions", [], list(Summary.decode)),
+          }
+        )
+      );
+    };
+
+    let toString = ({offset, totalSize, extensions}) => {
+      let extensionCount = List.length(extensions);
+
+      let extensionStrings =
+        extensions |> List.map(Summary.toString) |> String.concat("---\n");
+      Printf.sprintf(
+        "Showing extensions %d - %d of %d\n%s",
+        offset,
+        offset + extensionCount,
+        totalSize,
+        extensionStrings,
+      );
+    };
+  };
+
+  let search = (~offset, ~setup, query) => {
+    let url = Url.search(~query, ~offset);
+    Service_Net.Request.json(~setup, ~decoder=SearchResponse.decode, url);
   };
 };

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -1,5 +1,15 @@
 open Oni_Core;
 module Catalog: {
+  module Identifier: {
+    type t = {
+      publisher: string,
+      name: string,
+    };
+
+    let fromString: string => option(t);
+    let toString: t => string;
+  };
+
   module VersionInfo: {
     type t = {
       version: string,
@@ -7,7 +17,7 @@ module Catalog: {
     };
   };
 
-  module Entry: {
+  module Details: {
     type t = {
       downloadUrl: string,
       repositoryUrl: string,
@@ -29,5 +39,32 @@ module Catalog: {
     let toString: t => string;
   };
 
-  let query: (~setup: Setup.t, string) => Lwt.t(Entry.t);
+  module Summary: {
+    type t = {
+      url: string,
+      downloadUrl: string,
+      iconUrl: option(string),
+      version: string,
+      name: string,
+      namespace: string,
+      displayName: string,
+      description: string,
+    };
+
+    let toString: t => string;
+  };
+
+  module SearchResponse: {
+    type t = {
+      offset: int,
+      totalSize: int,
+      extensions: list(Summary.t),
+    };
+
+    let toString: t => string;
+  };
+
+  let details: (~setup: Setup.t, Identifier.t) => Lwt.t(Details.t);
+  let search:
+    (~offset: int, ~setup: Setup.t, string) => Lwt.t(SearchResponse.t);
 };


### PR DESCRIPTION
This hooks up an API call for us to query against the open-vsx registry for extensions. There's no UI exposed for this, yet, but some output is shown when running `--query-extension`, ie:

`oni2 --query-extension java` results in:

```
Showing extensions 0 - 16 of 16
redhat.java:
- Name: Language Support for Java(TM) by Red Hat
- Description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
- Url: https://open-vsx.org/api/redhat/java
- Version: 0.63.0
      ---
vscode.java:
- Name: Java Language Basics (built-in)
- Description: Provides snippets, syntax highlighting, bracket matching and folding in Java files.
- Url: https://open-vsx.org/api/vscode/java
- Version: 1.46.1
      ---
vscjava.vscode-maven:
- Name: Maven for Java
- Description: Manage Maven projects, execute goals, generate project from archetype, improve user experience for Java developers.
- Url: https://open-vsx.org/api/vscjava/vscode-maven
- Version: 0.21.2
      ---
```