### PR TITLE
fix(extensions): Fix extension uninstall blockers

### DIFF
--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -232,7 +232,7 @@ let update = (~extHostClient, msg, model) => {
     (model |> Internal.addPendingUninstall(~extensionId), Effect(eff));
   | UninstallExtensionSuccess({extensionId}) => (
       model |> Internal.uninstalled(~extensionId),
-      NotifyFailure(
+      NotifySuccess(
         Printf.sprintf("Successfully uninstalled %s", extensionId),
       ),
     )

--- a/src/Service/Extensions/Effects.re
+++ b/src/Service/Extensions/Effects.re
@@ -1,3 +1,12 @@
+open Oni_Core.Utility;
+
+module Internal = {
+  let exceptionToString =
+    fun
+    | LuvEx.LuvException(exn) => Luv.Error.strerror(exn)
+    | exn => Printexc.to_string(exn);
+};
+
 let uninstall = (~extensionsFolder, ~toMsg, extensionId) =>
   Isolinear.Effect.createWithDispatch(
     ~name="Service_Extensions.Effect.uninstall", dispatch => {
@@ -5,7 +14,7 @@ let uninstall = (~extensionsFolder, ~toMsg, extensionId) =>
 
     Lwt.on_success(promise, () => dispatch(Ok()));
     Lwt.on_failure(promise, exn => {
-      dispatch(Error(Printexc.to_string(exn)))
+      dispatch(Error(Internal.exceptionToString(exn)))
     });
   })
   |> Isolinear.Effect.map(toMsg);
@@ -22,7 +31,7 @@ let install = (~extensionsFolder, ~toMsg, extensionId) =>
 
     Lwt.on_success(promise, scanResult => dispatch(Ok(scanResult)));
     Lwt.on_failure(promise, exn => {
-      dispatch(Error(Printexc.to_string(exn)))
+      dispatch(Error(Internal.exceptionToString(exn)))
     });
   })
   |> Isolinear.Effect.map(toMsg);

--- a/src/Service/Extensions/Management.re
+++ b/src/Service/Extensions/Management.re
@@ -165,7 +165,7 @@ let uninstall = (~extensionsFolder=?, extensionId) => {
     });
 
     Lwt.on_failure(promise, _ => {
-      Log.errorf(m => m("Unable to install extension: %s", extensionId))
+      Log.errorf(m => m("Unable to uninstall extension: %s", extensionId))
     });
 
     promise;

--- a/src/Service/OS/Service_OS.re
+++ b/src/Service/OS/Service_OS.re
@@ -118,20 +118,26 @@ module Api = {
            Lwt.bind(Internal.readdir(dir), dirents => {
              dirents
              |> Array.to_list
-             |> List.map((dirent: Luv.File.Dirent.t) => {
-                  let name = Rench.Path.join(candidate, dirent.name);
-                  switch (dirent.kind) {
-                  | `LINK
-                  | `FILE => unlink(Rench.Path.join(candidate, dirent.name))
-                  | `DIR => loop(Rench.Path.join(candidate, name))
-                  | _ =>
-                    Log.warnf(m =>
-                      m("Unknown file type encountered: %s", name)
-                    );
-                    Lwt.return();
-                  };
-                })
-             |> Lwt.join
+             |> List.fold_left(
+                  (acc, dirent: Luv.File.Dirent.t) => {
+                    acc
+                    |> LwtEx.flatMap(_ => {
+                         let name = Rench.Path.join(candidate, dirent.name);
+                         switch (dirent.kind) {
+                         | `LINK
+                         | `FILE =>
+                           unlink(Rench.Path.join(candidate, dirent.name))
+                         | `DIR => loop(Rench.Path.join(candidate, name))
+                         | _ =>
+                           Log.warnf(m =>
+                             m("Unknown file type encountered: %s", name)
+                           );
+                           Lwt.return();
+                         };
+                       })
+                  },
+                  Lwt.return(),
+                )
              |> bind(_ => Internal.closedir(dir))
              |> bind(_ => rmdirNonRecursive(candidate))
            })


### PR DESCRIPTION
__Issue:__ There were a few bugs with the uninstall experience:
1) The error messages coming from luv weren't readable via `Printexc.to_string`
2) On OSX, we were getting 'too many open files' error for large extensions
3) The uninstall notification was an 'error' even though it should be success'

__Fix:__
1) For luv exceptions, use `Luv.Error.strerror` to get a more readable form
2)The `rmdir` was heavily parallelized - this moves the operation to be sequential, which doesn't open as many files. It's a bit slower, so we may want to look at clustering or combining some of the operations up to a fixed limit.
3) Use proper notification kind