### PR TITLE
fix(scm): SCM pane grabbing focus on opening file

### DIFF
--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -178,6 +178,7 @@ module Msg = {
 
 type outmsg =
   | Effect(Isolinear.Effect.t(msg))
+  | EffectAndFocus(Isolinear.Effect.t(msg))
   | Focus
   | Nothing;
 
@@ -444,7 +445,7 @@ let update = (extHostClient: Exthost.Client.t, model, msg) =>
 
   | KeyPressed({key: "<CR>"}) => (
       model,
-      Effect(
+      EffectAndFocus(
         Isolinear.Effect.batch(
           model.providers
           |> List.map((provider: Provider.t) =>
@@ -468,7 +469,7 @@ let update = (extHostClient: Exthost.Client.t, model, msg) =>
     let inputBox = Feature_InputText.handleInput(~key, model.inputBox);
     (
       {...model, inputBox},
-      Effect(
+      EffectAndFocus(
         Isolinear.Effect.batch(
           model.providers
           |> List.map((provider: Provider.t) =>
@@ -486,7 +487,7 @@ let update = (extHostClient: Exthost.Client.t, model, msg) =>
     let inputBox = Feature_InputText.paste(~text, model.inputBox);
     (
       {...model, inputBox},
-      Effect(
+      EffectAndFocus(
         Isolinear.Effect.batch(
           model.providers
           |> List.map((provider: Provider.t) =>

--- a/src/Feature/SCM/Feature_SCM.rei
+++ b/src/Feature/SCM/Feature_SCM.rei
@@ -66,6 +66,7 @@ module Msg: {
 
 type outmsg =
   | Effect(Isolinear.Effect.t(msg))
+  | EffectAndFocus(Isolinear.Effect.t(msg))
   | Focus
   | Nothing;
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -353,7 +353,8 @@ let update =
     let (state, eff) =
       switch ((maybeOutmsg: Feature_SCM.outmsg)) {
       | Focus => (FocusManager.push(Focus.SCM, state), Effect.none)
-      | Effect(eff) => (FocusManager.push(Focus.SCM, state), eff)
+      | Effect(eff) => (state, eff)
+      | EffectAndFocus(eff) => (FocusManager.push(Focus.SCM, state), eff)
       | Nothing => (state, Effect.none)
       };
 


### PR DESCRIPTION
__Issue:__ The SCM pane would grab focus when a document is opened and an original source (for diffs) is found.

__Defect:__ The SCM feature had the unintuitive implicit behavior of acquiring focus when any effect was produced. 

__Fix:__ Differentiate between cases where we want to be focus to kept or maintained, and cases where an effect can be produced without changing focus state.