### PR TITLE
fix(editor): Default not set for lineheight configuration

### DIFF
--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -121,6 +121,7 @@ let contributions = [
   fontFamily.spec,
   fontLigatures.spec,
   fontSize.spec,
+  lineHeight.spec,
   largeFileOptimization.spec,
   highlightActiveIndentGuide.spec,
   indentSize.spec,


### PR DESCRIPTION
__Issue:__ Warnings were shown in the logs about no default for `editor.lineHeight`, ie: 

```
[30m[43m[WARN] [0;30m[0m    +0ms [90mOni2.Core.Config[0m : Missing default value for `editor.lineHeight`
```

__Defect:__ The`lineHeight` configuration spec wasn't included in the editor contributions, so the default was never registered

__Fix:__ Add to contributions