### PR TITLE
feat(scm): Wire up status-bar commands

### DIFF
--- a/src/Exthost/Command.re
+++ b/src/Exthost/Command.re
@@ -3,7 +3,7 @@ open Oni_Core;
 [@deriving show]
 type t = {
   id: string,
-  title: option(string),
+  label: option(Label.t),
 };
 
 module Decode = {
@@ -12,7 +12,7 @@ module Decode = {
       obj(({field, _}) =>
         {
           id: field.required("id", string),
-          title: field.optional("title", string),
+          label: field.optional("title", Label.decode),
         }
       )
     );

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -470,16 +470,23 @@ module SCM: {
     module Decode: {let splices: Json.decoder(Splices.t);};
   };
 
+  module ProviderFeatures: {
+    type t = {
+      hasQuickDiffProvider: bool,
+      count: option(int),
+      commitTemplate: option(string),
+      acceptInputCommand: option(command),
+      statusBarCommands: list(Command.t),
+    };
+
+    let decode: Json.decoder(t);
+  };
+
   module GroupFeatures: {
     [@deriving show({with_path: false})]
     type t = {hideWhenEmpty: bool};
 
     let decode: Json.decoder(t);
-  };
-
-  module Decode: {
-    //let resource: Yojson.Safe.t => Resource.t;
-    let command: Yojson.Safe.t => option(command);
   };
 };
 
@@ -1307,10 +1314,7 @@ module Msg: {
       | UnregisterSourceControl({handle: int})
       | UpdateSourceControl({
           handle: int,
-          hasQuickDiffProvider: option(bool),
-          count: option(int),
-          commitTemplate: option(string),
-          acceptInputCommand: option(SCM.command),
+          features: SCM.ProviderFeatures.t,
         })
       // statusBarCommands: option(_),
       | RegisterSCMResourceGroup({

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -5,11 +5,26 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module Label: {
+  [@deriving show]
+  type segment =
+    | Text(string)
+    | Icon(string);
+
+  [@deriving show]
+  type t = list(segment);
+
+  let ofString: string => t;
+  let toString: t => string;
+
+  let decode: Json.decoder(t);
+};
+
 module Command: {
   [@deriving show]
   type t = {
     id: string,
-    title: option(string),
+    label: option(Label.t),
   };
 
   let decode: Json.decoder(t);
@@ -254,21 +269,6 @@ module ReferenceContext: {
   type t = {includeDeclaration: bool};
 
   let encode: Json.encoder(t);
-};
-
-module Label: {
-  [@deriving show]
-  type segment =
-    | Text(string)
-    | Icon(string);
-
-  [@deriving show]
-  type t = list(segment);
-
-  let ofString: string => t;
-  let toString: t => string;
-
-  let decode: Json.decoder(t);
 };
 
 module Progress: {

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -494,12 +494,7 @@ let handleExtensionMessage = (~dispatch, msg: Exthost.Msg.SCM.msg) =>
       command => dispatch(AcceptInputCommandChanged({handle, command})),
       acceptInputCommand,
     );
-
-    prerr_endline("Update source control: ");
-    statusBarCommands
-    |> List.iter(sc => Exthost.Command.show(sc) |> prerr_endline);
-
-    dispatch(StatusBarCommandsChanged({handle, statusBarCommands}));
+    
   | SetInputBoxPlaceholder(_) =>
     // TODO: Set up replacement for '{0}'
     //dispatch(InputBoxPlaceholderChanged({handle, placeholder: value}))

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -495,6 +495,8 @@ let handleExtensionMessage = (~dispatch, msg: Exthost.Msg.SCM.msg) =>
       acceptInputCommand,
     );
 
+    dispatch(StatusBarCommandsChanged({handle, statusBarCommands}));
+
   | SetInputBoxPlaceholder(_) =>
     // TODO: Set up replacement for '{0}'
     //dispatch(InputBoxPlaceholderChanged({handle, placeholder: value}))

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -494,7 +494,7 @@ let handleExtensionMessage = (~dispatch, msg: Exthost.Msg.SCM.msg) =>
       command => dispatch(AcceptInputCommandChanged({handle, command})),
       acceptInputCommand,
     );
-    
+
   | SetInputBoxPlaceholder(_) =>
     // TODO: Set up replacement for '{0}'
     //dispatch(InputBoxPlaceholderChanged({handle, placeholder: value}))

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -456,16 +456,16 @@ let handleExtensionMessage = (~dispatch, msg: Exthost.Msg.SCM.msg) =>
               )
             });
        });
