### PR TITLE
feat(exthost): Implement $updateConfigurationOption/$removeConfigurationOption

### DIFF
--- a/src/Core/ConfigurationTransformer.re
+++ b/src/Core/ConfigurationTransformer.re
@@ -22,3 +22,15 @@ let setField = (fieldName, value, json) => {
     json;
   };
 };
+
+let removeField = (fieldName, json) => {
+  switch (json) {
+  | `Assoc(elems) =>
+    let filtered =
+      elems |> List.filter(((key, _)) => !String.equal(key, fieldName));
+    `Assoc(filtered);
+  | _ =>
+    Log.warn("Unable to transform json - not an association list");
+    json;
+  };
+};

--- a/src/Exthost/Configuration.re
+++ b/src/Exthost/Configuration.re
@@ -91,6 +91,7 @@ let create =
 // Must be kept in-sync with:
 // https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/platform/configuration/common/configuration.ts#L30
 module Target = {
+  [@deriving show]
   type t = 
   | User
   | UserLocal
@@ -138,6 +139,7 @@ module Target = {
 };
 
 module Overrides = {
+    [@deriving show]
     type t = {
       overrideIdentifier: option(string),
       resource: option(Oni_Core.Uri.t),

--- a/src/Exthost/Configuration.re
+++ b/src/Exthost/Configuration.re
@@ -87,3 +87,64 @@ let create =
   user,
   workspace,
 };
+
+// Must be kept in-sync with:
+// https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/platform/configuration/common/configuration.ts#L30
+module Target = {
+  type t = 
+  | User
+  | UserLocal
+  | UserRemote
+  | Workspace
+  | WorkspaceFolder
+  | Default
+  | Memory;
+
+  let toInt = fun
+  | User => 1
+  | UserLocal => 2
+  | UserRemote => 3
+  | Workspace => 4
+  | WorkspaceFolder => 5
+  | Default => 6
+  | Memory => 7;
+
+  let ofInt = fun
+  | 1 => Some(User)
+  | 2 => Some(UserLocal)
+  | 3 => Some(UserRemote)
+  | 4 => Some(Workspace)
+  | 5 => Some(WorkspaceFolder)
+  | 6 => Some(Default)
+  | 7 => Some(Memory)
+  | _ => None
+
+  let toString = fun
+  | User => "USER"
+  | UserLocal => "USER_LOCAL"
+  | UserRemote => "USER_REMOTE"
+  | Workspace => "WORKSPACE"
+  | WorkspaceFolder => "WORKSPACE_FOLDER"
+  | Default => "DEFAULT"
+  | Memory => "MEMORY";
+
+  let encode = target => target |> toInt |> Json.Encode.int;
+
+  let decode = Json.Decode.(int |> map(ofInt) |> and_then(
+    fun
+  | Some(target) => succeed(target)
+  | None => fail("Unable to parse target")
+  ))
+};
+
+module Overrides = {
+    type t = {
+      overrideIdentifier: option(string),
+      resource: option(Oni_Core.Uri.t),
+    };
+
+    let decode = Json.Decode.(obj(({field, _}) => {
+      overrideIdentifier: field.optional("overrideIdentifier", string),
+      resource: field.optional("resource", Oni_Core.Uri.decode)
+    }));
+}

--- a/src/Exthost/Configuration.re
+++ b/src/Exthost/Configuration.re
@@ -92,61 +92,74 @@ let create =
 // https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/platform/configuration/common/configuration.ts#L30
 module Target = {
   [@deriving show]
-  type t = 
-  | User
-  | UserLocal
-  | UserRemote
-  | Workspace
-  | WorkspaceFolder
-  | Default
-  | Memory;
+  type t =
+    | User
+    | UserLocal
+    | UserRemote
+    | Workspace
+    | WorkspaceFolder
+    | Default
+    | Memory;
 
-  let toInt = fun
-  | User => 1
-  | UserLocal => 2
-  | UserRemote => 3
-  | Workspace => 4
-  | WorkspaceFolder => 5
-  | Default => 6
-  | Memory => 7;
+  let toInt =
+    fun
+    | User => 1
+    | UserLocal => 2
+    | UserRemote => 3
+    | Workspace => 4
+    | WorkspaceFolder => 5
+    | Default => 6
+    | Memory => 7;
 
-  let ofInt = fun
-  | 1 => Some(User)
-  | 2 => Some(UserLocal)
-  | 3 => Some(UserRemote)
-  | 4 => Some(Workspace)
-  | 5 => Some(WorkspaceFolder)
-  | 6 => Some(Default)
-  | 7 => Some(Memory)
-  | _ => None
+  let ofInt =
+    fun
+    | 1 => Some(User)
+    | 2 => Some(UserLocal)
+    | 3 => Some(UserRemote)
+    | 4 => Some(Workspace)
+    | 5 => Some(WorkspaceFolder)
+    | 6 => Some(Default)
+    | 7 => Some(Memory)
+    | _ => None;
 
-  let toString = fun
-  | User => "USER"
-  | UserLocal => "USER_LOCAL"
-  | UserRemote => "USER_REMOTE"
-  | Workspace => "WORKSPACE"
-  | WorkspaceFolder => "WORKSPACE_FOLDER"
-  | Default => "DEFAULT"
-  | Memory => "MEMORY";
+  let toString =
+    fun
+    | User => "USER"
+    | UserLocal => "USER_LOCAL"
+    | UserRemote => "USER_REMOTE"
+    | Workspace => "WORKSPACE"
+    | WorkspaceFolder => "WORKSPACE_FOLDER"
+    | Default => "DEFAULT"
+    | Memory => "MEMORY";
 
   let encode = target => target |> toInt |> Json.Encode.int;
 
-  let decode = Json.Decode.(int |> map(ofInt) |> and_then(
-    fun
-  | Some(target) => succeed(target)
-  | None => fail("Unable to parse target")
-  ))
+  let decode =
+    Json.Decode.(
+      int
+      |> map(ofInt)
+      |> and_then(
+           fun
+           | Some(target) => succeed(target)
+           | None => fail("Unable to parse target"),
+         )
+    );
 };
 
 module Overrides = {
-    [@deriving show]
-    type t = {
-      overrideIdentifier: option(string),
-      resource: option(Oni_Core.Uri.t),
-    };
+  [@deriving show]
+  type t = {
+    overrideIdentifier: option(string),
+    resource: option(Oni_Core.Uri.t),
+  };
 
-    let decode = Json.Decode.(obj(({field, _}) => {
-      overrideIdentifier: field.optional("overrideIdentifier", string),
-      resource: field.optional("resource", Oni_Core.Uri.decode)
-    }));
-}
+  let decode =
+    Json.Decode.(
+      obj(({field, _}) =>
+        {
+          overrideIdentifier: field.optional("overrideIdentifier", string),
+          resource: field.optional("resource", Oni_Core.Uri.decode),
+        }
+      )
+    );
+};

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -625,14 +625,14 @@ module Configuration: {
   };
 
   module Target: {
-    type t = 
-    | User
-    | UserLocal
-    | UserRemote
-    | Workspace
-    | WorkspaceFolder
-    | Default
-    | Memory;
+    type t =
+      | User
+      | UserLocal
+      | UserRemote
+      | Workspace
+      | WorkspaceFolder
+      | Default
+      | Memory;
 
     let toInt: t => int;
     let ofInt: int => option(t);
@@ -640,7 +640,7 @@ module Configuration: {
 
     let encode: Json.encoder(t);
     let decode: Json.decoder(t);
-  }
+  };
 
   module Overrides: {
     type t = {
@@ -1015,19 +1015,19 @@ module Msg: {
   module Configuration: {
     [@deriving show]
     type msg =
-    | UpdateConfigurationOption({
-      target: option(Configuration.Target.t),
-      key: string,
-      value: Yojson.Safe.t,
-      overrides: option(Configuration.Overrides.t),
-      scopeToLanguage: bool,
-    })
-    | RemoveConfigurationOption({
-      target: option(Configuration.Target.t),
-      key: string,
-      overrides: option(Configuration.Overrides.t),
-      scopeToLanguage: bool,
-    })
+      | UpdateConfigurationOption({
+          target: option(Configuration.Target.t),
+          key: string,
+          value: Yojson.Safe.t,
+          overrides: option(Configuration.Overrides.t),
+          scopeToLanguage: bool,
+        })
+      | RemoveConfigurationOption({
+          target: option(Configuration.Target.t),
+          key: string,
+          overrides: option(Configuration.Overrides.t),
+          scopeToLanguage: bool,
+        });
   };
 
   module Console: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -624,6 +624,33 @@ module Configuration: {
     let toString: t => string;
   };
 
+  module Target: {
+    type t = 
+    | User
+    | UserLocal
+    | UserRemote
+    | Workspace
+    | WorkspaceFolder
+    | Default
+    | Memory;
+
+    let toInt: t => int;
+    let fromInt: int => option(t);
+    let toString: t => string;
+
+    let encode: Json.encoder(t);
+    let decode: Json.decoder(t);
+  }
+
+  module Overrides: {
+    type t = {
+      overrideIdentifier: option(string),
+      resource: option(Oni_Core.Uri.t),
+    };
+
+    let decode: Json.decoder(t);
+  };
+
   type t;
 
   let to_yojson: t => Json.t;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -635,7 +635,7 @@ module Configuration: {
     | Memory;
 
     let toInt: t => int;
-    let fromInt: int => option(t);
+    let ofInt: int => option(t);
     let toString: t => string;
 
     let encode: Json.encoder(t);
@@ -1010,6 +1010,24 @@ module Msg: {
           retry: bool,
         })
       | GetCommands;
+  };
+
+  module Configuration: {
+    [@deriving show]
+    type msg =
+    | UpdateConfigurationOption({
+      target: option(Configuration.Target.t),
+      key: string,
+      value: Yojson.Safe.t,
+      overrides: option(Configuration.Overrides.t),
+      scopeToLanguage: bool,
+    })
+    | RemoveConfigurationOption({
+      target: option(Configuration.Target.t),
+      key: string,
+      overrides: option(Configuration.Overrides.t),
+      scopeToLanguage: bool,
+    })
   };
 
   module Console: {
@@ -1427,6 +1445,7 @@ module Msg: {
     | Ready
     | Clipboard(Clipboard.msg)
     | Commands(Commands.msg)
+    | Configuration(Configuration.msg)
     | Console(Console.msg)
     | DebugService(DebugService.msg)
     | Decorations(Decorations.msg)

--- a/src/Exthost/Handlers.re
+++ b/src/Exthost/Handlers.re
@@ -75,7 +75,10 @@ let handlers =
       "MainThreadCommands",
     ),
     mainNotImplemented("MainThreadComments"),
-    mainNotImplemented("MainThreadConfiguration"),
+    main(
+      ~handler=Msg.Configuration.handle,
+      ~mapper=msg => Msg.Configuration(msg),
+      "MainThreadConfiguration"),
     main(
       ~handler=Msg.Console.handle,
       ~mapper=msg => Msg.Console(msg),

--- a/src/Exthost/Handlers.re
+++ b/src/Exthost/Handlers.re
@@ -78,7 +78,8 @@ let handlers =
     main(
       ~handler=Msg.Configuration.handle,
       ~mapper=msg => Msg.Configuration(msg),
-      "MainThreadConfiguration"),
+      "MainThreadConfiguration",
+    ),
     main(
       ~handler=Msg.Console.handle,
       ~mapper=msg => Msg.Console(msg),

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -1,4 +1,5 @@
 module ExtCommand = Command;
+module ExtConfig = Configuration;
 open Oni_Core;
 
 module Internal = {
@@ -11,6 +12,11 @@ module Internal = {
 
 module Decode = {
   open Json.Decode;
+
+  let bool = one_of([
+    ("bool", bool),
+    ("false", succeed(false))
+  ]);
 
   let int =
     one_of([
@@ -136,6 +142,59 @@ module Commands = {
     | _ => Error("Unhandled method: " ++ method)
     };
   };
+};
+
+module Configuration = {
+  [@deriving show]
+  type msg =
+    | UpdateConfigurationOption({
+      target: option(ExtConfig.Target.t),
+      key: string,
+      value: Yojson.Safe.t,
+      overrides: option(ExtConfig.Overrides.t),
+      scopeToLanguage: bool,
+    })
+    | RemoveConfigurationOption({
+      target: option(ExtConfig.Target.t),
+      key: string,
+      overrides: option(ExtConfig.Overrides.t),
+      scopeToLanguage: bool,
+    });
+
+  let handle = (method, args: Yojson.Safe.t) => {
+    Base.Result.Let_syntax.(
+      switch (method, args) {
+      | ("$updateConfigurationOption", `List([
+        targetJson,
+        `String(key),
+        valueJson,
+        overridesJson,
+        scopeToLanguageJson,
+      ])) => {
+
+        let%bind target = targetJson |> Internal.decode_value(
+          Json.Decode.(nullable(ExtConfig.Target.decode))
+        );
+
+        let%bind overrides = overridesJson |> Internal.decode_value(
+          Json.Decode.(nullable(ExtConfig.Overrides.decode))
+        );
+
+        let%bind scopeToLanguage = scopeToLanguageJson |> Internal.decode_value(
+          Decode.bool
+        );
+        Ok(UpdateConfigurationOption({
+          target,
+          key,
+          value: valueJson,
+          overrides,
+          scopeToLanguage,
+        }));
+        
+      }
+     | _ => Error("Unhandled Configuration method: " ++ method);
+     })
+     };
 };
 
 module Console = {
@@ -1472,6 +1531,7 @@ type t =
   | Ready
   | Clipboard(Clipboard.msg)
   | Commands(Commands.msg)
+  | Configuration(Configuration.msg)
   | Console(Console.msg)
   | DebugService(DebugService.msg)
   | Decorations(Decorations.msg)

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -221,6 +221,24 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
         );
         Lwt.return(Reply.okEmpty);
 
+      | Configuration(RemoveConfigurationOption({key, _})) =>
+        dispatch(
+          Actions.ConfigurationTransform(
+            "configuration.json",
+            ConfigurationTransformer.removeField(key),
+          ),
+        );
+        Lwt.return(Reply.okEmpty);
+
+      | Configuration(UpdateConfigurationOption({key, value, _})) =>
+        dispatch(
+          Actions.ConfigurationTransform(
+            "configuration.json",
+            ConfigurationTransformer.setField(key, value),
+          ),
+        );
+        Lwt.return(Reply.okEmpty);
+
       | LanguageFeatures(
           RegisterDocumentSymbolProvider({handle, selector, label}),
         ) =>


### PR DESCRIPTION
__Issue:__ Several extensions - like Java, clangd, etc - offer to persist various options, like `clangd.path`, or `  "java.configuration.checkProjectSettingsExclusions": false`. They do this via the `updateConfigurationOption`/`removeConfigurationOption` API.

__Defect:__ We weren't handling these requests, or persisting them in the user configuration.

__Fix:__ We already have the machinery to tweak the user configuration (we do this for setting themes, for example), but we we weren't handling these requests.