### PR TITLE
fix(editor): Fix 'smooth scroll' when switching between editors

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -23,8 +23,8 @@ type viewLine = {
 };
 
 [@deriving show]
-// TODO: This type needs to be private, so we can maintain invariants with the `EditorBuffer.t` and computed properties
 type t = {
+  key: [@opaque] Brisk_reconciler.Key.t,
   buffer: [@opaque] EditorBuffer.t,
   editorId: EditorId.t,
   scrollX: float,
@@ -46,6 +46,7 @@ type t = {
   pixelHeight: int,
 };
 
+let key = ({key, _}) => key;
 let totalViewLines = ({viewLines, _}) => viewLines;
 let selection = ({selection, _}) => selection;
 let setSelection = (~selection, editor) => {...editor, selection};
@@ -113,11 +114,13 @@ let bufferLineCharacterToPixel =
 
 let create = (~config, ~font, ~buffer, ()) => {
   let id = GlobalState.generateId();
+  let key = Brisk_reconciler.Key.create();
 
   let isMinimapEnabled = EditorConfiguration.Minimap.enabled.get(config);
 
   {
     editorId: id,
+    key,
     isMinimapEnabled,
     isScrollAnimated: false,
     buffer,
@@ -148,8 +151,9 @@ let create = (~config, ~font, ~buffer, ()) => {
 
 let copy = editor => {
   let id = GlobalState.generateId();
+  let key = Brisk_reconciler.Key.create();
 
-  {...editor, editorId: id};
+  {...editor, key, editorId: id};
 };
 
 type scrollbarMetrics = {

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -31,6 +31,7 @@ let create:
   t;
 let copy: t => t;
 
+let key: t => Brisk_reconciler.Key.t;
 let getId: t => int;
 let getBufferId: t => int;
 let getTopVisibleLine: t => int;

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -55,6 +55,7 @@ module Parts = {
         editorDispatch(CursorsChanged([cursor]));
 
       <EditorSurface
+        key={editor |> Feature_Editor.Editor.key}
         dispatch=editorDispatch
         ?backgroundColor
         ?foregroundColor


### PR DESCRIPTION
__Issue:__ With smooth scroll on, when switching between editors at different scrolls, the editor would 'smooth scroll' to the new position. This is actually a bit jarring when switching files.

__Defect:__ The component instance was 'common' between the editors - the reconciler didn't know it needed to be changed, and that it should reset animations. 

__Fix:__ This creates a per-editor `Brisk_reconciler.Key.t` - like the key property in React - to ensure that each editor gets mounted / unmounted when changing, which fixes the scroll issue because there is no previous state.