### PR TITLE
fix(extensions/#2140): Avoid hang in #2140 by removing text-overflow ellipsis

### DIFF
--- a/src/Feature/Extensions/ItemView.re
+++ b/src/Feature/Extensions/ItemView.re
@@ -25,7 +25,8 @@ module Styles = {
   let titleText = (~width, ~theme) => [
     color(Colors.SideBar.foreground.from(theme)),
     marginVertical(2),
-    textOverflow(`Ellipsis),
+    // TODO: Workaround for #2140
+    //textOverflow(`Ellipsis),
     Style.width(width),
   ];
   let versionText = (~width, ~theme) => [
@@ -43,7 +44,8 @@ module Styles = {
       |> Revery.Color.multiplyAlpha(0.75),
     ),
     marginVertical(2),
-    textOverflow(`Ellipsis),
+    // TODO: Workaround for #2140
+    //textOverflow(`Ellipsis),
     textWrap(Revery.TextWrapping.NoWrap),
   ];
   let imageContainer =


### PR DESCRIPTION
Temporary fix / workaround to avoid the hang in #2140 - searching the 'p' character would bring in an extension that had an emoji as a final character - and then a bug in our shaping / text-overflow would hang when we tried to shorten & ellipsize the text.  This works around it by removing the `textOverflow(Ellipsis)` style