### PR TITLE
refactor(exthost): Add $deltaExtensions API

### DIFF
--- a/src/Exthost/Client.re
+++ b/src/Exthost/Client.re
@@ -34,10 +34,16 @@ let start =
   let requestIdToReply = Hashtbl.create(128);
   let send = message =>
     switch (protocolClient^) {
-    | None => ()
+    | None =>
+      Log.warnf(m =>
+        m(
+          "Tried to send message before protocolClient: %s, could not send",
+          Protocol.Message.Outgoing.show(message),
+        )
+      )
     | Some(protocol) =>
-      Log.info(
-        "Sending message: " ++ Protocol.Message.Outgoing.show(message),
+      Log.infof(m =>
+        m("Sending message: %s", Protocol.Message.Outgoing.show(message))
       );
       Protocol.send(~message, protocol);
     };
@@ -199,6 +205,14 @@ let notify =
       ~args,
       {lastRequestId, client, initPromise, _}: t,
     ) => {
+  Log.tracef(m =>
+    m(
+      "Sending request to %s:%s with args %s",
+      rpcName,
+      method,
+      args |> Yojson.Safe.to_string,
+    )
+  );
   Lwt.on_success(
     initPromise,
     () => {

--- a/src/Exthost/ExtensionActivationReason.re
+++ b/src/Exthost/ExtensionActivationReason.re
@@ -1,0 +1,22 @@
+open Oni_Core;
+
+type t = {
+  startup: bool,
+  extensionId: ExtensionId.t,
+  activationEvent: string,
+};
+
+let create = (~startup: bool, ~extensionId: string, ~activationEvent) => {
+  startup,
+  extensionId,
+  activationEvent,
+};
+
+let encode = ({startup, extensionId, activationEvent}) =>
+  Json.Encode.(
+    obj([
+      ("startup", startup |> bool),
+      ("extensionId", extensionId |> ExtensionId.encode),
+      ("activationEvent", activationEvent |> string),
+    ])
+  );

--- a/src/Exthost/ExtensionId.re
+++ b/src/Exthost/ExtensionId.re
@@ -13,3 +13,5 @@ let decode =
       one_of([("simple", simple), ("value", value)]);
     }
   );
+
+let encode = Json.Encode.string;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -18,6 +18,7 @@ module DocumentSelector = DocumentSelector;
 module DocumentSymbol = DocumentSymbol;
 module Edit = Edit;
 module Eol = Eol;
+module ExtensionActivationReason = ExtensionActivationReason;
 module ExtensionId = ExtensionId;
 module FormattingOptions = FormattingOptions;
 module Hover = Hover;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1053,6 +1053,14 @@ module Request: {
 
   module ExtensionService: {
     let activateByEvent: (~event: string, Client.t) => unit;
+
+    let deltaExtensions:
+      (
+        ~toAdd: list(Exthost_Extension.InitData.Extension.t),
+        ~toRemove: list(ExtensionId.t),
+        Client.t
+      ) =>
+      Lwt.t(unit);
   };
 
   module LanguageFeatures: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -117,6 +117,15 @@ module Edit: {
   };
 };
 
+module ExtensionActivationReason: {
+  type t;
+
+  let create:
+    (~startup: bool, ~extensionId: string, ~activationEvent: string) => t;
+
+  let encode: Json.encoder(t);
+};
+
 module ExtensionId: {
   [@deriving show]
   type t = string;
@@ -1053,6 +1062,10 @@ module Request: {
 
   module ExtensionService: {
     let activateByEvent: (~event: string, Client.t) => unit;
+
+    let activate:
+      (~extensionId: string, ~reason: ExtensionActivationReason.t, Client.t) =>
+      Lwt.t(bool);
 
     let deltaExtensions:
       (

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -186,6 +186,20 @@ module ExtensionService = {
     );
   };
 
+  let activate = (~extensionId, ~reason, client) => {
+    Client.request(
+      ~decoder=Json.Decode.bool,
+      ~rpcName="ExtHostExtensionService",
+      ~method="$activate",
+      ~args=
+        `List([
+          extensionId |> encode_value(string),
+          reason |> encode_value(ExtensionActivationReason.encode),
+        ]),
+      client,
+    );
+  };
+
   let deltaExtensions = (~toAdd, ~toRemove, client) => {
     Client.request(
       ~decoder=Json.Decode.null,

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -176,11 +176,28 @@ module DocumentsAndEditors = {
 };
 
 module ExtensionService = {
+  open Json.Encode;
   let activateByEvent = (~event, client) => {
     Client.notify(
       ~rpcName="ExtHostExtensionService",
       ~method="$activateByEvent",
       ~args=`List([`String(event)]),
+      client,
+    );
+  };
+
+  let deltaExtensions = (~toAdd, ~toRemove, client) => {
+    Client.request(
+      ~decoder=Json.Decode.null,
+      ~rpcName="ExtHostExtensionService",
+      ~method="$deltaExtensions",
+      ~args=
+        `List([
+          `List(
+            toAdd |> List.map(Exthost_Extension.InitData.Extension.to_yojson),
+          ),
+          `List(toRemove |> List.map(encode_value(ExtensionId.encode))),
+        ]),
       client,
     );
   };

--- a/test/Exthost/ActivationEventsTest.re
+++ b/test/Exthost/ActivationEventsTest.re
@@ -51,77 +51,61 @@ describe("ActivationEventsTest", ({describe, _}) => {
     })
   });
   describe("deltaExtensions", ({test, _}) => {
-    test("wildcard", _
-      => {
-        let extensionToAdd = Test.getExtensionManifest("oni-always-activate");
-        let waitForActivation =
-          fun
-          | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
-            extensionId == "oni-always-activate"
-          | _ => false;
+    test("wildcard", _ => {
+      let extensionToAdd = Test.getExtensionManifest("oni-always-activate");
+      let waitForActivation =
+        fun
+        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
+          extensionId == "oni-always-activate"
+        | _ => false;
 
-        Test.startWithExtensions([])
-        |> Test.waitForReady
-        |> Test.waitForInitialized
-        |> Test.withClientRequest(
-             ~name="$deltaExtensions: add oni-always-activate",
-             ~validate=
-               () => {
-                 prerr_endline("GOT MESSAGE");
-                 true;
-               },
-             client => {
-               prerr_endline("SENDING MESSAGE!");
-               Exthost.Request.ExtensionService.deltaExtensions(
-                 ~toAdd=[extensionToAdd],
-                 ~toRemove=[],
-                 client,
-               );
-             },
-           )
-        |> Test.activate(
-             ~extensionId="oni-always-activate",
-             ~reason=
-               Exthost.ExtensionActivationReason.create(
-                 ~extensionId="oni-always-activate",
-                 ~startup=true,
-                 ~activationEvent="*",
-               ),
-           )
-        |> Test.waitForMessage(~name="Activation", waitForActivation)
-        |> Test.terminate
-        |> Test.waitForProcessClosed;
-      })
-      //    test("onLanguage:testlang", _ => {
-      //      let extensionToAdd = Test.getExtensionManifest("oni-activation-events");
-      //      let waitForActivation =
-      //        fun
-      //        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
-      //          extensionId == "oni-activation-events"
-      //        | _ => false;
-      //
-      //      Test.startWithExtensions([])
-      //      |> Test.waitForReady
-      //      |> Test.waitForInitialized
-      //      |> Test.withClientRequest(
-      //        ~name="$deltaExtensions: add oni-activation-events",
-      //        ~validate=() => {
-      //          prerr_endline ("GOT MESSAGE");
-      //          true;
-      //        },
-      //        (client) => {
-      //          prerr_endline ("SENDING MESSAGE!");
-      //          Exthost.Request.ExtensionService.deltaExtensions(
-      //            ~toAdd=[extensionToAdd],
-      //            ~toRemove=[],
-      //            client
-      //          );
-      //        }
-      //      )
-      //      |> Test.activateByEvent(~event="onLanguage:testlang")
-      //      |> Test.waitForMessage(~name="Activation", waitForActivation)
-      //      |> Test.terminate
-      //      |> Test.waitForProcessClosed;
-      //    })
+      Test.startWithExtensions([])
+      |> Test.waitForReady
+      |> Test.waitForInitialized
+      |> Test.withClientRequest(
+           ~name="$deltaExtensions: add oni-always-activate",
+           ~validate=() => true,
+           Exthost.Request.ExtensionService.deltaExtensions(
+             ~toAdd=[extensionToAdd],
+             ~toRemove=[],
+           ),
+         )
+      |> Test.activate(
+           ~extensionId="oni-always-activate",
+           ~reason=
+             Exthost.ExtensionActivationReason.create(
+               ~extensionId="oni-always-activate",
+               ~startup=true,
+               ~activationEvent="*",
+             ),
+         )
+      |> Test.waitForMessage(~name="Activation", waitForActivation)
+      |> Test.terminate
+      |> Test.waitForProcessClosed;
+    });
+    test("onLanguage:testlang", _ => {
+      let extensionToAdd = Test.getExtensionManifest("oni-activation-events");
+      let waitForActivation =
+        fun
+        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
+          extensionId == "oni-activation-events"
+        | _ => false;
+
+      Test.startWithExtensions([])
+      |> Test.waitForReady
+      |> Test.waitForInitialized
+      |> Test.withClientRequest(
+           ~name="$deltaExtensions: add oni-activation-events",
+           ~validate=() => true,
+           Exthost.Request.ExtensionService.deltaExtensions(
+             ~toAdd=[extensionToAdd],
+             ~toRemove=[],
+           ),
+         )
+      |> Test.activateByEvent(~event="onLanguage:testlang")
+      |> Test.waitForMessage(~name="Activation", waitForActivation)
+      |> Test.terminate
+      |> Test.waitForProcessClosed;
+    });
   });
 });

--- a/test/Exthost/ActivationEventsTest.re
+++ b/test/Exthost/ActivationEventsTest.re
@@ -50,4 +50,78 @@ describe("ActivationEventsTest", ({describe, _}) => {
       |> Test.waitForProcessClosed;
     })
   });
