### PR TITLE
fix(theme): Crash when XML not found

### DIFF
--- a/src/reason-textmate/Grammar.re
+++ b/src/reason-textmate/Grammar.re
@@ -2,6 +2,9 @@
  TextMateGrammar.re
  */
 
+open Oni_Core;
+open Oni_Core.Utility;
+
 type t = {
   initialScopeStack: ScopeStack.t,
   scopeName: string,
@@ -177,10 +180,11 @@ module Xml = {
   };
 
   let of_file = path => {
-    let%bind plist =
-      SimpleXml.of_file(path) |> Option.get |> XmlPlistParser.parse;
-
-    PlistDecoder.grammar(plist);
+    path
+    |> SimpleXml.of_file
+    |> Option.to_result(~none="Unable to load file: " ++ path)
+    |> ResultEx.flatMap(XmlPlistParser.parse)
+    |> ResultEx.flatMap(xml => PlistDecoder.grammar(xml));
   };
 };
 

--- a/src/reason-textmate/Theme.re
+++ b/src/reason-textmate/Theme.re
@@ -2,6 +2,8 @@
  Theme.re
  */
 
+open Oni_Core.Utility;
+
 open Rench;
 
 type t = {
@@ -164,10 +166,12 @@ let rec from_file = (~isDark=?, path: string) => {
       switch (Utility.JsonEx.from_file(path)) {
       | Ok(json) => Ok(of_yojson(~isDark?, ~themeLoader, json))
       | Error(_) =>
-        let%bind plist =
-          SimpleXml.of_file(path) |> Option.get |> XmlPlistParser.parse;
+          SimpleXml.of_file(path)
+          |> Option.to_result(~none="Unable to load file: " ++ path)
+          |> ResultEx.flatMap(XmlPlistParser.parse)
+          |> ResultEx.flatMap(
+        PlistDecoder.theme(~isDark?));
 
-        PlistDecoder.theme(~isDark?, plist);
       };
 
     Hashtbl.add(_themeCache, path, theme);

--- a/src/reason-textmate/Theme.re
+++ b/src/reason-textmate/Theme.re
@@ -166,12 +166,10 @@ let rec from_file = (~isDark=?, path: string) => {
       switch (Utility.JsonEx.from_file(path)) {
       | Ok(json) => Ok(of_yojson(~isDark?, ~themeLoader, json))
       | Error(_) =>
-          SimpleXml.of_file(path)
-          |> Option.to_result(~none="Unable to load file: " ++ path)
-          |> ResultEx.flatMap(XmlPlistParser.parse)
-          |> ResultEx.flatMap(
-        PlistDecoder.theme(~isDark?));
-
+        SimpleXml.of_file(path)
+        |> Option.to_result(~none="Unable to load file: " ++ path)
+        |> ResultEx.flatMap(XmlPlistParser.parse)
+        |> ResultEx.flatMap(PlistDecoder.theme(~isDark?))
       };
 
     Hashtbl.add(_themeCache, path, theme);


### PR DESCRIPTION
__Issue:__ In testing themes downloaded from open-vsx.org, some were crashing the editor on load.

__Defect:__ There was some code that was using `Option.get`, assuming that the file load would always be successful. Apparently - this isn't always the case.

__Fix:__ The code was very strange - it used `let%bind` for a monadic result, but didn't bother transforming from the option monad to the result monad... This transforms the `Option` to a `Result` monad, and flatMaps to return the final result.