### PR TITLE
fix(osx/#2090): Prefer integrated to discrete GPU

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -124,6 +124,7 @@ if (process.platform == "linux") {
         CFBundleSignature: "????",
         CFBundleExecutable: "Oni2_editor",
         NSHighResolutionCapable: true,
+        NSSupportsAutomaticGraphicsSwitching: true,
         CFBundleDocumentTypes: package.build.fileAssociations.map((fileAssoc) => {
             return {
                 CFBundleTypeExtensions: fileAssoc.ext.map((ext) => ext.substr(1)),


### PR DESCRIPTION
__Issue:__ When running Onivim 2 on a dual-GPU Mac, Onivim would only use the discrete GPU (which is more expensive for battle life).

__Defect:__ By default, when creating an OpenGL context, OSX prefers the discrete GPU. The [`NSSupportsAutomaticGraphicsSwitching`](https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching) attribute is necessary to allow use of the integrated GPU.

__Fix:__ Add `NSSupportsAutomaticGraphicsSwitching: true` to our `Info.plist`

Fixes #2090 