### PR TITLE
fix(completion): don't show empty hover windows.

### DIFF
--- a/src/Core/BufferLine.re
+++ b/src/Core/BufferLine.re
@@ -109,7 +109,7 @@ module Internal = {
         (typeface, cache.font.fontSize, cache.font.smoothing, uchar),
         measurementsCache,
       );
-      Log.debugf(m =>
+      Log.tracef(m =>
         m(
           "MeasurementCache : Hit! Typeface : %s, Font Size: %f, Uchar: %s (%d)",
           Skia.Typeface.getFamilyName(typeface),
@@ -120,7 +120,7 @@ module Internal = {
       );
       pixelWidth;
     | None =>
-      Log.debugf(m =>
+      Log.tracef(m =>
         m(
           "MeasurementCache : Miss! Typeface : %s, Uchar: %s (%d)",
           Skia.Typeface.getFamilyName(typeface),
@@ -195,7 +195,7 @@ module Internal = {
         let pixelWidth =
           measure(~typeface=skiaFace, ~cache, glyphSubstr, uchar);
 
-        Log.debugf(m =>
+        Log.tracef(m =>
           m(
             "resolveTo loop: uchar : %s, glyphStringByte : %d, pixelPosition : %f, glyphNumber : %d",
             Zed_utf8.singleton(uchar),
@@ -222,12 +222,12 @@ module Internal = {
         // Since all OCaml strings are 8bits/1byte, if the next position would
         // overshoot the length of the string, we go to the next glyph string
         if (glyphStringByte^ + 2 >= String.length(glyphStr)) {
-          Log.debug("Reached end of current glyphString");
+          Log.trace("Reached end of current glyphString");
           glyphStringByte := 0;
           glyphStrings := List.tl(glyphStrings^);
         } else {
           // Otherwise we go to the next two bytes
-          Log.debug("Continuing on current glyphString");
+          Log.trace("Continuing on current glyphString");
           glyphStringByte := glyphStringByte^ + 2;
         };
         incr(i);

--- a/src/Feature/LanguageSupport/Hover.re
+++ b/src/Feature/LanguageSupport/Hover.re
@@ -272,6 +272,8 @@ module Popup = {
       ) =>
     if (model.editorID != editorId) {
       None;
+    } else if (model.contents == []) {
+      None;
     } else {
       let maybeLocation: option(EditorCoreTypes.CharacterPosition.t) =
         switch (model.triggeredFrom, model.shown) {


### PR DESCRIPTION
Tiny change to stop these tiny empty hover elements:

<img width="35" alt="image" src="https://user-images.githubusercontent.com/10038688/91580963-c415ce00-e945-11ea-833b-76f5e65e5cf9.png">

I also changed the debugging output in BufferLine since it really heavily hits the logs, and moved it behind `trace`  so you need to do `--trace` rather than `--debug`. On my Mac it can actually slow down the rendering and scrolling as well (MacBook Air with Kitty terminal), but also because it can pollute the user logs making it harder to find the real issue.