### PR TITLE
fix(ux): SymbolIcon theme colors

### DIFF
--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -949,21 +949,40 @@ module View = {
     | Issue => Codicon.symbolMisc
     | Snippet => Codicon.symbolText;
 
-  let kindToColor = (tokenTheme: TokenTheme.t) =>
-    fun
-    | Text => Some(tokenTheme.textColor)
-    | Method => Some(tokenTheme.functionColor)
-    | Function => Some(tokenTheme.functionColor)
-    | Constructor => Some(tokenTheme.entityColor)
-    | Struct => Some(tokenTheme.typeColor)
-    | Module => Some(tokenTheme.entityColor)
-    | Unit => Some(tokenTheme.entityColor)
-    | Keyword => Some(tokenTheme.keywordColor)
-    | Enum => Some(tokenTheme.entityColor)
-    | Constant => Some(tokenTheme.constantColor)
-    | Property => Some(tokenTheme.entityColor)
-    | Interface => Some(tokenTheme.entityColor)
-    | _ => None;
+  let kindToColor = (colors: Oni_Core.ColorTheme.Colors.t) =>
+    Feature_Theme.Colors.SymbolIcon.(
+      {
+        fun
+        | Method => methodForeground.from(colors)
+        | Function => functionForeground.from(colors)
+        | Constructor => constructorForeground.from(colors)
+        | Field => fieldForeground.from(colors)
+        | Variable => variableForeground.from(colors)
+        | Class => classForeground.from(colors)
+        | Struct => structForeground.from(colors)
+        | Interface => interfaceForeground.from(colors)
+        | Module => moduleForeground.from(colors)
+        | Property => propertyForeground.from(colors)
+        | Event => eventForeground.from(colors)
+        | Operator => operatorForeground.from(colors)
+        | Unit => unitForeground.from(colors)
+        | Value
+        | Constant => constantForeground.from(colors)
+        | Enum => enumeratorForeground.from(colors)
+        | EnumMember => enumeratorMemberForeground.from(colors)
+        | Keyword => keywordForeground.from(colors)
+        | Text => textForeground.from(colors)
+        | Color => colorForeground.from(colors)
+        | File => fileForeground.from(colors)
+        | Reference => referenceForeground.from(colors)
+        | Customcolor => colorForeground.from(colors)
+        | Folder => folderForeground.from(colors)
+        | TypeParameter => typeParameterForeground.from(colors)
+        | User => nullForeground.from(colors)
+        | Issue => nullForeground.from(colors)
+        | Snippet => snippetForeground.from(colors);
+      }
+    );
 
   module Colors = {
     type t = {
@@ -1048,17 +1067,14 @@ module View = {
         ~text,
         ~kind,
         ~highlight,
+        ~theme: Oni_Core.ColorTheme.Colors.t,
         ~colors: Colors.t,
-        ~tokenTheme,
         ~editorFont: Service_Font.font,
         (),
       ) => {
     let icon = kind |> kindToIcon;
 
-    let iconColor =
-      kind
-      |> kindToColor(tokenTheme)
-      |> Option.value(~default=colors.editorForeground);
+    let iconColor = kind |> kindToColor(theme);
 
     <View style={Styles.item(~isFocused, ~colors)}>
       <View style={Styles.icon(~color=iconColor)}>
@@ -1180,8 +1196,8 @@ module View = {
                 text
                 kind
                 highlight
+                theme
                 colors
-                tokenTheme
                 editorFont
               />;
             }}

--- a/src/Feature/Theme/Feature_Theme.re
+++ b/src/Feature/Theme/Feature_Theme.re
@@ -52,6 +52,7 @@ let defaults =
     Colors.SideBar.defaults,
     Colors.SideBarSectionHeader.defaults,
     Colors.StatusBar.defaults,
+    Colors.SymbolIcon.defaults,
     Colors.Tab.defaults,
     Colors.TextLink.defaults,
     Colors.TitleBar.defaults,

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -917,6 +917,107 @@ module StatusBar = {
   let defaults = [background, foreground];
 };
 
+module SymbolIcon = {
+  let arrayForeground =
+    define("symbolIcon.arrayForeground", all(ref(foreground)));
+  let booleanForeground =
+    define("symbolIcon.booleanForeground", all(ref(foreground)));
+  let classForeground =
+    define("symbolIcon.classForeground", all(ref(foreground)));
+  let colorForeground =
+    define("symbolIcon.colorForeground", all(ref(foreground)));
+  let constantForeground =
+    define("symbolIcon.constantForeground", all(ref(foreground)));
+  let constructorForeground =
+    define("symbolIcon.constructorForeground", all(ref(foreground)));
+  let enumeratorForeground =
+    define("symbolIcon.enumeratorForeground", all(ref(foreground)));
+  let enumeratorMemberForeground =
+    define("symbolIcon.enumeratorMemberForeground", all(ref(foreground)));
+  let eventForeground =
+    define("symbolIcon.eventForeground", all(ref(foreground)));
+  let fieldForeground =
+    define("symbolIcon.fieldForeground", all(ref(foreground)));
+  let fileForeground =
+    define("symbolIcon.fileForeground", all(ref(foreground)));
+  let folderForeground =
+    define("symbolIcon.folderForeground", all(ref(foreground)));
+  let functionForeground =
+    define("symbolIcon.functionForeground", all(ref(foreground)));
+  let interfaceForeground =
+    define("symbolIcon.interfaceForeground", all(ref(foreground)));
+  let keyForeground =
+    define("symbolIcon.keyForeground", all(ref(foreground)));
+  let keywordForeground =
+    define("symbolIcon.keywordForeground", all(ref(foreground)));
+  let methodForeground =
+    define("symbolIcon.methodForeground", all(ref(foreground)));
+  let moduleForeground =
+    define("symbolIcon.moduleForeground", all(ref(foreground)));
+  let namespaceForeground =
+    define("symbolIcon.namespaceForeground", all(ref(foreground)));
+  let nullForeground =
+    define("symbolIcon.nullForeground", all(ref(foreground)));
+  let objectForeground =
+    define("symbolIcon.objectForeground", all(ref(foreground)));
+  let operatorForeground =
+    define("symbolIcon.operatorForeground", all(ref(foreground)));
+  let packageForeground =
+    define("symbolIcon.packageForeground", all(ref(foreground)));
+  let propertyForeground =
+    define("symbolIcon.propertyForeground", all(ref(foreground)));
+  let referenceForeground =
+    define("symbolIcon.referenceForeground", all(ref(foreground)));
+  let snippetForeground =
+    define("symbolIcon.snippetForeground", all(ref(foreground)));
+  let stringForeground =
+    define("symbolIcon.stringForeground", all(ref(foreground)));
+  let structForeground =
+    define("symbolIcon.structForeground", all(ref(foreground)));
+  let textForeground =
+    define("symbolIcon.textForeground", all(ref(foreground)));
+  let typeParameterForeground =
+    define("symbolIcon.typeParameterForeground", all(ref(foreground)));
+  let unitForeground =
+    define("symbolIcon.unitForeground", all(ref(foreground)));
+  let variableForeground =
+    define("symbolIcon.variableForeground", all(ref(foreground)));
+
+  let defaults = [
+    arrayForeground,
+    booleanForeground,
+    classForeground,
+    colorForeground,
+    constantForeground,
+    constructorForeground,
+    enumeratorForeground,
+    enumeratorMemberForeground,
+    eventForeground,
+    fieldForeground,
+    fileForeground,
+    folderForeground,
+    functionForeground,
+    interfaceForeground,
+    keyForeground,
+    keywordForeground,
+    methodForeground,
+    moduleForeground,
+    namespaceForeground,
+    nullForeground,
+    objectForeground,
+    packageForeground,
+    propertyForeground,
+    referenceForeground,
+    snippetForeground,
+    stringForeground,
+    structForeground,
+    textForeground,
+    typeParameterForeground,
+    unitForeground,
+    variableForeground,
+  ];
+};
+
 module Tab = {
   // BACKGROUND
 


### PR DESCRIPTION
Hooks up the `symbolIcon.*` theme colors to the completion view