### PR TITLE
fix(extensions): Readme field should be optional

### DIFF
--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -138,23 +138,42 @@ let make =
     let description =
       selected |> Selected.description |> Option.value(~default="");
 
-    let readmeUrl = selected |> Selected.readme;
+    let maybeReadmeUrl = selected |> Selected.readme;
     let extensionId = selected |> Selected.identifier;
     let version = selected |> Selected.version;
 
+    let contents =
+      switch (maybeReadmeUrl) {
+      | None =>
+        <View
+          style=Style.[
+            flexGrow(1),
+            justifyContent(`Center),
+            alignItems(`Center),
+          ]>
+          <Text
+            fontFamily={font.family}
+            fontSize=18.
+            text="No README available"
+          />
+        </View>
+      | Some(readmeUrl) =>
+        <ScrollView style=Style.[paddingLeft(64), flexGrow(1)]>
+          <RemoteMarkdown
+            url=readmeUrl
+            colorTheme=theme
+            tokenTheme
+            languageInfo=Exthost.LanguageInfo.initial
+            grammars=Oni_Syntax.GrammarRepository.empty
+            fontFamily={font.family}
+            codeFontFamily={font.family}
+          />
+        </ScrollView>
+      };
+
     <View style=Styles.container>
       <header font maybeLogo displayName description extensionId version />
-      <ScrollView style=Style.[paddingLeft(64), flexGrow(1)]>
-        <RemoteMarkdown
-          url=readmeUrl
-          colorTheme=theme
-          tokenTheme
-          languageInfo=Exthost.LanguageInfo.initial
-          grammars=Oni_Syntax.GrammarRepository.empty
-          fontFamily={font.family}
-          codeFontFamily={font.family}
-        />
-      </ScrollView>
+      contents
     </View>;
   };
 };

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -89,7 +89,8 @@ module Selected = {
 
   let readme =
     fun
-    | Local(scanResult) => Rench.Path.join(scanResult.path, "README.md")
+    | Local(scanResult) =>
+      Some(Rench.Path.join(scanResult.path, "README.md"))
     | Remote({readmeUrl, _}) => readmeUrl;
 
   let version =

--- a/src/Service/Extensions/Catalog.re
+++ b/src/Service/Extensions/Catalog.re
@@ -61,7 +61,7 @@ module Details = {
     homepageUrl: string,
     manifestUrl: string,
     iconUrl: option(string),
-    readmeUrl: string,
+    readmeUrl: option(string),
     licenseName: option(string),
     //      licenseUrl: string,
     name: string,
@@ -109,7 +109,7 @@ module Details = {
     let downloadUrl = files("download", string);
     let manifestUrl = files("manifest", string);
     let iconUrl = files("icon", nullable(string));
-    let readmeUrl = files("readme", string);
+    let readmeUrl = files("readme", nullable(string));
     let homepageUrl = field("publishedBy", field("homepage", string));
 
     let decode =

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -25,7 +25,7 @@ module Catalog: {
       homepageUrl: string,
       manifestUrl: string,
       iconUrl: option(string),
-      readmeUrl: string,
+      readmeUrl: option(string),
       licenseName: option(string),
       //      licenseUrl: string,
       name: string,


### PR DESCRIPTION
__Issue:__  The scala metal extension fails to install

__Defect:__ Some extensions don't have a README defined - like https://open-vsx.org/extension/scalameta/metals We assume there is a readme field, and our parsing fails if there is not one.

__Fix:__ Make readmeUrl an optional field

__Related:__ #2243 