### PR TITLE
refactor(exthost): Split LanguageInfo / GrammarInfo 

### DIFF
--- a/integration_test/lib/SyntaxServerTest.re
+++ b/integration_test/lib/SyntaxServerTest.re
@@ -60,7 +60,7 @@ let run = (~parentPid=?, ~name, f) => {
       ~onClose,
       ~onHighlights=(~bufferId as _, ~tokens as _) => (),
       ~onHealthCheckResult=_ => (),
-      LanguageInfo.initial,
+      GrammarInfo.initial,
       Setup.default(),
     )
     |> Result.get_ok;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -53,4 +53,5 @@ module Request = Request;
 module NamedPipe = NamedPipe;
 
 module Msg = Msg;
+module GrammarInfo = GrammarInfo;
 module LanguageInfo = LanguageInfo;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1597,4 +1597,5 @@ module Request: {
   };
 };
 
+module GrammarInfo = GrammarInfo;
 module LanguageInfo = LanguageInfo;

--- a/src/Exthost/GrammarInfo.re
+++ b/src/Exthost/GrammarInfo.re
@@ -3,51 +3,31 @@
  */
 
 open Oni_Core;
-open Oni_Core.Utility;
-open Rench;
 
 open Exthost_Extension;
 open Scanner.ScanResult;
 
-module Log = (val Log.withNamespace("Oni2.LanguageInfo"));
-
-type configurationLoadState =
-  | Loaded(LanguageConfiguration.t)
-  | ErrorLoading;
+module Log = (val Log.withNamespace("Oni2.GrammarInfo"));
 
 [@deriving show]
 type t = {
   grammars: list(Contributions.Grammar.t),
-  languages: list(Contributions.Language.t),
-  extToLanguage: [@opaque] StringMap.t(string),
-  languageCache: [@opaque] Hashtbl.t(string, configurationLoadState),
-  languageToConfigurationPath: [@opaque] StringMap.t(string),
-  languageToScope: [@opaque] StringMap.t(string),
   scopeToGrammarPath: [@opaque] StringMap.t(string),
   scopeToTreesitterPath: [@opaque] StringMap.t(option(string)),
 };
 
