### PR TITLE
fix(exthost/#2305): Tsconfig pops up randomly

### DIFF
--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -72,7 +72,7 @@ let simpleEditor =
 
 let createUpdateAction = (oldBuffer: Buffer.t, update: BufferUpdate.t) => {
   let newBuffer = Buffer.update(oldBuffer, update);
-  Actions.BufferUpdate({update, oldBuffer, newBuffer, triggerKey: None});
+  Actions.Buffers(Feature_Buffers.Update(({update, oldBuffer, newBuffer, triggerKey: None})));
 };
 
 let thousandLineBuffer = Buffer.ofLines(thousandLines);

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -35,13 +35,12 @@ function activate(context) {
 
     cleanup(
         vscode.commands.registerCommand("developer.oni.tryOpenDocument", () => {
-            vscode.workspace.openTextDocument(vscode.Uri.file("/Users/bryphe/oni2/package.json"))
+            vscode.workspace.openTextDocument(vscode.Uri.file("package.json"))
             .then((document) => {
                 let text = document.getText();
-                //vscode.window.showInformationMessage(JSON.stringify(text));
-                vscode.window.showInformationMessage("SUCCESS: " + text);
+                vscode.window.showInformationMessage("Got text document: " + text);
             }, err => {
-                vscode.window.showErrorMessage("FAILURE: " + err.toString());
+                vscode.window.showErrorMessage("Failed to get text document: " + err.toString());
             })
         }),
     )

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -32,6 +32,19 @@ function activate(context) {
             item.hide();
         }),
     )
