### PR TITLE
fix(extensions): Fix stale results when searching extensions

### DIFF
--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -208,10 +208,12 @@ let update = (~extHostClient, msg, model) => {
         ~query=model.latestQuery,
       );
     ({...model, searchText: searchText', latestQuery}, Focus);
-  | SearchQueryResults(queryResults) => (
-      {...model, latestQuery: Some(queryResults)},
-      Nothing,
-    )
+  | SearchQueryResults(queryResults) =>
+    queryResults
+    |> Service_Extensions.Query.searchText
+    == (model.searchText |> Feature_InputText.value)
+      ? ({...model, latestQuery: Some(queryResults)}, Nothing)
+      : (model, Nothing)
   | SearchQueryError(_queryResults) =>
     // TODO: Error experience?
     ({...model, latestQuery: None}, Nothing)

--- a/src/Service/Extensions/Query.re
+++ b/src/Service/Extensions/Query.re
@@ -21,6 +21,7 @@ let isComplete = ({maybeRemainingCount, _}) => {
 };
 
 let results = ({items, _}) => items;
+let searchText = ({searchText, _}) => searchText;
 
 let percentComplete = ({items, maybeRemainingCount, _}) => {
   switch (maybeRemainingCount) {

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -93,6 +93,7 @@ module Query: {
   let create: (~searchText: string) => t;
 
   let isComplete: t => bool;
+  let searchText: t => string;
   let percentComplete: t => float;
   let results: t => list(Catalog.Summary.t);
 };


### PR DESCRIPTION
__Issue:__ There was a race condition in our search experience - if a long-running query gave results after a short-lived query, it would displace the more recent one.

__Defect:__ We always assumed the latest query was the right one.

__Fix:__ Verify the search text for the query results matches the current search text