### PR TITLE
fix(scm/#2226): Command submodules showing on save

### DIFF
--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -15,13 +15,13 @@ module Diagnostic = Feature_LanguageSupport.Diagnostic;
 module LanguageFeatures = Feature_LanguageSupport.LanguageFeatures;
 
 let start = (extensions, extHostClient: Exthost.Client.t) => {
-  let gitRefreshEffect = (scm: Feature_SCM.model) =>
+  let gitRefreshEffect = (scm: Feature_SCM.model, uri) =>
     if (scm == Feature_SCM.initial) {
       Isolinear.Effect.none;
     } else {
       Service_Exthost.Effects.Commands.executeContributedCommand(
         ~command="git.refresh",
-        ~arguments=[],
+        ~arguments=[`String(uri |> Oni_Core.Uri.toFileSystemPath)],
         extHostClient,
       );
     };
@@ -144,10 +144,18 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
         ),
       )
 
-    | BufferSaved(_) => (
+    | BufferSaved(bufferId) =>
+      let effect = state.buffers
+      |> Oni_Model.Buffers.getBuffer(bufferId)
+      |> Option.map(buffer => {
+        gitRefreshEffect(state.scm, buffer |> Oni_Core.Buffer.getUri)
+      })
+      |> Option.value(~default=Isolinear.Effect.none);
+
+      (
         state,
-        Isolinear.Effect.batch([gitRefreshEffect(state.scm)]),
-      )
+        effect,
+      );
 
     | StatusBar(ContributedItemClicked({command, _})) => (
         state,

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -145,17 +145,15 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
       )
 
     | BufferSaved(bufferId) =>
-      let effect = state.buffers
-      |> Oni_Model.Buffers.getBuffer(bufferId)
-      |> Option.map(buffer => {
-        gitRefreshEffect(state.scm, buffer |> Oni_Core.Buffer.getUri)
-      })
-      |> Option.value(~default=Isolinear.Effect.none);
+      let effect =
+        state.buffers
+        |> Oni_Model.Buffers.getBuffer(bufferId)
+        |> Option.map(buffer => {
+             gitRefreshEffect(state.scm, buffer |> Oni_Core.Buffer.getUri)
+           })
+        |> Option.value(~default=Isolinear.Effect.none);
 
-      (
-        state,
-        effect,
-      );
+      (state, effect);
 
     | StatusBar(ContributedItemClicked({command, _})) => (
         state,


### PR DESCRIPTION
__Issue:__ When saving in a folder that has multiple git repos, or when saving a file from a repo other than the active one, a menu will pop up asking to clarify the repo.

__Defect:__ After save, we send the `git.refresh` command to get an up-to-date view of the source control.  The git source control extension would try and infer what repository to refresh: https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/extensions/git/src/commands.ts#L2399 - this would be fine if there was only one repository. However, if there were multiple, the extension would open a pop-up to disambiguate.

__Fix:__ The command takes a 'hint' URL to specify which repository - having the file path is an acceptable hint, so sending the filepath along with `git.refresh` does not require the disambiguation step

Fixes #2226 