+
+    cleanup(
+        vscode.commands.registerCommand("developer.oni.tryOpenDocument", () => {
+            vscode.workspace.openTextDocument(vscode.Uri.file("/Users/bryphe/oni2/package.json"))
+            .then((document) => {
+                let text = document.getText();
+                //vscode.window.showInformationMessage(JSON.stringify(text));
+                vscode.window.showInformationMessage("SUCCESS: " + text);
+            }, err => {
+                vscode.window.showErrorMessage("FAILURE: " + err.toString());
+            })
+        }),
+    )
     
     cleanup(
         vscode.commands.registerCommand("developer.oni.showStatusBar", () => {

--- a/development_extensions/oni-dev-extension/package.json
+++ b/development_extensions/oni-dev-extension/package.json
@@ -37,6 +37,10 @@
 				"title": "Onivim - Developer: Show Visible Editors"
 			},
 			{
+				"command": "developer.oni.tryOpenDocument",
+				"title": "Onivim - Developer: Try Open Document (package.json)"
+			},
+			{
 				"command": "developer.oni.showWorkspaceRootPath",
 				"title": "Onivim - Developer: Show Workspace Root Path"
 			},

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -8,7 +8,7 @@ open Oni_Core;
 
 module Log = (val Log.withNamespace("Oni2.Model.Buffers"));
 
-type t = IntMap.t(Buffer.t);
+type model = IntMap.t(Buffer.t);
 
 let empty = IntMap.empty;
 
@@ -18,9 +18,9 @@ let map = IntMap.map;
 let update = IntMap.update;
 let remove = IntMap.remove;
 
-let getBuffer = (id, map) => IntMap.find_opt(id, map);
+let get = (id, model) => IntMap.find_opt(id, model);
 
-let anyModified = (buffers: t) => {
+let anyModified = (buffers: model) => {
   IntMap.fold(
     (_key, v, prev) => Buffer.isModified(v) || prev,
     buffers,
@@ -28,7 +28,11 @@ let anyModified = (buffers: t) => {
   );
 };
 
-let isModifiedByPath = (buffers: t, filePath: string) => {
+let add = (buffer, model) => {
+  model |> IntMap.add(Buffer.getId(buffer), buffer);
+};
+
+let isModifiedByPath = (buffers: model, filePath: string) => {
   IntMap.exists(
     (_id, v) => {
       let bufferPath = Buffer.getFilePath(v);
@@ -55,12 +59,48 @@ let setModified = modified =>
 let setLineEndings = le =>
   Option.map(buffer => Buffer.setLineEndings(le, buffer));
 
-let reduce = (state: t, action: Actions.t) => {
-  switch (action) {
-  | BufferDisableSyntaxHighlighting(id) =>
-    IntMap.update(id, disableSyntaxHighlighting, state)
+[@deriving show({with_path: false})]
+type msg =
+  | SyntaxHighlightingDisabled(int)
+  | Entered({
+      id: int,
+      fileType: option(string),
+      lineEndings: [@opaque] option(Vim.lineEnding),
+      filePath: option(string),
+      isModified: bool,
+      version: int,
+      font: Font.t,
+      // TODO: This duplication-of-truth is really awkward,
+      // but I want to remove it shortly
+      buffer: [@opaque] Buffer.t,
+    })
+  | FilenameChanged({
+      id: int,
+      newFilePath: option(string),
+      newFileType: option(string),
+      version: int,
+      isModified: bool,
+    })
+  | Update({
+      update: [@opaque] BufferUpdate.t,
+      oldBuffer: [@opaque] Buffer.t,
+      newBuffer: [@opaque] Buffer.t,
+      triggerKey: option(string),
+    })
+  | LineEndingsChanged({
+      id: int,
+      lineEndings: [@opaque] Vim.lineEnding,
+    })
+  | Saved(int)
+  | IndentationSet(int, [@opaque] IndentationSettings.t)
+  | ModifiedSet(int, bool);
 
-  | BufferEnter({
+let update = (msg: msg, model: model) => {
+  switch (msg) {
+  | SyntaxHighlightingDisabled(id) =>
+    IntMap.update(id, disableSyntaxHighlighting, model)
+
+  | Entered({
       id,
       fileType,
       lineEndings,
@@ -100,9 +140,9 @@ let reduce = (state: t, action: Actions.t) => {
         |> maybeSetLineEndings(lineEndings)
         |> Option.some
     );
-    IntMap.update(id, updater, state);
+    IntMap.update(id, updater, model);
 
-  | BufferFilenameChanged({id, newFileType, newFilePath, version, isModified}) =>
+  | FilenameChanged({id, newFileType, newFilePath, version, isModified}) =>
     let updater = (
       fun
       | Some(buffer) =>
@@ -115,20 +155,19 @@ let reduce = (state: t, action: Actions.t) => {
         |> Option.some
       | None => None
     );
-    IntMap.update(id, updater, state);
+    IntMap.update(id, updater, model);
   /* | BufferDelete(bd) => IntMap.remove(bd, state) */
-  | BufferSetModified(id, isModified) =>
-    IntMap.update(id, setModified(isModified), state)
+  | ModifiedSet(id, isModified) =>
+    IntMap.update(id, setModified(isModified), model)
 
-  | BufferSetIndentation(id, indent) =>
-    IntMap.update(id, setIndentation(indent), state)
+  | IndentationSet(id, indent) =>
+    IntMap.update(id, setIndentation(indent), model)
 
-  | BufferLineEndingsChanged({id, lineEndings}) =>
-    IntMap.update(id, setLineEndings(lineEndings), state)
+  | LineEndingsChanged({id, lineEndings}) =>
+    IntMap.update(id, setLineEndings(lineEndings), model)
 
-  | BufferUpdate({update, newBuffer, _}) =>
-    IntMap.add(update.id, newBuffer, state)
+  | Update({update, newBuffer, _}) => IntMap.add(update.id, newBuffer, model)
 
-  | _ => state
+  | _ => model
   };
 };

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -15,7 +15,6 @@ let empty = IntMap.empty;
 type mapFunction = Buffer.t => Buffer.t;
 
 let map = IntMap.map;
-let update = IntMap.update;
 let remove = IntMap.remove;
 
 let get = (id, model) => IntMap.find_opt(id, model);
@@ -30,6 +29,10 @@ let anyModified = (buffers: model) => {
 
 let add = (buffer, model) => {
   model |> IntMap.add(Buffer.getId(buffer), buffer);
+};
+
+let filter = (f, model) => {
+  model |> IntMap.bindings |> List.map(snd) |> List.filter(f);
 };
 
 let isModifiedByPath = (buffers: model, filePath: string) => {

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -1,0 +1,12 @@
+(library
+    (name Feature_Buffers)
+    (public_name Oni2.feature.buffers)
+    (libraries 
+      Oni2.editor-core-types
+      Oni2.core
+      Oni2.service.exthost
+      Revery
+      isolinear
+      base
+    )
+    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Exthost/Feature_Exthost.rei
+++ b/src/Feature/Exthost/Feature_Exthost.rei
@@ -1,10 +1,28 @@
+[@deriving show]
+type msg;
+
+module Msg: {
+  let document: (Exthost.Msg.Documents.msg, Lwt.u(Exthost.Reply.t)) => msg;
+};
+
+type model;
+
+let initial: model;
+
+type outmsg =
+  | Nothing
+  | Effect(Isolinear.Effect.t(msg));
+
+let update: (msg, model) => (model, outmsg);
+
 // SUBSCRIPTION
 
 let subscription:
   (
-    ~buffers: list(Oni_Core.Buffer.t),
+    ~buffers: Feature_Buffers.model,
     ~editors: list(Feature_Editor.Editor.t),
     ~activeEditorId: option(Feature_Editor.EditorId.t),
-    ~client: Exthost.Client.t
+    ~client: Exthost.Client.t,
+    model
   ) =>
-  Isolinear.Sub.t(unit);
+  Isolinear.Sub.t(msg);

--- a/src/Feature/Exthost/dune
+++ b/src/Feature/Exthost/dune
@@ -4,8 +4,11 @@
     (libraries
       Oni2.core
       Oni2.components
+      Oni2.exthost
+      Oni2.feature.buffers
       Oni2.feature.editor
       Oni2.service.exthost
+      Oni2.service.vim
       Revery
       isolinear
     )

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -22,6 +22,7 @@ type t =
   | Buffers(Feature_Buffers.msg)
   | BufferRenderer(BufferRenderer.action)
   | Clipboard(Feature_Clipboard.msg)
+  | Exthost(Feature_Exthost.msg)
   | Syntax(Feature_Syntax.msg)
   | SignatureHelp(Feature_SignatureHelp.msg)
   | Changelog(Feature_Changelog.msg)

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -19,40 +19,8 @@ module Diagnostic = Feature_LanguageSupport.Diagnostic;
 type t =
   | Init
   | ActivityBar(ActivityBar.action)
-  | BufferDisableSyntaxHighlighting(int)
-  | BufferEnter({
-      id: int,
-      fileType: option(string),
-      lineEndings: [@opaque] option(Vim.lineEnding),
-      filePath: option(string),
-      isModified: bool,
-      version: int,
-      font: Font.t,
-      // TODO: This duplication-of-truth is really awkward,
-      // but I want to remove it shortly
-      buffer: [@opaque] Buffer.t,
-    })
-  | BufferFilenameChanged({
-      id: int,
-      newFilePath: option(string),
-      newFileType: option(string),
-      version: int,
-      isModified: bool,
-    })
-  | BufferUpdate({
-      update: [@opaque] BufferUpdate.t,
-      oldBuffer: [@opaque] Buffer.t,
-      newBuffer: [@opaque] Buffer.t,
-      triggerKey: option(string),
-    })
-  | BufferLineEndingsChanged({
-      id: int,
-      lineEndings: [@opaque] Vim.lineEnding,
-    })
+  | Buffers(Feature_Buffers.msg)
   | BufferRenderer(BufferRenderer.action)
-  | BufferSaved(int)
-  | BufferSetIndentation(int, [@opaque] IndentationSettings.t)
-  | BufferSetModified(int, bool)
   | Clipboard(Feature_Clipboard.msg)
   | Syntax(Feature_Syntax.msg)
   | SignatureHelp(Feature_SignatureHelp.msg)

--- a/src/Model/Oni_Model.re
+++ b/src/Model/Oni_Model.re
@@ -8,7 +8,6 @@
 
 module Actions = Actions;
 module ActivityBar = ActivityBar;
-module Buffers = Buffers;
 module BufferRenderer = BufferRenderer;
 module BufferRenderers = BufferRenderers;
 module ContextKeys = ContextKeys;

--- a/src/Model/Selectors.re
+++ b/src/Model/Selectors.re
@@ -10,11 +10,11 @@ open Oni_Core.Utility;
 module Editor = Feature_Editor.Editor;
 
 let getBufferById = (state: State.t, id: int) => {
-  Buffers.getBuffer(id, state.buffers);
+  Feature_Buffers.get(id, state.buffers);
 };
 
 let getBufferForEditor = (buffers, editor: Editor.t) => {
-  Buffers.getBuffer(Editor.getBufferId(editor), buffers);
+  Feature_Buffers.get(Editor.getBufferId(editor), buffers);
 };
 
 let getConfigurationValue = (state: State.t, buffer: Buffer.t, f) => {

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -41,6 +41,7 @@ type t = {
   // Token theme is theming for syntax highlights
   tokenTheme: TokenTheme.t,
   extensions: Feature_Extensions.model,
+  exthost: Feature_Exthost.model,
   iconTheme: IconTheme.t,
   isQuitting: bool,
   keyBindings: Keybindings.t,
@@ -133,6 +134,7 @@ let initial =
         ~workspacePersistence=extensionWorkspacePersistence,
         ~extensionsFolder,
       ),
+    exthost: Feature_Exthost.initial,
     languageFeatures: LanguageFeatures.empty,
     languageSupport: Feature_LanguageSupport.initial,
     lifecycle: Lifecycle.create(),

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -19,7 +19,7 @@ type windowDisplayMode =
   | Fullscreen;
 
 type t = {
-  buffers: Buffers.t,
+  buffers: Feature_Buffers.model,
   bufferRenderers: BufferRenderers.t,
   bufferHighlights: BufferHighlights.t,
   changelog: Feature_Changelog.model,
@@ -106,8 +106,7 @@ let initial =
   };
 
   {
-    buffers:
-      Buffers.empty |> IntMap.add(Buffer.getId(initialBuffer), initialBuffer),
+    buffers: Feature_Buffers.empty |> Feature_Buffers.add(initialBuffer),
     bufferHighlights: BufferHighlights.initial,
     bufferRenderers: initialBufferRenderers,
     changelog: Feature_Changelog.initial,

--- a/src/Model/dune
+++ b/src/Model/dune
@@ -21,6 +21,7 @@
         Oni2.service.font
         Oni2.service.file-watcher
         Oni2.components
+        Oni2.feature.buffers
         Oni2.feature.clipboard
         Oni2.feature.configuration
         Oni2.feature.contextMenu

--- a/src/Model/dune
+++ b/src/Model/dune
@@ -25,6 +25,7 @@
         Oni2.feature.clipboard
         Oni2.feature.configuration
         Oni2.feature.contextMenu
+        Oni2.feature.exthost
         Oni2.feature.extensions
         Oni2.feature.messages
         Oni2.feature.theme

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -274,7 +274,7 @@ module Sub = {
 
   module BufferSubscription =
     Isolinear.Sub.Make({
-      type nonrec msg = unit;
+      type nonrec msg = [ | `Added];
       type nonrec params = bufferParams;
       type state = {didAdd: bool};
 
@@ -283,7 +283,7 @@ module Sub = {
         params.buffer |> Oni_Core.Buffer.getId |> string_of_int;
       };
 
-      let init = (~params, ~dispatch as _) => {
+      let init = (~params, ~dispatch) => {
         let bufferId = Oni_Core.Buffer.getId(params.buffer);
 
         Log.infof(m => m("Starting buffer subscription for: %d", bufferId));
@@ -308,6 +308,7 @@ module Sub = {
             ~delta=addedDelta,
             params.client,
           );
+          dispatch(`Added);
           {didAdd: true};
         | None => {didAdd: false}
         };
@@ -336,8 +337,8 @@ module Sub = {
         };
     });
 
-  let buffer = (~buffer, ~client) =>
-    BufferSubscription.create({buffer, client});
+  let buffer = (~buffer, ~client, ~toMsg) =>
+    BufferSubscription.create({buffer, client}) |> Isolinear.Sub.map(toMsg);
 
   type editorParams = {
     client: Exthost.Client.t,

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -96,8 +96,12 @@ module Effects: {
 
 module Sub: {
   let buffer:
-    (~buffer: Oni_Core.Buffer.t, ~client: Exthost.Client.t) =>
-    Isolinear.Sub.t(unit);
+    (
+      ~buffer: Oni_Core.Buffer.t,
+      ~client: Exthost.Client.t,
+      ~toMsg: [ | `Added] => 'msg
+    ) =>
+    Isolinear.Sub.t('msg);
 
   let editor:
     (~editor: Exthost.TextEditor.AddData.t, ~client: Exthost.Client.t) =>

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -98,6 +98,19 @@ module Effects = {
 
       dispatch(toMsg(cursors));
     });
+
+  let loadBuffer = (~filePath: string, toMsg) => {
+    Isolinear.Effect.createWithDispatch(~name="loadBuffer", dispatch => {
+      let currentBuffer = Vim.Buffer.getCurrent();
+
+      let newBuffer = Vim.Buffer.openFile(filePath);
+
+      // Revert to previous buffer
+      Vim.Buffer.setCurrent(currentBuffer);
+
+      dispatch(toMsg(~bufferId=Vim.Buffer.getId(newBuffer)));
+    });
+  };
 };
 
 module Sub = {

--- a/src/Service/Vim/Service_Vim.rei
+++ b/src/Service/Vim/Service_Vim.rei
@@ -23,6 +23,9 @@ module Effects: {
     ) =>
     Isolinear.Effect.t('msg);
 
+  let loadBuffer:
+    (~filePath: string, (~bufferId: int) => 'msg) => Isolinear.Effect.t('msg);
+
   let applyCompletion:
     (
       ~meetColumn: Index.t,

--- a/src/Service/Vim/dune
+++ b/src/Service/Vim/dune
@@ -4,6 +4,7 @@
     (libraries 
       Oni2.editor-core-types
       Oni2.core
+      Oni2.service.font
       isolinear
     )
     (preprocess (pps ppx_let ppx_deriving.show)))

--- a/src/Store/BufferRendererReducer.re
+++ b/src/Store/BufferRendererReducer.re
@@ -12,7 +12,9 @@ let reduce = (state: BufferRenderers.t, action) => {
     let reduceForBuffer = (id, renderer) => {
       BufferRenderer.(
         switch (renderer, action) {
-        | (Welcome, BufferUpdate(bu)) when bu.update.id == id => Editor
+        | (Welcome, Buffers(Feature_Buffers.Update(bu)))
+            when bu.update.id == id =>
+          Editor
         | (Version, _) => Version
         | (Editor, _) => Editor
         | (Terminal(state), Terminal(msg)) =>

--- a/src/Store/ConfigurationStoreConnector.re
+++ b/src/Store/ConfigurationStoreConnector.re
@@ -53,7 +53,7 @@ let start =
       Log.error("Unable to load configuration: " ++ msg);
       Isolinear.Effect.none;
     | Ok(configPath) =>
-      if (!Buffers.isModifiedByPath(buffers, configPath)) {
+      if (!Feature_Buffers.isModifiedByPath(buffers, configPath)) {
         Oni_Core.Log.perf("Apply configuration transform", () => {
           let parsedJson = Yojson.Safe.from_file(configPath);
           let newJson = transformer(parsedJson);

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -150,30 +150,13 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
         Lwt.return(Reply.okEmpty);
 
       | Documents(documentsMsg) =>
-        switch (documentsMsg) {
-        | Documents.TryOpenDocument({uri}) =>
-          if (Oni_Core.Uri.getScheme(uri) == Oni_Core.Uri.Scheme.File) {
-            dispatch(
-              Actions.OpenFileByPath(
-                Oni_Core.Uri.toFileSystemPath(uri),
-                None,
-                None,
-              ),
-            );
-          } else {
-            Log.warnf(m =>
-              m(
-                "TryOpenDocument: Unable to open %s",
-                uri |> Oni_Core.Uri.toString,
-              )
-            );
-          }
-        | Documents.TrySaveDocument(_) =>
-          Log.warn("TrySaveDocument is not yet implemented.")
-        | Documents.TryCreateDocument(_) =>
-          Log.warn("TryCreateDocument is not yet implemented.")
-        };
-        Lwt.return(Reply.okEmpty);
+        let (promise, resolver) = Lwt.task();
+        dispatch(
+          Actions.Exthost(
+            Feature_Exthost.Msg.document(documentsMsg, resolver),
+          ),
+        );
+        promise;
 
       | ExtensionService(extMsg) =>
         Log.infof(m => m("ExtensionService: %s", Exthost.Msg.show(msg)));

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -132,7 +132,9 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
         ]),
       )
 
-    | BufferUpdate({update, newBuffer, triggerKey, oldBuffer}) => (
+    | Buffers(
+        Feature_Buffers.Update({update, newBuffer, triggerKey, oldBuffer}),
+      ) => (
         state,
         Service_Exthost.Effects.Documents.modelChanged(
           ~previousBuffer=oldBuffer,
@@ -144,10 +146,10 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
         ),
       )
 
-    | BufferSaved(bufferId) =>
+    | Buffers(Feature_Buffers.Saved(bufferId)) =>
       let effect =
         state.buffers
-        |> Oni_Model.Buffers.getBuffer(bufferId)
+        |> Feature_Buffers.get(bufferId)
         |> Option.map(buffer => {
              gitRefreshEffect(state.scm, buffer |> Oni_Core.Buffer.getUri)
            })
@@ -166,7 +168,7 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
 
     | DirectoryChanged(path) => (state, changeWorkspaceEffect(path))
 
-    | BufferEnter({id, filePath, _}) =>
+    | Buffers(Feature_Buffers.Entered({id, filePath, _})) =>
       let eff =
         switch (filePath) {
         | Some(path) =>

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -133,6 +133,18 @@ let update =
 
     ({...state, clipboard: model}, eff);
 
+  | Exthost(msg) =>
+    let (model, outMsg) = Feature_Exthost.update(msg, state.exthost);
+
+    let state = {...state, exthost: model};
+    let eff =
+      switch (outMsg) {
+      | Feature_Exthost.Nothing => Isolinear.Effect.none
+      | Feature_Exthost.Effect(eff) =>
+        eff |> Isolinear.Effect.map(msg => Exthost(msg))
+      };
+    (state, eff);
+
   | Extensions(msg) =>
     let (model, outMsg) =
       Feature_Extensions.update(~extHostClient, msg, state.extensions);

--- a/src/Store/IndentationStoreConnector.re
+++ b/src/Store/IndentationStoreConnector.re
@@ -37,13 +37,15 @@ let start = () => {
         };
 
       dispatch(
-        Actions.BufferSetIndentation(
-          Buffer.getId(buffer),
-          IndentationSettings.create(
-            ~mode=guess.mode,
-            ~size,
-            ~tabSize=size,
-            (),
+        Actions.Buffers(
+          Feature_Buffers.IndentationSet(
+            Buffer.getId(buffer),
+            IndentationSettings.create(
+              ~mode=guess.mode,
+              ~size,
+              ~tabSize=size,
+              (),
+            ),
           ),
         ),
       );
@@ -53,9 +55,11 @@ let start = () => {
     Isolinear.Effect.createWithDispatch(
       ~name="indentation.setConfigured", dispatch =>
       dispatch(
-        Actions.BufferSetIndentation(
-          Buffer.getId(buffer),
-          IndentationSettings.ofConfiguration(state.configuration),
+        Actions.Buffers(
+          Feature_Buffers.IndentationSet(
+            Buffer.getId(buffer),
+            IndentationSettings.ofConfiguration(state.configuration),
+          ),
         ),
       )
     );
@@ -79,9 +83,9 @@ let start = () => {
 
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
-    | Actions.BufferEnter({buffer, _}) =>
+    | Actions.Buffers(Feature_Buffers.Entered({buffer, _})) =>
       let id = Oni_Core.Buffer.getId(buffer);
-      switch (Buffers.getBuffer(id, state.buffers)) {
+      switch (Feature_Buffers.get(id, state.buffers)) {
       | Some(buffer) when !Buffer.isIndentationSet(buffer) => (
           state,
           checkIndentationEffect(state, buffer),
@@ -89,7 +93,7 @@ let start = () => {
       | _ => (state, Isolinear.Effect.none)
       };
 
-    | Actions.BufferUpdate({oldBuffer, newBuffer, _})
+    | Actions.Buffers(Feature_Buffers.Update({oldBuffer, newBuffer, _}))
         when
           Buffer.getNumberOfLines(oldBuffer) <= 1
           && Buffer.getNumberOfLines(newBuffer) > 2 => (

--- a/src/Store/LifecycleStoreConnector.re
+++ b/src/Store/LifecycleStoreConnector.re
@@ -11,7 +11,7 @@ let start = (~quit, ~raiseWindow) => {
   let quitAllEffect = (state: State.t, force) => {
     let handlers = state.lifecycle.onQuitFunctions;
 
-    let anyModified = Buffers.anyModified(state.buffers);
+    let anyModified = Feature_Buffers.anyModified(state.buffers);
     let canClose = force || !anyModified;
 
     Isolinear.Effect.createWithDispatch(~name="lifecycle.quitAll", dispatch =>

--- a/src/Store/Reducer.re
+++ b/src/Store/Reducer.re
@@ -14,9 +14,6 @@ let reduce: (State.t, Actions.t) => State.t =
     | a =>
       let s = {
         ...s,
-        buffers: Buffers.reduce(s.buffers, a),
-        /*syntaxHighlights:
-          BufferSyntaxHighlightsReducer.reduce(s.syntaxHighlights, a),*/
         bufferHighlights:
           BufferHighlightsReducer.reduce(s.bufferHighlights, a),
         bufferRenderers: BufferRendererReducer.reduce(s.bufferRenderers, a),

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -298,7 +298,7 @@ let start =
     let activeBufferId = Feature_Editor.Editor.getBufferId(activeEditor);
     let activePosition = Feature_Editor.Editor.getPrimaryCursor(activeEditor);
     let maybeActiveBuffer =
-      Model.Buffers.getBuffer(activeBufferId, state.buffers);
+      Feature_Buffers.get(activeBufferId, state.buffers);
 
     let extHostSubscription =
       Feature_Exthost.subscription(
@@ -401,7 +401,7 @@ let start =
   Option.iter(
     window =>
       Revery.Window.setCanQuitCallback(window, () =>
-        if (Model.Buffers.anyModified(getState().buffers)) {
+        if (Feature_Buffers.anyModified(getState().buffers)) {
           dispatch(Model.Actions.WindowCloseBlocked);
           false;
         } else {

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -302,12 +302,13 @@ let start =
 
     let extHostSubscription =
       Feature_Exthost.subscription(
-        ~buffers=visibleBuffers,
+        ~buffers=state.buffers,
         ~editors=visibleEditors,
         ~activeEditorId=Some(activeEditorId),
         ~client=extHostClient,
+        state.exthost,
       )
-      |> Isolinear.Sub.map(() => Model.Actions.Noop);
+      |> Isolinear.Sub.map(msg => Model.Actions.Exthost(msg));
 
     let fileExplorerActiveFileSub =
       Model.Sub.activeFile(

--- a/src/Store/TitleStoreConnector.re
+++ b/src/Store/TitleStoreConnector.re
@@ -159,8 +159,7 @@ let start = (setTitle, maximize, minimize, restore, close) => {
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
     | Init => (state, Effects.updateTitle(state))
-    | BufferEnter(_) => (state, Effects.updateTitle(state))
-    | BufferSetModified(_) => (state, Effects.updateTitle(state))
+    | Buffers(_) => (state, Effects.updateTitle(state))
 
     // TODO: This shouldn't exist, but needs to  be here because it depends on
     // `setTitle` being passed in. It would however be better to have a more

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -66,7 +66,8 @@ let start =
 
   let _: unit => unit =
     Vim.Buffer.onLineEndingsChanged((id, lineEndings) => {
-      Actions.BufferLineEndingsChanged({id, lineEndings}) |> dispatch
+      Actions.Buffers(Feature_Buffers.LineEndingsChanged({id, lineEndings}))
+      |> dispatch
     });
 
   let handleGoto = gotoType => {
@@ -200,24 +201,30 @@ let start =
         };
 
       dispatch(
-        Actions.BufferFilenameChanged({
-          id: meta.id,
-          newFileType: fileType,
-          newFilePath: meta.filePath,
-          isModified: meta.modified,
-          version: meta.version,
-        }),
+        Actions.Buffers(
+          Feature_Buffers.FilenameChanged({
+            id: meta.id,
+            newFileType: fileType,
+            newFilePath: meta.filePath,
+            isModified: meta.modified,
+            version: meta.version,
+          }),
+        ),
       );
     });
 
   let _: unit => unit =
     Vim.Buffer.onModifiedChanged((id, isModified) => {
       Log.debugf(m => m("Buffer metadata changed: %n | %b", id, isModified));
-      dispatch(Actions.BufferSetModified(id, isModified));
+      dispatch(
+        Actions.Buffers(Feature_Buffers.ModifiedSet(id, isModified)),
+      );
     });
 
   let _: unit => unit =
-    Vim.Buffer.onWrite(id => {dispatch(Actions.BufferSaved(id))});
+    Vim.Buffer.onWrite(id => {
+      dispatch(Actions.Buffers(Feature_Buffers.Saved(id)))
+    });
 
   let _: unit => unit =
     Vim.Search.onStopSearchHighlight(() => {
@@ -344,17 +351,19 @@ let start =
           |> Oni_Core.Buffer.setFileType(fileType);
 
         dispatch(
-          Actions.BufferEnter({
-            id: metadata.id,
-            buffer,
-            fileType,
-            lineEndings,
-            // Version must be 0 so that a buffer update will be processed
-            version: 0,
-            isModified: metadata.modified,
-            filePath: metadata.filePath,
-            font: Oni_Core.Buffer.getFont(buffer),
-          }),
+          Actions.Buffers(
+            Feature_Buffers.Entered({
+              id: metadata.id,
+              buffer,
+              fileType,
+              lineEndings,
+              // Version must be 0 so that a buffer update will be processed
+              version: 0,
+              isModified: metadata.modified,
+              filePath: metadata.filePath,
+              font: Oni_Core.Buffer.getFont(buffer),
+            }),
+          ),
         );
       };
     });
@@ -367,7 +376,7 @@ let start =
 
       let isFull = update.endLine == (-1);
 
-      let maybeBuffer = Buffers.getBuffer(update.id, getState().buffers);
+      let maybeBuffer = Feature_Buffers.get(update.id, getState().buffers);
 
       // If this is a 'full' update, check if there was a previous buffer.
       // We need to keep track of the previous line count for some
@@ -428,12 +437,14 @@ let start =
                };
 
              dispatch(
-               Actions.BufferUpdate({
-                 update: bu,
-                 newBuffer,
-                 oldBuffer,
-                 triggerKey: currentTriggerKey^,
-               }),
+               Actions.Buffers(
+                 Feature_Buffers.Update({
+                   update: bu,
+                   newBuffer,
+                   oldBuffer,
+                   triggerKey: currentTriggerKey^,
+                 }),
+               ),
              );
            });
       } else {
@@ -933,7 +944,7 @@ let start =
                 editor =>
                   if (Editor.getBufferId(editor) == bufferId) {
                     state.buffers
-                    |> Buffers.getBuffer(bufferId)
+                    |> Feature_Buffers.get(bufferId)
                     |> Option.map(buffer => {
                          let updatedBuffer =
                            buffer

--- a/src/Store/dune
+++ b/src/Store/dune
@@ -21,6 +21,7 @@
         Oni2.service.vim
         Oni2.components
         Oni2.ui
+        Oni2.feature.buffers
         Oni2.feature.clipboard
         Oni2.feature.commands
         Oni2.feature.contextMenu

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -218,7 +218,7 @@ let make =
 
     let title = editor => {
       let (_, title, _) =
-        Buffers.getBuffer(Editor.getBufferId(editor), state.buffers)
+        Feature_Buffers.get(Editor.getBufferId(editor), state.buffers)
         |> getBufferMetadata;
 
       let renderer =
@@ -236,7 +236,7 @@ let make =
 
     let isModified = editor => {
       let (modified, _, _) =
-        Buffers.getBuffer(Editor.getBufferId(editor), state.buffers)
+        Feature_Buffers.get(Editor.getBufferId(editor), state.buffers)
         |> getBufferMetadata;
 
       modified;
@@ -244,7 +244,7 @@ let make =
 
     let icon = editor => {
       let buffer =
-        Buffers.getBuffer(Editor.getBufferId(editor), state.buffers);
+        Feature_Buffers.get(Editor.getBufferId(editor), state.buffers);
       let (_, _, filePath) = getBufferMetadata(buffer);
 
       let language =

--- a/test/Model/BuffersTests.re
+++ b/test/Model/BuffersTests.re
@@ -1,6 +1,6 @@
 open TestFramework;
 
-module Buffers = Oni_Model.Buffers;
+module Buffers = Feature_Buffers;
 module Buffer = Oni_Core.Buffer;
 
 let getFilePathOrFail = (v: option(Buffer.t)) => {
@@ -34,9 +34,8 @@ describe("Buffer List Tests", ({test, _}) => {
     let bufferList = Buffers.empty;
 
     let added =
-      Buffers.reduce(
-        bufferList,
-        BufferEnter({
+      Buffers.update(
+        Buffers.Entered({
           id: 0,
           buffer: emptyBuffer,
           fileType: None,
@@ -46,9 +45,10 @@ describe("Buffer List Tests", ({test, _}) => {
           filePath: Some("/test1.re"),
           font: Oni_Core.Font.default,
         }),
+        bufferList,
       );
 
-    expect.string(Buffers.getBuffer(0, added) |> getFilePathOrFail).toMatch(
+    expect.string(Buffers.get(0, added) |> getFilePathOrFail).toMatch(
       "/test1.re",
     );
   });
@@ -64,9 +64,8 @@ describe("Buffer List Tests", ({test, _}) => {
     let bufferList = Buffers.empty;
 
     let added =
-      Buffers.reduce(
-        bufferList,
-        BufferEnter({
+      Buffers.update(
+        Buffers.Entered({
           id: 0,
           buffer: emptyBuffer,
           filePath: Some("/test1.re"),
@@ -76,11 +75,11 @@ describe("Buffer List Tests", ({test, _}) => {
           lineEndings: None,
           font: Oni_Core.Font.default,
         }),
+        bufferList,
       );
     let addedAgain =
-      Buffers.reduce(
-        added,
-        BufferEnter({
+      Buffers.update(
+        Buffers.Entered({
           id: 0,
           buffer: emptyBuffer,
           filePath: Some("/test2.re"),
@@ -90,9 +89,10 @@ describe("Buffer List Tests", ({test, _}) => {
           lineEndings: None,
           font: Oni_Core.Font.default,
         }),
+        added,
       );
 
-    expect.string(Buffers.getBuffer(0, addedAgain) |> getFilePathOrFail).
+    expect.string(Buffers.get(0, addedAgain) |> getFilePathOrFail).
       toMatch(
       "/test2.re",
     );
@@ -101,9 +101,8 @@ describe("Buffer List Tests", ({test, _}) => {
   test("Should correctly find the active bufferId", ({expect, _}) => {
     let bufferList = Buffers.empty;
     let updated =
-      Buffers.reduce(
-        bufferList,
-        BufferEnter({
+      Buffers.update(
+        Buffers.Entered({
           id: 4,
           buffer: emptyBuffer,
           filePath: Some("/myfile.js"),
@@ -113,8 +112,9 @@ describe("Buffer List Tests", ({test, _}) => {
           lineEndings: None,
           font: Oni_Core.Font.default,
         }),
+        bufferList,
       );
-    let activeBuffer = Buffers.getBuffer(4, updated);
+    let activeBuffer = Buffers.get(4, updated);
     let path = getFilePathOrFail(activeBuffer);
     expect.string(path).toMatch("/myfile.js");
   });
@@ -122,9 +122,8 @@ describe("Buffer List Tests", ({test, _}) => {
   test("Should set filetype", ({expect, _}) => {
     let bufferList = Buffers.empty;
     let updated =
-      Buffers.reduce(
-        bufferList,
-        BufferEnter({
+      Buffers.update(
+        Buffers.Entered({
           id: 4,
           buffer: emptyBuffer,
           filePath: Some("/myfile.js"),
@@ -134,8 +133,9 @@ describe("Buffer List Tests", ({test, _}) => {
           lineEndings: None,
           font: Oni_Core.Font.default,
         }),
+        bufferList
       );
-    let activeBuffer = Buffers.getBuffer(4, updated);
+    let activeBuffer = Buffers.get(4, updated);
     let fileType = getFileTypeOrFail(activeBuffer);
     expect.string(fileType).toEqual("reason");
   });


### PR DESCRIPTION
__Issue:__ The `tsconfig.json` will pop up randomly, due to us incorrectly handling the `$tryOpenDocument` API method

__Defect:__ The `$tryOpenDocument` method is intended just to load a file, and send the data to the extension host - however, we were actually showing the editor for it.

__Fix:__ Don't show the editor for `$tryOpenDocument`. The full functionality requires some changes to our 'imperative' buffer handling - but this keeps does some initial refactoring to support the full functionality, and keeps the `$tryOpenDocument` from opening rogue editors.