### PR TITLE
fix(ux): Extension list should expand to fit sidebar

### DIFF
--- a/src/Feature/Extensions/ListView.re
+++ b/src/Feature/Extensions/ListView.re
@@ -9,7 +9,6 @@ module Colors = Feature_Theme.Colors;
 module Styles = {
   open Style;
   let container = (~width) => [
-    Style.width(width),
     flexDirection(`Column),
     flexGrow(1),
     overflow(`Hidden),

--- a/src/Feature/Extensions/ListView.re
+++ b/src/Feature/Extensions/ListView.re
@@ -8,11 +8,7 @@ module Colors = Feature_Theme.Colors;
 
 module Styles = {
   open Style;
-  let container = (~width) => [
-    flexDirection(`Column),
-    flexGrow(1),
-    overflow(`Hidden),
-  ];
+  let container = [flexDirection(`Column), flexGrow(1), overflow(`Hidden)];
   let input = [flexGrow(1), margin(12)];
 };
 
@@ -186,7 +182,7 @@ let%component make =
   let isBusy = Model.isSearchInProgress(model) || Model.isBusy(model);
 
   <View
-    style={Styles.container(~width)}
+    style=Styles.container
     onDimensionsChanged={({width, _}) =>
       localDispatch(WidthChanged(width))
     }>


### PR DESCRIPTION
The extensions pane was resizable, but the contents would not grow / stretch to fit the resized sidebar.

This fixes by removing the width constraint.