### PR TITLE
fix(editor): set UTF-8 encoding for tabPaint

### DIFF
--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -202,6 +202,7 @@ Skia.Paint.setTextEncoding(tabPaint, GlyphId);
 Skia.Paint.setLcdRenderText(tabPaint, true);
 Skia.Paint.setAntiAlias(tabPaint, true);
 Skia.Paint.setTextSize(tabPaint, 10.);
+Skia.Paint.setTextEncoding(tabPaint, Utf8);
 
 let token = (~context, ~line, ~colors: Colors.t, token: BufferViewTokenizer.t) => {
   let font =


### PR DESCRIPTION
This was my mistake when I pulled out the drawing of the tab icon from the deprecated Skia API in #2113. The tab icon was appearing as a check mark -- now it appears correctly.