### PR TITLE
fix(ci): Simple lint check

### DIFF
--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -40,6 +40,8 @@ steps:
     displayName: esy format
   - script: git diff --exit-code
     displayName: 'check that formatting is correct. If this fails, run `esy format` and re-submit PR.'
+  - script: esy lint
+    displayName: esy lint
   - script: yarn audit
     workingDirectory: node
     displayName: 'yarn audit: node'

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "format": "esy dune build @fmt --auto-promote",
     "checkhealth": "esy x Oni2 -f --checkhealth",
     "check": "esy b dune build @check",
+    "lint": "esy b bash ./scripts/lint.sh",
     "run": "esy x Oni2",
     "watch": "dune build --watch -p libvim,textmate,Oni2 -j4",
     "create-release": "esy node ./scripts/release.js",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,34 @@
+cd src
+
+echo "Linting in : $(pwd)"
+
+PRERR_COUNT=$(git grep prerr_endline | wc -l)
+PRINT_COUNT=$(git grep print_endline | wc -l)
+PRINTF_COUNT=$(git grep Printf.printf | wc -l)
+
+echo "prrerr_endline count: $PRERR_COUNT"
+echo "print_endline count: $PRINT_COUNT"
+echo "Printf.printf count: $PRINTF_COUNT"
+
+if [ "$PRERR_COUNT" -ne "6" ]; then
+    echo "New prerr_endline introduced; please remove and re-check:"
+    echo "---"
+    echo "Output: $(git grep prerr_endline)"
+    exit 3
+fi
+
+if [ "$PRINT_COUNT" -ne "15" ]; then
+    echo "New print_endline introduced; please remove and re-check."
+    echo "---"
+    echo "Output: $(git grep print_endline)"
+    exit 3
+fi
+
+if [ "$PRINTF_COUNT" -ne "2" ]; then
+    echo "New Printf.printf introduced; please remove and re-check."
+    echo "---"
+    echo "Output: $(git grep Printf.printf)"
+    exit 3
+fi
+
+echo "Lint check OK"

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -6,8 +6,6 @@ open Utility;
 exception TaskFailed;
 module Log = (val Kernel.Log.withNamespace("Oni2.Core.NodeTask"));
 
-print_endline ("test");
-
 let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
   Log.info("Starting task: " ++ name);
   let (promise, resolver) = Lwt.task();

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -6,6 +6,8 @@ open Utility;
 exception TaskFailed;
 module Log = (val Kernel.Log.withNamespace("Oni2.Core.NodeTask"));
 
+print_endline ("test");
+
 let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
   Log.info("Starting task: " ++ name);
   let (promise, resolver) = Lwt.task();


### PR DESCRIPTION
Related to #2333 - this is a quick-and-dirty lint script to help verify inadvert `print_endline`, `prerr_endline`, etc are not introduced accidentally in commits.

Was looking for a more robust, full-fledged lint tool for OCaml / ReasonML - but couldn't find anything. Would be a really nice addition! Hopefully at some point we can replace this tool with a real linter.