### PR TITLE
fix(vim/#2357): Part 1 - Show pending operator in status bar

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03fcb789f98a1964a223269a253e696f",
+  "checksum": "a5ed0a677c5a2d951a81b9682fdfc3d0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.55@d41d8cd9": {
-      "id": "libvim@8.10869.55@d41d8cd9",
+    "libvim@8.10869.56@d41d8cd9": {
+      "id": "libvim@8.10869.56@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.55",
+      "version": "8.10869.56",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.55.tgz#sha1:0ec26790ce7a9ea83286018e5040fff905c79cc7"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.56.tgz#sha1:bf7e2064a97260f5affa0a76d4f9178f20bd2b36"
         ]
       },
       "overrides": [],
@@ -943,7 +943,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.55@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.56@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
@@ -973,7 +973,7 @@
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
@@ -1156,7 +1156,7 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1164,7 +1164,7 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
@@ -3078,15 +3078,15 @@
       ],
       "devDependencies": []
     },
-    "@opam/charInfo_width@opam:1.1.0@b400bb29": {
-      "id": "@opam/charInfo_width@opam:1.1.0@b400bb29",
+    "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
+      "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
       "version": "opam:1.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c4/c4ab038e06f06a29692c05fdd7c268c5#md5:c4ab038e06f06a29692c05fdd7c268c5",
-          "archive:https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz#md5:c4ab038e06f06a29692c05fdd7c268c5"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a539436d1da4aeb93711303f107bec7e#md5:a539436d1da4aeb93711303f107bec7e",
+          "archive:https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz#md5:a539436d1da4aeb93711303f107bec7e"
         ],
         "opam": {
           "name": "charInfo_width",

--- a/bench.esy.lock/opam/charInfo_width.1.1.0/opam
+++ b/bench.esy.lock/opam/charInfo_width.1.1.0/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
 maintainer: "zandoye@gmail.com"
 authors: [ "ZAN DoYe" ]
-homepage: "https://bitbucket.org/zandoye/charinfo_width/"
-bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+homepage: "https://github.com/kandu/charinfo_width/"
+bug-reports: "https://github.com/kandu/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "git://github.com/kandu/charinfo_width.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
@@ -22,6 +22,6 @@ description: """
 This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
 
 url {
-  src:"https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz"
-  checksum: "md5=c4ab038e06f06a29692c05fdd7c268c5"
+  src:"https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz"
+  checksum: "md5=a539436d1da4aeb93711303f107bec7e"
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03fcb789f98a1964a223269a253e696f",
+  "checksum": "a5ed0a677c5a2d951a81b9682fdfc3d0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.55@d41d8cd9": {
-      "id": "libvim@8.10869.55@d41d8cd9",
+    "libvim@8.10869.56@d41d8cd9": {
+      "id": "libvim@8.10869.56@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.55",
+      "version": "8.10869.56",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.55.tgz#sha1:0ec26790ce7a9ea83286018e5040fff905c79cc7"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.56.tgz#sha1:bf7e2064a97260f5affa0a76d4f9178f20bd2b36"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.55@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.56@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
@@ -972,7 +972,7 @@
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
@@ -1155,7 +1155,7 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1163,7 +1163,7 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
@@ -3077,15 +3077,15 @@
       ],
       "devDependencies": []
     },
-    "@opam/charInfo_width@opam:1.1.0@b400bb29": {
-      "id": "@opam/charInfo_width@opam:1.1.0@b400bb29",
+    "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
+      "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
       "version": "opam:1.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c4/c4ab038e06f06a29692c05fdd7c268c5#md5:c4ab038e06f06a29692c05fdd7c268c5",
-          "archive:https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz#md5:c4ab038e06f06a29692c05fdd7c268c5"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a539436d1da4aeb93711303f107bec7e#md5:a539436d1da4aeb93711303f107bec7e",
+          "archive:https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz#md5:a539436d1da4aeb93711303f107bec7e"
         ],
         "opam": {
           "name": "charInfo_width",

--- a/esy.lock/opam/charInfo_width.1.1.0/opam
+++ b/esy.lock/opam/charInfo_width.1.1.0/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
 maintainer: "zandoye@gmail.com"
 authors: [ "ZAN DoYe" ]
-homepage: "https://bitbucket.org/zandoye/charinfo_width/"
-bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+homepage: "https://github.com/kandu/charinfo_width/"
+bug-reports: "https://github.com/kandu/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "git://github.com/kandu/charinfo_width.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
@@ -22,6 +22,6 @@ description: """
 This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
 
 url {
-  src:"https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz"
-  checksum: "md5=c4ab038e06f06a29692c05fdd7c268c5"
+  src:"https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz"
+  checksum: "md5=a539436d1da4aeb93711303f107bec7e"
 }

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03fcb789f98a1964a223269a253e696f",
+  "checksum": "a5ed0a677c5a2d951a81b9682fdfc3d0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.55@d41d8cd9": {
-      "id": "libvim@8.10869.55@d41d8cd9",
+    "libvim@8.10869.56@d41d8cd9": {
+      "id": "libvim@8.10869.56@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.55",
+      "version": "8.10869.56",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.55.tgz#sha1:0ec26790ce7a9ea83286018e5040fff905c79cc7"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.56.tgz#sha1:bf7e2064a97260f5affa0a76d4f9178f20bd2b36"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.55@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.56@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
@@ -972,7 +972,7 @@
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
@@ -1155,7 +1155,7 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1163,7 +1163,7 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
@@ -3078,15 +3078,15 @@
       ],
       "devDependencies": []
     },
-    "@opam/charInfo_width@opam:1.1.0@b400bb29": {
-      "id": "@opam/charInfo_width@opam:1.1.0@b400bb29",
+    "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
+      "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
       "version": "opam:1.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c4/c4ab038e06f06a29692c05fdd7c268c5#md5:c4ab038e06f06a29692c05fdd7c268c5",
-          "archive:https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz#md5:c4ab038e06f06a29692c05fdd7c268c5"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a539436d1da4aeb93711303f107bec7e#md5:a539436d1da4aeb93711303f107bec7e",
+          "archive:https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz#md5:a539436d1da4aeb93711303f107bec7e"
         ],
         "opam": {
           "name": "charInfo_width",

--- a/integrationtest.esy.lock/opam/charInfo_width.1.1.0/opam
+++ b/integrationtest.esy.lock/opam/charInfo_width.1.1.0/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
 maintainer: "zandoye@gmail.com"
 authors: [ "ZAN DoYe" ]
-homepage: "https://bitbucket.org/zandoye/charinfo_width/"
-bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+homepage: "https://github.com/kandu/charinfo_width/"
+bug-reports: "https://github.com/kandu/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "git://github.com/kandu/charinfo_width.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
@@ -22,6 +22,6 @@ description: """
 This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
 
 url {
-  src:"https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz"
-  checksum: "md5=c4ab038e06f06a29692c05fdd7c268c5"
+  src:"https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz"
+  checksum: "md5=a539436d1da4aeb93711303f107bec7e"
 }

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.55",
+    "libvim": "8.10869.56",
     "ocaml": "~4.7.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reasonFuzz": "*",

--- a/src/Core/Mode.re
+++ b/src/Core/Mode.re
@@ -11,7 +11,7 @@ type t =
   | Visual({range: VisualRange.t})
   | Select({range: VisualRange.t})
   | Replace
-  | Operator
+  | Operator({ pending: Vim.Operator.pending })
   | CommandLine
   // Additional modes
   | TerminalInsert
@@ -37,7 +37,7 @@ let toString =
     | None => "Select"
     }
   | Replace => "Replace"
-  | Operator => "Operator"
+  | Operator({ pending }) => Vim.Operator.toString(pending)
   | CommandLine => "Command Line"
   | TerminalInsert => "Terminal Insert"
   | TerminalNormal => "Terminal Normal"

--- a/src/Core/Mode.re
+++ b/src/Core/Mode.re
@@ -11,7 +11,7 @@ type t =
   | Visual({range: VisualRange.t})
   | Select({range: VisualRange.t})
   | Replace
-  | Operator({ pending: Vim.Operator.pending })
+  | Operator({pending: Vim.Operator.pending})
   | CommandLine
   // Additional modes
   | TerminalInsert
@@ -37,7 +37,7 @@ let toString =
     | None => "Select"
     }
   | Replace => "Replace"
-  | Operator({ pending }) => Vim.Operator.toString(pending)
+  | Operator({pending}) => Vim.Operator.toString(pending)
   | CommandLine => "Command Line"
   | TerminalInsert => "Terminal Insert"
   | TerminalNormal => "Terminal Normal"

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -249,8 +249,7 @@ let notificationCount =
   </item>;
 };
 
-let diagnosticCount =
-    (~font: UiFont.t, ~theme, ~diagnostics, ~dispatch, ()) => {
+let diagnosticCount = (~font: UiFont.t, ~theme, ~diagnostics, ~dispatch, ()) => {
   let color = Colors.StatusBar.foreground.from(theme);
   let text = diagnostics |> Diagnostics.count |> string_of_int;
 
@@ -276,19 +275,28 @@ let diagnosticCount =
   </item>;
 };
 
-let modeIndicator = (~font: UiFont.t, ~theme, ~mode, ()) => {
-  let background = Colors.Oni.backgroundFor(mode).from(theme);
-  let foreground = Colors.Oni.foregroundFor(mode).from(theme);
+module ModeIndicator = {
+  let transitionDuration = Revery.Time.milliseconds(300);
 
-  <item backgroundColor=background>
-    <Text
-      style={Styles.text(~color=foreground)}
-      text={Mode.toString(mode)}
-      fontFamily={font.family}
-      fontWeight=Medium
-      fontSize=11.
-    />
-  </item>;
+  let%component make = (~font: UiFont.t, ~theme, ~mode, ()) => {
+    let background = Colors.Oni.backgroundFor(mode).from(theme);
+    let foreground = Colors.Oni.foregroundFor(mode).from(theme);
+
+    let%hook background =
+      CustomHooks.colorTransition(~duration=transitionDuration, background);
+    let%hook foreground =
+      CustomHooks.colorTransition(~duration=transitionDuration, foreground);
+
+    <item backgroundColor=background>
+      <Text
+        style={Styles.text(~color=foreground)}
+        text={Mode.toString(mode)}
+        fontFamily={font.family}
+        fontWeight=Medium
+        fontSize=11.
+      />
+    </item>;
+  };
 };
 
 let transitionAnimation =
@@ -491,7 +499,7 @@ module View = {
         </section>
         <notificationPopups />
       </sectionGroup>
-      <section align=`FlexEnd> <modeIndicator font theme mode /> </section>
+      <section align=`FlexEnd> <ModeIndicator font theme mode /> </section>
     </View>;
   };
 };

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -128,15 +128,15 @@ module Styles = {
   let item = bg => [
     flexDirection(`Column),
     justifyContent(`Center),
+    alignItems(`Center),
     backgroundColor(bg),
     paddingHorizontal(10),
     minWidth(50),
   ];
 
-  let text = (~color, ~background) => [
+  let text = (~color) => [
     textWrap(TextWrapping.NoWrap),
     Style.color(color),
-    backgroundColor(background),
   ];
 };
 
@@ -179,7 +179,6 @@ let textItem = (~onClick=?, ~background, ~font: UiFont.t, ~theme, ~text, ()) =>
     <Text
       style={Styles.text(
         ~color=Colors.StatusBar.foreground.from(theme),
-        ~background,
       )}
       fontFamily={font.family}
       fontSize=11.
@@ -244,7 +243,7 @@ let notificationCount =
         <FontIcon icon=FontAwesome.bell color />
       </View>
       <Text
-        style={Styles.text(~color, ~background)}
+        style={Styles.text(~color)}
         text
         fontFamily={font.family}
         fontSize=11.
@@ -271,7 +270,7 @@ let diagnosticCount =
         <FontIcon icon=FontAwesome.timesCircle color />
       </View>
       <Text
-        style={Styles.text(~color, ~background)}
+        style={Styles.text(~color)}
         text
         fontFamily={font.family}
         fontSize=11.
@@ -286,7 +285,7 @@ let modeIndicator = (~font: UiFont.t, ~theme, ~mode, ()) => {
 
   <item backgroundColor=background>
     <Text
-      style={Styles.text(~color=foreground, ~background)}
+      style={Styles.text(~color=foreground)}
       text={Mode.toString(mode)}
       fontFamily={font.family}
       fontWeight=Medium

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -174,12 +174,10 @@ let item =
   };
 };
 
-let textItem = (~onClick=?, ~background, ~font: UiFont.t, ~theme, ~text, ()) =>
+let textItem = (~onClick=?, ~font: UiFont.t, ~theme, ~text, ()) =>
   <item ?onClick>
     <Text
-      style={Styles.text(
-        ~color=Colors.StatusBar.foreground.from(theme),
-      )}
+      style={Styles.text(~color=Colors.StatusBar.foreground.from(theme))}
       fontFamily={font.family}
       fontSize=11.
       text
@@ -191,7 +189,6 @@ let notificationCount =
       ~theme,
       ~font: UiFont.t,
       ~foreground as color,
-      ~background,
       ~notifications: Feature_Notification.model,
       ~contextMenu,
       ~dispatch,
@@ -253,7 +250,7 @@ let notificationCount =
 };
 
 let diagnosticCount =
-    (~font: UiFont.t, ~background, ~theme, ~diagnostics, ~dispatch, ()) => {
+    (~font: UiFont.t, ~theme, ~diagnostics, ~dispatch, ()) => {
   let color = Colors.StatusBar.foreground.from(theme);
   let text = diagnostics |> Diagnostics.count |> string_of_int;
 
@@ -417,7 +414,7 @@ module View = {
     let indentation = () => {
       let text = indentationSettings |> indentationToString;
 
-      <textItem font background theme text />;
+      <textItem font theme text />;
     };
 
     let fileType = () => {
@@ -429,7 +426,6 @@ module View = {
 
       <textItem
         font
-        background
         theme
         text
         onClick={() => {dispatch(FileTypeClicked)}}
@@ -446,7 +442,7 @@ module View = {
       activeBuffer
       |> OptionEx.flatMap(Buffer.getLineEndings)
       |> Option.map(toString)
-      |> Option.map(text => {<textItem font background theme text />})
+      |> Option.map(text => {<textItem font theme text />})
       |> Option.value(~default=React.empty);
     };
 
@@ -457,7 +453,7 @@ module View = {
         |> positionToString;
       };
 
-      <textItem font background theme text />;
+      <textItem font theme text />;
     };
 
     let notificationPopups = () =>
@@ -475,7 +471,6 @@ module View = {
           theme
           font
           foreground
-          background
           notifications
           contextMenu
         />
@@ -483,7 +478,7 @@ module View = {
       <sectionGroup>
         <section align=`FlexStart> leftItems </section>
         <section align=`FlexStart>
-          <diagnosticCount font background theme diagnostics dispatch />
+          <diagnosticCount font theme diagnostics dispatch />
           scmItems
         </section>
         <section align=`Center />

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -601,7 +601,7 @@ module Oni = {
     | TerminalVisual(_)
     | Visual(_) => visualModeBackground
     | CommandLine => commandlineModeBackground
-    | Operator => operatorModeBackground
+    | Operator(_) => operatorModeBackground
     | TerminalInsert
     | Insert => insertModeBackground
     | Replace => replaceModeBackground
@@ -615,7 +615,7 @@ module Oni = {
     | TerminalVisual(_)
     | Visual(_) => visualModeForeground
     | CommandLine => commandlineModeForeground
-    | Operator => operatorModeForeground
+    | Operator(_) => operatorModeForeground
     | TerminalInsert
     | Insert => insertModeForeground
     | Replace => replaceModeForeground

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -29,7 +29,8 @@ let current: State.t => Oni_Core.Mode.t =
            | Vim.Mode.Select({range}) =>
              Mode.Select({range: Oni_Core.VisualRange.ofVim(range)})
            | Vim.Mode.Replace => Mode.Replace
-           | Vim.Mode.Operator({pending}) => Mode.Operator({pending: pending})
+           | Vim.Mode.Operator({pending}) =>
+             Mode.Operator({pending: pending})
            | Vim.Mode.CommandLine => Mode.CommandLine
            },
        );

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -5,7 +5,7 @@ module Internal = {
     fun
     | Vim.Mode.Visual({range}) =>
       Mode.TerminalVisual({range: Oni_Core.VisualRange.ofVim(range)})
-    | Vim.Mode.Operator => Mode.Operator
+    | Vim.Mode.Operator({pending}) => Mode.Operator({pending: pending})
     | Vim.Mode.CommandLine => Mode.CommandLine
     | _ => Mode.TerminalNormal;
 };
@@ -29,7 +29,7 @@ let current: State.t => Oni_Core.Mode.t =
            | Vim.Mode.Select({range}) =>
              Mode.Select({range: Oni_Core.VisualRange.ofVim(range)})
            | Vim.Mode.Replace => Mode.Replace
-           | Vim.Mode.Operator => Mode.Operator
+           | Vim.Mode.Operator({pending}) => Mode.Operator({pending: pending})
            | Vim.Mode.CommandLine => Mode.CommandLine
            },
        );

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -4,7 +4,7 @@ type t =
   | CommandLine
   | Replace
   | Visual({range: VisualRange.t})
-  | Operator
+  | Operator({pending: Operator.pending})
   | Select({range: VisualRange.t});
 
 let show = (mode: t) => {
@@ -13,7 +13,7 @@ let show = (mode: t) => {
   | Visual(_) => "Visual"
   | CommandLine => "CommandLine"
   | Replace => "Replace"
-  | Operator => "Operator"
+  | Operator(_) => "Operator"
   | Insert => "Insert"
   | Select(_) => "Select"
   };
@@ -35,7 +35,9 @@ let current = () => {
     })
   | Native.CommandLine => CommandLine
   | Native.Replace => Replace
-  | Native.Operator => Operator
+  | Native.Operator => Operator({
+    pending: Operator.get() |> Option.value(~default=Operator.default)
+  })
   | Native.Insert => Insert
   | Native.Select =>
     Select({

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -35,9 +35,10 @@ let current = () => {
     })
   | Native.CommandLine => CommandLine
   | Native.Replace => Replace
-  | Native.Operator => Operator({
-    pending: Operator.get() |> Option.value(~default=Operator.default)
-  })
+  | Native.Operator =>
+    Operator({
+      pending: Operator.get() |> Option.value(~default=Operator.default),
+    })
   | Native.Insert => Insert
   | Native.Select =>
     Select({

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -1,6 +1,47 @@
 type buffer = Types.buffer;
 type lineEnding = Types.lineEnding;
 
+// Must be kept in sync with:
+// https://github.com/onivim/libvim/blob/9d3b7fb8c73850a28526caf38beea50901a322f4/src/vim.h#L1364
+type operation =
+| NoPending
+| Delete
+| Yank
+| Change
+| LeftShift
+| RightShift
+| Filter
+| SwitchCase
+| Indent
+| Format
+| Colon
+| MakeUpperCase
+| MakeLowerCase
+| Join
+| JoinNS
+| Rot13
+| Replace
+| Insert
+| Append
+| Fold
+| FoldOpen
+| FoldOpenRecursive
+| FoldClose
+| FoldCloseRecursive
+| FoldDelete
+| FoldDeleteRecursive
+| Format2
+| Function
+| NumberAdd
+| NumberSubtract
+| Comment;
+
+type operatorPendingInfo = {
+  operation,
+  register: int,
+  count: int
+};
+
 type mode =
   | Normal
   | Insert
@@ -75,6 +116,8 @@ external vimCursorSetPosition: (int, int) => unit =
   "libvim_vimCursorSetPosition";
 
 external vimEval: string => option(string) = "libvim_vimEval";
+
+external vimOperatorGetPending: unit => option(operatorPendingInfo) = "libvim_vimGetPendingOperator";
 
 external vimOptionSetTabSize: int => unit = "libvim_vimOptionSetTabSize";
 external vimOptionSetInsertSpaces: bool => unit =

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -4,42 +4,42 @@ type lineEnding = Types.lineEnding;
 // Must be kept in sync with:
 // https://github.com/onivim/libvim/blob/9d3b7fb8c73850a28526caf38beea50901a322f4/src/vim.h#L1364
 type operation =
-| NoPending
-| Delete
-| Yank
-| Change
-| LeftShift
-| RightShift
-| Filter
-| SwitchCase
-| Indent
-| Format
-| Colon
-| MakeUpperCase
-| MakeLowerCase
-| Join
-| JoinNS
-| Rot13
-| Replace
-| Insert
-| Append
-| Fold
-| FoldOpen
-| FoldOpenRecursive
-| FoldClose
-| FoldCloseRecursive
-| FoldDelete
-| FoldDeleteRecursive
-| Format2
-| Function
-| NumberAdd
-| NumberSubtract
-| Comment;
+  | NoPending
+  | Delete
+  | Yank
+  | Change
+  | LeftShift
+  | RightShift
+  | Filter
+  | SwitchCase
+  | Indent
+  | Format
+  | Colon
+  | MakeUpperCase
+  | MakeLowerCase
+  | Join
+  | JoinNS
+  | Rot13
+  | Replace
+  | Insert
+  | Append
+  | Fold
+  | FoldOpen
+  | FoldOpenRecursive
+  | FoldClose
+  | FoldCloseRecursive
+  | FoldDelete
+  | FoldDeleteRecursive
+  | Format2
+  | Function
+  | NumberAdd
+  | NumberSubtract
+  | Comment;
 
 type operatorPendingInfo = {
   operation,
   register: int,
-  count: int
+  count: int,
 };
 
 type mode =
@@ -117,7 +117,8 @@ external vimCursorSetPosition: (int, int) => unit =
 
 external vimEval: string => option(string) = "libvim_vimEval";
 
-external vimOperatorGetPending: unit => option(operatorPendingInfo) = "libvim_vimGetPendingOperator";
+external vimOperatorGetPending: unit => option(operatorPendingInfo) =
+  "libvim_vimGetPendingOperator";
 
 external vimOptionSetTabSize: int => unit = "libvim_vimOptionSetTabSize";
 external vimOptionSetInsertSpaces: bool => unit =

--- a/src/reason-libvim/Operator.re
+++ b/src/reason-libvim/Operator.re
@@ -1,0 +1,75 @@
+type operation = Native.operation =
+| NoPending
+| Delete
+| Yank
+| Change
+| LeftShift
+| RightShift
+| Filter
+| SwitchCase
+| Indent
+| Format
+| Colon
+| MakeUpperCase
+| MakeLowerCase
+| Join
+| JoinNS
+| Rot13
+| Replace
+| Insert
+| Append
+| Fold
+| FoldOpen
+| FoldOpenRecursive
+| FoldClose
+| FoldCloseRecursive
+| FoldDelete
+| FoldDeleteRecursive
+| Format2
+| Function
+| NumberAdd
+| NumberSubtract
+| Comment;
+
+let operationToString = fun
+| NoPending => ""
+| Delete => "d"
+| Yank => "y"
+| Change => "c"
+| LeftShift => "<"
+| RightShift => ">"
+| Filter => "!"
+| SwitchCase => "g~"
+| Indent => "="
+| Format => "gq"
+| Colon => ":"
+| MakeUpperCase => "gU"
+| MakeLowerCase => "gu"
+| Join => "J"
+| JoinNS => "gJ"
+| Rot13 => "g?"
+| Replace => "r"
+| Insert => "I"
+| Append => "A"
+| Fold => "zf"
+| FoldOpen => "zo"
+| FoldOpenRecursive => "zO"
+| FoldClose => "zc"
+| FoldCloseRecursive => "zC"
+| FoldDelete => "zd"
+| FoldDeleteRecursive => "zD"
+| Format2 => "gw"
+| Function => "g@"
+| NumberAdd => "+"
+| NumberSubtract => "-"
+| Comment => "gc";
+
+type pending = {
+    operation,
+    register: int,
+    count: int,
+};
+
+let get = () => {
+    None;
+}

--- a/src/reason-libvim/Operator.re
+++ b/src/reason-libvim/Operator.re
@@ -1,96 +1,93 @@
-type operation = Native.operation =
-| NoPending
-| Delete
-| Yank
-| Change
-| LeftShift
-| RightShift
-| Filter
-| SwitchCase
-| Indent
-| Format
-| Colon
-| MakeUpperCase
-| MakeLowerCase
-| Join
-| JoinNS
-| Rot13
-| Replace
-| Insert
-| Append
-| Fold
-| FoldOpen
-| FoldOpenRecursive
-| FoldClose
-| FoldCloseRecursive
-| FoldDelete
-| FoldDeleteRecursive
-| Format2
-| Function
-| NumberAdd
-| NumberSubtract
-| Comment;
+type operation =
+  Native.operation =
+    | NoPending
+    | Delete
+    | Yank
+    | Change
+    | LeftShift
+    | RightShift
+    | Filter
+    | SwitchCase
+    | Indent
+    | Format
+    | Colon
+    | MakeUpperCase
+    | MakeLowerCase
+    | Join
+    | JoinNS
+    | Rot13
+    | Replace
+    | Insert
+    | Append
+    | Fold
+    | FoldOpen
+    | FoldOpenRecursive
+    | FoldClose
+    | FoldCloseRecursive
+    | FoldDelete
+    | FoldDeleteRecursive
+    | Format2
+    | Function
+    | NumberAdd
+    | NumberSubtract
+    | Comment;
 
-let operationToString = fun
-| NoPending => ""
-| Delete => "d"
-| Yank => "y"
-| Change => "c"
-| LeftShift => "<"
-| RightShift => ">"
-| Filter => "!"
-| SwitchCase => "g~"
-| Indent => "="
-| Format => "gq"
-| Colon => ":"
-| MakeUpperCase => "gU"
-| MakeLowerCase => "gu"
-| Join => "J"
-| JoinNS => "gJ"
-| Rot13 => "g?"
-| Replace => "r"
-| Insert => "I"
-| Append => "A"
-| Fold => "zf"
-| FoldOpen => "zo"
-| FoldOpenRecursive => "zO"
-| FoldClose => "zc"
-| FoldCloseRecursive => "zC"
-| FoldDelete => "zd"
-| FoldDeleteRecursive => "zD"
-| Format2 => "gw"
-| Function => "g@"
-| NumberAdd => "+"
-| NumberSubtract => "-"
-| Comment => "gc";
+let operationToString =
+  fun
+  | NoPending => ""
+  | Delete => "d"
+  | Yank => "y"
+  | Change => "c"
+  | LeftShift => "<"
+  | RightShift => ">"
+  | Filter => "!"
+  | SwitchCase => "g~"
+  | Indent => "="
+  | Format => "gq"
+  | Colon => ":"
+  | MakeUpperCase => "gU"
+  | MakeLowerCase => "gu"
+  | Join => "J"
+  | JoinNS => "gJ"
+  | Rot13 => "g?"
+  | Replace => "r"
+  | Insert => "I"
+  | Append => "A"
+  | Fold => "zf"
+  | FoldOpen => "zo"
+  | FoldOpenRecursive => "zO"
+  | FoldClose => "zc"
+  | FoldCloseRecursive => "zC"
+  | FoldDelete => "zd"
+  | FoldDeleteRecursive => "zD"
+  | Format2 => "gw"
+  | Function => "g@"
+  | NumberAdd => "+"
+  | NumberSubtract => "-"
+  | Comment => "gc";
 
 type pending = {
-    operation,
-    register: int,
-    count: int,
+  operation,
+  register: int,
+  count: int,
 };
 
-let default = {
-    operation: NoPending,
-    register: 0,
-    count: 0,
-};
+let default = {operation: NoPending, register: 0, count: 0};
 
-let toString = ({operation, count, _}) => {
-    if (count > 0) {
-        Printf.sprintf("%d%s", count, operation |> operationToString)
-    } else {
-        operation |> operationToString
-    }
-};
+let toString = ({operation, count, _}) =>
+  if (count > 0) {
+    Printf.sprintf("%d%s", count, operation |> operationToString);
+  } else {
+    operation |> operationToString;
+  };
 
 let get = () => {
-    Native.vimOperatorGetPending()
-    |> Option.map((nativeOp: Native.operatorPendingInfo) => {
-    ({
-        operation: nativeOp.operation,
-        register: nativeOp.register,
-        count: nativeOp.count
-    })
-    });
-}
+  Native.vimOperatorGetPending()
+  |> Option.map((nativeOp: Native.operatorPendingInfo) => {
+       {
+         operation: nativeOp.operation,
+         register: nativeOp.register,
+         count: nativeOp.count,
+       }
+     });
+};

--- a/src/reason-libvim/Operator.re
+++ b/src/reason-libvim/Operator.re
@@ -70,6 +70,27 @@ type pending = {
     count: int,
 };
 
+let default = {
+    operation: NoPending,
+    register: 0,
+    count: 0,
+};
+
+let toString = ({operation, count, _}) => {
+    if (count > 0) {
+        Printf.sprintf("%d%s", count, operation |> operationToString)
+    } else {
+        operation |> operationToString
+    }
+};
+
 let get = () => {
-    None;
+    Native.vimOperatorGetPending()
+    |> Option.map((nativeOp: Native.operatorPendingInfo) => {
+    ({
+        operation: nativeOp.operation,
+        register: nativeOp.register,
+        count: nativeOp.count
+    })
+    });
 }

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -17,6 +17,7 @@ module Effect = Effect;
 module Event = Event;
 module Format = Format;
 module Goto = Goto;
+module Operator = Operator;
 module TabPage = TabPage;
 module Mode = Mode;
 module Options = Options;

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -58,43 +58,43 @@ module Context: {
 module Registers: {let get: (~register: char) => option(array(string));};
 
 module Operator: {
-  type operation=
-  | NoPending
-  | Delete
-  | Yank
-  | Change
-  | LeftShift
-  | RightShift
-  | Filter
-  | SwitchCase
-  | Indent
-  | Format
-  | Colon
-  | MakeUpperCase
-  | MakeLowerCase
-  | Join
-  | JoinNS
-  | Rot13
-  | Replace
-  | Insert
-  | Append
-  | Fold
-  | FoldOpen
-  | FoldOpenRecursive
-  | FoldClose
-  | FoldCloseRecursive
-  | FoldDelete
-  | FoldDeleteRecursive
-  | Format2
-  | Function
-  | NumberAdd
-  | NumberSubtract
-  | Comment;
+  type operation =
+    | NoPending
+    | Delete
+    | Yank
+    | Change
+    | LeftShift
+    | RightShift
+    | Filter
+    | SwitchCase
+    | Indent
+    | Format
+    | Colon
+    | MakeUpperCase
+    | MakeLowerCase
+    | Join
+    | JoinNS
+    | Rot13
+    | Replace
+    | Insert
+    | Append
+    | Fold
+    | FoldOpen
+    | FoldOpenRecursive
+    | FoldClose
+    | FoldCloseRecursive
+    | FoldDelete
+    | FoldDeleteRecursive
+    | Format2
+    | Function
+    | NumberAdd
+    | NumberSubtract
+    | Comment;
 
   type pending = {
-      operation,
-      register: int,
-      count: int,
+    operation,
+    register: int,
+    count: int,
   };
 
   let get: unit => option(pending);
@@ -314,7 +314,7 @@ module Mode: {
     | CommandLine
     | Replace
     | Visual({range: VisualRange.t})
-    | Operator({ pending: Operator.pending })
+    | Operator({pending: Operator.pending})
     | Select({range: VisualRange.t});
 
   let current: unit => t;

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -57,6 +57,49 @@ module Context: {
 
 module Registers: {let get: (~register: char) => option(array(string));};
 
+module Operator: {
+  type operation=
+  | NoPending
+  | Delete
+  | Yank
+  | Change
+  | LeftShift
+  | RightShift
+  | Filter
+  | SwitchCase
+  | Indent
+  | Format
+  | Colon
+  | MakeUpperCase
+  | MakeLowerCase
+  | Join
+  | JoinNS
+  | Rot13
+  | Replace
+  | Insert
+  | Append
+  | Fold
+  | FoldOpen
+  | FoldOpenRecursive
+  | FoldClose
+  | FoldCloseRecursive
+  | FoldDelete
+  | FoldDeleteRecursive
+  | Format2
+  | Function
+  | NumberAdd
+  | NumberSubtract
+  | Comment;
+
+  type pending = {
+      operation,
+      register: int,
+      count: int,
+  };
+
+  let get: unit => option(pending);
+};
+
 module Edit: {
   [@deriving show]
   type t = {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -98,6 +98,8 @@ module Operator: {
   };
 
   let get: unit => option(pending);
+
+  let toString: pending => string;
 };
 
 module Edit: {
@@ -312,7 +314,7 @@ module Mode: {
     | CommandLine
     | Replace
     | Visual({range: VisualRange.t})
-    | Operator
+    | Operator({ pending: Operator.pending })
     | Select({range: VisualRange.t});
 
   let current: unit => t;

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -563,6 +563,15 @@ CAMLprim value libvim_vimBufferGetModifiable(value vBuf) {
   return Val_bool(modifiable);
 }
 
+CAMLprim value libvim_vimGetPendingOperator(value unit) {
+  CAMLparam0();
+  CAMLlocal1(ret);
+
+  ret = Val_none;
+
+  CAMLreturn(ret);
+}
+
 CAMLprim value libvim_vimBufferSetModifiable(value vMod, value vBuf) {
   buf_T *buf = (buf_T *)vBuf;
   int modifiable = Bool_val(vMod);

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -567,8 +567,6 @@ CAMLprim value libvim_vimGetPendingOperator(value unit) {
   CAMLparam0();
   CAMLlocal2(inner, ret);
 
-  printf("vimGetPendingOperator - 1\n");
-
   pendingOp_T pendingOp;
   if (vimGetPendingOperator(&pendingOp)) {
     inner = caml_alloc(3, 0);

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -565,9 +565,20 @@ CAMLprim value libvim_vimBufferGetModifiable(value vBuf) {
 
 CAMLprim value libvim_vimGetPendingOperator(value unit) {
   CAMLparam0();
-  CAMLlocal1(ret);
+  CAMLlocal2(inner, ret);
 
-  ret = Val_none;
+  printf("vimGetPendingOperator - 1\n");
+
+  pendingOp_T pendingOp;
+  if (vimGetPendingOperator(&pendingOp)) {
+    inner = caml_alloc(3, 0);
+    Store_field(inner, 0, Val_int(pendingOp.op_type));
+    Store_field(inner, 1, Val_int(pendingOp.regname));
+    Store_field(inner, 2, Val_int(pendingOp.count));
+    ret = Val_some(inner);
+  } else {
+    ret = Val_none;
+  }
 
   CAMLreturn(ret);
 }

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5e8524c242a61726b3a1543f3764573d",
+  "checksum": "93eaf2f1c45cef69c8b9aefbc506cf49",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/ctypes@opam:0.15.1@b0227b2f",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#10cab2d@d41d8cd9"
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.55@d41d8cd9": {
-      "id": "libvim@8.10869.55@d41d8cd9",
+    "libvim@8.10869.56@d41d8cd9": {
+      "id": "libvim@8.10869.56@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.55",
+      "version": "8.10869.56",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.55.tgz#sha1:0ec26790ce7a9ea83286018e5040fff905c79cc7"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.56.tgz#sha1:bf7e2064a97260f5affa0a76d4f9178f20bd2b36"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.55@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.56@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
@@ -973,7 +973,7 @@
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/dir@github:bryphe/reason-native:dir.opam#fd0225@d41d8cd9",
         "@opam/decoders-yojson@opam:0.4.0@cb39dea6",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/angstrom@opam:0.14.1@07e286b0",
         "@glennsl/timber@1.2.0@d41d8cd9"
       ],
@@ -1156,7 +1156,7 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1164,7 +1164,7 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/charInfo_width@opam:1.1.0@b400bb29",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
@@ -3078,15 +3078,15 @@
       ],
       "devDependencies": []
     },
-    "@opam/charInfo_width@opam:1.1.0@b400bb29": {
-      "id": "@opam/charInfo_width@opam:1.1.0@b400bb29",
+    "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
+      "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
       "version": "opam:1.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c4/c4ab038e06f06a29692c05fdd7c268c5#md5:c4ab038e06f06a29692c05fdd7c268c5",
-          "archive:https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz#md5:c4ab038e06f06a29692c05fdd7c268c5"
+          "archive:https://opam.ocaml.org/cache/md5/a5/a539436d1da4aeb93711303f107bec7e#md5:a539436d1da4aeb93711303f107bec7e",
+          "archive:https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz#md5:a539436d1da4aeb93711303f107bec7e"
         ],
         "opam": {
           "name": "charInfo_width",

--- a/test.esy.lock/opam/charInfo_width.1.1.0/opam
+++ b/test.esy.lock/opam/charInfo_width.1.1.0/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
 maintainer: "zandoye@gmail.com"
 authors: [ "ZAN DoYe" ]
-homepage: "https://bitbucket.org/zandoye/charinfo_width/"
-bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+homepage: "https://github.com/kandu/charinfo_width/"
+bug-reports: "https://github.com/kandu/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "git://github.com/kandu/charinfo_width.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
@@ -22,6 +22,6 @@ description: """
 This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
 
 url {
-  src:"https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz"
-  checksum: "md5=c4ab038e06f06a29692c05fdd7c268c5"
+  src:"https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz"
+  checksum: "md5=a539436d1da4aeb93711303f107bec7e"
 }

--- a/test/reason-libvim/ModeTest.re
+++ b/test/reason-libvim/ModeTest.re
@@ -26,4 +26,59 @@ describe("Mode", ({describe, _}) => {
       expect.equal(Vim.Mode.isSelect(Vim.Mode.current()), true);
     })
   });
