### PR TITLE
feat(exthost): Implement MainThreadDocuments API

### DIFF
--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1093,6 +1093,17 @@ module Msg: {
         });
   };
 
+  module Documents: {
+    [@deriving show]
+    type msg =
+      | TryCreateDocument({
+          language: option(string),
+          content: option(string),
+        })
+      | TryOpenDocument({uri: Oni_Core.Uri.t})
+      | TrySaveDocument({uri: Oni_Core.Uri.t});
+  };
+
   module DownloadService: {
     [@deriving show]
     type msg =
@@ -1469,6 +1480,7 @@ module Msg: {
     | Decorations(Decorations.msg)
     | Diagnostics(Diagnostics.msg)
     | DocumentContentProvider(DocumentContentProvider.msg)
+    | Documents(Documents.msg)
     | DownloadService(DownloadService.msg)
     | Errors(Errors.msg)
     | ExtensionService(ExtensionService.msg)

--- a/src/Exthost/Handlers.re
+++ b/src/Exthost/Handlers.re
@@ -101,7 +101,11 @@ let handlers =
       "MainThreadDiagnostics",
     ),
     mainNotImplemented("MainThreadDialogs"),
-    mainNotImplemented("MainThreadDocuments"),
+    main(
+      ~handler=Msg.Documents.handle,
+      ~mapper=msg => Msg.Documents(msg),
+      "MainThreadDocuments",
+    ),
     main(
       ~handler=Msg.DocumentContentProvider.handle,
       ~mapper=msg => Msg.DocumentContentProvider(msg),

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -431,6 +431,63 @@ module DocumentContentProvider = {
   };
 };
 
+module Documents = {
+  module CreateOptions = {
+    type t = {
+      language: option(string),
+      content: option(string),
+    };
+
+    let decode =
+      Json.Decode.(
+        obj(({field, _}) =>
+          {
+            language: field.optional("language", string),
+            content: field.optional("content", string),
+          }
+        )
+      );
+  };
+
+  [@deriving show]
+  type msg =
+    | TryCreateDocument({
+        language: option(string),
+        content: option(string),
+      })
+    | TryOpenDocument({uri: Oni_Core.Uri.t})
+    | TrySaveDocument({uri: Oni_Core.Uri.t});
+
+  let handle = (method, args) => {
+    Base.Result.Let_syntax.(
+      switch (method, args) {
+      | ("$tryCreateDocument", `List([])) =>
+        Ok(TryCreateDocument({language: None, content: None}))
+
+      | ("$tryCreateDocument", `List([optionsJson])) =>
+        let%bind options =
+          optionsJson |> Internal.decode_value(CreateOptions.decode);
+        Ok(
+          TryCreateDocument({
+            language: options.language,
+            content: options.content,
+          }),
+        );
+
+      | ("$tryOpenDocument", `List([uriJson])) =>
+        let%bind uri = uriJson |> Internal.decode_value(Oni_Core.Uri.decode);
+        Ok(TryOpenDocument({uri: uri}));
+
+      | ("$trySaveDocument", `List([uriJson])) =>
+        let%bind uri = uriJson |> Internal.decode_value(Oni_Core.Uri.decode);
+        Ok(TrySaveDocument({uri: uri}));
+
+      | _ => Error("Unhandled method: " ++ method)
+      }
+    );
+  };
+};
+
 module DownloadService = {
   [@deriving show]
   type msg =
@@ -1583,6 +1640,7 @@ type t =
   | Decorations(Decorations.msg)
   | Diagnostics(Diagnostics.msg)
   | DocumentContentProvider(DocumentContentProvider.msg)
+  | Documents(Documents.msg)
   | DownloadService(DownloadService.msg)
   | Errors(Errors.msg)
   | ExtensionService(ExtensionService.msg)

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -270,6 +270,32 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
         dispatch(DecorationsChanged({handle, uris}));
         Lwt.return(Reply.okEmpty);
 
+      | Documents(documentsMsg) =>
+        switch (documentsMsg) {
+        | Documents.TryOpenDocument({uri}) =>
+          if (Oni_Core.Uri.getScheme(uri) == Oni_Core.Uri.Scheme.File) {
+            dispatch(
+              Actions.OpenFileByPath(
+                Oni_Core.Uri.toFileSystemPath(uri),
+                None,
+                None,
+              ),
+            );
+          } else {
+            Log.warnf(m =>
+              m(
+                "TryOpenDocument: Unable to open %s",
+                uri |> Oni_Core.Uri.toString,
+              )
+            );
+          }
+        | Documents.TrySaveDocument(_) =>
+          Log.warn("TrySaveDocument is not yet implemented.")
+        | Documents.TryCreateDocument(_) =>
+          Log.warn("TryCreateDocument is not yet implemented.")
+        };
+        Lwt.return(Reply.okEmpty);
+
       | ExtensionService(extMsg) =>
         Log.infof(m => m("ExtensionService: %s", Exthost.Msg.show(msg)));
         dispatch(


### PR DESCRIPTION
This hooks up the `$tryOpenDocument` API, which is helpful for picking up the language server logs.