### PR TITLE
Normalize byte / index conversion

### DIFF
--- a/src/Core/BufferLine.re
+++ b/src/Core/BufferLine.re
@@ -370,15 +370,13 @@ let getPixelPositionAndWidth = (~index: int, bufferLine: t) => {
 };
 
 module Slow = {
-  let getByteFromPixel = (~pixel, bufferLine) => {
-    let length = lengthInBytes(bufferLine);
-    Internal.resolveTo(~index=length, bufferLine);
-
+  let getIndexFromPixel = (~pixel, bufferLine) => {
+    let characterLength = lengthSlow(bufferLine);
     let rec loop = (low, high) =>
       if (high == low) {
-        getIndex(~byte=high, bufferLine);
+        high;
       } else if (high < low) {
-        getIndex(~byte=length - 1, bufferLine);
+        characterLength - 1;
       } else {
         let mid = (low + high) / 2;
         let (midPixel, midPixelWidth) =
@@ -388,10 +386,10 @@ module Slow = {
         } else if (pixel > midPixel +. midPixelWidth) {
           loop(mid + 1, high);
         } else {
-          getIndex(~byte=mid, bufferLine);
+          mid;
         };
       };
 
-    loop(0, length - 1);
+    loop(0, characterLength - 1);
   };
 };

--- a/src/Core/BufferLine.rei
+++ b/src/Core/BufferLine.rei
@@ -57,10 +57,10 @@ let getPixelPositionAndWidth: (~index: int, t) => (float, float);
 
 module Slow: {
   /*
-   * [getByteFromPixel(~position, str)] returns the pixel position [index].
+   * [getIndexFromPixel(~position, str)] returns the character index at pixel position [position].
    * The position of a character is dependent on indentation settings, multi-width characters, etc.
    *
    * _slow_ because requires traversal of the string, currently.
    */
-  let getByteFromPixel: (~pixel: float, t) => int;
+  let getIndexFromPixel: (~pixel: float, t) => int;
 };

--- a/src/Feature/Editor/ContentView.re
+++ b/src/Feature/Editor/ContentView.re
@@ -186,9 +186,9 @@ let renderText =
       let bufferLine = Editor.viewLine(editor, item).contents;
       let startPixel = Editor.scrollX(editor);
       let startCharacter =
-        BufferLine.Slow.getByteFromPixel(~pixel=startPixel, bufferLine);
+        BufferLine.Slow.getIndexFromPixel(~pixel=startPixel, bufferLine);
       let endCharacter =
-        BufferLine.Slow.getByteFromPixel(
+        BufferLine.Slow.getIndexFromPixel(
           ~pixel=startPixel +. float(bufferWidthInPixels),
           bufferLine,
         );

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -559,11 +559,14 @@ module Slow = {
 
     if (line >= 0 && line < totalLinesInBuffer) {
       let bufferLine = Buffer.getLine(line, buffer);
-      let byte =
-        BufferLine.Slow.getByteFromPixel(
+      let index =
+        BufferLine.Slow.getIndexFromPixel(
           ~pixel=pixelX +. view.scrollX,
           bufferLine,
         );
+
+      let byte = BufferLine.getByteFromIndex(~index, bufferLine);
+
       (line, byte);
     } else {
       (


### PR DESCRIPTION
This fixes a small bug in the `getIndexFromPixel` case (formerly `getByteFromPixel`) - in the traversal, we were mixing byte indices with character indices. Yet another case where having this enforced by the type system would help!

Specifically, we would call `getIndex(~byte)` on byte positions, which would return a character index, and then pass that into `loop` - so `loop` now is operating on character indices, but we'd pass those again into `getIndex(~byte)`, which would return unpredictable results - and give us an artificially low result, because if we're assuming the index is a byte position, for multi-byte characters, that would put us earlier in the string.

This fixes the codepath by operating only on indices - the downside is we can't rely on `lengthInBytes` anymore, so we have to use zed to find the 'character length' of the string.