### PR TITLE
fix: Revert change to Control+V binding

### DIFF
--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -71,7 +71,7 @@ let start = maybeKeyBindingsFilePath => {
       {
         key: "<C-V>",
         command: Feature_Clipboard.Commands.paste.id,
-        condition: "insertMode || commandLineFocus" |> WhenExpr.parse, 
+        condition: "insertMode || commandLineFocus" |> WhenExpr.parse,
       },
       {
         key: "<D-V>",

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -71,7 +71,7 @@ let start = maybeKeyBindingsFilePath => {
       {
         key: "<C-V>",
         command: Feature_Clipboard.Commands.paste.id,
-        condition: WhenExpr.Value(True),
+        condition: "insertMode || commandLineFocus" |> WhenExpr.parse, 
       },
       {
         key: "<D-V>",


### PR DESCRIPTION
Fix regression from #2092, which breaks entering visual block mode.