-  | UpdateSourceControl({
-      handle,
+  | UpdateSourceControl({handle, features}) =>
+    let {
       hasQuickDiffProvider,
       count,
       commitTemplate,
       acceptInputCommand,
-    }) =>
-    Option.iter(
-      available => dispatch(QuickDiffProviderChanged({handle, available})),
-      hasQuickDiffProvider,
+      statusBarCommands,
+    }: Exthost.SCM.ProviderFeatures.t = features;
+    dispatch(
+      QuickDiffProviderChanged({handle, available: hasQuickDiffProvider}),
     );
     Option.iter(count => dispatch(CountChanged({handle, count})), count);
     Option.iter(
@@ -476,6 +476,10 @@ let handleExtensionMessage = (~dispatch, msg: Exthost.Msg.SCM.msg) =>
       command => dispatch(AcceptInputCommandChanged({handle, command})),
       acceptInputCommand,
     );
+
+    prerr_endline("Update source control: ");
+    statusBarCommands
+    |> List.iter(sc => Exthost.Command.show(sc) |> prerr_endline);
   | SetInputBoxPlaceholder(_) =>
     // TODO: Set up replacement for '{0}'
     //dispatch(InputBoxPlaceholderChanged({handle, placeholder: value}))

--- a/src/Feature/SCM/Feature_SCM.rei
+++ b/src/Feature/SCM/Feature_SCM.rei
@@ -51,6 +51,8 @@ type model;
 
 let initial: model;
 
+let statusBarCommands: model => list(Exthost.Command.t);
+
 // EFFECTS
 
 module Effects: {
@@ -75,8 +77,6 @@ type outmsg =
   | Nothing;
 
 let update: (Exthost.Client.t, model, msg) => (model, outmsg);
-
-let statusBarCommands: model => list(Exthost.Command.t);
 
 let handleExtensionMessage:
   (~dispatch: msg => unit, Exthost.Msg.SCM.msg) => unit;

--- a/src/Feature/SCM/Feature_SCM.rei
+++ b/src/Feature/SCM/Feature_SCM.rei
@@ -42,6 +42,7 @@ module Provider: {
     acceptInputCommand: option(command),
     inputVisible: bool,
     validationEnabled: bool,
+    statusBarCommands: list(Exthost.Command.t),
   };
 };
 
@@ -74,6 +75,8 @@ type outmsg =
   | Nothing;
 
 let update: (Exthost.Client.t, model, msg) => (model, outmsg);
+
+let statusBarCommands: model => list(Exthost.Command.t);
 
 let handleExtensionMessage:
   (~dispatch: msg => unit, Exthost.Msg.SCM.msg) => unit;

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -315,6 +315,7 @@ module View = {
                   ~activeBuffer: option(Oni_Core.Buffer.t),
                   ~activeEditor: option(Feature_Editor.Editor.t),
                   ~indentationSettings: IndentationSettings.t,
+                  ~scm: Feature_SCM.model,
                   ~statusBar: model,
                   ~theme,
                   ~dispatch,
@@ -392,6 +393,17 @@ module View = {
          )
       |> React.listToElement;
 
+    let scmItems =
+      scm
+      |> Feature_SCM.statusBarCommands
+      |> List.filter_map((item: Exthost.Command.t) =>
+           item.label
+           |> Option.map(label => {
+                toStatusBarElement(~command=item.id, label)
+              })
+         )
+      |> React.listToElement;
+
     let rightItems =
       statusBar.items
       |> List.filter((item: Item.t) => item.alignment == Right)
@@ -463,6 +475,7 @@ module View = {
         <section align=`FlexStart> leftItems </section>
         <section align=`FlexStart>
           <diagnosticCount font background theme diagnostics dispatch />
+          scmItems
         </section>
         <section align=`Center />
         <section align=`FlexEnd> rightItems </section>

--- a/src/Feature/StatusBar/dune
+++ b/src/Feature/StatusBar/dune
@@ -8,6 +8,7 @@
       Oni2.feature.editor
       Oni2.feature.language_support
       Oni2.feature.notification
+      Oni2.feature.scm
       Oni2.feature.theme
       Oni2.components
       Oni2.service.exthost

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -105,6 +105,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
           contextMenu
           diagnostics={state.diagnostics}
           font={state.uiFont}
+          scm={state.scm}
           statusBar={state.statusBar}
           activeBuffer=maybeActiveBuffer
           activeEditor={Some(activeEditor)}

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -92,7 +92,10 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
                      command:
                        Some(
                          Exthost.Command.{
-                           title: Some("codelens: command1"),
+                           label:
+                             Some(
+                               Exthost.Label.ofString("codelens: command1"),
+                             ),
                            id: "codelens.command1",
                          },
                        ),
@@ -103,7 +106,10 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
                      command:
                        Some(
                          Exthost.Command.{
-                           title: Some("codelens: command2"),
+                           label:
+                             Some(
+                               Exthost.Label.ofString("codelens: command2"),
+                             ),
                            id: "codelens.command2",
                          },
                        ),


### PR DESCRIPTION
__Issue:__ The SCM provider from the exthost was sending status bar commands, but we weren't showing them - it's helpful context, like the current branch and current state of the repro:

![image](https://user-images.githubusercontent.com/13532591/88462329-7fd37180-ce5f-11ea-8264-eef2e334ef4d.png)


__Fix:__ Wire up the status bar commands from the SCM provider, show in status bar