### PR TITLE
feat(font): stylistic sets & other OpenType features

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "92e531b497ea7979ae6e49dc0bbf76a7",
+  "checksum": "b64b8f7a36bcf4e1824e6ab95ff90312",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -649,7 +649,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
-        "@reason-native-web/piaf@1.4.0@d41d8cd9",
+        "@reason-native-web/piaf@1.3.0@d41d8cd9",
         "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -1050,6 +1050,7 @@
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": [
@@ -1215,14 +1216,14 @@
       ],
       "devDependencies": []
     },
-    "@reason-native-web/piaf@1.4.0@d41d8cd9": {
-      "id": "@reason-native-web/piaf@1.4.0@d41d8cd9",
+    "@reason-native-web/piaf@1.3.0@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.0@d41d8cd9",
       "name": "@reason-native-web/piaf",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.4.0.tgz#sha1:da2d1a07b553989e032f51986873c4bdff936ed5"
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.0.tgz#sha1:d9b0e14ab13a424bdcb7945b221c8ec975f5f05b"
         ]
       },
       "overrides": [],
@@ -1272,7 +1273,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
         "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
@@ -1280,32 +1281,32 @@
       ],
       "devDependencies": []
     },
-    "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9": {
-      "id": "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9",
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
       "name": "@reason-native-web/h2-lwt",
-      "version": "0.6.1002",
+      "version": "0.6.1001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1002.tgz#sha1:ab32c96ef1d5eabe0685b30c2edfc296cb63d5a8"
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@reason-native-web/h2@0.6.1002@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
         "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
       ],
       "devDependencies": []
     },