-let toString = languageInfo => {
-  show(languageInfo)
+let toString = grammarInfo => {
+  show(grammarInfo)
   ++ "\n Grammars: \n"
   ++ StringMap.fold(
        (key, v, acc) => {acc ++ "\n" ++ "key: " ++ key ++ " val: " ++ v},
-       languageInfo.scopeToGrammarPath,
+       grammarInfo.scopeToGrammarPath,
        "",
      );
 };
 
-module Regexes = {
-  let oniPath = Oniguruma.OnigRegExp.create("oni:\\/\\/([a-z]*)\\/(.*)");
-};
-
 let initial = {
   grammars: [],
-  languages: [],
-  languageCache: Hashtbl.create(16),
-  extToLanguage: StringMap.empty,
-  languageToConfigurationPath: StringMap.empty,
-  languageToScope: StringMap.empty,
   scopeToGrammarPath: StringMap.empty,
   scopeToTreesitterPath: StringMap.empty,
 };
@@ -55,102 +35,6 @@ let initial = {
 let getGrammars = (li: t) => {
   li.grammars;
 };
-
-let defaultLanguage = "plaintext";
-
-let getLanguageFromExtension = (li: t, ext: string) => {
-  switch (StringMap.find_opt(ext, li.extToLanguage)) {
-  | Some(v) => v
-  | None => defaultLanguage
-  };
-};
-
-let getLanguageFromFilePath = (li: t, fp: string) => {
-  let default = Path.extname(fp) |> getLanguageFromExtension(li);
-
-  Regexes.oniPath
-  |> Stdlib.Result.to_option
-  |> Utility.OptionEx.flatMap(regex => {
-       let matches = Oniguruma.OnigRegExp.search(fp, 0, regex);
-       if (Array.length(matches) == 0) {
-         None;
-       } else {
-         Some(Oniguruma.OnigRegExp.Match.getText(matches[1]));
-       };
-     })
-  |> Stdlib.Option.value(~default);
-};
-
-let getLanguageFromBuffer = (li: t, buffer: Buffer.t) => {
-  switch (Buffer.getFilePath(buffer)) {
-  | None => defaultLanguage
-  | Some(v) => getLanguageFromFilePath(li, v)
-  };
-};
-
-module Internal = {
-  let getLanguageConfigurationPath = (li: t, languageId: string) => {
-    StringMap.find_opt(languageId, li.languageToConfigurationPath);
-  };
-
-  let loadLanguage: string => result(LanguageConfiguration.t, string) =
-    path => {
-      path
-      |> JsonEx.from_file
-      |> ResultEx.flatMap(json =>
-           json
-           |> Json.Decode.decode_value(LanguageConfiguration.decode)
-           |> Stdlib.Result.map_error(Json.Decode.string_of_error)
-         )
-      |> Stdlib.Result.map_error(FunEx.tap(Log.error));
-    };
-
-  let loadLanguageConfiguration = (~languageId, languageInfo: t) => {
-    languageId
-    |> getLanguageConfigurationPath(languageInfo)
-    |> Option.map(
-         FunEx.tap(p =>
-           Log.infof(m =>
-             m("Got path for %s, loading from %s", languageId, p)
-           )
-         ),
-       )
-    |> OptionEx.flatMap(path => {
-         switch (loadLanguage(path)) {
-         | Ok(languageConfig) =>
-           Hashtbl.add(
-             languageInfo.languageCache,
-             languageId,
-             Loaded(languageConfig),
-           );
-           Some(languageConfig);
-         | Error(_) =>
-           Hashtbl.add(languageInfo.languageCache, languageId, ErrorLoading);
-           None;
-         }
-       });
-  };
-};
-
-let getLanguageConfiguration = (languageInfo: t, languageId: string) => {
-  languageId
-  |> Hashtbl.find_opt(languageInfo.languageCache)
-  |> (
-    fun
-    | Some(Loaded(languageConfig)) => Some(languageConfig)
-    | Some(ErrorLoading) => None
-    | None => Internal.loadLanguageConfiguration(~languageId, languageInfo)
-  );
-};
-
-let getScopeFromLanguage = (li: t, languageId: string) => {
-  StringMap.find_opt(languageId, li.languageToScope);
-};
-
-let getScopeFromExtension = (li: t, ext: string) => {
-  getLanguageFromExtension(li, ext) |> getScopeFromLanguage(li);
-};
-
 let getGrammarPathFromScope = (li: t, scope: string) => {
   StringMap.find_opt(scope, li.scopeToGrammarPath);
 };
@@ -159,44 +43,17 @@ let getTreesitterPathFromScope = (li: t, scope: string) => {
   li.scopeToTreesitterPath |> StringMap.find_opt(scope) |> Option.join;
 };
 
-let _getLanguageTuples = (lang: Contributions.Language.t) => {
-  List.map(extension => (extension, lang.id), lang.extensions);
-};
-
-let _getGrammars = (extensions: list(Scanner.ScanResult.t)) => {
-  extensions |> List.map(v => v.manifest.contributes.grammars) |> List.flatten;
-};
-
-let _getLanguages = (extensions: list(Scanner.ScanResult.t)) => {
-  extensions |> List.map(v => v.manifest.contributes.languages) |> List.flatten;
+module Internal = {
+  let getGrammars = (extensions: list(Scanner.ScanResult.t)) => {
+    extensions
+    |> List.map(v => v.manifest.contributes.grammars)
+    |> List.flatten;
+  };
 };
 
 let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
-  let grammars = _getGrammars(extensions);
-  let languages = _getLanguages(extensions);
-
-  let extToLanguage =
-    languages
-    |> List.map(_getLanguageTuples)
-    |> List.flatten
-    |> List.fold_left(
-         (prev, v) => {
-           let (extension, language) = v;
-           StringMap.add(extension, language, prev);
-         },
-         StringMap.empty,
-       );
+  let grammars = Internal.getGrammars(extensions);
   open Contributions.Grammar;
-  let languageToScope =
-    grammars
-    |> List.fold_left(
-         (prev, curr) =>
-           switch (curr.language) {
-           | None => prev
-           | Some(v) => StringMap.add(v, curr.scopeName, prev)
-           },
-         StringMap.empty,
-       );
 
   let scopeToGrammarPath =
     grammars
@@ -214,26 +71,5 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
          StringMap.empty,
        );
 
-  let languageToConfigurationPath =
-    languages
-    |> List.fold_left(
-         (prev, {id, configuration, _}: Contributions.Language.t) => {
-           switch (configuration) {
-           | None => prev
-           | Some(configPath) => StringMap.add(id, configPath, prev)
-           }
-         },
-         StringMap.empty,
-       );
-
-  {
-    ...initial,
-    grammars,
-    languages,
-    extToLanguage,
-    languageToConfigurationPath,
-    languageToScope,
-    scopeToGrammarPath,
-    scopeToTreesitterPath,
-  };
+  {grammars, scopeToGrammarPath, scopeToTreesitterPath};
 };

--- a/src/Exthost/GrammarInfo.re
+++ b/src/Exthost/GrammarInfo.re
@@ -1,0 +1,239 @@
+/*
+ * GrammarInfo.re
+ */
+
+open Oni_Core;
+open Oni_Core.Utility;
+open Rench;
+
+open Exthost_Extension;
+open Scanner.ScanResult;
+
+module Log = (val Log.withNamespace("Oni2.LanguageInfo"));
+
+type configurationLoadState =
+  | Loaded(LanguageConfiguration.t)
+  | ErrorLoading;
+
+[@deriving show]
+type t = {
+  grammars: list(Contributions.Grammar.t),
+  languages: list(Contributions.Language.t),
+  extToLanguage: [@opaque] StringMap.t(string),
+  languageCache: [@opaque] Hashtbl.t(string, configurationLoadState),
+  languageToConfigurationPath: [@opaque] StringMap.t(string),
+  languageToScope: [@opaque] StringMap.t(string),
+  scopeToGrammarPath: [@opaque] StringMap.t(string),
+  scopeToTreesitterPath: [@opaque] StringMap.t(option(string)),
+};
+
+let toString = languageInfo => {
+  show(languageInfo)
+  ++ "\n Grammars: \n"
+  ++ StringMap.fold(
+       (key, v, acc) => {acc ++ "\n" ++ "key: " ++ key ++ " val: " ++ v},
+       languageInfo.scopeToGrammarPath,
+       "",
+     );
+};
+
+module Regexes = {
+  let oniPath = Oniguruma.OnigRegExp.create("oni:\\/\\/([a-z]*)\\/(.*)");
+};
+
+let initial = {
+  grammars: [],
+  languages: [],
+  languageCache: Hashtbl.create(16),
+  extToLanguage: StringMap.empty,
+  languageToConfigurationPath: StringMap.empty,
+  languageToScope: StringMap.empty,
+  scopeToGrammarPath: StringMap.empty,
+  scopeToTreesitterPath: StringMap.empty,
+};
+
+let getGrammars = (li: t) => {
+  li.grammars;
+};
+
+let defaultLanguage = "plaintext";
+
+let getLanguageFromExtension = (li: t, ext: string) => {
+  switch (StringMap.find_opt(ext, li.extToLanguage)) {
+  | Some(v) => v
+  | None => defaultLanguage
+  };
+};
+
+let getLanguageFromFilePath = (li: t, fp: string) => {
+  let default = Path.extname(fp) |> getLanguageFromExtension(li);
+
+  Regexes.oniPath
+  |> Stdlib.Result.to_option
+  |> Utility.OptionEx.flatMap(regex => {
+       let matches = Oniguruma.OnigRegExp.search(fp, 0, regex);
+       if (Array.length(matches) == 0) {
+         None;
+       } else {
+         Some(Oniguruma.OnigRegExp.Match.getText(matches[1]));
+       };
+     })
+  |> Stdlib.Option.value(~default);
+};
+
+let getLanguageFromBuffer = (li: t, buffer: Buffer.t) => {
+  switch (Buffer.getFilePath(buffer)) {
+  | None => defaultLanguage
+  | Some(v) => getLanguageFromFilePath(li, v)
+  };
+};
+
+module Internal = {
+  let getLanguageConfigurationPath = (li: t, languageId: string) => {
+    StringMap.find_opt(languageId, li.languageToConfigurationPath);
+  };
+
+  let loadLanguage: string => result(LanguageConfiguration.t, string) =
+    path => {
+      path
+      |> JsonEx.from_file
+      |> ResultEx.flatMap(json =>
+           json
+           |> Json.Decode.decode_value(LanguageConfiguration.decode)
+           |> Stdlib.Result.map_error(Json.Decode.string_of_error)
+         )
+      |> Stdlib.Result.map_error(FunEx.tap(Log.error));
+    };
+
+  let loadLanguageConfiguration = (~languageId, languageInfo: t) => {
+    languageId
+    |> getLanguageConfigurationPath(languageInfo)
+    |> Option.map(
+         FunEx.tap(p =>
+           Log.infof(m =>
+             m("Got path for %s, loading from %s", languageId, p)
+           )
+         ),
+       )
+    |> OptionEx.flatMap(path => {
+         switch (loadLanguage(path)) {
+         | Ok(languageConfig) =>
+           Hashtbl.add(
+             languageInfo.languageCache,
+             languageId,
+             Loaded(languageConfig),
+           );
+           Some(languageConfig);
+         | Error(_) =>
+           Hashtbl.add(languageInfo.languageCache, languageId, ErrorLoading);
+           None;
+         }
+       });
+  };
+};
+
+let getLanguageConfiguration = (languageInfo: t, languageId: string) => {
+  languageId
+  |> Hashtbl.find_opt(languageInfo.languageCache)
+  |> (
+    fun
+    | Some(Loaded(languageConfig)) => Some(languageConfig)
+    | Some(ErrorLoading) => None
+    | None => Internal.loadLanguageConfiguration(~languageId, languageInfo)
+  );
+};
+
+let getScopeFromLanguage = (li: t, languageId: string) => {
+  StringMap.find_opt(languageId, li.languageToScope);
+};
+
+let getScopeFromExtension = (li: t, ext: string) => {
+  getLanguageFromExtension(li, ext) |> getScopeFromLanguage(li);
+};
+
+let getGrammarPathFromScope = (li: t, scope: string) => {
+  StringMap.find_opt(scope, li.scopeToGrammarPath);
+};
+
+let getTreesitterPathFromScope = (li: t, scope: string) => {
+  li.scopeToTreesitterPath |> StringMap.find_opt(scope) |> Option.join;
+};
+
+let _getLanguageTuples = (lang: Contributions.Language.t) => {
+  List.map(extension => (extension, lang.id), lang.extensions);
+};
+
+let _getGrammars = (extensions: list(Scanner.ScanResult.t)) => {
+  extensions |> List.map(v => v.manifest.contributes.grammars) |> List.flatten;
+};
+
+let _getLanguages = (extensions: list(Scanner.ScanResult.t)) => {
+  extensions |> List.map(v => v.manifest.contributes.languages) |> List.flatten;
+};
+
+let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
+  let grammars = _getGrammars(extensions);
+  let languages = _getLanguages(extensions);
+
+  let extToLanguage =
+    languages
+    |> List.map(_getLanguageTuples)
+    |> List.flatten
+    |> List.fold_left(
+         (prev, v) => {
+           let (extension, language) = v;
+           StringMap.add(extension, language, prev);
+         },
+         StringMap.empty,
+       );
+  open Contributions.Grammar;
+  let languageToScope =
+    grammars
+    |> List.fold_left(
+         (prev, curr) =>
+           switch (curr.language) {
+           | None => prev
+           | Some(v) => StringMap.add(v, curr.scopeName, prev)
+           },
+         StringMap.empty,
+       );
+
+  let scopeToGrammarPath =
+    grammars
+    |> List.fold_left(
+         (prev, curr) => {StringMap.add(curr.scopeName, curr.path, prev)},
+         StringMap.empty,
+       );
+
+  let scopeToTreesitterPath =
+    grammars
+    |> List.fold_left(
+         (prev, curr) => {
+           StringMap.add(curr.scopeName, curr.treeSitterPath, prev)
+         },
+         StringMap.empty,
+       );
+
+  let languageToConfigurationPath =
+    languages
+    |> List.fold_left(
+         (prev, {id, configuration, _}: Contributions.Language.t) => {
+           switch (configuration) {
+           | None => prev
+           | Some(configPath) => StringMap.add(id, configPath, prev)
+           }
+         },
+         StringMap.empty,
+       );
+
+  {
+    ...initial,
+    grammars,
+    languages,
+    extToLanguage,
+    languageToConfigurationPath,
+    languageToScope,
+    scopeToGrammarPath,
+    scopeToTreesitterPath,
+  };
+};

