### PR TITLE
fix(windows): Remove 'detached' flag for NodeTask

### DIFF
--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -29,7 +29,6 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
     let%bind _: Luv.Process.t =
       LuvEx.Process.spawn(
         ~on_exit,
-        ~detached=true,
         ~redirect=[
           Luv.Process.to_parent_pipe(
             ~fd=Luv.Process.stdout,


### PR DESCRIPTION
The 'detached' flag causes a new console window to be allocated on Windows - similar issue to #1744 / #1746 