### PR TITLE
fix(completion/#2300): Manual invoke not working as expected

### DIFF
--- a/src/Exthost/CompletionContext.re
+++ b/src/Exthost/CompletionContext.re
@@ -1,8 +1,10 @@
+[@deriving show]
 type triggerKind =
   | Invoke
   | TriggerCharacter
   | TriggerForIncompleteCompletions;
 
+[@deriving show]
 type t = {
   triggerKind,
   triggerCharacter: option(string),

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -36,11 +36,13 @@ module Command: {
 };
 
 module CompletionContext: {
+  [@deriving show]
   type triggerKind =
     | Invoke
     | TriggerCharacter
     | TriggerForIncompleteCompletions;
 
+  [@deriving show]
   type t = {
     triggerKind,
     triggerCharacter: option(string),


### PR DESCRIPTION
__Issue:__ When manually invoking completion (via `Control+Space` or `Control+N`), a completion session would not always be initiated, as described in #2300 

__Defect:__ When completion was manually invoked, we would look for a completion meet based on trigger characters to start the session. 

__Fix:__ There won't always be a completion meet available when manually invoking - in the manual-invoke case, we'll use the cursor position as the meet position, and send appropriate context (triggerKind) to the extension host in this case.