### PR TITLE
feat(cli): Add option to override default renderer selection

### DIFF
--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -10,6 +10,7 @@ module CoreLog = Log;
 module Log = (val Log.withNamespace("Oni2.Core.Cli"));
 
 type t = {
+  gpuAcceleration: [ | `Auto | `ForceSoftware | `ForceHardware],
   folder: option(string),
   filesToOpen: list(string),
   forceScaleFactor: option(float),
@@ -83,6 +84,14 @@ let parse = args => {
   let shouldLoadConfiguration = ref(true);
   let shouldSyntaxHighlight = ref(true);
 
+  let gpuAcceleration = ref(`Auto);
+
+  let setGpuAcceleration =
+    fun
+    | "software" => gpuAcceleration := `ForceSoftware
+    | "hardware" => gpuAcceleration := `ForceHardware
+    | unknown => ();
+
   let setEffect = effect => {
     Arg.Unit(() => {eff := effect});
   };
@@ -110,6 +119,7 @@ let parse = args => {
       ("--disable-extensions", Unit(disableExtensionLoading), ""),
       ("--disable-configuration", Unit(disableLoadConfiguration), ""),
       ("--disable-syntax-highlighting", Unit(disableSyntaxHighlight), ""),
+      ("--gpu-acceleration", String(setGpuAcceleration), ""),
       ("--log-file", String(Timber.App.setLogFile), ""),
       ("--log-filter", String(Timber.App.setNamespaceFilter), ""),
       ("--checkhealth", setEffect(CheckHealth), ""),
@@ -221,6 +231,7 @@ let parse = args => {
     folder,
     filesToOpen,
     forceScaleFactor: scaleFactor^,
+    gpuAcceleration: gpuAcceleration^,
     overriddenExtensionsDir: extensionsDir^,
     shouldClose: shouldClose^,
     shouldLoadExtensions: shouldLoadExtensions^,

--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -90,7 +90,7 @@ let parse = args => {
     fun
     | "software" => gpuAcceleration := `ForceSoftware
     | "hardware" => gpuAcceleration := `ForceHardware
-    | unknown => ();
+    | _unknown => ();
 
   let setEffect = effect => {
     Arg.Unit(() => {eff := effect});

--- a/src/CLI/Oni_CLI.rei
+++ b/src/CLI/Oni_CLI.rei
@@ -1,4 +1,5 @@
 type t = {
+  gpuAcceleration: [ | `Auto | `ForceSoftware | `ForceHardware],
   folder: option(string),
   filesToOpen: list(string),
   forceScaleFactor: option(float),

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -220,6 +220,7 @@ switch (eff) {
         ~createOptions=
           WindowCreateOptions.create(
             ~forceScaleFactor,
+            ~acceleration=cliOptions.gpuAcceleration,
             ~maximized,
             ~vsync=Vsync.Immediate,
             ~icon,

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -50,6 +50,17 @@ let spec =
       " Do not load user configuration (use default configuration).",
     ),
     (
+      "--gpu-acceleration",
+      passthroughString,
+      " Override default renderer strategy - one of: "
+      ++ {|
+
+      - auto: automatically choose between software / hardware rendering (default)
+      - hardware: force hardware renderer
+      - software: force software renderer
+      |},
+    ),
+    (
       "--install-extension",
       passthroughStringAndStayAttached,
       " Install extension by specifying a path to the .vsix file",


### PR DESCRIPTION
By default, Onivim will try to find the best renderer (either software or hardware, preferring hardware) - but this adds a CLI flag that overrides this behavior.

For example, with the default settings, my integrated GPU gets picked up:
![image](https://user-images.githubusercontent.com/13532591/90562287-ccf0ed80-e156-11ea-8767-dadb04e3b8c8.png)

But if I run with `esy run -f --gpu-acceleration=software`, Onivim will pick up the Apple OpenGL software renderer:
![image](https://user-images.githubusercontent.com/13532591/90562362-e5f99e80-e156-11ea-8e03-7a18dac9c203.png)

This is a step towards #1558, but for software rendering to be useful, we need to improve & streamline our rendering strategy.
