### PR TITLE
fix(theme/#1933): Scope matching precedence

### DIFF
--- a/src/Syntax/TextmateTokenizerJob.re
+++ b/src/Syntax/TextmateTokenizerJob.re
@@ -150,7 +150,7 @@ let doWork = (pending: pendingWork, completed: completedWork) => {
       |> List.map(token => {
            let {position, scopes, _}: Textmate.Token.t = token;
            let combinedScopes = scopes |> String.concat(" ") |> String.trim;
-           prerr_endline ("COMBINED SCOPES: " ++ combinedScopes);
+           prerr_endline("COMBINED SCOPES: " ++ combinedScopes);
 
            let resolvedColor =
              TokenTheme.match(pending.theme, combinedScopes);

--- a/src/Syntax/TextmateTokenizerJob.re
+++ b/src/Syntax/TextmateTokenizerJob.re
@@ -150,7 +150,6 @@ let doWork = (pending: pendingWork, completed: completedWork) => {
       |> List.map(token => {
            let {position, scopes, _}: Textmate.Token.t = token;
            let combinedScopes = scopes |> String.concat(" ") |> String.trim;
-           prerr_endline("COMBINED SCOPES: " ++ combinedScopes);
 
            let resolvedColor =
              TokenTheme.match(pending.theme, combinedScopes);

--- a/src/Syntax/TextmateTokenizerJob.re
+++ b/src/Syntax/TextmateTokenizerJob.re
@@ -150,6 +150,7 @@ let doWork = (pending: pendingWork, completed: completedWork) => {
       |> List.map(token => {
            let {position, scopes, _}: Textmate.Token.t = token;
            let combinedScopes = scopes |> String.concat(" ") |> String.trim;
+           prerr_endline ("COMBINED SCOPES: " ++ combinedScopes);
 
            let resolvedColor =
              TokenTheme.match(pending.theme, combinedScopes);

--- a/src/reason-textmate/ThemeScopes.re
+++ b/src/reason-textmate/ThemeScopes.re
@@ -46,7 +46,8 @@ module Scopes = {
     |> String.split_on_char(' ')
     |> List.map(v => Scope.ofString(String.trim(v)));
 
-  let toString = scopes => String.concat("\n", scopes |> List.map(Scope.toString));
+  let toString = scopes =>
+    String.concat("\n", scopes |> List.map(Scope.toString));
 
   let rec matches = (selector: t, v: t) => {
     switch (selector, v) {

--- a/src/reason-textmate/ThemeScopes.re
+++ b/src/reason-textmate/ThemeScopes.re
@@ -63,6 +63,22 @@ module Scopes = {
   };
 };
 
+module ResolvedStyle = {
+  type t = {
+    foreground: string,
+    background: string,
+    bold: bool,
+    italic: bool,
+  };
+
+  let default = (~foreground, ~background, ()) => {
+    foreground,
+    background,
+    bold: false,
+    italic: false,
+  };
+};
+
 module TokenStyle = {
   [@deriving show({with_path: false})]
   type t = {
@@ -77,6 +93,66 @@ module TokenStyle = {
     | None => "Foreground: None"
     | Some(_) => "Foreground: Some"
     };
+  };
+
+  let merge = (prev, style) => {
+    let foreground =
+      switch (prev.foreground, style.foreground) {
+      | (Some(v), _) => Some(v)
+      | (_, Some(v)) => Some(v)
+      | _ => None
+      };
+
+    let background =
+      switch (prev.background, style.background) {
+      | (Some(v), _) => Some(v)
+      | (_, Some(v)) => Some(v)
+      | _ => None
+      };
+
+    let bold =
+      switch (prev.bold, style.bold) {
+      | (Some(v), _) => Some(v)
+      | (_, Some(v)) => Some(v)
+      | _ => None
+      };
+
+    let italic =
+      switch (prev.italic, style.italic) {
+      | (Some(v), _) => Some(v)
+      | (_, Some(v)) => Some(v)
+      | _ => None
+      };
+
+    {background, foreground, bold, italic};
+  };
+
+  let resolve = (~default: ResolvedStyle.t, style) => {
+    let foreground =
+      switch (style.foreground) {
+      | Some(v) => v
+      | None => default.foreground
+      };
+
+    let bold =
+      switch (style.bold) {
+      | Some(v) => v
+      | None => default.bold
+      };
+
+    let italic =
+      switch (style.italic) {
+      | Some(v) => v
+      | None => default.italic
+      };
+
+    let background =
+      switch (style.background) {
+      | Some(v) => v
+      | None => default.background
+      };
+
+    ResolvedStyle.{bold, italic, foreground, background};
   };
 
   let create =
@@ -98,22 +174,6 @@ module TokenStyle = {
     background: None,
     bold: None,
     italic: None,
-  };
-};
-
-module ResolvedStyle = {
-  type t = {
-    foreground: string,
-    background: string,
-    bold: bool,
-    italic: bool,
-  };
-
-  let default = (~foreground, ~background, ()) => {
-    foreground,
-    background,
-    bold: false,
-    italic: false,
   };
 };
 

--- a/src/reason-textmate/ThemeScopes.re
+++ b/src/reason-textmate/ThemeScopes.re
@@ -13,6 +13,8 @@ module Scope = {
 
   let ofString = s => String.split_on_char('.', s);
 
+  let toString = scope => String.concat(".", scope);
+
   let rec matches = (selector: t, v: t) => {
     switch (selector, v) {
     | ([], _) => true
@@ -43,6 +45,8 @@ module Scopes = {
     s
     |> String.split_on_char(' ')
     |> List.map(v => Scope.ofString(String.trim(v)));
+
+  let toString = scopes => String.concat("\n", scopes |> List.map(Scope.toString));
 
   let rec matches = (selector: t, v: t) => {
     switch (selector, v) {

--- a/src/reason-textmate/TokenTheme.re
+++ b/src/reason-textmate/TokenTheme.re
@@ -206,16 +206,11 @@ let show = (v: t) => {
   );
 };
 
-type styleWithScore = {
-  style: TokenStyle.t,
-  score: int,
-};
-
 let match = (theme: t, scopes: string) => {
   let scopes = Scopes.ofString(scopes) |> List.rev;
 
   let rec calculateStyle =
-          (~parentScopes, ~acc: list(styleWithScore), scopes) => {
+          (~parentScopes, ~acc: list(TokenStyle.t), scopes) => {
     switch (scopes) {
     | [] => acc
     | [scope, ...nextScope] =>
@@ -292,7 +287,7 @@ let match = (theme: t, scopes: string) => {
         let acc =
           maybeTokenStyle
           |> Option.map(tokenStyle =>
-               [{style: tokenStyle, score: 0}, ...acc]
+               [tokenStyle, ...acc]
              )
           |> Option.value(~default=acc);
 
@@ -305,15 +300,12 @@ let match = (theme: t, scopes: string) => {
     };
   };
 
-  let scoredStyles = calculateStyle(~parentScopes=[], ~acc=[], scopes);
+  let styles = calculateStyle(~parentScopes=[], ~acc=[], scopes);
 
   let result: TokenStyle.t =
-    scoredStyles
-    //  |> List.sort((a, b) => {
-    //    b.score - a.score
-    //  })
+    styles
     |> List.fold_left(
-         (acc, {style, _}) => {TokenStyle.merge(acc, style)},
+         (acc, style) => {TokenStyle.merge(acc, style)},
          TokenStyle.default,
        );
 

--- a/src/reason-textmate/TokenTheme.re
+++ b/src/reason-textmate/TokenTheme.re
@@ -209,8 +209,7 @@ let show = (v: t) => {
 let match = (theme: t, scopes: string) => {
   let scopes = Scopes.ofString(scopes) |> List.rev;
 
-  let rec calculateStyle =
-          (~parentScopes, ~acc: list(TokenStyle.t), scopes) => {
+  let rec calculateStyle = (~parentScopes, ~acc: list(TokenStyle.t), scopes) => {
     switch (scopes) {
     | [] => acc
     | [scope, ...nextScope] =>
@@ -286,9 +285,7 @@ let match = (theme: t, scopes: string) => {
 
         let acc =
           maybeTokenStyle
-          |> Option.map(tokenStyle =>
-               [tokenStyle, ...acc]
-             )
+          |> Option.map(tokenStyle => [tokenStyle, ...acc])
           |> Option.value(~default=acc);
 
         calculateStyle(

--- a/test/reason-textmate/TokenThemeTests.re
+++ b/test/reason-textmate/TokenThemeTests.re
@@ -70,7 +70,7 @@ describe("TokenTheme", ({describe, _}) => {
       let style: ResolvedStyle.t =
         TokenTheme.match(
           simpleTokenTheme,
-          "source.js constant.numeric.meta.js",
+          "constant.numeric.meta.js source.js",
         );
 
       expect.string(style.foreground).toEqual("#990000");
@@ -82,7 +82,7 @@ describe("TokenTheme", ({describe, _}) => {
       let style: ResolvedStyle.t =
         TokenTheme.match(
           simpleTokenTheme,
-          "source.js constant.numeric.meta.js some-unmatched-style",
+          "some-unmatched-style constant.numeric.meta.js source.js",
         );
 
       expect.string(style.foreground).toEqual("#990000");
@@ -92,20 +92,21 @@ describe("TokenTheme", ({describe, _}) => {
     });
     test("background color should be picked up", ({expect, _}) => {
       let style: ResolvedStyle.t =
-        TokenTheme.match(simpleTokenTheme, "text.html.basic source.js");
+        TokenTheme.match(simpleTokenTheme, "source.js text.html.basic");
 
       expect.string(style.foreground).toEqual("navy");
       expect.string(style.background).toEqual("cornflowerBlue");
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(false);
     });
+    // Test case from https://macromates.com/manual/en/scope_selectors (13.2)
     test(
       "deeper rule should win (source.php string over text.html source.php)",
       ({expect, _}) => {
       let style: ResolvedStyle.t =
         TokenTheme.match(
           simpleTokenTheme,
-          "text.html.basic source.php.html string.quoted",
+          "string.quoted source.php.embedded.html text.html.basic"
         );
 
       expect.string(style.foreground).toEqual("peachPuff");
@@ -115,7 +116,7 @@ describe("TokenTheme", ({describe, _}) => {
     });
     test("parent rule (meta html) gets applied", ({expect, _}) => {
       let style: ResolvedStyle.t =
-        TokenTheme.match(simpleTokenTheme, "meta html");
+        TokenTheme.match(simpleTokenTheme, "html meta");
 
       expect.string(style.foreground).toEqual("smoke");
       expect.string(style.background).toEqual("#000");
@@ -123,7 +124,7 @@ describe("TokenTheme", ({describe, _}) => {
       expect.bool(style.italic).toBe(false);
 
       let style: ResolvedStyle.t =
-        TokenTheme.match(simpleTokenTheme, "meta.source.js html");
+        TokenTheme.match(simpleTokenTheme, "html meta.source.js");
 
       expect.string(style.foreground).toEqual("smoke");
       expect.string(style.background).toEqual("#000");
@@ -426,16 +427,16 @@ describe("TokenTheme", ({describe, _}) => {
 //        TokenTheme.match(theme, "support.function.console.js");
 //      expect.string(style.foreground).toEqual("#AAAAAA");
 //
-//      //...and introducing source.js should still be the same, since it is less specific
-//      let style: ResolvedStyle.t =
-//        TokenTheme.match(theme, "source.js support.function.console.js");
-//      expect.string(style.foreground).toEqual("#AAAAAA");
-      
+      //...and introducing source.js should still be the same, since it is less specific
       prerr_endline ("-- START");
       let style: ResolvedStyle.t =
         TokenTheme.match(theme, "support.function.console.js source.js");
       expect.string(style.foreground).toEqual("#AAAAAA");
       prerr_endline ("-- DONE");
+      
+//      let style: ResolvedStyle.t =
+//        TokenTheme.match(theme, "support.function.console.js source.js");
+//      expect.string(style.foreground).toEqual("#AAAAAA");
     });
   });
 });

--- a/test/reason-textmate/TokenThemeTests.re
+++ b/test/reason-textmate/TokenThemeTests.re
@@ -387,5 +387,49 @@ describe("TokenTheme", ({describe, _}) => {
       expect.bool(style.bold).toBe(false);
       expect.bool(style.italic).toBe(true);
     });
+    test("dracula: source should not override all styles", ({expect, _}) => {
+      let json =
+        Yojson.Safe.from_string(
+          {|
+       [
+        {
+            "scope": [
+                "source"
+            ],
+            "settings": {
+                "foreground": "#FF0000"
+            }
+        },
+        {
+            "name": "Built-in functions / properties",
+            "scope": [
+                "support.function",
+                "support.type.property-name"
+            ],
+            "settings": {
+                "fontStyle": "regular",
+                "foreground": "#AAAAAA"
+            }
+        }
+       ]
+      |},
+        );
+      let theme =
+        TokenTheme.of_yojson(
+          ~defaultForeground="#fff",
+          ~defaultBackground="#000",
+          json,
+        );
+
+      // Just support.function.console.js should resolve to the support.function
+      let style: ResolvedStyle.t =
+        TokenTheme.match(theme, "support.function.console.js");
+      expect.string(style.foreground).toEqual("#AAAAAA");
+
+      //...and introducing source.js should still be the same, since it is less specific
+      let style: ResolvedStyle.t =
+        TokenTheme.match(theme, "support.function.console.js source.js");
+      expect.string(style.foreground).toEqual("#AAAAAA");
+    });
   });
 });

--- a/test/reason-textmate/TokenThemeTests.re
+++ b/test/reason-textmate/TokenThemeTests.re
@@ -106,7 +106,7 @@ describe("TokenTheme", ({describe, _}) => {
       let style: ResolvedStyle.t =
         TokenTheme.match(
           simpleTokenTheme,
-          "string.quoted source.php.embedded.html text.html.basic"
+          "string.quoted source.php.embedded.html text.html.basic",
         );
 
       expect.string(style.foreground).toEqual("peachPuff");
@@ -422,21 +422,20 @@ describe("TokenTheme", ({describe, _}) => {
           json,
         );
 
-//      // Just support.function.console.js should resolve to the support.function
-//      let style: ResolvedStyle.t =
-//        TokenTheme.match(theme, "support.function.console.js");
-//      expect.string(style.foreground).toEqual("#AAAAAA");
-//
+      //      // Just support.function.console.js should resolve to the support.function
+      //      let style: ResolvedStyle.t =
+      //        TokenTheme.match(theme, "support.function.console.js");
+      //      expect.string(style.foreground).toEqual("#AAAAAA");
+      //
       //...and introducing source.js should still be the same, since it is less specific
-      prerr_endline ("-- START");
+      prerr_endline("-- START");
       let style: ResolvedStyle.t =
         TokenTheme.match(theme, "support.function.console.js source.js");
       expect.string(style.foreground).toEqual("#AAAAAA");
-      prerr_endline ("-- DONE");
-      
-//      let style: ResolvedStyle.t =
-//        TokenTheme.match(theme, "support.function.console.js source.js");
-//      expect.string(style.foreground).toEqual("#AAAAAA");
+      prerr_endline("-- DONE");
+      //      let style: ResolvedStyle.t =
+      //        TokenTheme.match(theme, "support.function.console.js source.js");
+      //      expect.string(style.foreground).toEqual("#AAAAAA");
     });
   });
 });

--- a/test/reason-textmate/TokenThemeTests.re
+++ b/test/reason-textmate/TokenThemeTests.re
@@ -422,20 +422,15 @@ describe("TokenTheme", ({describe, _}) => {
           json,
         );
 
-      //      // Just support.function.console.js should resolve to the support.function
-      //      let style: ResolvedStyle.t =
-      //        TokenTheme.match(theme, "support.function.console.js");
-      //      expect.string(style.foreground).toEqual("#AAAAAA");
-      //
+      // Just support.function.console.js should resolve to the support.function
+      let style: ResolvedStyle.t =
+        TokenTheme.match(theme, "support.function.console.js");
+      expect.string(style.foreground).toEqual("#AAAAAA");
+
       //...and introducing source.js should still be the same, since it is less specific
-      prerr_endline("-- START");
       let style: ResolvedStyle.t =
         TokenTheme.match(theme, "support.function.console.js source.js");
       expect.string(style.foreground).toEqual("#AAAAAA");
-      prerr_endline("-- DONE");
-      //      let style: ResolvedStyle.t =
-      //        TokenTheme.match(theme, "support.function.console.js source.js");
-      //      expect.string(style.foreground).toEqual("#AAAAAA");
     });
   });
 });

--- a/test/reason-textmate/TokenThemeTests.re
+++ b/test/reason-textmate/TokenThemeTests.re
@@ -421,15 +421,21 @@ describe("TokenTheme", ({describe, _}) => {
           json,
         );
 
-      // Just support.function.console.js should resolve to the support.function
-      let style: ResolvedStyle.t =
-        TokenTheme.match(theme, "support.function.console.js");
-      expect.string(style.foreground).toEqual("#AAAAAA");
-
-      //...and introducing source.js should still be the same, since it is less specific
+//      // Just support.function.console.js should resolve to the support.function
+//      let style: ResolvedStyle.t =
+//        TokenTheme.match(theme, "support.function.console.js");
+//      expect.string(style.foreground).toEqual("#AAAAAA");
+//
+//      //...and introducing source.js should still be the same, since it is less specific
+//      let style: ResolvedStyle.t =
+//        TokenTheme.match(theme, "source.js support.function.console.js");
+//      expect.string(style.foreground).toEqual("#AAAAAA");
+      
+      prerr_endline ("-- START");
       let style: ResolvedStyle.t =
         TokenTheme.match(theme, "support.function.console.js source.js");
       expect.string(style.foreground).toEqual("#AAAAAA");
+      prerr_endline ("-- DONE");
     });
   });
 });


### PR DESCRIPTION
__Issue:__ Our scope-selection strategy was not correct in some cases - particularly, the precedence in which we would apply the scopes.

For example, in #1933 - with the dracula theme - there'd be a case where a token would have the following textmate scopes:
- `support.function.console.js`
- `meta.function-call.js`
- `source.js`

For the dracula theme, there is a `source` selector that is intended to be a fallback - however, it was taking precedence over some of the other theme selectors that should've been applied, like `meta.function-call`.

This would cause the entire source file to be highlighted with the `source` scope selector, instead of the more specific ones.

__Defect:__ We apply selectors in reverse order (first, we apply any selectors matching `source.js`, and then `meta.function-call.js source.js`, etc...) - this gives us right precedence. However, if we had a match, we were failing to 'fall-back' to a more specific selector.

__Fix:__ Add a test case to reproduce, and fall back to override with more specific scopes.

This looks to fix a couple of related issues:
- #1933 - no syntax highlighting with OneDark / Dracula for some files
- #2006  - incorrect syntax highlighting for tsx files
- #1879  - html syntax highlighting not displayed
- #1878 - nested syntax highlights not shown

Thanks @CrossR for the helpful tool improvements in #2255 and @thismat for the investigation to narrow down the issue in #1933 !

`dracula` theme - __before__:

![image](https://user-images.githubusercontent.com/13532591/90297301-e2a6a000-de42-11ea-9380-178dc6345bf8.png)

`dracula` theme - __after__:

![image](https://user-images.githubusercontent.com/13532591/90297344-feaa4180-de42-11ea-999c-95936b4e3369.png)

