### PR TITLE
fix(exthost): Successful install and load extension (flutter/dart) (#2097)

### DIFF
--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -126,6 +126,12 @@ module Contributions: {
 };
 
 module Manifest: {
+  module Kind: {
+    [@deriving show]
+    type t =
+      | Ui
+      | Workspace;
+  };
   [@deriving show]
   type t = {
     name: string,
@@ -142,16 +148,15 @@ module Manifest: {
     activationEvents: list(string),
     extensionDependencies: list(string),
     extensionPack: list(string),
-    extensionKind: list(string),
+    extensionKind: list(Kind.t),
     contributes: Contributions.t,
     enableProposedApi: bool,
-  }
+  };
 
   let decode: Oni_Core.Json.decoder(t);
 
   let identifier: t => string;
   let getDisplayName: t => string;
-
 };
 
 module Scanner: {

--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -142,21 +142,16 @@ module Manifest: {
     activationEvents: list(string),
     extensionDependencies: list(string),
     extensionPack: list(string),
-    extensionKind: kind,
+    extensionKind: list(string),
     contributes: Contributions.t,
     enableProposedApi: bool,
   }
-
-  and kind =
-    | Ui
-    | Workspace;
 
   let decode: Oni_Core.Json.decoder(t);
 
   let identifier: t => string;
   let getDisplayName: t => string;
 
-  module Encode: {let kind: Oni_Core.Json.encoder(kind);};
 };
 
 module Scanner: {
@@ -199,7 +194,7 @@ module InitData: {
       engines: string,
       activationEvents: list(string),
       extensionDependencies: list(string),
-      extensionKind: string,
+      extensionKind: list(string),
       enableProposedApi: bool,
     };
 

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -24,7 +24,7 @@ module Extension = {
     engines: string,
     activationEvents: list(string),
     extensionDependencies: list(string),
-    extensionKind: string,
+    extensionKind: list(string),
     enableProposedApi: bool,
   };
 
@@ -41,7 +41,7 @@ module Extension = {
     activationEvents: manifest.activationEvents,
     extensionDependencies: manifest.extensionDependencies,
     // TODO: Convert correctly
-    extensionKind: "ui",
+    extensionKind: ["ui"],
     enableProposedApi: manifest.enableProposedApi,
   };
 };

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -40,8 +40,7 @@ module Extension = {
     engines: manifest.engines,
     activationEvents: manifest.activationEvents,
     extensionDependencies: manifest.extensionDependencies,
-    // TODO: Convert correctly
-    extensionKind: ["ui"],
+    extensionKind: manifest.extensionKind |> List.map(Manifest.Kind.toString),
     enableProposedApi: manifest.enableProposedApi,
   };
 };

--- a/src/Exthost/Extension/Manifest.re
+++ b/src/Exthost/Extension/Manifest.re
@@ -13,6 +13,11 @@ module Kind = {
     | Ui
     | Workspace;
 
+  let toString =
+    fun
+    | Ui => "ui"
+    | Workspace => "workspace";
+
   module Decode = {
     open Json.Decode;
 

--- a/src/Exthost/Extension/Manifest.re
+++ b/src/Exthost/Extension/Manifest.re
@@ -23,7 +23,7 @@ type t = {
   activationEvents: list(string),
   extensionDependencies: list(string),
   extensionPack: list(string),
-  extensionKind: kind,
+  extensionKind: list(string),
   contributes: Contributions.t,
   enableProposedApi: bool,
 }
@@ -45,15 +45,6 @@ let displayName = ({displayName, _}) => {
 
 module Decode = {
   open Json.Decode;
-
-  let kind =
-    string
-    |> map(
-         fun
-         | "ui" => Ui
-         | "workspace" => Workspace
-         | _ => Ui,
-       );
 
   let author =
     one_of([("string", string), ("object", field("name", string))]);
@@ -88,7 +79,7 @@ module Decode = {
             field.withDefault("extensionDependencies", [], list(string)),
           extensionPack:
             field.withDefault("extensionPack", [], list(string)),
-          extensionKind: field.withDefault("extensionKind", Ui, kind),
+          extensionKind: field.withDefault("extensionKind", [], list(string)),
           contributes:
             field.withDefault(
               "contributes",
@@ -103,12 +94,6 @@ module Decode = {
 };
 
 module Encode = {
-  let kind =
-    Json.Encode.(
-      fun
-      | Ui => string("ui")
-      | Workspace => string("workspace")
-    );
 };
 
 let decode = Decode.manifest;


### PR DESCRIPTION
Change property extensionKind to list of strings as described in
https://code.visualstudio.com/api/advanced-topics/remote-extensions#:~:text=%22extensionKind%22%3A%20%5B%22workspace,extensions%20fall%20into%20this%20category

The property extensionKind have only
  "extensionKind": ["workspace"]
  "extensionKind": ["ui"]
  "extensionKind": ["ui", "workspace"]
  "extensionKind": ["workspace", "ui"]

Therefore the old way "extensionKind":"workspace" or "extensionKind": "ui"
is not valid anymore and has also be updated in InitData.re

Fixes #2097