-    "@reason-native-web/h2@0.6.1002@d41d8cd9": {
-      "id": "@reason-native-web/h2@0.6.1002@d41d8cd9",
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
       "name": "@reason-native-web/h2",
-      "version": "0.6.1002",
+      "version": "0.6.1001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1002.tgz#sha1:6918f1df7d74b3880c78c5a94b9e644de8fa7ecc"
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
         ]
       },
       "overrides": [],

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -33,6 +33,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.fontSmoothing` __(_"none"|"antialiased"|"subpixel-antialiased"_)__ - The smoothing strategy used when rendering fonts. The `"antialiased"` setting smooths font edges, and `"subpixel-antialiased"` means characters may be positioned fractionally on the pixel grid. 
 
+- `editor.fontLigatures` __(_string|bool_ default: `true`)__ - Sets whether or not font ligatures are enabled. When `true`, the font's default features are enabled. When `false`, contextual alternates and standard ligatues are disabled. If a string is entered, it must be of the form `"'tag1', 'tag2', ..."`, where each tag listed will be enabled. This is particularly useful for enabling stylistic sets, i.e. `"'ss01', 'ss02', ..."`.
+
 - `editor.hover.delay` __(_int_ default: `1000`)__ - The delay in milliseconds before showing the hover UI.
 
 - `editor.hover.enabled` __(_bool_ default: `true`)__ - Controls whether or not the hover UI is enabled.

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "92e531b497ea7979ae6e49dc0bbf76a7",
+  "checksum": "b64b8f7a36bcf4e1824e6ab95ff90312",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -649,7 +649,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
-        "@reason-native-web/piaf@1.4.0@d41d8cd9",
+        "@reason-native-web/piaf@1.3.0@d41d8cd9",
         "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -1049,6 +1049,7 @@
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": [
@@ -1214,14 +1215,14 @@
       ],
       "devDependencies": []
     },
-    "@reason-native-web/piaf@1.4.0@d41d8cd9": {
-      "id": "@reason-native-web/piaf@1.4.0@d41d8cd9",
+    "@reason-native-web/piaf@1.3.0@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.0@d41d8cd9",
       "name": "@reason-native-web/piaf",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.4.0.tgz#sha1:da2d1a07b553989e032f51986873c4bdff936ed5"
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.0.tgz#sha1:d9b0e14ab13a424bdcb7945b221c8ec975f5f05b"
         ]
       },
       "overrides": [],
@@ -1271,7 +1272,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
         "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
@@ -1279,32 +1280,32 @@
       ],
       "devDependencies": []
     },
-    "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9": {
-      "id": "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9",
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
       "name": "@reason-native-web/h2-lwt",
-      "version": "0.6.1002",
+      "version": "0.6.1001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1002.tgz#sha1:ab32c96ef1d5eabe0685b30c2edfc296cb63d5a8"
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@reason-native-web/h2@0.6.1002@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
         "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
       ],
       "devDependencies": []
     },
-    "@reason-native-web/h2@0.6.1002@d41d8cd9": {
-      "id": "@reason-native-web/h2@0.6.1002@d41d8cd9",
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
       "name": "@reason-native-web/h2",
-      "version": "0.6.1002",
+      "version": "0.6.1001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1002.tgz#sha1:6918f1df7d74b3880c78c5a94b9e644de8fa7ecc"
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
         ]
       },
       "overrides": [],

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "92e531b497ea7979ae6e49dc0bbf76a7",
+  "checksum": "b64b8f7a36bcf4e1824e6ab95ff90312",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -649,7 +649,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "fetch-core@0.1.0-alpha.5@d41d8cd9",
-        "@reason-native-web/piaf@1.4.0@d41d8cd9",
+        "@reason-native-web/piaf@1.3.0@d41d8cd9",
         "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -1049,6 +1049,7 @@
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": [
@@ -1214,14 +1215,14 @@
       ],
       "devDependencies": []
     },
-    "@reason-native-web/piaf@1.4.0@d41d8cd9": {
-      "id": "@reason-native-web/piaf@1.4.0@d41d8cd9",
+    "@reason-native-web/piaf@1.3.0@d41d8cd9": {
+      "id": "@reason-native-web/piaf@1.3.0@d41d8cd9",
       "name": "@reason-native-web/piaf",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.4.0.tgz#sha1:da2d1a07b553989e032f51986873c4bdff936ed5"
+          "archive:https://registry.npmjs.org/@reason-native-web/piaf/-/piaf-1.3.0.tgz#sha1:d9b0e14ab13a424bdcb7945b221c8ec975f5f05b"
         ]
       },
       "overrides": [],
@@ -1271,7 +1272,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9",
+        "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
         "@reason-native-web/gluten-lwt-unix@0.2.1@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/faraday-lwt-unix@opam:0.7.1@4854f547",
@@ -1279,32 +1280,32 @@
       ],
       "devDependencies": []
     },
-    "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9": {
-      "id": "@reason-native-web/h2-lwt@0.6.1002@d41d8cd9",
+    "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2-lwt@0.6.1001@d41d8cd9",
       "name": "@reason-native-web/h2-lwt",
-      "version": "0.6.1002",
+      "version": "0.6.1001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1002.tgz#sha1:ab32c96ef1d5eabe0685b30c2edfc296cb63d5a8"
+          "archive:https://registry.npmjs.org/@reason-native-web/h2-lwt/-/h2-lwt-0.6.1001.tgz#sha1:d65c9da48b345c9d7d366cc61e0beaaa0129c457"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@reason-native-web/h2@0.6.1002@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "@reason-native-web/h2@0.6.1001@d41d8cd9",
         "@reason-native-web/gluten-lwt@0.2.1@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@aef1678b"
       ],
       "devDependencies": []
     },
-    "@reason-native-web/h2@0.6.1002@d41d8cd9": {
-      "id": "@reason-native-web/h2@0.6.1002@d41d8cd9",
+    "@reason-native-web/h2@0.6.1001@d41d8cd9": {
+      "id": "@reason-native-web/h2@0.6.1001@d41d8cd9",
       "name": "@reason-native-web/h2",
-      "version": "0.6.1002",
+      "version": "0.6.1001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1002.tgz#sha1:6918f1df7d74b3880c78c5a94b9e644de8fa7ecc"
+          "archive:https://registry.npmjs.org/@reason-native-web/h2/-/h2-0.6.1001.tgz#sha1:93b1fc6cd204f3e4b6909ff400527a4136ff27e3"
         ]
       },
       "overrides": [],

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
   },
   "dependencies": {
     "@glennsl/timber": "^1.2.0",
+    "@opam/angstrom": "^0.14.1",
     "@opam/charInfo_width": "*",
     "@opam/decoders-yojson": "^0.4.0",
     "@opam/dir": "*",

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -35,12 +35,14 @@ type quickSuggestionsEnabled = {
   strings: bool,
 };
 
+type fontLigatures = [ | `Bool(bool) | `List(list(string))];
+
 type t = {
   editorAutoClosingBrackets: autoClosingBrackets,
   editorDetectIndentation: bool,
   editorFontFile: string,
   editorFontSize: float,
-  editorFontLigatures: bool,
+  editorFontLigatures: fontLigatures,
   editorFontSmoothing: fontSmoothing,
   editorHoverDelay: int,
   editorHoverEnabled: bool,
@@ -91,7 +93,7 @@ let default = {
   editorFontFile: Constants.defaultFontFile,
   editorFontSmoothing: Default,
   editorFontSize: Constants.defaultFontSize,
-  editorFontLigatures: true,
+  editorFontLigatures: `Bool(true),
   editorHoverDelay: 1000,
   editorHoverEnabled: true,
   editorLargeFileOptimizations: true,

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -21,5 +21,6 @@
         timber
         ReasonFuzz
         decoders-yojson
