### PR TITLE
fix(ci): Harfbuzz build failure on master/nightly

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "735081d75b83090a71d0493b13704c1d",
+  "checksum": "c8bd82b4b1d6e4557a029941286d3817",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+    "revery@github:revery-ui/revery#a08ec1a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#71ad8c5b",
+      "version": "github:revery-ui/revery#a08ec1a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#71ad8c5b" ]
+        "source": [ "github:revery-ui/revery#a08ec1a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -991,7 +991,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25be7e0a3aba7b2bf31d1189d9abd0ab",
+  "checksum": "735081d75b83090a71d0493b13704c1d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#926dabd4@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#926dabd4",
+      "version": "github:revery-ui/revery#71ad8c5b",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#926dabd4" ]
+        "source": [ "github:revery-ui/revery#71ad8c5b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -144,12 +144,12 @@
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
-        "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+        "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -834,7 +834,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/menhir@opam:20200624@8629ff13",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
@@ -852,7 +852,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -991,7 +991,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
@@ -1011,12 +1011,12 @@
         "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/reason@opam:3.6.0@2da53ff9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "@opam/reason@opam:3.6.0@58adb39a", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_inline_test@opam:v0.13.1@dbfe49b7",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
@@ -1058,18 +1058,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-harfbuzz@2.6.8000@d41d8cd9": {
-      "id": "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+    "@revery/esy-harfbuzz@2.6.8001@d41d8cd9": {
+      "id": "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
       "name": "@revery/esy-harfbuzz",
-      "version": "2.6.8000",
+      "version": "2.6.8001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8000.tgz#sha1:2a78f826c54b1244accec6c8d07c3968efe6ced2"
+          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8001.tgz#sha1:86a4382a4dcd54e5ac1a5589e8092edd65c3945f"
         ]
       },
       "overrides": [],
