### PR TITLE
fix(scm/#2358): Dialog popping up on save in non-git repos

### DIFF
--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -838,6 +838,16 @@ module Files: {
     let decode: Json.decoder(t);
     let encode: Json.encoder(t);
   };
+
+  module FileSystemEvents: {
+    type t = {
+      created: list(Oni_Core.Uri.t),
+      changed: list(Oni_Core.Uri.t),
+      deleted: list(Oni_Core.Uri.t),
+    };
+
+    let encode: Json.encoder(t);
+  };
 };
 
 module ModelAddedDelta: {
@@ -1689,6 +1699,17 @@ module Request: {
         Client.t
       ) =>
       Lwt.t(unit);
+  };
+
+  module FileSystemEventService: {
+    let onFileEvent: (
+      ~events: Files.FileSystemEvents.t,
+      Client.t
+    ) => unit;
+
+    // TODO
+    // - onWillRunFileOperation
+    // - onDidRunFileOperation
   };
 
   module LanguageFeatures: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1702,11 +1702,7 @@ module Request: {
   };
 
   module FileSystemEventService: {
-    let onFileEvent: (
-      ~events: Files.FileSystemEvents.t,
-      Client.t
-    ) => unit;
-
+    let onFileEvent: (~events: Files.FileSystemEvents.t, Client.t) => unit;
     // TODO
     // - onWillRunFileOperation
     // - onDidRunFileOperation

--- a/src/Exthost/Files.re
+++ b/src/Exthost/Files.re
@@ -236,3 +236,19 @@ module ReadDirResult = {
       value(`List([name |> string, fileType |> FileType.encode]))
     );
 };
+
+module FileSystemEvents = {
+  type t = {
+    created: list(Oni_Core.Uri.t),
+    changed: list(Oni_Core.Uri.t),
+    deleted: list(Oni_Core.Uri.t),
+  };
+
+  let encode = ({created, changed, deleted}) => {
+    Json.Encode.(obj([
+      ("created", created |> list(Oni_Core.Uri.encode)),
+      ("changed", changed |> list(Oni_Core.Uri.encode)),
+      ("deleted", deleted |> list(Oni_Core.Uri.encode)),
+    ]))
+  }
+}

--- a/src/Exthost/Files.re
+++ b/src/Exthost/Files.re
@@ -245,10 +245,12 @@ module FileSystemEvents = {
   };
 
   let encode = ({created, changed, deleted}) => {
-    Json.Encode.(obj([
-      ("created", created |> list(Oni_Core.Uri.encode)),
-      ("changed", changed |> list(Oni_Core.Uri.encode)),
-      ("deleted", deleted |> list(Oni_Core.Uri.encode)),
-    ]))
-  }
-}
+    Json.Encode.(
+      obj([
+        ("created", created |> list(Oni_Core.Uri.encode)),
+        ("changed", changed |> list(Oni_Core.Uri.encode)),
+        ("deleted", deleted |> list(Oni_Core.Uri.encode)),
+      ])
+    );
+  };
+};

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -217,6 +217,19 @@ module ExtensionService = {
   };
 };
 
+module FileSystemEventService = {
+  open Json.Encode;
+  
+  let onFileEvent = (~events, client) => {
+    Client.notify(
+      ~rpcName="ExtHostFileSystemEventService",
+      ~method="$onFileEvent",
+      ~args=`List([events |> encode_value(Files.FileSystemEvents.encode)]),
+      client
+    );
+  };
+}
+
 module LanguageFeatures = {
   let provideCodeLenses = (~handle: int, ~resource: Uri.t, client) => {
     let decoder = Json.Decode.(nullable(CodeLens.List.decode));

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -219,16 +219,16 @@ module ExtensionService = {
 
 module FileSystemEventService = {
   open Json.Encode;
-  
+
   let onFileEvent = (~events, client) => {
     Client.notify(
       ~rpcName="ExtHostFileSystemEventService",
       ~method="$onFileEvent",
       ~args=`List([events |> encode_value(Files.FileSystemEvents.encode)]),
-      client
+      client,
     );
   };
-}
+};
 
 module LanguageFeatures = {
   let provideCodeLenses = (~handle: int, ~resource: Uri.t, client) => {

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -51,6 +51,16 @@ module Effects = {
         })
       );
   };
+  module FileSystemEventService = {
+    let onFileEvent = (~events, extHostClient) =>
+      Isolinear.Effect.create(~name="fileSystemEventService.onFileEvent", () => {
+        Exthost.Request.FileSystemEventService.onFileEvent(
+          ~events,
+          extHostClient,
+        )
+      });
+  };
+
   module SCM = {
     let getOriginalContent = (~handle, ~uri, ~toMsg, client) =>
       Isolinear.Effect.createWithDispatch(

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -23,6 +23,12 @@ module Effects: {
       Isolinear.Effect.t('msg);
   };
 
+  module FileSystemEventService: {
+    let onFileEvent:
+      (~events: Exthost.Files.FileSystemEvents.t, Exthost.Client.t) =>
+      Isolinear.Effect.t(_);
+  };
+
   module SCM: {
     let getOriginalContent:
       (

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -359,7 +359,7 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
   };
 
   let redirect =
-    if (Timber.App.isEnabled()) {
+//    if (Timber.App.isEnabled()) {
       [
         Luv.Process.inherit_fd(
           ~fd=Luv.Process.stdin,
@@ -377,9 +377,9 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
           (),
         ),
       ];
-    } else {
-      [];
-    };
+//    } else {
+//      [];
+//    };
 
   let _process: Luv.Process.t =
     LuvEx.Process.spawn(

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -359,7 +359,7 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
   };
 
   let redirect =
-//    if (Timber.App.isEnabled()) {
+    if (Timber.App.isEnabled()) {
       [
         Luv.Process.inherit_fd(
           ~fd=Luv.Process.stdin,
@@ -377,9 +377,9 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
           (),
         ),
       ];
-//    } else {
-//      [];
-//    };
+    } else {
+      [];
+    };
 
   let _process: Luv.Process.t =
     LuvEx.Process.spawn(

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -19,11 +19,23 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
     if (scm == Feature_SCM.initial) {
       Isolinear.Effect.none;
     } else {
-      Service_Exthost.Effects.Commands.executeContributedCommand(
-        ~command="git.refresh",
-        ~arguments=[`String(uri |> Oni_Core.Uri.toFileSystemPath)],
-        extHostClient,
-      );
+      Isolinear.Effect.create(~name="fileevent", () => {
+        Exthost.Request.FileSystemEventService.onFileEvent(
+          ~events=Exthost.Files.FileSystemEvents.{
+            created: [],
+            deleted: [],
+            changed: [
+              uri
+            ]
+          },
+          extHostClient
+        );
+      });
+//      Service_Exthost.Effects.Commands.executeContributedCommand(
+//        ~command="git.refresh",
+//        ~arguments=[`String(uri |> Oni_Core.Uri.toFileSystemPath)],
+//        extHostClient,
+//      );
     };
 
   let discoveredExtensionsEffect = extensions =>

--- a/src/Store/ExtensionClientStoreConnector.re
+++ b/src/Store/ExtensionClientStoreConnector.re
@@ -15,29 +15,6 @@ module Diagnostic = Feature_LanguageSupport.Diagnostic;
 module LanguageFeatures = Feature_LanguageSupport.LanguageFeatures;
 
 let start = (extensions, extHostClient: Exthost.Client.t) => {
-  let gitRefreshEffect = (scm: Feature_SCM.model, uri) =>
-    if (scm == Feature_SCM.initial) {
-      Isolinear.Effect.none;
-    } else {
-      Isolinear.Effect.create(~name="fileevent", () => {
-        Exthost.Request.FileSystemEventService.onFileEvent(
-          ~events=Exthost.Files.FileSystemEvents.{
-            created: [],
-            deleted: [],
-            changed: [
-              uri
-            ]
-          },
-          extHostClient
-        );
-      });
-//      Service_Exthost.Effects.Commands.executeContributedCommand(
-//        ~command="git.refresh",
-//        ~arguments=[`String(uri |> Oni_Core.Uri.toFileSystemPath)],
-//        extHostClient,
-//      );
-    };
-
   let discoveredExtensionsEffect = extensions =>
     Isolinear.Effect.createWithDispatch(
       ~name="exthost.discoverExtensions", dispatch =>
@@ -135,7 +112,15 @@ let start = (extensions, extHostClient: Exthost.Client.t) => {
         state.buffers
         |> Feature_Buffers.get(bufferId)
         |> Option.map(buffer => {
-             gitRefreshEffect(state.scm, buffer |> Oni_Core.Buffer.getUri)
+             Service_Exthost.Effects.FileSystemEventService.onFileEvent(
+               ~events=
+                 Exthost.Files.FileSystemEvents.{
+                   created: [],
+                   deleted: [],
+                   changed: [buffer |> Oni_Core.Buffer.getUri],
+                 },
+               extHostClient,
+             )
            })
         |> Option.value(~default=Isolinear.Effect.none);
 


### PR DESCRIPTION
__Issue:__ When saving a file in a non-git repo, we get an annoying dialog popping up.

__Defect:__ When we save, we send a `git.refresh` command - this was a hack in #1282 to get the git provider to refresh. This wasn't ideal before, because it doesn't work for other providers, and it strong arms the git extension (the git extension actually waits to refresh until is idle, which this avoids) - but it's even worse now that we have the dialog boxes more fully hooked up. Previously, we'd ignore this dialog, but now it is getting in the way on save.

__Fix:__ Instead of strong-arming a `git.refresh` command - the provider is actually set up to listen to file system events. This change sends a modified event on save, which hits the expected codepath on the git SCM provider to update decorations.

Fixes #2358 