--- a/src/Exthost/GrammarInfo.rei
+++ b/src/Exthost/GrammarInfo.rei
@@ -1,0 +1,16 @@
+/*
+ * GrammarInfo.rei
+ */
+open Oni_Core;
+
+open Exthost_Extension;
+
+type t;
+
+let initial: t;
+
+let getGrammars: t => list(Contributions.Grammar.t);
+let getGrammarPathFromScope: (t, string) => option(string);
+let getTreesitterPathFromScope: (t, string) => option(string);
+
+let ofExtensions: list(Scanner.ScanResult.t) => t;

--- a/src/Exthost/GrammarInfo.rei
+++ b/src/Exthost/GrammarInfo.rei
@@ -1,8 +1,6 @@
 /*
  * GrammarInfo.rei
  */
-open Oni_Core;
-
 open Exthost_Extension;
 
 type t;
@@ -14,3 +12,5 @@ let getGrammarPathFromScope: (t, string) => option(string);
 let getTreesitterPathFromScope: (t, string) => option(string);
 
 let ofExtensions: list(Scanner.ScanResult.t) => t;
+
+let toString: t => string;

--- a/src/Exthost/LanguageInfo.re
+++ b/src/Exthost/LanguageInfo.re
@@ -17,24 +17,15 @@ type configurationLoadState =
 
 [@deriving show]
 type t = {
-  grammars: list(Contributions.Grammar.t),
   languages: list(Contributions.Language.t),
   extToLanguage: [@opaque] StringMap.t(string),
   languageCache: [@opaque] Hashtbl.t(string, configurationLoadState),
   languageToConfigurationPath: [@opaque] StringMap.t(string),
   languageToScope: [@opaque] StringMap.t(string),
-  scopeToGrammarPath: [@opaque] StringMap.t(string),
-  scopeToTreesitterPath: [@opaque] StringMap.t(option(string)),
 };
 
 let toString = languageInfo => {
-  show(languageInfo)
-  ++ "\n Grammars: \n"
-  ++ StringMap.fold(
-       (key, v, acc) => {acc ++ "\n" ++ "key: " ++ key ++ " val: " ++ v},
-       languageInfo.scopeToGrammarPath,
-       "",
-     );
+  show(languageInfo);
 };
 
 module Regexes = {
@@ -42,18 +33,11 @@ module Regexes = {
 };
 
 let initial = {
-  grammars: [],
   languages: [],
   languageCache: Hashtbl.create(16),
   extToLanguage: StringMap.empty,
   languageToConfigurationPath: StringMap.empty,
   languageToScope: StringMap.empty,
-  scopeToGrammarPath: StringMap.empty,
-  scopeToTreesitterPath: StringMap.empty,
-};
-
-let getGrammars = (li: t) => {
-  li.grammars;
 };
 
 let defaultLanguage = "plaintext";
@@ -151,14 +135,6 @@ let getScopeFromExtension = (li: t, ext: string) => {
   getLanguageFromExtension(li, ext) |> getScopeFromLanguage(li);
 };
 
-let getGrammarPathFromScope = (li: t, scope: string) => {
-  StringMap.find_opt(scope, li.scopeToGrammarPath);
-};
-
-let getTreesitterPathFromScope = (li: t, scope: string) => {
-  li.scopeToTreesitterPath |> StringMap.find_opt(scope) |> Option.join;
-};
-
 let _getLanguageTuples = (lang: Contributions.Language.t) => {
   List.map(extension => (extension, lang.id), lang.extensions);
 };
@@ -198,22 +174,6 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
          StringMap.empty,
        );
 
