### PR TITLE
fix(exthost): Populate TelemetryInfo for extensions

### DIFF
--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -257,9 +257,10 @@ module InitData: {
   module TelemetryInfo: {
     [@deriving (show, yojson({strict: false}))]
     type t = {
-      sessionId: int,
-      machineId: int,
-      instanceId: int,
+      sessionId: string,
+      machineId: string,
+      instanceId: string,
+      msftInternal: bool,
     };
 
     let default: t;

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -99,12 +99,18 @@ module Remote = {
 module TelemetryInfo = {
   [@deriving (show, yojson({strict: false}))]
   type t = {
-    sessionId: int,
-    machineId: int,
-    instanceId: int,
+    sessionId: string,
+    machineId: string,
+    instanceId: string,
+    msftInternal: bool,
   };
 
-  let default = {sessionId: 0, machineId: 0, instanceId: 0};
+  let default = {
+    sessionId: "Anonymous",
+    machineId: "Anonymous",
+    instanceId: "Anonymous",
+    msftInternal: false,
+  };
 };
 
 [@deriving (show, yojson({strict: false}))]

--- a/src/Service/Extensions/Catalog.re
+++ b/src/Service/Extensions/Catalog.re
@@ -174,7 +174,7 @@ module Summary = {
         version: field.required("version", string),
         name: field.required("name", string),
         namespace: field.required("namespace", string),
-        displayName: field.required("displayName", nullable(string)),
+        displayName: field.optional("displayName", string),
         description: field.required("description", string),
       }
     );


### PR DESCRIPTION
Several first-party extensions rely on telemetry info being set in the extension host - we weren't sending it in the proper form. We don't actually populate or track these - so we just use 'Anonymous'.