+  
+  describe("operator pending mode mode", ({test, _}) => {
+    test("d", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      // delete pending op
+      let _ = Vim.input("d");
+      
+      let mode = Vim.Mode.current();
+      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
+        operation: Delete,
+        count: 0,
+        register: 0,
+      }}));
+    })
+    test("5d", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      // delete pending op, with multiplier
+      let _ = Vim.input("5d");
+      
+      let mode = Vim.Mode.current();
+      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
+        operation: Delete,
+        count: 5,
+        register: 0,
+      }}));
+    })
+    test("10gc", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      // Comment operator
+      let _ = Vim.input("10gc");
+      
+      let mode = Vim.Mode.current();
+      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
+        operation: Comment,
+        count: 10,
+        register: 0,
+      }}));
+    })
+    test("yank with register", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      // Yank to register a
+      let _ = Vim.input("\"ay");
+      
+      let mode = Vim.Mode.current();
+      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
+        operation: Yank,
+        count: 0,
+        register: int_of_char('a'),
+      }}));
+    })
+  });
 });

--- a/test/reason-libvim/ModeTest.re
+++ b/test/reason-libvim/ModeTest.re
@@ -26,59 +26,68 @@ describe("Mode", ({describe, _}) => {
       expect.equal(Vim.Mode.isSelect(Vim.Mode.current()), true);
     })
   });