+  describe("deltaExtensions", ({test, _}) => {
+    test("wildcard", _
+      => {
+        let extensionToAdd = Test.getExtensionManifest("oni-always-activate");
+        let waitForActivation =
+          fun
+          | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
+            extensionId == "oni-always-activate"
+          | _ => false;
+
+        Test.startWithExtensions([])
+        |> Test.waitForReady
+        |> Test.waitForInitialized
+        |> Test.withClientRequest(
+             ~name="$deltaExtensions: add oni-always-activate",
+             ~validate=
+               () => {
+                 prerr_endline("GOT MESSAGE");
+                 true;
+               },
+             client => {
+               prerr_endline("SENDING MESSAGE!");
+               Exthost.Request.ExtensionService.deltaExtensions(
+                 ~toAdd=[extensionToAdd],
+                 ~toRemove=[],
+                 client,
+               );
+             },
+           )
+        |> Test.activate(
+             ~extensionId="oni-always-activate",
+             ~reason=
+               Exthost.ExtensionActivationReason.create(
+                 ~extensionId="oni-always-activate",
+                 ~startup=true,
+                 ~activationEvent="*",
+               ),
+           )
+        |> Test.waitForMessage(~name="Activation", waitForActivation)
+        |> Test.terminate
+        |> Test.waitForProcessClosed;
+      })
+      //    test("onLanguage:testlang", _ => {
+      //      let extensionToAdd = Test.getExtensionManifest("oni-activation-events");
+      //      let waitForActivation =
+      //        fun
+      //        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
+      //          extensionId == "oni-activation-events"
+      //        | _ => false;
+      //
+      //      Test.startWithExtensions([])
+      //      |> Test.waitForReady
+      //      |> Test.waitForInitialized
+      //      |> Test.withClientRequest(
+      //        ~name="$deltaExtensions: add oni-activation-events",
+      //        ~validate=() => {
+      //          prerr_endline ("GOT MESSAGE");
+      //          true;
+      //        },
+      //        (client) => {
+      //          prerr_endline ("SENDING MESSAGE!");
+      //          Exthost.Request.ExtensionService.deltaExtensions(
+      //            ~toAdd=[extensionToAdd],
+      //            ~toRemove=[],
+      //            client
+      //          );
+      //        }
+      //      )
+      //      |> Test.activateByEvent(~event="onLanguage:testlang")
+      //      |> Test.waitForMessage(~name="Activation", waitForActivation)
+      //      |> Test.terminate
+      //      |> Test.waitForProcessClosed;
+      //    })
+  });
 });

