### PR TITLE
fix(extensions): Unblock rust-analyzer extension

### DIFF
--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -188,6 +188,7 @@ module Scanner: {
       category,
       manifest: Manifest.t,
       path: string,
+      rawPackageJson: Yojson.Safe.t,
     };
   };
 
@@ -206,7 +207,7 @@ module InitData: {
     [@deriving (show, yojson({strict: false}))]
     type t;
 
-    let ofManifestAndPath: (Manifest.t, string) => t;
+    let ofScanResult: Scanner.ScanResult.t => t;
   };
 
   module Environment: {

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -1,5 +1,7 @@
 open Oni_Core;
 
+module Log = (val Timber.Log.withNamespace("Exthost.Extension.InitData"));
+
 module Identifier = {
   [@deriving (show, yojson({strict: false}))]
   type t = {
@@ -12,42 +14,26 @@ module Identifier = {
 
 module Extension = {
   [@deriving (show, yojson({strict: false}))]
-  type t = {
-    identifier: Identifier.t,
-    extensionLocation: Uri.t,
-    name: string,
-    displayName: option(string),
-    description: option(string),
-    main: option(string),
-    icon: option(string),
-    version: string,
-    engines: string,
-    defaults: Yojson.Safe.t,
-    activationEvents: list(string),
-    extensionDependencies: list(string),
-    runtimeDependencies: Yojson.Safe.t,
-    extensionKind: list(string),
-    contributes: Contributions.t,
-    enableProposedApi: bool,
-  };
+  type t = Yojson.Safe.t;
 
-  let ofManifestAndPath = (manifest: Manifest.t, path: string) => {
-    identifier: manifest |> Manifest.identifier |> Identifier.fromString,
-    extensionLocation: path |> Uri.fromPath,
-    displayName: manifest |> Manifest.displayName,
-    description: manifest.description,
-    icon: manifest.icon,
-    name: manifest.name,
-    main: manifest.main,
-    version: manifest.version,
-    engines: manifest.engines,
-    defaults: manifest.defaults,
-    activationEvents: manifest.activationEvents,
-    extensionDependencies: manifest.extensionDependencies,
-    runtimeDependencies: manifest.runtimeDependencies,
-    extensionKind: manifest.extensionKind |> List.map(Manifest.Kind.toString),
-    enableProposedApi: manifest.enableProposedApi,
-    contributes: manifest.contributes,
+  let ofScanResult = (scanner: Scanner.ScanResult.t) => {
+    let identifier =
+      scanner.manifest |> Manifest.identifier |> Identifier.fromString;
+    let extensionLocation = scanner.path |> Uri.fromPath;
+
+    switch (scanner.rawPackageJson) {
+    | `Assoc(items) =>
+      `Assoc([
+        ("identifier", Identifier.to_yojson(identifier)),
+        ("extensionLocation", Uri.to_yojson(extensionLocation)),
+        ...items,
+      ])
+    | json =>
+      Log.warnf(m =>
+        m("Unexpected package format: %s", Yojson.Safe.to_string(json))
+      );
+      json;
+    };
   };
 };
 

--- a/src/Exthost/Extension/Scanner.re
+++ b/src/Exthost/Extension/Scanner.re
@@ -20,6 +20,7 @@ module ScanResult = {
     category,
     manifest: Manifest.t,
     path: string,
+    rawPackageJson: Yojson.Safe.t,
   };
 };
 
@@ -54,7 +55,9 @@ let load = (~category, packageFile) => {
   | Ok(parsedManifest) =>
     let manifest = parsedManifest |> remapManifest(directory) |> localize;
 
-    Some(ScanResult.{category, manifest, path: directory});
+    Some(
+      ScanResult.{category, manifest, path: directory, rawPackageJson: json},
+    );
 
   | Error(err) =>
     Log.errorf(m =>

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -30,14 +30,7 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
   let extensionInfo =
-    extensions
-    |> List.map(
-         ({manifest, path, _}: Exthost.Extension.Scanner.ScanResult.t) =>
-         Exthost.Extension.InitData.Extension.ofManifestAndPath(
-           manifest,
-           path,
-         )
-       );
+    extensions |> List.map(Exthost.Extension.InitData.Extension.ofScanResult);
 
   let onRegisterDocumentSymbolProvider = (handle, selector, label, client) => {
     let id = "exthost." ++ string_of_int(handle);

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -29,9 +29,7 @@ let getExtensionManifest =
     p =>
       Rench.Path.join(p, "package.json")
       |> Scanner.load(~category=Scanner.Bundled)
-      |> Option.map(({manifest, path, _}: Extension.Scanner.ScanResult.t) => {
-           InitData.Extension.ofManifestAndPath(manifest, path)
-         })
+      |> Option.map(InitData.Extension.ofScanResult)
       |> Option.get
   );
 };
@@ -66,9 +64,7 @@ let startWithExtensions =
     |> List.map(p => Rench.Path.join(p, "package.json"))
     |> List.map(Scanner.load(~category=Scanner.Bundled))
     |> List.filter_map(v => v)
-    |> List.map((Extension.Scanner.ScanResult.{manifest, path, _}) => {
-         InitData.Extension.ofManifestAndPath(manifest, path)
-       });
+    |> List.map(InitData.Extension.ofScanResult);
 
   extensions |> List.iter(m => m |> InitData.Extension.show |> prerr_endline);
 


### PR DESCRIPTION
__Issue:__ The `rust-analyzer` extension would fail when trying to determine where to get the `rust-analyzer` language server.

__Defect:__ The rust extension uses the `releaseTag` in the `package.json` to decide where to find the server (ie, `nightly` vs a tagged branch). First, we were not passing this value at all, and second, the publish script to release `rust-analyzer` on open-vsx is not properly populating this value (https://github.com/open-vsx/publish-extensions/issues/106)

__Fix:__ The not-passing-the-value is a class of issues we had - we were not passing through anything that we did not parse, although extensions expect to have the full package.json available (this was also an issue with the C# extension - fixed in #2184 ). Instead of just trying to add these one-by-one, this sends the whole manifest (and tags it with some extra properties that are defined here: https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/platform/extensions/common/extensions.ts#L234

For the second issue - added a temporary, manual hack to populate the `releaseTag` value in the case of `rust-analyzer` - but hopefully that go away soon if the `releaseTag` is populated on open-vsx.

This unblocks the `rust-analyzer` extension provided on `open-vsx.org`:
![image](https://user-images.githubusercontent.com/13532591/89467409-56052f00-d72a-11ea-9135-4eb848a6ebc2.png)

![image](https://user-images.githubusercontent.com/13532591/89467435-60bfc400-d72a-11ea-9c18-9b0441b57e8d.png)

