### PR TITLE
fix(extensions): Add 'restart required' notification after installation

### DIFF
--- a/src/Feature/Extensions/ItemView.re
+++ b/src/Feature/Extensions/ItemView.re
@@ -48,6 +48,14 @@ module Styles = {
     //textOverflow(`Ellipsis),
     textWrap(Revery.TextWrapping.NoWrap),
   ];
+
+  let restartText = (~theme) => [
+    color(Colors.EditorError.foreground.from(theme)),
+    marginVertical(2),
+    // TODO: Workaround for #2140
+    //textOverflow(`Ellipsis),
+    textWrap(Revery.TextWrapping.NoWrap),
+  ];
   let imageContainer =
     Style.[
       width(Constants.imageContainerSize),
@@ -106,6 +114,7 @@ let make =
       ~theme,
       ~displayName,
       ~author,
+      ~isRestartRequired,
       ~version,
       ~font: UiFont.t,
       (),
@@ -120,6 +129,22 @@ let make =
 
   let descriptionWidth = width - Constants.imageContainerSize;
   let defaultWidth = 100;
+
+  let authorOrRestart =
+    isRestartRequired
+      ? <Text
+          style={Styles.restartText(~theme)}
+          fontFamily={font.family}
+          fontSize={font.size}
+          text="Restart Required"
+          italic=true
+        />
+      : <Text
+          style={Styles.text(~theme)}
+          fontFamily={font.family}
+          fontSize={font.size}
+          text=author
+        />;
 
   <View style={Styles.container(~width)}>
     <View style=Styles.imageContainer> icon </View>
@@ -142,14 +167,7 @@ let make =
       </View>
       <View
         style=Style.[flexDirection(`Row), justifyContent(`SpaceBetween)]>
-        <View style=Style.[flexShrink(1)]>
-          <Text
-            style={Styles.text(~theme)}
-            fontFamily={font.family}
-            fontSize={font.size}
-            text=author
-          />
-        </View>
+        <View style=Style.[flexShrink(1)]> authorOrRestart </View>
         <View style=Style.[flexBasis(Constants.buttonWidth), flexShrink(0)]>
           actionButton
         </View>

--- a/src/Feature/Extensions/ListView.re
+++ b/src/Feature/Extensions/ListView.re
@@ -94,6 +94,7 @@ let%component make =
       displayName
       author
       version
+      isRestartRequired=false
       font
     />;
   };
@@ -108,6 +109,7 @@ let%component make =
     let id = Manifest.identifier(extension.manifest);
 
     let extensionId = extension.manifest |> Manifest.identifier;
+    let isRestartRequired = Model.isRestartRequired(~extensionId, model);
     let actionButton =
       Model.isUninstalling(~extensionId=id, model)
         ? <progressButton extensionId font title="Uninstalling" />
@@ -121,6 +123,7 @@ let%component make =
       displayName
       author
       version
+      isRestartRequired
       font
     />;
   };
@@ -168,6 +171,9 @@ let%component make =
              let {namespace, version, iconUrl, _}: Service_Extensions.Catalog.Summary.t = summary;
              let author = namespace;
 
+             let isRestartRequired =
+               Model.isRestartRequired(~extensionId, model);
+
              let actionButton =
                Model.isInstalling(~extensionId, model)
                  ? <progressButton extensionId title="Installing" font />
@@ -178,6 +184,7 @@ let%component make =
                iconPath=iconUrl
                theme
                displayName
+               isRestartRequired
                author
                version
                font


### PR DESCRIPTION
Since we do not currently implement the 'delta' API for adding / remove extensions in the extension host (and picking up new languages / configurations) - the editor needs to be restarted after picking up new extensions.

This just adds a small notification to notify that a restart is required.