### PR TITLE
feat(editor): folder drag and drop

### DIFF
--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -183,7 +183,7 @@ type t =
   | Pane(Feature_Pane.msg)
   | PaneTabClicked(Feature_Pane.pane)
   | PaneCloseButtonClicked
-  | VimDirectoryChanged(string)
+  | DirectoryChanged(string)
   | VimExecuteCommand(string)
   | VimMessageReceived({
       priority: [@opaque] Vim.Types.msgPriority,

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -155,7 +155,7 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
         ),
       )
 
-    | VimDirectoryChanged(path) => (state, changeWorkspaceEffect(path))
+    | DirectoryChanged(path) => (state, changeWorkspaceEffect(path))
 
     | BufferEnter({id, filePath, _}) =>
       let eff =

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -561,10 +561,10 @@ let update =
   | FilesDropped({paths}) =>
     let eff =
       Service_OS.Effect.statMultiple(paths, (path, stats) =>
-        if (stats.st_kind == S_REG) {
-          OpenFileByPath(path, None, None);
-        } else {
-          Noop;
+        switch (stats.st_kind) {
+        | S_REG => OpenFileByPath(path, None, None)
+        | S_DIR => DirectoryChanged(path)
+        | _ => Noop
         }
       );
     (state, eff);

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -563,7 +563,11 @@ let update =
       Service_OS.Effect.statMultiple(paths, (path, stats) =>
         switch (stats.st_kind) {
         | S_REG => OpenFileByPath(path, None, None)
-        | S_DIR => DirectoryChanged(path)
+        | S_DIR =>
+          switch (Luv.Path.chdir(path)) {
+          | Ok () => DirectoryChanged(path)
+          | Error(_) => Noop
+          }
         | _ => Noop
         }
       );

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -128,7 +128,7 @@ let start =
 
   let _: unit => unit =
     Vim.onDirectoryChanged(newDir =>
-      dispatch(Actions.VimDirectoryChanged(newDir))
+      dispatch(Actions.DirectoryChanged(newDir))
     );
 
   let _: unit => unit =
@@ -909,7 +909,7 @@ let start =
         copyActiveFilepathToClipboardEffect,
       )
 
-    | VimDirectoryChanged(workingDirectory) =>
+    | DirectoryChanged(workingDirectory) =>
       let newState = {
         ...state,
         workspace: {


### PR DESCRIPTION
As of right now, we only support dropping _files_ onto the editor. This adds the behavior that if you drop a folder/directory onto the editor, it will change the directory in the same way that `:cd x/y/z` changes the directory.