### PR TITLE
fix(exthost): Status Bar - handle float priority

### DIFF
--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -14,6 +14,7 @@ module Decode = {
 
   let int =
     one_of([
+      ("float", float |> map(int_of_float)),
       ("int", int),
       (
         "string",


### PR DESCRIPTION
__Issue:__ The java extension was sending a `float` as the status bar priority, which we we weren't handling.

__Fix:__ Update our decoder to parse the float and coerce to an int. May have to revisit to see if a `float` would be more appropriate (from JS - there is just the `number` type).