### PR TITLE
fix(vim/#2349): Crash on :enew

### DIFF
--- a/integration_test/Regression2349EnewTest.re
+++ b/integration_test/Regression2349EnewTest.re
@@ -1,0 +1,42 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(~name="Regression: Command line no completions", (dispatch, wait, _) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    Feature_Vim.mode(state.vim) == Vim.Types.Normal
+  );
+
+  let initialEditorId = ref(None);
+
+  wait(~name="Wait for first editor to be created", (state: State.t) => {
+    let initialEditor = Feature_Layout.activeEditor(state.layout);
+    initialEditorId := Some(initialEditor |> Feature_Editor.Editor.getId);
+    true;
+  });
+
+  dispatch(Actions.VimExecuteCommand("enew"));
+
+  wait(~name="New editor created", (state: State.t) => {
+    let currentEditorId =
+      state.layout
+      |> Feature_Layout.activeEditor
+      |> Feature_Editor.Editor.getId;
+
+    Some(currentEditorId) != initialEditorId^;
+  });
+
+  wait(~name="New buffer should have filetype plaintext", (state: State.t) => {
+    let currentBufferId =
+      state.layout
+      |> Feature_Layout.activeEditor
+      |> Feature_Editor.Editor.getBufferId;
+
+    let fileTypeString =
+      state.buffers
+      |> Feature_Buffers.get(currentBufferId)
+      |> Option.map(Oni_Core.Buffer.getFileType)
+      |> Option.map(Oni_Core.Buffer.FileType.toString);
+
+    fileTypeString == Some("plaintext");
+  });
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -35,6 +35,7 @@
            SyntaxServerParentPidCorrectTest
            SyntaxServerReadExceptionTest
            Regression1671Test
+           Regression2349EnewTest
            RegressionCommandLineNoCompletionTest
            RegressionFontFallbackTest
            RegressionFileModifiedIndicationTest
@@ -93,6 +94,7 @@
         LineEndingsLFTest.exe
         QuickOpenEventuallyCompletesTest.exe
         Regression1671Test.exe
+        Regression2349EnewTest.exe
         RegressionCommandLineNoCompletionTest.exe
         RegressionFileModifiedIndicationTest.exe
         RegressionFontFallbackTest.exe

--- a/src/Core/Utility/Path.re
+++ b/src/Core/Utility/Path.re
@@ -1,5 +1,8 @@
 // Not very robust path-handling utilities.
-// TODO: Make good
+// TODO: Replace with a strongly-typed solution like `fp`:
+// https://github.com/facebookexperimental/reason-native/tree/master/src/fp
+
+module Log = (val Kernel.Log.withNamespace("Oni2.Core.Utility.Path"));
 
 let hasTrailingSeparator = path => {
   let len = String.length(path);
@@ -39,10 +42,19 @@ let trimTrailingSeparator = path => {
   };
 };
 
+let filename = path =>
+  try(Rench.Path.filename(path)) {
+  | Invalid_argument(_) =>
+    Log.warnf(m => m("getExtension - invalid filename: %s", path));
+    "";
+  };
+
 let getExtension = path => {
   let fileName =
     try(Rench.Path.filename(path)) {
-    | Invalid_argument(_) => ""
+    | Invalid_argument(_) =>
+      Log.warnf(m => m("getExtension - invalid filename: %s", path));
+      "";
     };
 
   if (String.length(fileName) == 0) {

--- a/src/Exthost/LanguageInfo.re
+++ b/src/Exthost/LanguageInfo.re
@@ -4,7 +4,6 @@
 
 open Oni_Core;
 open Oni_Core.Utility;
-open Rench;
 
 open Exthost_Extension;
 open Scanner.ScanResult;
@@ -133,7 +132,7 @@ let getLanguageFromFirstLine = (li: t, buffer: Buffer.t) => {
 };
 
 let getLanguageFromFilePath = (li: t, fp: string) => {
-  let fileName = Path.filename(fp);
+  let fileName = Utility.Path.filename(fp);
   let extension = Utility.Path.getExtension(fp);
 
   let updateIfDefault = (f, res) =>


### PR DESCRIPTION
__Issue:__ `:enew` would crash the editor

__Defect:__ We were crashing when trying to infer the language type from the filename - in this code: https://github.com/onivim/oni2/blob/d3b6eb51c168474079c3a4f3bd8142bc62667cd2/src/Exthost/LanguageInfo.re#L136

The `Rench.Path.filename` (which uses `Fpath` under the hood) - is not robust against an empty filename.

__Fix:__ Don't crash in that case - if it's an empty file name, just use the default ("plaintext") filetype. Add a regression test so we can ensure this doesn't break again in the future.

Longer term, I'd like to look at moving towards a strongly-typed solution for file path / name management - would like to integrate: https://github.com/facebookexperimental/reason-native/tree/master/src/fp

Fixes #2349 