### PR TITLE
fix(crash/#2331): Remove debug prints

### DIFF
--- a/src/reason-libvim/BufferInternal.re
+++ b/src/reason-libvim/BufferInternal.re
@@ -71,8 +71,6 @@ let checkBufferForUpdate = buffer => {
         };
 
         if (!String.equal(string_opt(lastFt), string_opt(newFiletype))) {
-          prerr_endline("last filetype: " ++ string_opt(lastFt));
-          prerr_endline("new filetype: " ++ string_opt(newFiletype));
           lastFiletype := newFiletype;
           Event.dispatch(
             BufferMetadata.ofBuffer(buffer),


### PR DESCRIPTION
Fixes #2331.

I think this is the cause of #2331, as I can't repro it on mac and Windows I believe this can cause a crash as a terminal isn't allocated when launched normally, which would explain why it is fine with `-f` on Windows.