-      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-cmake@0.3.5001@d41d8cd9": {
@@ -1551,8 +1551,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/reason@opam:3.6.0@2da53ff9": {
-      "id": "@opam/reason@opam:3.6.0@2da53ff9",
+    "@opam/reason@opam:3.6.0@58adb39a": {
+      "id": "@opam/reason@opam:3.6.0@58adb39a",
       "name": "@opam/reason",
       "version": "opam:3.6.0",
       "source": {
@@ -1719,8 +1719,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.13.0@e0dac6a1": {
-      "id": "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+    "@opam/ppxlib@opam:0.13.0@3d7c6edb": {
+      "id": "@opam/ppxlib@opam:0.13.0@3d7c6edb",
       "name": "@opam/ppxlib",
       "version": "opam:0.13.0",
       "source": {
@@ -1752,8 +1752,8 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
-    "@opam/ppxfind@opam:1.4@1e01d2a5": {
-      "id": "@opam/ppxfind@opam:1.4@1e01d2a5",
+    "@opam/ppxfind@opam:1.4@d75848d2": {
+      "id": "@opam/ppxfind@opam:1.4@d75848d2",
       "name": "@opam/ppxfind",
       "version": "opam:1.4",
       "source": {
@@ -1808,8 +1808,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1": {
-      "id": "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+    "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414": {
+      "id": "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
       "name": "@opam/ppx_tools_versioned",
       "version": "opam:5.4.0",
       "source": {
@@ -1879,12 +1879,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1906,12 +1906,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1935,9 +1935,9 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
-        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1946,12 +1946,12 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_deriving@opam:4.5@bb81afdc": {
-      "id": "@opam/ppx_deriving@opam:4.5@bb81afdc",
+    "@opam/ppx_deriving@opam:4.5@d89f2934": {
+      "id": "@opam/ppx_deriving@opam:4.5@d89f2934",
       "name": "@opam/ppx_deriving",
       "version": "opam:4.5",
       "source": {
@@ -1969,7 +1969,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -2434,8 +2434,8 @@
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt_ppx@opam:2.0.1@ab0debb8": {
-      "id": "@opam/lwt_ppx@opam:2.0.1@ab0debb8",
+    "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
+      "id": "@opam/lwt_ppx@opam:2.0.1@e6a764a0",
       "name": "@opam/lwt_ppx",
       "version": "opam:2.0.1",
       "source": {
@@ -2453,14 +2453,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2692,12 +2692,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2742,11 +2742,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
@@ -2941,12 +2941,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -3647,7 +3647,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]

--- a/bench.esy.lock/opam/lwt_ppx.2.0.1/opam
+++ b/bench.esy.lock/opam/lwt_ppx.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "lwt"
   "ocaml" {>= "4.02.0"}
-  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_tools_versioned" {>= "5.3.0"}
 ]
 

--- a/bench.esy.lock/opam/ppx_deriving.4.5/opam
+++ b/bench.esy.lock/opam/ppx_deriving.4.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"     {>= "1.6.3"}
   "cppo"     {build}
   "ppxfind"  {build}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"
   "ppx_tools"  {>= "4.02.3"}
   "result"

--- a/bench.esy.lock/opam/ppx_tools_versioned.5.4.0/opam
+++ b/bench.esy.lock/opam/ppx_tools_versioned.5.4.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0" & < "2.0.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {

--- a/bench.esy.lock/opam/ppxfind.1.4/opam
+++ b/bench.esy.lock/opam/ppxfind.1.4/opam
@@ -12,7 +12,7 @@ doc: "https://jeremiedimino.github.io/ppxfind/"
 bug-reports: "https://github.com/jeremiedimino/ppxfind/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ocamlfind"
   "ocaml" {>= "4.02.3"}
 ]

--- a/bench.esy.lock/opam/ppxlib.0.13.0/opam
+++ b/bench.esy.lock/opam/ppxlib.0.13.0/opam
@@ -18,7 +18,7 @@ depends: [
   "base"                    {>= "v0.11.0"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
   "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}

--- a/bench.esy.lock/opam/reason.3.6.0/opam
+++ b/bench.esy.lock/opam/reason.3.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "merlin-extend" {>= "0.4"}
   "fix"
   "result"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Reason: Syntax & Toolchain for OCaml"
 description: """

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "735081d75b83090a71d0493b13704c1d",
+  "checksum": "c8bd82b4b1d6e4557a029941286d3817",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+    "revery@github:revery-ui/revery#a08ec1a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#71ad8c5b",
+      "version": "github:revery-ui/revery#a08ec1a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#71ad8c5b" ]
+        "source": [ "github:revery-ui/revery#a08ec1a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -991,7 +991,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25be7e0a3aba7b2bf31d1189d9abd0ab",
+  "checksum": "735081d75b83090a71d0493b13704c1d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#926dabd4@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#926dabd4",
+      "version": "github:revery-ui/revery#71ad8c5b",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#926dabd4" ]
+        "source": [ "github:revery-ui/revery#71ad8c5b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -144,12 +144,12 @@
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
-        "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+        "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -834,7 +834,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/menhir@opam:20200624@8629ff13",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
@@ -852,7 +852,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -991,7 +991,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
@@ -1010,12 +1010,12 @@
         "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/reason@opam:3.6.0@2da53ff9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "@opam/reason@opam:3.6.0@58adb39a", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_inline_test@opam:v0.13.1@dbfe49b7",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
@@ -1057,18 +1057,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-harfbuzz@2.6.8000@d41d8cd9": {
-      "id": "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+    "@revery/esy-harfbuzz@2.6.8001@d41d8cd9": {
+      "id": "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
       "name": "@revery/esy-harfbuzz",
-      "version": "2.6.8000",
+      "version": "2.6.8001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8000.tgz#sha1:2a78f826c54b1244accec6c8d07c3968efe6ced2"
+          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8001.tgz#sha1:86a4382a4dcd54e5ac1a5589e8092edd65c3945f"
         ]
       },
       "overrides": [],
-      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-cmake@0.3.5001@d41d8cd9": {
@@ -1550,8 +1550,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/reason@opam:3.6.0@2da53ff9": {
-      "id": "@opam/reason@opam:3.6.0@2da53ff9",
+    "@opam/reason@opam:3.6.0@58adb39a": {
+      "id": "@opam/reason@opam:3.6.0@58adb39a",
       "name": "@opam/reason",
       "version": "opam:3.6.0",
       "source": {
@@ -1718,8 +1718,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.13.0@e0dac6a1": {
-      "id": "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+    "@opam/ppxlib@opam:0.13.0@3d7c6edb": {
+      "id": "@opam/ppxlib@opam:0.13.0@3d7c6edb",
       "name": "@opam/ppxlib",
       "version": "opam:0.13.0",
       "source": {
@@ -1751,8 +1751,8 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
-    "@opam/ppxfind@opam:1.4@1e01d2a5": {
-      "id": "@opam/ppxfind@opam:1.4@1e01d2a5",
+    "@opam/ppxfind@opam:1.4@d75848d2": {
+      "id": "@opam/ppxfind@opam:1.4@d75848d2",
       "name": "@opam/ppxfind",
       "version": "opam:1.4",
       "source": {
@@ -1807,8 +1807,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1": {
-      "id": "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+    "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414": {
+      "id": "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
       "name": "@opam/ppx_tools_versioned",
       "version": "opam:5.4.0",
       "source": {
@@ -1878,12 +1878,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1905,12 +1905,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1934,9 +1934,9 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
-        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1945,12 +1945,12 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_deriving@opam:4.5@bb81afdc": {
-      "id": "@opam/ppx_deriving@opam:4.5@bb81afdc",
+    "@opam/ppx_deriving@opam:4.5@d89f2934": {
+      "id": "@opam/ppx_deriving@opam:4.5@d89f2934",
       "name": "@opam/ppx_deriving",
       "version": "opam:4.5",
       "source": {
@@ -1968,7 +1968,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -2433,8 +2433,8 @@
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt_ppx@opam:2.0.1@ab0debb8": {
-      "id": "@opam/lwt_ppx@opam:2.0.1@ab0debb8",
+    "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
+      "id": "@opam/lwt_ppx@opam:2.0.1@e6a764a0",
       "name": "@opam/lwt_ppx",
       "version": "opam:2.0.1",
       "source": {
@@ -2452,14 +2452,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2691,12 +2691,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2741,11 +2741,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
@@ -2940,12 +2940,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -3646,7 +3646,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]

--- a/esy.lock/opam/lwt_ppx.2.0.1/opam
+++ b/esy.lock/opam/lwt_ppx.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "lwt"
   "ocaml" {>= "4.02.0"}
-  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_tools_versioned" {>= "5.3.0"}
 ]
 

--- a/esy.lock/opam/ppx_deriving.4.5/opam
+++ b/esy.lock/opam/ppx_deriving.4.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"     {>= "1.6.3"}
   "cppo"     {build}
   "ppxfind"  {build}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"
   "ppx_tools"  {>= "4.02.3"}
   "result"

--- a/esy.lock/opam/ppx_tools_versioned.5.4.0/opam
+++ b/esy.lock/opam/ppx_tools_versioned.5.4.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0" & < "2.0.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {

--- a/esy.lock/opam/ppxfind.1.4/opam
+++ b/esy.lock/opam/ppxfind.1.4/opam
@@ -12,7 +12,7 @@ doc: "https://jeremiedimino.github.io/ppxfind/"
 bug-reports: "https://github.com/jeremiedimino/ppxfind/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ocamlfind"
   "ocaml" {>= "4.02.3"}
 ]

--- a/esy.lock/opam/ppxlib.0.13.0/opam
+++ b/esy.lock/opam/ppxlib.0.13.0/opam
@@ -18,7 +18,7 @@ depends: [
   "base"                    {>= "v0.11.0"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
   "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}

--- a/esy.lock/opam/reason.3.6.0/opam
+++ b/esy.lock/opam/reason.3.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "merlin-extend" {>= "0.4"}
   "fix"
   "result"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Reason: Syntax & Toolchain for OCaml"
 description: """

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25be7e0a3aba7b2bf31d1189d9abd0ab",
+  "checksum": "735081d75b83090a71d0493b13704c1d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#926dabd4@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#926dabd4",
+      "version": "github:revery-ui/revery#71ad8c5b",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#926dabd4" ]
+        "source": [ "github:revery-ui/revery#71ad8c5b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -144,12 +144,12 @@
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
-        "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+        "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -834,7 +834,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/menhir@opam:20200624@8629ff13",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
@@ -852,7 +852,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -991,7 +991,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
@@ -1010,12 +1010,12 @@
         "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/reason@opam:3.6.0@2da53ff9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "@opam/reason@opam:3.6.0@58adb39a", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_inline_test@opam:v0.13.1@dbfe49b7",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
@@ -1057,18 +1057,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-harfbuzz@2.6.8000@d41d8cd9": {
-      "id": "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+    "@revery/esy-harfbuzz@2.6.8001@d41d8cd9": {
+      "id": "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
       "name": "@revery/esy-harfbuzz",
-      "version": "2.6.8000",
+      "version": "2.6.8001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8000.tgz#sha1:2a78f826c54b1244accec6c8d07c3968efe6ced2"
+          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8001.tgz#sha1:86a4382a4dcd54e5ac1a5589e8092edd65c3945f"
         ]
       },
       "overrides": [],
-      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-cmake@0.3.5001@d41d8cd9": {
@@ -1550,8 +1550,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/reason@opam:3.6.0@2da53ff9": {
-      "id": "@opam/reason@opam:3.6.0@2da53ff9",
+    "@opam/reason@opam:3.6.0@58adb39a": {
+      "id": "@opam/reason@opam:3.6.0@58adb39a",
       "name": "@opam/reason",
       "version": "opam:3.6.0",
       "source": {
@@ -1718,8 +1718,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.13.0@e0dac6a1": {
-      "id": "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+    "@opam/ppxlib@opam:0.13.0@3d7c6edb": {
+      "id": "@opam/ppxlib@opam:0.13.0@3d7c6edb",
       "name": "@opam/ppxlib",
       "version": "opam:0.13.0",
       "source": {
@@ -1751,8 +1751,8 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
-    "@opam/ppxfind@opam:1.4@1e01d2a5": {
-      "id": "@opam/ppxfind@opam:1.4@1e01d2a5",
+    "@opam/ppxfind@opam:1.4@d75848d2": {
+      "id": "@opam/ppxfind@opam:1.4@d75848d2",
       "name": "@opam/ppxfind",
       "version": "opam:1.4",
       "source": {
@@ -1807,8 +1807,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1": {
-      "id": "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+    "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414": {
+      "id": "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
       "name": "@opam/ppx_tools_versioned",
       "version": "opam:5.4.0",
       "source": {
@@ -1878,12 +1878,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1905,12 +1905,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1934,9 +1934,9 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
-        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1945,12 +1945,12 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_deriving@opam:4.5@bb81afdc": {
-      "id": "@opam/ppx_deriving@opam:4.5@bb81afdc",
+    "@opam/ppx_deriving@opam:4.5@d89f2934": {
+      "id": "@opam/ppx_deriving@opam:4.5@d89f2934",
       "name": "@opam/ppx_deriving",
       "version": "opam:4.5",
       "source": {
@@ -1968,7 +1968,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -2434,8 +2434,8 @@
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt_ppx@opam:2.0.1@ab0debb8": {
-      "id": "@opam/lwt_ppx@opam:2.0.1@ab0debb8",
+    "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
+      "id": "@opam/lwt_ppx@opam:2.0.1@e6a764a0",
       "name": "@opam/lwt_ppx",
       "version": "opam:2.0.1",
       "source": {
@@ -2453,14 +2453,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2692,12 +2692,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2742,11 +2742,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
@@ -2941,12 +2941,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -3647,7 +3647,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "735081d75b83090a71d0493b13704c1d",
+  "checksum": "c8bd82b4b1d6e4557a029941286d3817",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+    "revery@github:revery-ui/revery#a08ec1a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#71ad8c5b",
+      "version": "github:revery-ui/revery#a08ec1a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#71ad8c5b" ]
+        "source": [ "github:revery-ui/revery#a08ec1a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -991,7 +991,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/integrationtest.esy.lock/opam/lwt_ppx.2.0.1/opam
+++ b/integrationtest.esy.lock/opam/lwt_ppx.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "lwt"
   "ocaml" {>= "4.02.0"}
-  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_tools_versioned" {>= "5.3.0"}
 ]
 

--- a/integrationtest.esy.lock/opam/ppx_deriving.4.5/opam
+++ b/integrationtest.esy.lock/opam/ppx_deriving.4.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"     {>= "1.6.3"}
   "cppo"     {build}
   "ppxfind"  {build}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"
   "ppx_tools"  {>= "4.02.3"}
   "result"

--- a/integrationtest.esy.lock/opam/ppx_tools_versioned.5.4.0/opam
+++ b/integrationtest.esy.lock/opam/ppx_tools_versioned.5.4.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0" & < "2.0.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {

--- a/integrationtest.esy.lock/opam/ppxfind.1.4/opam
+++ b/integrationtest.esy.lock/opam/ppxfind.1.4/opam
@@ -12,7 +12,7 @@ doc: "https://jeremiedimino.github.io/ppxfind/"
 bug-reports: "https://github.com/jeremiedimino/ppxfind/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ocamlfind"
   "ocaml" {>= "4.02.3"}
 ]

--- a/integrationtest.esy.lock/opam/ppxlib.0.13.0/opam
+++ b/integrationtest.esy.lock/opam/ppxlib.0.13.0/opam
@@ -18,7 +18,7 @@ depends: [
   "base"                    {>= "v0.11.0"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
   "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}

--- a/integrationtest.esy.lock/opam/reason.3.6.0/opam
+++ b/integrationtest.esy.lock/opam/reason.3.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "merlin-extend" {>= "0.4"}
   "fix"
   "result"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Reason: Syntax & Toolchain for OCaml"
 description: """

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
   },
   "resolutions": {
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "revery": "revery-ui/revery#926dabd4",
+    "revery": "revery-ui/revery#71ad8c5b",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-skia": "revery-ui/esy-skia#a3785f9",
     "rench": "bryphe/rench#a976fe5",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
   },
   "resolutions": {
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "revery": "revery-ui/revery#71ad8c5b",
+    "revery": "revery-ui/revery#a08ec1a",
     "editor-core-types": "onivim/editor-core-types#6a8afaf",
     "esy-skia": "revery-ui/esy-skia#a3785f9",
     "rench": "bryphe/rench#a976fe5",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "baa2683d382a0b04b52edb8e460e6abc",
+  "checksum": "84c0fcd15f2589f3921c46e915b0d876",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+    "revery@github:revery-ui/revery#a08ec1a@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#71ad8c5b",
+      "version": "github:revery-ui/revery#a08ec1a",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#71ad8c5b" ]
+        "source": [ "github:revery-ui/revery#a08ec1a" ]
       },
       "overrides": [],
       "dependencies": [
@@ -991,7 +991,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
+        "revery@github:revery-ui/revery#a08ec1a@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c25e323c5241713156465e82784d601e",
+  "checksum": "baa2683d382a0b04b52edb8e460e6abc",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.1@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#926dabd4@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+    "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#926dabd4",
+      "version": "github:revery-ui/revery#71ad8c5b",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#926dabd4" ]
+        "source": [ "github:revery-ui/revery#71ad8c5b" ]
       },
       "overrides": [],
       "dependencies": [
@@ -144,12 +144,12 @@
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
-        "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+        "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@ab0debb8", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -834,7 +834,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/menhir@opam:20200624@8629ff13",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
@@ -852,7 +852,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -991,7 +991,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
-        "revery@github:revery-ui/revery#926dabd4@d41d8cd9",
+        "revery@github:revery-ui/revery#71ad8c5b@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
@@ -1010,12 +1010,12 @@
         "@reason-native-web/esy-openssl@1.1.1006@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/reason@opam:3.6.0@2da53ff9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "@opam/reason@opam:3.6.0@58adb39a", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_inline_test@opam:v0.13.1@dbfe49b7",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
@@ -1057,18 +1057,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-harfbuzz@2.6.8000@d41d8cd9": {
-      "id": "@revery/esy-harfbuzz@2.6.8000@d41d8cd9",
+    "@revery/esy-harfbuzz@2.6.8001@d41d8cd9": {
+      "id": "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
       "name": "@revery/esy-harfbuzz",
-      "version": "2.6.8000",
+      "version": "2.6.8001",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8000.tgz#sha1:2a78f826c54b1244accec6c8d07c3968efe6ced2"
+          "archive:https://registry.npmjs.org/@revery/esy-harfbuzz/-/esy-harfbuzz-2.6.8001.tgz#sha1:86a4382a4dcd54e5ac1a5589e8092edd65c3945f"
         ]
       },
       "overrides": [],
-      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-cmake@0.3.5001@d41d8cd9": {
@@ -1550,8 +1550,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/reason@opam:3.6.0@2da53ff9": {
-      "id": "@opam/reason@opam:3.6.0@2da53ff9",
+    "@opam/reason@opam:3.6.0@58adb39a": {
+      "id": "@opam/reason@opam:3.6.0@58adb39a",
       "name": "@opam/reason",
       "version": "opam:3.6.0",
       "source": {
@@ -1718,8 +1718,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.13.0@e0dac6a1": {
-      "id": "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+    "@opam/ppxlib@opam:0.13.0@3d7c6edb": {
+      "id": "@opam/ppxlib@opam:0.13.0@3d7c6edb",
       "name": "@opam/ppxlib",
       "version": "opam:0.13.0",
       "source": {
@@ -1751,8 +1751,8 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
-    "@opam/ppxfind@opam:1.4@1e01d2a5": {
-      "id": "@opam/ppxfind@opam:1.4@1e01d2a5",
+    "@opam/ppxfind@opam:1.4@d75848d2": {
+      "id": "@opam/ppxfind@opam:1.4@d75848d2",
       "name": "@opam/ppxfind",
       "version": "opam:1.4",
       "source": {
@@ -1807,8 +1807,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1": {
-      "id": "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+    "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414": {
+      "id": "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
       "name": "@opam/ppx_tools_versioned",
       "version": "opam:5.4.0",
       "source": {
@@ -1878,12 +1878,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1905,12 +1905,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -1934,9 +1934,9 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
-        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/result@opam:1.5@6b753c82", "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1945,12 +1945,12 @@
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
-        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ppx_deriving@opam:4.5@bb81afdc": {
-      "id": "@opam/ppx_deriving@opam:4.5@bb81afdc",
+    "@opam/ppx_deriving@opam:4.5@d89f2934": {
+      "id": "@opam/ppx_deriving@opam:4.5@d89f2934",
       "name": "@opam/ppx_deriving",
       "version": "opam:4.5",
       "source": {
@@ -1968,7 +1968,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxfind@opam:1.4@1e01d2a5",
+        "@opam/ppxfind@opam:1.4@d75848d2",
         "@opam/ppx_tools@opam:6.2@62a3aff2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -2433,8 +2433,8 @@
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt_ppx@opam:2.0.1@ab0debb8": {
-      "id": "@opam/lwt_ppx@opam:2.0.1@ab0debb8",
+    "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
+      "id": "@opam/lwt_ppx@opam:2.0.1@e6a764a0",
       "name": "@opam/lwt_ppx",
       "version": "opam:2.0.1",
       "source": {
@@ -2452,14 +2452,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
+        "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2691,12 +2691,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2741,11 +2741,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
@@ -2940,12 +2940,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@2da53ff9",
+        "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.6.0@58adb39a",
         "@opam/fp@github:bryphe/reason-native:fp.opam#fd0225c@d41d8cd9",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -3646,7 +3646,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@e0dac6a1",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.13.0@3d7c6edb",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]

--- a/test.esy.lock/opam/lwt_ppx.2.0.1/opam
+++ b/test.esy.lock/opam/lwt_ppx.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "lwt"
   "ocaml" {>= "4.02.0"}
-  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_tools_versioned" {>= "5.3.0"}
 ]
 

--- a/test.esy.lock/opam/ppx_deriving.4.5/opam
+++ b/test.esy.lock/opam/ppx_deriving.4.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"     {>= "1.6.3"}
   "cppo"     {build}
   "ppxfind"  {build}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"
   "ppx_tools"  {>= "4.02.3"}
   "result"

--- a/test.esy.lock/opam/ppx_tools_versioned.5.4.0/opam
+++ b/test.esy.lock/opam/ppx_tools_versioned.5.4.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0" & < "2.0.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {

--- a/test.esy.lock/opam/ppxfind.1.4/opam
+++ b/test.esy.lock/opam/ppxfind.1.4/opam
@@ -12,7 +12,7 @@ doc: "https://jeremiedimino.github.io/ppxfind/"
 bug-reports: "https://github.com/jeremiedimino/ppxfind/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ocamlfind"
   "ocaml" {>= "4.02.3"}
 ]

--- a/test.esy.lock/opam/ppxlib.0.13.0/opam
+++ b/test.esy.lock/opam/ppxlib.0.13.0/opam
@@ -18,7 +18,7 @@ depends: [
   "base"                    {>= "v0.11.0"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
   "stdio"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}

--- a/test.esy.lock/opam/reason.3.6.0/opam
+++ b/test.esy.lock/opam/reason.3.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "merlin-extend" {>= "0.4"}
   "fix"
   "result"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Reason: Syntax & Toolchain for OCaml"
 description: """


### PR DESCRIPTION
__Issue:__ The `master` (nightly) builds were failing, with this error:

```
error: build failed with exit code: 1
  build log:
    # esy-build-package: building: @revery/esy-harfbuzz@2.6.8000

    # esy-build-package: pwd: C:\Users\VssAdministrator\.esy\3\b\revery__s__esy_harfbuzz-2.6.8000-2c0b225d

    # esy-build-package: running: "./esy/prep.sh"

    # esy-build-package: running: "bash" "-c" "./esy/configure-windows.sh"

    Install: /cygdrive/c/Users/VssAdministrator/.esy/3______________________________________________________/s/revery__s__esy_harfbuzz-2.6.8000-2c0b225d
    error: command failed: "bash" "-c" "./esy/configure-windows.sh" (exited with 127)

    esy-build-package: exiting with errors above...

    
  building @revery/esy-harfbuzz@2.6.8000
esy: exiting due to errors above
```

__Defect:__ There's an issue with the latest `cmake` install on Windows - it's no longer installing correctly in a way that provides the `cmake` executable.

__Fix:__ `cmake` was removed as a dependency for harfbuzz and replaced with a `./configure` script: https://github.com/revery-ui/esy-harfbuzz/commit/380833bb511ace7b700825fbbe51023ef7ffb6fb

This picks up that fix for Onivim