--- a/test/Exthost/ExtensionsTest.re
+++ b/test/Exthost/ExtensionsTest.re
@@ -29,7 +29,7 @@ let waitForExtensionsEvent = (~name, f, context) => {
      );
 };
 
-// Test cases for the vscode extesnsions API:
+// Test cases for the vscode extensions API:
 // https://code.visualstudio.com/api/references/vscode-api#extensions
 describe("ExtensionsTest", ({test, _}) => {
   test("change workspaces", ({expect, _}) => {

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -640,6 +640,25 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
          )
       |> finishTest;
     });
+    test("range formatting: extension ID is correct", _ => {
+      let waitForRegisterRangeFormattingSupport =
+        fun
+        | Msg.LanguageFeatures(
+            RegisterRangeFormattingSupport({extensionId, displayName, _}),
+          ) => {
+            extensionId == "oni-language-features"
+            && displayName == "oni-language-features";
+          }
+        | _ => false;
+
+      startTest()
+      |> Test.waitForMessage(
+           ~name="RegisterRangeFormattingSupport",
+           waitForRegisterRangeFormattingSupport,
+         )
+      |> finishTest;
+    });
+
     test("range formatting", ({expect, _}) => {
       let documentRangeFormattingHandle = ref(-1);
 

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -60,8 +60,6 @@ let startWithExtensions =
 
   Timber.App.enable();
 
-  Timber.App.setLevel(Timber.Level.trace);
-
   let extensions =
     extensions
     |> List.map(Rench.Path.join(rootPath))

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -18,6 +18,24 @@ type t = {
 let noopHandler = _ => Lwt.return(Reply.okEmpty);
 let noopErrorHandler = _ => ();
 
+let getExtensionManifest =
+    (
+      ~rootPath=Rench.Path.join(Sys.getcwd(), "test/collateral/extensions"),
+      name,
+    ) => {
+  name
+  |> Rench.Path.join(rootPath)
+  |> (
+    p =>
+      Rench.Path.join(p, "package.json")
+      |> Scanner.load(~category=Scanner.Bundled)
+      |> Option.map(({manifest, path, _}: Extension.Scanner.ScanResult.t) => {
+           InitData.Extension.ofManifestAndPath(manifest, path)
+         })
+      |> Option.get
+  );
+};
+
 let startWithExtensions =
     (
       ~rootPath=Rench.Path.join(Sys.getcwd(), "test/collateral/extensions"),
@@ -41,6 +59,8 @@ let startWithExtensions =
   };
 
   Timber.App.enable();
+
+  Timber.App.setLevel(Timber.Level.trace);
 
   let extensions =
     extensions
@@ -149,6 +169,10 @@ let waitForReady = context => {
   waitForMessage(~name="Ready", msg => msg == Ready, context);
 };
 
+let waitForInitialized = context => {
+  waitForMessage(~name="Initialized", msg => msg == Initialized, context);
+};
+
 let waitForExtensionActivation = (expectedExtensionId, context) => {
   let waitForActivation =
     fun
@@ -189,6 +213,15 @@ let withClientRequest = (~name, ~validate, f, context) => {
   );
 
   context;
+};
+
+let activate = (~extensionId, ~reason, context) => {
+  context
+  |> withClientRequest(
+       ~name="Activating extension: " ++ extensionId,
+       ~validate=v => v,
+       Exthost.Request.ExtensionService.activate(~extensionId, ~reason),
+     );
 };
 
 let validateNoPendingRequests = context => {


### PR DESCRIPTION
The vscode extension host exposes a `deltaExtensions` API - an API where we can load extensions on-demand (right now, we only load extensions on startup).

This is helpful for two use cases for us:
1) When installing an extension, we can activate it immediately, without needing the user to restart the extension host or editor
2) We could make our extension loading on startup asynchronous, and stream extensions to the `deltaExtensions` API as we load (right now, extension loading is totally synchronous on startup - not ideal for startup perf!)

This adds an API for calling into via our `Exthost` module, along with some simple test cases.