### PR TITLE
feat(workbench) adds configurable sidebar position

### DIFF
--- a/src/Core/ConfigurationDefaults.re
+++ b/src/Core/ConfigurationDefaults.re
@@ -32,7 +32,7 @@ let getDefaultConfigString = configName =>
   "workbench.activityBar.visible": true,
   "workbench.editor.showTabs": true,
   "workbench.iconTheme": "vs-seti",
-  "workbench.sideBar.position": "left",
+  "workbench.sideBar.location": "left",
   "workbench.sideBar.visible": true,
   "workbench.statusBar.visible": true,
   "workbench.tree.indent": 2,

--- a/src/Core/ConfigurationDefaults.re
+++ b/src/Core/ConfigurationDefaults.re
@@ -32,6 +32,7 @@ let getDefaultConfigString = configName =>
   "workbench.activityBar.visible": true,
   "workbench.editor.showTabs": true,
   "workbench.iconTheme": "vs-seti",
+  "workbench.sideBar.position": "left",
   "workbench.sideBar.visible": true,
   "workbench.statusBar.visible": true,
   "workbench.tree.indent": 2,

--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -381,10 +381,10 @@ let configurationParsers: list(configurationTuple) = [
     (config, json) => {...config, workbenchEditorShowTabs: parseBool(json)},
   ),
   (
-    "workbench.sideBar.position",
+    "workbench.sideBar.location",
     (config, json) => {
       ...config,
-      workbenchSideBarPosition: parseString(json),
+      workbenchSideBarLocation: parseString(json),
     },
   ),
   (

--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -381,6 +381,13 @@ let configurationParsers: list(configurationTuple) = [
     (config, json) => {...config, workbenchEditorShowTabs: parseBool(json)},
   ),
   (
+    "workbench.sideBar.position",
+    (config, json) => {
+      ...config,
+      workbenchSideBarPosition: parseString(json),
+    },
+  ),
+  (
     "workbench.sideBar.visible",
     (config, json) => {...config, workbenchSideBarVisible: parseBool(json)},
   ),

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -60,7 +60,7 @@ type t = {
   workbenchActivityBarVisible: bool,
   workbenchColorTheme: string,
   workbenchIconTheme: string,
-  workbenchSideBarPosition: string,
+  workbenchSideBarLocation: string,
   /* Onivim2 specific setting */
   workbenchSideBarVisible: bool,
   workbenchEditorShowTabs: bool,
@@ -110,7 +110,7 @@ let default = {
   workbenchActivityBarVisible: true,
   workbenchColorTheme: "LaserWave Italic",
   workbenchEditorShowTabs: true,
-  workbenchSideBarPosition: "left",
+  workbenchSideBarLocation: "left",
   workbenchSideBarVisible: true,
   workbenchStatusBarVisible: true,
   workbenchIconTheme: "vs-seti",

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -60,6 +60,7 @@ type t = {
   workbenchActivityBarVisible: bool,
   workbenchColorTheme: string,
   workbenchIconTheme: string,
+  workbenchSideBarPosition: string,
   /* Onivim2 specific setting */
   workbenchSideBarVisible: bool,
   workbenchEditorShowTabs: bool,
@@ -109,6 +110,7 @@ let default = {
   workbenchActivityBarVisible: true,
   workbenchColorTheme: "LaserWave Italic",
   workbenchEditorShowTabs: true,
+  workbenchSideBarPosition: "left",
   workbenchSideBarVisible: true,
   workbenchStatusBarVisible: true,
   workbenchIconTheme: "vs-seti",

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -100,13 +100,7 @@ let toggle = (pane, state) =>
   };
 
 let setDefaultLocation = (state, setting) => {
-  let location =
-    switch (setting) {
-    | "right" => Right
-    | "left" => Left
-    | _ => Left
-    };
-
+  let location = setting == "right" ? Right : Left;
   {...state, location};
 };
 

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -44,11 +44,16 @@ let initial = {
   location: Left,
 };
 
-let width = ({width, resizeDelta, isOpen, shouldSnapShut, _}) =>
+let width = ({width, resizeDelta, isOpen, location, shouldSnapShut, _}) =>
   if (!isOpen) {
     0;
   } else {
-    let candidate = width + resizeDelta;
+    let candidate =
+      switch (location) {
+      | Left => width + resizeDelta
+      | Right => width - resizeDelta
+      };
+
     if (candidate < Constants.minWidth && shouldSnapShut) {
       0;
     } else if (candidate > Constants.maxWidth) {

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -3,6 +3,10 @@ type pane =
   | SCM
   | Extensions;
 
+type position =
+  | Left
+  | Right;
+
 [@deriving show]
 type msg =
   | ResizeInProgress(int)
@@ -23,10 +27,12 @@ type model = {
   width: int,
   resizeDelta: int,
   shouldSnapShut: bool,
+  position,
 };
 
 let selected = ({selected, _}) => selected;
 let isOpen = ({isOpen, _}) => isOpen;
+let position = ({position, _}) => position;
 
 let initial = {
   openByDefault: false,
@@ -35,6 +41,7 @@ let initial = {
   width: Constants.defaultWidth,
   resizeDelta: 0,
   shouldSnapShut: true,
+  position: Left,
 };
 
 let width = ({width, resizeDelta, isOpen, shouldSnapShut, _}) =>
@@ -91,3 +98,25 @@ let toggle = (pane, state) =>
   } else {
     {...state, shouldSnapShut: true, isOpen: true, selected: pane};
   };
+
+let setDefaultPosition = (state, setting) => {
+  let position =
+    switch (setting) {
+    | "right" => Right
+    | "left" => Left
+    | _ => Left
+    };
+
+  {...state, position};
+};
+
+type settings = {
+  sideBarPosition: string,
+  sideBarVisibility: bool,
+};
+
+let setDefaults = (state, settings) => {
+  let {sideBarVisibility, sideBarPosition} = settings;
+  let state = setDefaultPosition(state, sideBarPosition);
+  setDefaultVisibility(state, sideBarVisibility);
+};

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -3,7 +3,7 @@ type pane =
   | SCM
   | Extensions;
 
-type position =
+type location =
   | Left
   | Right;
 
@@ -27,12 +27,12 @@ type model = {
   width: int,
   resizeDelta: int,
   shouldSnapShut: bool,
-  position,
+  location,
 };
 
 let selected = ({selected, _}) => selected;
 let isOpen = ({isOpen, _}) => isOpen;
-let position = ({position, _}) => position;
+let location = ({location, _}) => location;
 
 let initial = {
   openByDefault: false,
@@ -41,7 +41,7 @@ let initial = {
   width: Constants.defaultWidth,
   resizeDelta: 0,
   shouldSnapShut: true,
-  position: Left,
+  location: Left,
 };
 
 let width = ({width, resizeDelta, isOpen, shouldSnapShut, _}) =>
@@ -99,24 +99,24 @@ let toggle = (pane, state) =>
     {...state, shouldSnapShut: true, isOpen: true, selected: pane};
   };
 
-let setDefaultPosition = (state, setting) => {
-  let position =
+let setDefaultLocation = (state, setting) => {
+  let location =
     switch (setting) {
     | "right" => Right
     | "left" => Left
     | _ => Left
     };
 
-  {...state, position};
+  {...state, location};
 };
 
 type settings = {
-  sideBarPosition: string,
+  sideBarLocation: string,
   sideBarVisibility: bool,
 };
 
 let setDefaults = (state, settings) => {
-  let {sideBarVisibility, sideBarPosition} = settings;
-  let state = setDefaultPosition(state, sideBarPosition);
+  let {sideBarVisibility, sideBarLocation} = settings;
+  let state = setDefaultLocation(state, sideBarLocation);
   setDefaultVisibility(state, sideBarVisibility);
 };

--- a/src/Feature/SideBar/Feature_SideBar.rei
+++ b/src/Feature/SideBar/Feature_SideBar.rei
@@ -3,7 +3,7 @@ type pane =
   | SCM
   | Extensions;
 
-type position =
+type location =
   | Left
   | Right;
 
@@ -21,15 +21,15 @@ let initial: model;
 let width: model => int;
 let isOpen: model => bool;
 let selected: model => pane;
-let position: model => position;
+let location: model => location;
 
 let isVisible: (pane, model) => bool;
 let toggle: (pane, model) => model;
 let setDefaultVisibility: (model, bool) => model;
-let setDefaultPosition: (model, string) => model;
+let setDefaultLocation: (model, string) => model;
 
 type settings = {
-  sideBarPosition: string,
+  sideBarLocation: string,
   sideBarVisibility: bool,
 };
 

--- a/src/Feature/SideBar/Feature_SideBar.rei
+++ b/src/Feature/SideBar/Feature_SideBar.rei
@@ -3,6 +3,10 @@ type pane =
   | SCM
   | Extensions;
 
+type position =
+  | Left
+  | Right;
+
 type model;
 
 [@deriving show]
@@ -17,7 +21,16 @@ let initial: model;
 let width: model => int;
 let isOpen: model => bool;
 let selected: model => pane;
+let position: model => position;
 
 let isVisible: (pane, model) => bool;
 let toggle: (pane, model) => model;
 let setDefaultVisibility: (model, bool) => model;
+let setDefaultPosition: (model, string) => model;
+
+type settings = {
+  sideBarPosition: string,
+  sideBarVisibility: bool,
+};
+
+let setDefaults: (model, settings) => model;

--- a/src/Store/SideBarReducer.re
+++ b/src/Store/SideBarReducer.re
@@ -27,9 +27,11 @@ let reduce = (~zenMode, state: Feature_SideBar.model, action: Actions.t) => {
   | ActivityBar(ActivityBar.ExtensionsClick) when !zenMode =>
     Feature_SideBar.toggle(Feature_SideBar.Extensions, state)
   | ConfigurationSet(newConfig) =>
-    let sideBarSetting =
+    let sideBarPosition =
+      Configuration.getValue(c => c.workbenchSideBarPosition, newConfig);
+    let sideBarVisibility =
       Configuration.getValue(c => c.workbenchSideBarVisible, newConfig);
-    Feature_SideBar.setDefaultVisibility(state, sideBarSetting);
+    Feature_SideBar.setDefaults(state, {sideBarPosition, sideBarVisibility});
   | _ => state
   };
 };

--- a/src/Store/SideBarReducer.re
+++ b/src/Store/SideBarReducer.re
@@ -27,11 +27,11 @@ let reduce = (~zenMode, state: Feature_SideBar.model, action: Actions.t) => {
   | ActivityBar(ActivityBar.ExtensionsClick) when !zenMode =>
     Feature_SideBar.toggle(Feature_SideBar.Extensions, state)
   | ConfigurationSet(newConfig) =>
-    let sideBarPosition =
-      Configuration.getValue(c => c.workbenchSideBarPosition, newConfig);
+    let sideBarLocation =
+      Configuration.getValue(c => c.workbenchSideBarLocation, newConfig);
     let sideBarVisibility =
       Configuration.getValue(c => c.workbenchSideBarVisible, newConfig);
-    Feature_SideBar.setDefaults(state, {sideBarPosition, sideBarVisibility});
+    Feature_SideBar.setDefaults(state, {sideBarLocation, sideBarVisibility});
   | _ => state
   };
 };

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -24,20 +24,28 @@ module Styles = {
     transform(Transform.[TranslateX(offsetX)]),
   ];
 
-  let item = (~isHovered, ~isActive, ~theme) => [
-    position(`Relative),
-    height(50),
-    width(50),
-    justifyContent(`Center),
-    alignItems(`Center),
-    borderLeft(
-      ~width=2,
-      ~color=(isActive ? Colors.activeBorder : Colors.border).from(theme),
-    ),
-    backgroundColor(
-      theme |> (isHovered ? Colors.activeBackground : Colors.background).from,
-    ),
-  ];
+  let item = (~isHovered, ~isActive, ~theme, ~sideBar) => {
+    let borderFn =
+      switch (Feature_SideBar.location(sideBar)) {
+      | Feature_SideBar.Right => borderRight
+      | Feature_SideBar.Left => borderLeft
+      };
+
+    [
+      position(`Relative),
+      height(50),
+      width(50),
+      justifyContent(`Center),
+      alignItems(`Center),
+      borderFn(
+        ~width=2,
+        ~color=(isActive ? Colors.activeBorder : Colors.border).from(theme),
+      ),
+      backgroundColor(
+        theme |> (isHovered ? Colors.activeBackground : Colors.background).from,
+      ),
+    ];
+  };
 
   let notification = (~scale, ~theme, ~padding) => [
     position(`Absolute),
@@ -99,6 +107,7 @@ let%component item =
               (
                 ~notification: option(notification)=?,
                 ~onClick,
+                ~sideBar,
                 ~theme,
                 ~isActive,
                 ~icon,
@@ -131,7 +140,7 @@ let%component item =
     <Sneakable
       sneakId="item"
       onClick
-      style={Styles.item(~isHovered, ~isActive, ~theme)}>
+      style={Styles.item(~isHovered, ~isActive, ~theme, ~sideBar)}>
       <icon />
       notificationElement
     </Sneakable>
@@ -183,6 +192,7 @@ let%component make =
     <item
       font
       onClick=onExplorerClick
+      sideBar
       theme
       isActive={isSidebarVisible(FileExplorer)}
       icon=FontAwesome.copy
@@ -191,6 +201,7 @@ let%component make =
     <item
       font
       onClick=onSearchClick
+      sideBar
       theme
       isActive={isPaneVisible(Search)}
       icon=FontAwesome.search
@@ -198,6 +209,7 @@ let%component make =
     <item
       font
       onClick=onSCMClick
+      sideBar
       theme
       isActive={isSidebarVisible(SCM)}
       icon=FontAwesome.codeBranch
@@ -205,6 +217,7 @@ let%component make =
     <item
       font
       onClick=onExtensionsClick
+      sideBar
       theme
       isActive={isSidebarVisible(Extensions)}
       icon=FontAwesome.thLarge

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -174,6 +174,18 @@ let make = (~dispatch, ~state: State.t, ()) => {
     | Oni_Model.State.Windowed => Feature_TitleBar.Windowed
     | Oni_Model.State.Fullscreen => Feature_TitleBar.Fullscreen;
 
+  let defaultSurfaceComponents = [
+    <activityBar />,
+    <sideBar />,
+    <EditorView state theme dispatch />,
+  ];
+
+  let surfaceComponents =
+    switch (Feature_SideBar.position(state.sideBar)) {
+    | Feature_SideBar.Left => defaultSurfaceComponents
+    | Feature_SideBar.Right => List.rev(defaultSurfaceComponents)
+    };
+
   <View style={Styles.root(theme, state.windowDisplayMode)}>
     <Feature_TitleBar.View
       isFocused={state.windowIsFocused}
@@ -185,9 +197,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
     />
     <View style=Styles.workspace>
       <View style=Styles.surface>
-        <activityBar />
-        <sideBar />
-        <EditorView state theme dispatch />
+        {React.listToElement(surfaceComponents)}
       </View>
       <PaneView theme uiFont editorFont state />
     </View>

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -181,7 +181,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
   ];
 
   let surfaceComponents =
-    switch (Feature_SideBar.position(state.sideBar)) {
+    switch (Feature_SideBar.location(state.sideBar)) {
     | Feature_SideBar.Left => defaultSurfaceComponents
     | Feature_SideBar.Right => List.rev(defaultSurfaceComponents)
     };

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -107,8 +107,8 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
   let separator =
     Feature_SideBar.isOpen(state.sideBar) && width > 4
       ? <separator /> : React.empty;
-  <View style={Styles.sidebar(~theme, ~transition)}>
-    separator
+
+  let content =
     <View style={Styles.contents(~width)}>
       <View style={Styles.heading(theme)}>
         <View style=Styles.titleContainer>
@@ -122,7 +122,9 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
         </View>
       </View>
       elem
-    </View>
+    </View>;
+
+  let resizer =
     <View style=Styles.resizer>
       <ResizeHandle.Vertical
         onDrag={delta =>
@@ -136,6 +138,17 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
           dispatch(Actions.SideBar(Feature_SideBar.ResizeCommitted))
         }
       />
-    </View>
+    </View>;
+
+  let defaultOrder = [content, resizer];
+  let items =
+    switch (Feature_SideBar.location(sideBar)) {
+    | Feature_SideBar.Left => defaultOrder
+    | Feature_SideBar.Right => List.rev(defaultOrder)
+    };
+
+  <View style={Styles.sidebar(~theme, ~transition)}>
+    separator
+    {React.listToElement(items)}
   </View>;
 };


### PR DESCRIPTION
This PR adds a configuration setting allowing the user to put the sidebar on the right side. This is accomplished by creating a list of the "surface" components, and reversing their order if the setting is set to `right`. The default CSS lays out the components correctly.

![wootGotIt](https://user-images.githubusercontent.com/4333144/90183768-ea921180-dd68-11ea-860f-0056081a7623.gif)
