### PR TITLE
fix(persistence/#2229): Bad window position on restore

### DIFF
--- a/src/Core/Utility/OptionEx.re
+++ b/src/Core/Utility/OptionEx.re
@@ -4,6 +4,11 @@ let bind2 = (a, b, f) =>
   | _ => None
   };
 
+let filter = f =>
+  fun
+  | Some(x) as v => f(x) ? v : None
+  | None => None;
+
 let flatMap = f =>
   fun
   | Some(x) => f(x)

--- a/src/Store/Persistence.re
+++ b/src/Store/Persistence.re
@@ -44,15 +44,13 @@ module Workspace = {
     open Persistence.Schema;
 
     let windowX =
-      define("windowX", option(int), None, ((_state, window)) =>
+      define("windowX", option(int), None, ((_state, window))
         // TODO: We should check if window is minimized
-        Some(Window.getPosition(window) |> fst)
-      );
+        => Some(Window.getPosition(window) |> fst));
     let windowY =
-      define("windowY", option(int), None, ((_state, window)) =>
+      define("windowY", option(int), None, ((_state, window))
         // TODO: We should check if window is minimized
-        Some(Window.getPosition(window) |> snd)
-      );
+        => Some(Window.getPosition(window) |> snd));
     let windowWidth =
       define("windowWidth", int, 800, ((_state, window)) =>
         Window.getSize(window).width

--- a/src/Store/Persistence.re
+++ b/src/Store/Persistence.re
@@ -45,10 +45,12 @@ module Workspace = {
 
     let windowX =
       define("windowX", option(int), None, ((_state, window)) =>
+        // TODO: We should check if window is minimized
         Some(Window.getPosition(window) |> fst)
       );
     let windowY =
       define("windowY", option(int), None, ((_state, window)) =>
+        // TODO: We should check if window is minimized
         Some(Window.getPosition(window) |> snd)
       );
     let windowWidth =


### PR DESCRIPTION
__Issue:__ When minimizing the window, on windows, we persist some extreme negative values (`-32000`) for `x` and `y`, causing the window to be shown offscreen.

__Fix:__ This is band-aid / hack for 0.5.0 - but we sanitize values past a certain threshold (-2000) and adjust them to be centered. 

A more complete fix would:
- Not persist `x`/`y` when Revery window is minimized (need to hook up the `isMinimized` API)
- Check the bounds of the current displays, such that we can have more complete validation, instead of an arbitrary constant.

Fixes #2229 