### PR TITLE
Formatting: Show formatting display name on success

### DIFF
--- a/extensions/reason-vscode/package.json
+++ b/extensions/reason-vscode/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "reason-vscode",
+	"displayName": "Reason / OCaml LSP",
 	"description": "IDE & Syntax support for Reason/OCaml",
 	"author": "Jared Forsyth",
 	"license": "ISC",

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -220,7 +220,12 @@ let update =
       switch (eff) {
       | Feature_Formatting.Nothing => Effect.none
       | Feature_Formatting.FormattingApplied({editCount, displayName}) =>
-        let msg = Printf.sprintf("Format: Applied %d edits with %s", editCount, displayName);
+        let msg =
+          Printf.sprintf(
+            "Format: Applied %d edits with %s",
+            editCount,
+            displayName,
+          );
         Internal.notificationEffect(~kind=Info, msg);
       | Feature_Formatting.FormatError(msg) =>
         Internal.notificationEffect(~kind=Error, "Format: " ++ msg)

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -219,9 +219,9 @@ let update =
     let effect =
       switch (eff) {
       | Feature_Formatting.Nothing => Effect.none
-      | Feature_Formatting.FormattingApplied({editCount, _}) =>
-        let msg = Printf.sprintf("Applied %d edits", editCount);
-        Internal.notificationEffect(~kind=Info, "Format: " ++ msg);
+      | Feature_Formatting.FormattingApplied({editCount, displayName}) =>
+        let msg = Printf.sprintf("Format: Applied %d edits with %s", editCount, displayName);
+        Internal.notificationEffect(~kind=Info, msg);
       | Feature_Formatting.FormatError(msg) =>
         Internal.notificationEffect(~kind=Error, "Format: " ++ msg)
       | Feature_Formatting.Effect(eff) =>


### PR DESCRIPTION
This shows the formatter display name after a successful format operation:

![image](https://user-images.githubusercontent.com/13532591/88460149-f451e480-ce4e-11ea-8c25-0915abcbf3fd.png)
