### PR TITLE
docs: fix trailing comma

### DIFF
--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -46,3 +46,9 @@ steps:
   - script: yarn audit
     workingDirectory: extensions
     displayName: 'yarn audit: extensions'
+  - script: npm install
+    workingDirectory: docs/website
+    displayName: 'install website dependencies'
+  - script: npm run build
+    workingDirectory: docs/website
+    displayName: 'build website'

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -23,7 +23,7 @@
       "languages/overview",
       "languages/reason-ocaml",
       "languages/python",
-      "languages/go",
+      "languages/go"
     ],
     "For Developers": [
       "for-developers/architecture",


### PR DESCRIPTION
A trailing comma was causing the docs to fail to build (and blocking nightly builds) - this adds a CI check for the documentation to prevent it from happening in the future, and fixes the issue.