-  let scopeToGrammarPath =
-    grammars
-    |> List.fold_left(
-         (prev, curr) => {StringMap.add(curr.scopeName, curr.path, prev)},
-         StringMap.empty,
-       );
-
-  let scopeToTreesitterPath =
-    grammars
-    |> List.fold_left(
-         (prev, curr) => {
-           StringMap.add(curr.scopeName, curr.treeSitterPath, prev)
-         },
-         StringMap.empty,
-       );
-
   let languageToConfigurationPath =
     languages
     |> List.fold_left(
@@ -228,12 +188,9 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
 
   {
     ...initial,
-    grammars,
     languages,
     extToLanguage,
     languageToConfigurationPath,
     languageToScope,
-    scopeToGrammarPath,
-    scopeToTreesitterPath,
   };
 };

--- a/src/Exthost/LanguageInfo.rei
+++ b/src/Exthost/LanguageInfo.rei
@@ -12,8 +12,6 @@ let toString: t => string;
 
 let defaultLanguage: string;
 
-let getGrammars: t => list(Contributions.Grammar.t);
-
 let getLanguageFromExtension: (t, string) => string;
 let getLanguageFromFilePath: (t, string) => string;
 let getLanguageFromBuffer: (t, Buffer.t) => string;
@@ -22,8 +20,5 @@ let getScopeFromLanguage: (t, string) => option(string);
 let getScopeFromExtension: (t, string) => option(string);
 
 let getLanguageConfiguration: (t, string) => option(LanguageConfiguration.t);
