### PR TITLE
fix(completion/#2234): Show direct match

### DIFF
--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -199,7 +199,7 @@ module Session = {
       items
       |> List.filter((item: Exthost.SuggestItem.t) => {
            let filterText = Exthost.SuggestItem.filterText(item);
-           if (String.length(filterText) <= String.length(query)) {
+           if (String.length(filterText) < String.length(query)) {
              false;
            } else {
              Filter.fuzzyMatches(explodedQuery, filterText);


### PR DESCRIPTION
__Issue:__ As described in #2234 - the fuzzy matching strategy was ignoring a complete match.

__Defect:__ Off-by-one case in our filtering logic - we should still show the complete match, so that the details / documentation are visible. Regression from #2202 

__Fix:__ Fix filter logic

Fixes #2234 