### PR TITLE
fix(metadata/#2260): License field in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Oni2",
   "version": "0.5.0",
   "description": "Lightweight code editor",
-  "license": "MIT",
+  "license": "SEE LICENSE IN Outrun-Labs-EULA-v1.1.md",
   "esy": {
     "build": "refmterr dune build -p libvim,textmate,Oni2 -j4",
     "buildEnv": { "MACOSX_DEPLOYMENT_TARGET": "10.12" },

--- a/scripts/generate-mit-readme.js
+++ b/scripts/generate-mit-readme.js
@@ -15,13 +15,12 @@ const lines = inputLines.replace("%%COMMITID%%", commitId)
 
 console.log(lines)
 
-console.log("Updating README.md...");
+console.log("Updating README.md...")
 fs.writeFileSync(destinationMd, lines, "utf8")
 
-console.log("Updating package.json license field...");
-let packageJsonPath = path.join(destPath, "package.json");
+console.log("Updating package.json license field...")
+let packageJsonPath = path.join(destPath, "package.json")
 
-let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-packageJson["license"] = "MIT";
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "  "));
-
+let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
+packageJson["license"] = "MIT"
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "  "))

--- a/scripts/generate-mit-readme.js
+++ b/scripts/generate-mit-readme.js
@@ -15,4 +15,13 @@ const lines = inputLines.replace("%%COMMITID%%", commitId)
 
 console.log(lines)
 
+console.log("Updating README.md...");
 fs.writeFileSync(destinationMd, lines, "utf8")
+
+console.log("Updating package.json license field...");
+let packageJsonPath = path.join(destPath, "package.json");
+
+let packageJson = JSON.parse(packageJsonPath);
+packageJson["license"] = "MIT";
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+

--- a/scripts/generate-mit-readme.js
+++ b/scripts/generate-mit-readme.js
@@ -21,7 +21,7 @@ fs.writeFileSync(destinationMd, lines, "utf8")
 console.log("Updating package.json license field...");
 let packageJsonPath = path.join(destPath, "package.json");
 
-let packageJson = JSON.parse(packageJsonPath);
+let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 packageJson["license"] = "MIT";
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "  "));
 


### PR DESCRIPTION
The license field should point to the EULA: https://github.com/onivim/oni2/blob/master/Outrun-Labs-EULA-v1.1.md

Also updated the MIT-relicense script so that the field gets properly set back to `MIT` when relicensing commits here: https://github.com/onivim/oni2-mit

Fixes #2260 - thanks @SqrtMinusOne for catching this!