-  
+
   describe("operator pending mode mode", ({test, _}) => {
     test("d", ({expect, _}) => {
       let _ = resetBuffer();
 
       // delete pending op
       let _ = Vim.input("d");
-      
+
       let mode = Vim.Mode.current();
-      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
-        operation: Delete,
-        count: 0,
-        register: 0,
-      }}));
-    })
+      expect.equal(
+        mode,
+        Vim.Mode.Operator({
+          pending: Vim.Operator.{operation: Delete, count: 0, register: 0},
+        }),
+      );
+    });
     test("5d", ({expect, _}) => {
       let _ = resetBuffer();
 
       // delete pending op, with multiplier
       let _ = Vim.input("5d");
-      
+
       let mode = Vim.Mode.current();
-      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
-        operation: Delete,
-        count: 5,
-        register: 0,
-      }}));
-    })
+      expect.equal(
+        mode,
+        Vim.Mode.Operator({
+          pending: Vim.Operator.{operation: Delete, count: 5, register: 0},
+        }),
+      );
+    });
     test("10gc", ({expect, _}) => {
       let _ = resetBuffer();
 
       // Comment operator
       let _ = Vim.input("10gc");
-      
+
       let mode = Vim.Mode.current();
-      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
-        operation: Comment,
-        count: 10,
-        register: 0,
-      }}));
-    })
+      expect.equal(
+        mode,
+        Vim.Mode.Operator({
+          pending: Vim.Operator.{operation: Comment, count: 10, register: 0},
+        }),
+      );
+    });
     test("yank with register", ({expect, _}) => {
       let _ = resetBuffer();
 
       // Yank to register a
       let _ = Vim.input("\"ay");
-      
+
       let mode = Vim.Mode.current();
-      expect.equal(mode, Vim.Mode.Operator({ pending: Vim.Operator.{
-        operation: Yank,
-        count: 0,
-        register: int_of_char('a'),
-      }}));
-    })
+      expect.equal(
+        mode,
+        Vim.Mode.Operator({
+          pending:
+            Vim.Operator.{
+              operation: Yank,
+              count: 0,
+              register: int_of_char('a'),
+            },
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
__Issue:__ As described in #2357 , we weren't showing any context around a pending operator in the status bar - this is really a step backward.

__Fix:__ This picks up https://github.com/onivim/libvim/pull/218 so that we get some context around the current pending operator, and we show it in now in the statusbar:

![2020-08-26 12 56 23](https://user-images.githubusercontent.com/13532591/91350541-b02e6880-e79b-11ea-8015-2670a7bf690f.gif)

This fixes the operator-pending part of #2357 - we're missing showing the in-progress count of a command, though.