-
-let getGrammarPathFromScope: (t, string) => option(string);
-let getTreesitterPathFromScope: (t, string) => option(string);
 
 let ofExtensions: list(Scanner.ScanResult.t) => t;

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -295,7 +295,12 @@ let subscription =
          !BufferMap.mem(Oni_Core.Buffer.getId(buffer), ignoredBuffers)
        )
     |> List.map(((buffer, visibleRanges)) => {
-         Service_Syntax.Sub.buffer(~client, ~buffer, ~languageInfo, ~visibleRanges)
+         Service_Syntax.Sub.buffer(
+           ~client,
+           ~buffer,
+           ~languageInfo,
+           ~visibleRanges,
+         )
          |> Isolinear.Sub.map(
               fun
               | Service_Syntax.ReceivedHighlights(tokens) => {

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -282,6 +282,7 @@ let update: (t, msg) => (t, outmsg) =
 let subscription =
     (
       ~config: Config.resolver,
+      ~grammarInfo,
       ~languageInfo,
       ~setup,
       ~tokenTheme,
@@ -294,7 +295,7 @@ let subscription =
          !BufferMap.mem(Oni_Core.Buffer.getId(buffer), ignoredBuffers)
        )
     |> List.map(((buffer, visibleRanges)) => {
-         Service_Syntax.Sub.buffer(~client, ~buffer, ~visibleRanges)
+         Service_Syntax.Sub.buffer(~client, ~buffer, ~languageInfo, ~visibleRanges)
          |> Isolinear.Sub.map(
               fun
               | Service_Syntax.ReceivedHighlights(tokens) => {
@@ -313,7 +314,7 @@ let subscription =
   let serverSubscription =
     Service_Syntax.Sub.server(
       ~useTreeSitter=Configuration.Experimental.treeSitter.get(config),
-      ~languageInfo,
+      ~grammarInfo,
       ~setup,
       ~tokenTheme,
     )

--- a/src/Feature/Syntax/Feature_Syntax.rei
+++ b/src/Feature/Syntax/Feature_Syntax.rei
@@ -57,6 +57,7 @@ module Effect: {
 let subscription:
   (
     ~config: Config.resolver,
+    ~grammarInfo: Exthost.GrammarInfo.t,
     ~languageInfo: Exthost.LanguageInfo.t,
     ~setup: Setup.t,
     ~tokenTheme: Oni_Syntax.TokenTheme.t,

--- a/src/Service/Syntax/Service_Syntax.re
+++ b/src/Service/Syntax/Service_Syntax.re
@@ -6,6 +6,10 @@ module OptionEx = Core.Utility.OptionEx;
 
 module Log = (val Core.Log.withNamespace("Oni2.Service_Syntax"));
 
+module Constants = {
+  let defaultScope = "source.text";
+};
+
 [@deriving show({with_path: false})]
 type serverMsg =
   | ServerStarted
@@ -46,7 +50,7 @@ module Internal = {
 module Sub = {
   type serverParams = {
     id: string,
-    languageInfo: Exthost.LanguageInfo.t,
+    grammarInfo: Exthost.GrammarInfo.t,
     setup: Core.Setup.t,
     tokenTheme: Syntax.TokenTheme.t,
     useTreeSitter: bool,
@@ -84,7 +88,7 @@ module Sub = {
                 Internal.notifyTokensReceived(bufferId, tokens)
               },
             ~onHealthCheckResult=_ => (),
-            params.languageInfo,
+            params.grammarInfo,
             params.setup,
           );
 
@@ -148,11 +152,11 @@ module Sub = {
       };
     });
 
-  let server = (~useTreeSitter, ~languageInfo, ~setup, ~tokenTheme) => {
+  let server = (~useTreeSitter, ~grammarInfo, ~setup, ~tokenTheme) => {
     SyntaxServerSubscription.create({
       id: "syntax-highligher",
       useTreeSitter,
-      languageInfo,
+      grammarInfo,
       setup,
       tokenTheme,
     });
@@ -161,6 +165,7 @@ module Sub = {
   type bufferParams = {
     client: Oni_Syntax_Client.t,
     buffer: Core.Buffer.t,
+    scope: string,
     visibleRanges: list(Range.t),
   };
 
@@ -177,13 +182,7 @@ module Sub = {
       let name = "BufferSubscription";
       let id = params => {
         let bufferId = params.buffer |> Core.Buffer.getId |> string_of_int;
-
-        let fileType =
-          params.buffer
-          |> Core.Buffer.getFileType
-          |> Option.value(~default="(none)");
-
-        bufferId ++ fileType;
+        bufferId ++ params.scope;
       };
 
       let init = (~params, ~dispatch) => {
@@ -195,17 +194,13 @@ module Sub = {
 
         Log.infof(m => m("Starting buffer subscription for: %d", bufferId));
 
-        params.buffer
-        |> Core.Buffer.getFileType
-        |> Option.iter(filetype => {
-             Oni_Syntax_Client.startHighlightingBuffer(
-               ~filetype,
-               ~bufferId,
-               ~visibleRanges=params.visibleRanges,
-               ~lines=Core.Buffer.getLines(params.buffer),
-               params.client,
-             )
-           });
+       Oni_Syntax_Client.startHighlightingBuffer(
+         ~scope=params.scope,
+         ~bufferId,
+         ~visibleRanges=params.visibleRanges,
+         ~lines=Core.Buffer.getLines(params.buffer),
+         params.client,
+       );
 
         {lastVisibleRanges: params.visibleRanges, unsubscribe};
       };
@@ -232,7 +227,13 @@ module Sub = {
       };
     });
 
-  let buffer = (~client, ~buffer, ~visibleRanges) => {
-    BufferSubscription.create({client, buffer, visibleRanges});
+  let buffer = (~client, ~buffer, ~languageInfo, ~visibleRanges) => {
+    let scope =
+      buffer
+      |> Core.Buffer.getFileType
+      |> OptionEx.flatMap(Exthost.LanguageInfo.getScopeFromLanguage(languageInfo))
+      |> Option.value(~default=Constants.defaultScope);
+
+    BufferSubscription.create({client, buffer, scope, visibleRanges});
   };
 };

--- a/src/Service/Syntax/Service_Syntax.re
+++ b/src/Service/Syntax/Service_Syntax.re
@@ -194,13 +194,13 @@ module Sub = {
 
         Log.infof(m => m("Starting buffer subscription for: %d", bufferId));
 
-       Oni_Syntax_Client.startHighlightingBuffer(
-         ~scope=params.scope,
-         ~bufferId,
-         ~visibleRanges=params.visibleRanges,
-         ~lines=Core.Buffer.getLines(params.buffer),
-         params.client,
-       );
+        Oni_Syntax_Client.startHighlightingBuffer(
+          ~scope=params.scope,
+          ~bufferId,
+          ~visibleRanges=params.visibleRanges,
+          ~lines=Core.Buffer.getLines(params.buffer),
+          params.client,
+        );
 
         {lastVisibleRanges: params.visibleRanges, unsubscribe};
       };
@@ -231,7 +231,9 @@ module Sub = {
     let scope =
       buffer
       |> Core.Buffer.getFileType
-      |> OptionEx.flatMap(Exthost.LanguageInfo.getScopeFromLanguage(languageInfo))
+      |> OptionEx.flatMap(
+           Exthost.LanguageInfo.getScopeFromLanguage(languageInfo),
+         )
       |> Option.value(~default=Constants.defaultScope);
 
     BufferSubscription.create({client, buffer, scope, visibleRanges});

--- a/src/Service/Syntax/Service_Syntax.rei
+++ b/src/Service/Syntax/Service_Syntax.rei
@@ -16,7 +16,7 @@ module Sub: {
   let server:
     (
       ~useTreeSitter: bool,
-      ~languageInfo: Exthost.LanguageInfo.t,
+      ~grammarInfo: Exthost.GrammarInfo.t,
       ~setup: Setup.t,
       ~tokenTheme: TokenTheme.t
     ) =>
@@ -26,6 +26,7 @@ module Sub: {
     (
       ~client: Oni_Syntax_Client.t,
       ~buffer: Buffer.t,
+      ~languageInfo: Exthost.LanguageInfo.t,
       ~visibleRanges: list(Range.t)
     ) =>
     Isolinear.Sub.t(bufferMsg);

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -115,7 +115,8 @@ let start =
       ~overriddenExtensionsDir,
     );
   let languageInfo = Exthost.LanguageInfo.ofExtensions(extensions);
-  let grammarRepository = Oni_Syntax.GrammarRepository.create(languageInfo);
+  let grammarInfo = Exthost.GrammarInfo.ofExtensions(extensions);
+  let grammarRepository = Oni_Syntax.GrammarRepository.create(grammarInfo);
 
   let commandUpdater = CommandStoreConnector.start();
   let (vimUpdater, vimStream) =
@@ -220,6 +221,7 @@ let start =
       shouldSyntaxHighlight && !state.isQuitting
         ? Feature_Syntax.subscription(
             ~config,
+            ~grammarInfo,
             ~languageInfo,
             ~setup,
             ~tokenTheme=state.tokenTheme,

--- a/src/Syntax/GrammarRepository.re
+++ b/src/Syntax/GrammarRepository.re
@@ -4,24 +4,24 @@
 
 type t = {
   scopeToGrammar: Hashtbl.t(string, Textmate.Grammar.t),
-  languageInfo: Exthost.LanguageInfo.t,
+  grammarInfo: Exthost.GrammarInfo.t,
   log: string => unit,
 };
 
-let create = (~log=_ => (), languageInfo) => {
+let create = (~log=_ => (), grammarInfo) => {
   log,
   scopeToGrammar: Hashtbl.create(32),
-  languageInfo,
+  grammarInfo,
 };
 
-let empty = create(Exthost.LanguageInfo.initial);
+let empty = create(Exthost.GrammarInfo.initial);
 
 let getGrammar = (~scope: string, gr: t) => {
   switch (Hashtbl.find_opt(gr.scopeToGrammar, scope)) {
   | Some(v) => Some(v)
   | None =>
     switch (
-      Exthost.LanguageInfo.getGrammarPathFromScope(gr.languageInfo, scope)
+      Exthost.GrammarInfo.getGrammarPathFromScope(gr.grammarInfo, scope)
     ) {
     | Some(grammarPath) =>
       gr.log("Loading grammar from: " ++ grammarPath);

--- a/src/Syntax/GrammarRepository.rei
+++ b/src/Syntax/GrammarRepository.rei
@@ -6,6 +6,6 @@ type t;
 
 let empty: t;
 
-let create: (~log: string => unit=?, Exthost.LanguageInfo.t) => t;
+let create: (~log: string => unit=?, Exthost.GrammarInfo.t) => t;
 
 let getGrammar: (~scope: string, t) => option(Textmate.Grammar.t);

--- a/src/Syntax/Protocol.re
+++ b/src/Syntax/Protocol.re
@@ -50,10 +50,12 @@ module ClientToServer = {
   [@deriving show({with_path: false})]
   type t =
     | Echo(string)
-    | Initialize([@opaque] Exthost.LanguageInfo.t, Setup.t)
+    | Initialize([@opaque] Exthost.GrammarInfo.t, Setup.t)
     | BufferStartHighlighting({
         bufferId: int,
-        filetype: string,
+        // We send in the actual textmate scope, ie:
+        // 'source.js' vs 'javascript'
+        scope: string,
         lines: [@opaque] array(string),
         visibleRanges: [@opaque] list(Range.t),
       })

--- a/src/Syntax_Client/Oni_Syntax_Client.re
+++ b/src/Syntax_Client/Oni_Syntax_Client.re
@@ -80,7 +80,7 @@ let start =
       ~onClose=_ => (),
       ~onHighlights,
       ~onHealthCheckResult,
-      languageInfo,
+      grammarInfo,
       setup,
     ) => {
   let parentPid =
@@ -122,7 +122,7 @@ let start =
              writeTransport(
                ~id=0,
                t,
-               Protocol.ClientToServer.Initialize(languageInfo, setup),
+               Protocol.ClientToServer.Initialize(grammarInfo, setup),
              )
            );
       }
@@ -141,13 +141,13 @@ let start =
 let startHighlightingBuffer =
     (
       ~bufferId: int,
-      ~filetype: string,
+      ~scope: string,
       ~visibleRanges: list(Range.t),
       ~lines: array(string),
       v: t,
     ) => {
   let message: Oni_Syntax.Protocol.ClientToServer.t =
-    BufferStartHighlighting({bufferId, filetype, lines, visibleRanges});
+    BufferStartHighlighting({bufferId, scope, lines, visibleRanges});
   ClientLog.tracef(m => m("Sending startHighlightingBuffer: %d", bufferId));
   write(v, message);
 };

--- a/src/Syntax_Client/Oni_Syntax_Client.rei
+++ b/src/Syntax_Client/Oni_Syntax_Client.rei
@@ -22,7 +22,7 @@ let start:
     ~onHighlights: (~bufferId: int, ~tokens: list(Protocol.TokenUpdate.t)) =>
                    unit,
     ~onHealthCheckResult: bool => unit,
-    Exthost.LanguageInfo.t,
+    Exthost.GrammarInfo.t,
     Setup.t
   ) =>
   result(t, string);
@@ -30,7 +30,7 @@ let start:
 let startHighlightingBuffer:
   (
     ~bufferId: int,
-    ~filetype: string,
+    ~scope: string,
     ~visibleRanges: list(Range.t),
     ~lines: array(string),
     t

--- a/src/Syntax_Server/Oni_Syntax_Server.re
+++ b/src/Syntax_Server/Oni_Syntax_Server.re
@@ -103,16 +103,16 @@ let start = (~parentPid, ~namedPipe, ~healthCheck) => {
           let res = healthCheck();
           write(Protocol.ServerToClient.HealthCheckPass(res == 0));
         }
-      | BufferStartHighlighting({bufferId, filetype, lines, visibleRanges}) => {
+      | BufferStartHighlighting({bufferId, scope, lines, visibleRanges}) => {
           log(
             Printf.sprintf(
-              "Buffer enter - id: %d filetype: %s",
+              "Buffer enter - id: %d scope: %s",
               bufferId,
-              filetype,
+              scope,
             ),
           );
           updateAndRestartTimer(
-            State.bufferEnter(~bufferId, ~filetype, ~lines, ~visibleRanges),
+            State.bufferEnter(~bufferId, ~scope, ~lines, ~visibleRanges),
           );
         }
 

--- a/src/Syntax_Server/State.re
+++ b/src/Syntax_Server/State.re
@@ -262,11 +262,6 @@ let bufferEnter =
       [bufferId, ...state.visibleBuffers];
     };
 
-// TODO: Send in scope
-//  let scope =
-//    Exthost.GrammarInfo.getScopeFromLanguage(state.grammarInfo, filetype)
-//    |> Option.value(~default=Constants.defaultScope);
-
   let bufferInfo =
     state.bufferInfo
     |> IntMap.update(

--- a/src/Syntax_Server/State.re
+++ b/src/Syntax_Server/State.re
@@ -11,6 +11,10 @@ open Oni_Syntax;
 
 type logFunc = string => unit;
 
+module Constants = {
+  let defaultScope = "source.text";
+};
+
 type bufferInfo = {
   lines: array(string),
   version: int,
@@ -21,7 +25,7 @@ type t = {
   useTreeSitter: bool,
   setup: option(Setup.t),
   bufferInfo: IntMap.t(bufferInfo),
-  languageInfo: Exthost.LanguageInfo.t,
+  grammarInfo: Exthost.GrammarInfo.t,
   treesitterRepository: TreesitterRepository.t,
   grammarRepository: GrammarRepository.t,
   theme: TokenTheme.t,
@@ -36,21 +40,17 @@ let empty = {
   visibleBuffers: [],
   highlightsMap: IntMap.empty,
   theme: TokenTheme.empty,
-  languageInfo: Exthost.LanguageInfo.initial,
+  grammarInfo: Exthost.GrammarInfo.initial,
   grammarRepository: GrammarRepository.empty,
   treesitterRepository: TreesitterRepository.empty,
 };
 
-let initialize = (~log, languageInfo, setup, state) => {
+let initialize = (~log, grammarInfo, setup, state) => {
   ...state,
-  languageInfo,
-  grammarRepository: GrammarRepository.create(~log, languageInfo),
-  treesitterRepository: TreesitterRepository.create(~log, languageInfo),
+  grammarInfo,
+  grammarRepository: GrammarRepository.create(~log, grammarInfo),
+  treesitterRepository: TreesitterRepository.create(~log, grammarInfo),
   setup: Some(setup),
-};
-
-module Constants = {
-  let defaultScope = "source.text";
 };
 
 let getVisibleBuffers = state => state.visibleBuffers;
@@ -253,7 +253,7 @@ let updateBufferVisibility =
 };
 
 let bufferEnter =
-    (~bufferId: int, ~filetype: string, ~lines, ~visibleRanges, state: t) => {
+    (~bufferId: int, ~scope: string, ~lines, ~visibleRanges, state: t) => {
   let exists = List.exists(id => id == bufferId, state.visibleBuffers);
   let visibleBuffers =
     if (exists) {
@@ -262,9 +262,10 @@ let bufferEnter =
       [bufferId, ...state.visibleBuffers];
     };
 
-  let scope =
-    Exthost.LanguageInfo.getScopeFromLanguage(state.languageInfo, filetype)
-    |> Option.value(~default=Constants.defaultScope);
+// TODO: Send in scope
+//  let scope =
+//    Exthost.GrammarInfo.getScopeFromLanguage(state.grammarInfo, filetype)
+//    |> Option.value(~default=Constants.defaultScope);
 
   let bufferInfo =
     state.bufferInfo

--- a/src/Syntax_Server/State.rei
+++ b/src/Syntax_Server/State.rei
@@ -13,7 +13,7 @@ let empty: t;
 
 type logFunc = string => unit;
 
-let initialize: (~log: logFunc, Exthost.LanguageInfo.t, Setup.t, t) => t;
+let initialize: (~log: logFunc, Exthost.GrammarInfo.t, Setup.t, t) => t;
 
 let getVisibleBuffers: t => list(int);
 let getVisibleHighlighters: t => list(NativeSyntaxHighlights.t);
@@ -24,7 +24,7 @@ let anyPendingWork: t => bool;
 let bufferEnter:
   (
     ~bufferId: int,
-    ~filetype: string,
+    ~scope: string,
     ~lines: array(string),
     ~visibleRanges: list(Range.t),
     t

--- a/src/Syntax_Server/TreesitterRepository.re
+++ b/src/Syntax_Server/TreesitterRepository.re
@@ -6,17 +6,17 @@ open Oni_Syntax;
 
 type t = {
   scopeToConverter: Hashtbl.t(string, TreeSitterScopes.TextMateConverter.t),
-  languageInfo: Exthost.LanguageInfo.t,
+  grammarInfo: Exthost.GrammarInfo.t,
   log: string => unit,
 };
 
-let create = (~log=_ => (), languageInfo) => {
+let create = (~log=_ => (), grammarInfo) => {
   log,
   scopeToConverter: Hashtbl.create(32),
-  languageInfo,
+  grammarInfo,
 };
 
-let empty = create(Exthost.LanguageInfo.initial);
+let empty = create(Exthost.GrammarInfo.initial);
 
 let getScopeConverter = (~scope: string, gr: t) => {
   switch (Hashtbl.find_opt(gr.scopeToConverter, scope)) {
@@ -28,7 +28,7 @@ let getScopeConverter = (~scope: string, gr: t) => {
       "getScopeConverter - querying language info for language: " ++ scope,
     );
     switch (
-      Exthost.LanguageInfo.getTreesitterPathFromScope(gr.languageInfo, scope)
+      Exthost.GrammarInfo.getTreesitterPathFromScope(gr.grammarInfo, scope)
     ) {
     | Some(grammarPath) =>
       gr.log("Loading tree sitter converter from: " ++ grammarPath);

--- a/src/Syntax_Server/TreesitterRepository.rei
+++ b/src/Syntax_Server/TreesitterRepository.rei
@@ -8,7 +8,7 @@ type t;
 
 let empty: t;
 
-let create: (~log: string => unit=?, Exthost.LanguageInfo.t) => t;
+let create: (~log: string => unit=?, Exthost.GrammarInfo.t) => t;
 
 let getScopeConverter:
   (~scope: string, t) => option(TreeSitterScopes.TextMateConverter.t);

--- a/src/bin_editor/HealthCheck.re
+++ b/src/bin_editor/HealthCheck.re
@@ -193,7 +193,7 @@ let mainChecks = [
           ~onClose=_ => {closed := true},
           ~onHighlights=(~bufferId as _, ~tokens as _) => (),
           ~onHealthCheckResult=res => {healthCheckResult := res},
-          Exthost.LanguageInfo.initial,
+          Exthost.GrammarInfo.initial,
           setup,
         )
         |> Result.get_ok;


### PR DESCRIPTION
This refactoring is intended to help un-block https://github.com/onivim/oni2/pull/2119

That PR is failing with an error: `Invalid_argument "output_value: abstract value (Custom)"` - which is happening when we try to send the `LanguageInfo` over to the syntax-server via the `Marshal` module. The root cause is that we are trying to serialize `OnigRegExp` objects, which are really C pointers with no custom serialization/deserialization - and we get this error when trying to send them via marshal.

However, we really only need to find grammar paths in the syntax server - we don't need all of the extra language information and configuration. This PR splits up language info into a grammar info that is a subset, and is just focused on locating grammars.

Apart from all the plumbing (changing `LanguageInfo` -> `GrammarInfo`) in a bunch of places, there was one spot that needed extension information to go from file type -> grammar scope in the syntax server. Instead of sending extra information to handle that, the protocol was changed to send the scope.