+        angstrom
     )
     (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Service/Font/Service_Font.re
+++ b/src/Service/Font/Service_Font.re
@@ -81,23 +81,26 @@ let setFont =
 
       // This is formatted this way to accomodate other future features
       let features =
-        []
-        |> (
-          features =>
-            fontLigatures
-              ? features
-              : [
-                Revery.Font.Feature.make(
-                  ~tag=Revery.Font.Features.contextualAlternates,
-                  ~value=0,
-                ),
-                Revery.Font.Feature.make(
-                  ~tag=Revery.Font.Features.standardLigatures,
-                  ~value=0,
-                ),
-                ...features,
-              ]
-        );
+        switch (fontLigatures) {
+        | `Bool(true) => []
+        | `Bool(false) => [
+            Revery.Font.Feature.make(
+              ~tag=Revery.Font.Features.contextualAlternates,
+              ~value=0,
+            ),
+            Revery.Font.Feature.make(
+              ~tag=Revery.Font.Features.standardLigatures,
+              ~value=0,
+            ),
+          ]
+        | `List(list) =>
+          list
+          |> List.map(tag => {
+               Log.infof(m => m("Enabling font feature: %s", tag));
+               let tag = Revery_Font.Feature.customTag(tag);
+               Revery.Font.Feature.make(~tag, ~value=1);
+             })
+        };
 
       let res =
         FontLoader.loadAndValidateEditorFont(
@@ -152,7 +155,7 @@ module Sub = {
   type params = {
     fontFamily: string,
     fontSize: float,
-    fontLigatures: bool,
+    fontLigatures: ConfigurationValues.fontLigatures,
     fontSmoothing: ConfigurationValues.fontSmoothing,
     uniqueId: string,
   };
@@ -162,7 +165,7 @@ module Sub = {
       type state = {
         fontFamily: string,
         fontSize: float,
-        fontLigatures: bool,
+        fontLigatures: ConfigurationValues.fontLigatures,
         fontSmoothing: ConfigurationValues.fontSmoothing,
         requestId: ref(int),
       };

--- a/src/Service/Font/Service_Font.rei
+++ b/src/Service/Font/Service_Font.rei
@@ -33,7 +33,7 @@ module Sub: {
       ~uniqueId: string,
       ~fontFamily: string,
       ~fontSize: float,
-      ~fontLigatures: bool,
+      ~fontLigatures: ConfigurationValues.fontLigatures,
       ~fontSmoothing: ConfigurationValues.fontSmoothing
     ) =>
     Isolinear.Sub.t(msg);

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bcb436d2a8e6f5d3c7bc6c72b9577a9d",
+  "checksum": "832474c590d69e74e632e0f110e35579",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -1049,6 +1049,7 @@
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
         "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
       "devDependencies": [

--- a/test/Core/ConfigurationParserTests.re
+++ b/test/Core/ConfigurationParserTests.re
@@ -291,6 +291,38 @@ describe("ConfigurationParser", ({test, describe, _}) => {
     };
   });
 
+  test("font ligatures (list)", ({expect, _}) => {
+    let configuration = {|
+    { "editor.fontLigatures": "'ss01', 'ss02', 'calt'" }
+    |};
+    let expected = `List(["ss01", "ss02", "calt"]);
+
+    switch (ConfigurationParser.ofString(configuration)) {
+    | Ok(v) =>
+      expect.equal(
+        expected,
+        Configuration.getValue(c => c.editorFontLigatures, v),
+      )
+    | Error(_) => expect.bool(false).toBe(true)
+    };
+  });
+
+  test("font ligatures (list, malformed)", ({expect, _}) => {
+    let configuration = {|
+    { "editor.fontLigatures": "'ss01', 'ss02' 'calt'" }
+    |};
+    let expected = `Bool(true);
+
+    switch (ConfigurationParser.ofString(configuration)) {
+    | Ok(v) =>
+      expect.equal(
+        expected,
+        Configuration.getValue(c => c.editorFontLigatures, v),
+      )
+    | Error(_) => expect.bool(false).toBe(true)
+    };
+  });
+
   test("resiliency tests", ({expect, _}) => {
     let trailingCommaInObject = {|
       { "editor.rulers": [120, 80], }


### PR DESCRIPTION
This fixes our current `editor.fontLigatures` flag to be able to take in a string of features, similar to what VSCode has.

I.e. `"editor.fontLigatures": "'ss02'"` enables the second stylistic set.

This is achieved through a custom parser using Angstrom. 

Fixes #1294 