### PR TITLE
fix(textmate/#2307): Crash when trying to load non-existent grammar

### DIFF
--- a/src/reason-textmate/Grammar.re
+++ b/src/reason-textmate/Grammar.re
@@ -183,7 +183,6 @@ module Xml = {
   let of_file = path => {
     path
     |> SimpleXml.of_file
-    |> Option.to_result(~none="Unable to load file: " ++ path)
     |> ResultEx.flatMap(XmlPlistParser.parse)
     |> ResultEx.flatMap(xml => PlistDecoder.grammar(xml));
   };

--- a/src/reason-textmate/SimpleXml.re
+++ b/src/reason-textmate/SimpleXml.re
@@ -20,4 +20,13 @@ let simplify = stream =>
      );
 
 let of_file = path =>
-  Markup.file(path) |> fst |> Markup.parse_xml |> Markup.signals |> simplify;
+  try(
+    Markup.file(path)
+    |> fst
+    |> Markup.parse_xml
+    |> Markup.signals
+    |> simplify
+    |> Option.to_result(~none="Unable to parse file: " ++ path)
+  ) {
+  | exn => Error(Printexc.to_string(exn))
+  };

--- a/src/reason-textmate/Theme.re
+++ b/src/reason-textmate/Theme.re
@@ -167,7 +167,6 @@ let rec from_file = (~isDark=?, path: string) => {
       | Ok(json) => Ok(of_yojson(~isDark?, ~themeLoader, json))
       | Error(_) =>
         SimpleXml.of_file(path)
-        |> Option.to_result(~none="Unable to load file: " ++ path)
         |> ResultEx.flatMap(XmlPlistParser.parse)
         |> ResultEx.flatMap(PlistDecoder.theme(~isDark?))
       };


### PR DESCRIPTION
This fixes an issue in #2307 - when there is a non-existent grammar, we could crash.

There were two places that were potentially throwing an exception - a call to `Yojson.Safe.from_file` and `SimpleXml.of_file` - these both return a `result` and an `option`, respectively, and it'd be expected that errors might be encapsulated in those - but both functions turn out not to be total and have scenarios that can throw.

This replaces `Yojson.Safe.from_file` in this path with `JsonEx.from_file`, which is total, and changes `SimpleXml.of_file` to return a `result` that is total.

Related #2307 