### PR TITLE
fix(vim/#888): Fix case where number is explicitly turned off

### DIFF
--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -92,13 +92,13 @@ module VimSettings = {
       let justRelative =
         fun
         | Some(true) => Some(`RelativeOnly)
-        | Some(false)
+        | Some(false) => Some(`Off)
         | None => None;
 
       let justAbsolute =
         fun
         | Some(true) => Some(`On)
-        | Some(false)
+        | Some(false) => Some(`Off)
         | None => None;
 
       OptionEx.map2(


### PR DESCRIPTION
__Issue:__ Running `:set nonumber` when `editor.lineNumbers` is set to `relative` or `on` would not turn off line numbers. The Vim setting should take precedence.

__Defect:__ We were treating the 'off' state the same as a not-set state.

__Fix:__ Handle `off`/`no` differently than not set.