### PR TITLE
fix(editor/#2335): Add tooltip for path

### DIFF
--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -60,6 +60,7 @@ module View: {
 
     let id: t => int;
     let title: t => string;
+    let tooltip: t => string;
     let icon: t => option(IconTheme.IconDefinition.t);
     let isModified: t => bool;
 

--- a/src/Feature/Layout/View.re
+++ b/src/Feature/Layout/View.re
@@ -17,6 +17,7 @@ module type ContentModel = {
 
   let id: t => int;
   let title: t => string;
+  let tooltip: t => string;
   let icon: t => option(Oni_Core.IconTheme.IconDefinition.t);
   let isModified: t => bool;
 
@@ -156,6 +157,7 @@ module Tab = {
   let%component make =
                 (
                   ~title,
+                  ~tooltip,
                   ~isGroupFocused,
                   ~isActive,
                   ~isModified,
@@ -211,13 +213,15 @@ module Tab = {
           justifyContent(`Center),
         ]>
         <View style=Styles.icon> fileIconView </View>
-        <Text
-          style={Styles.text(~isGroupFocused, ~isActive, ~theme)}
-          fontFamily={uiFont.family}
-          italic={isGroupFocused && isActive}
-          fontSize={uiFont.size}
-          text=title
-        />
+        <Tooltip text=tooltip>
+          <Text
+            style={Styles.text(~isGroupFocused, ~isActive, ~theme)}
+            fontFamily={uiFont.family}
+            italic={isGroupFocused && isActive}
+            fontSize={uiFont.size}
+            text=title
+          />
+        </Tooltip>
       </Sneakable>
       <Sneakable onClick=onClose style=Styles.icon sneakId={title ++ ".close"}>
         <FontIcon
@@ -256,6 +260,7 @@ module EditorGroupView = {
 
     let id: t => int;
     let title: t => string;
+    let tooltip: t => string;
     let icon: t => option(IconTheme.IconDefinition.t);
     let isModified: t => bool;
 
@@ -298,6 +303,7 @@ module EditorGroupView = {
                 uiFont
                 theme
                 title={ContentModel.title(item)}
+                tooltip={ContentModel.tooltip({item})}
                 isGroupFocused=isActive
                 isActive=isSelected
                 isModified={ContentModel.isModified(item)}
@@ -606,6 +612,7 @@ let make =
             uiFont
             theme
             title
+            tooltip=title
             isActive=isSelected
             isGroupFocused=true
             isModified

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -232,6 +232,24 @@ let make =
       };
     };
 
+    let tooltip = editor => {
+      let (_, _, filePath) =
+        Feature_Buffers.get(Editor.getBufferId(editor), state.buffers)
+        |> getBufferMetadata;
+
+      let renderer =
+        BufferRenderers.getById(
+          Editor.getBufferId(editor),
+          state.bufferRenderers,
+        );
+
+      switch (renderer) {
+      | Welcome => "Welcome"
+      | Terminal({title, _}) => title
+      | _ => filePath
+      };
+    };
+
     let isModified = editor => {
       let (modified, _, _) =
         Feature_Buffers.get(Editor.getBufferId(editor), state.buffers)


### PR DESCRIPTION
This adds a tooltip to show the fullpath of items in the editor tabs:

![2020-08-22 15 37 00](https://user-images.githubusercontent.com/13532591/90966949-71dc3500-e48d-11ea-8e41-6b4e734e1360.gif)

Fixes #2335 