### PR TITLE
feat(vim): Colorscheme ex command synchronization

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9f85322307d06c77239b8e487417b3f6",
+  "checksum": "f512b84a087bc1e7f23422c3a114f3a5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.58@d41d8cd9": {
-      "id": "libvim@8.10869.58@d41d8cd9",
+    "libvim@8.10869.59@d41d8cd9": {
+      "id": "libvim@8.10869.59@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.58",
+      "version": "8.10869.59",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.58.tgz#sha1:48d14b6ac8f7dc603fd877ef96e0121a136166d8"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.59.tgz#sha1:1402b1fd8bedbb7b344c447a3869177379fd811d"
         ]
       },
       "overrides": [],
@@ -943,7 +943,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.58@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.59@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "57801ebd99718c9ebfa748f2a52ed263",
+  "checksum": "d69f7cd39c16d9442576b6c80a471c87",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,16 +424,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.57@d41d8cd9": {
-      "id": "libvim@8.10869.57@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.57",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.57.tgz#sha1:e33e4d7d6f1531f395107322ee41e4e77c06392e"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -943,7 +938,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.57@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9f85322307d06c77239b8e487417b3f6",
+  "checksum": "f512b84a087bc1e7f23422c3a114f3a5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.58@d41d8cd9": {
-      "id": "libvim@8.10869.58@d41d8cd9",
+    "libvim@8.10869.59@d41d8cd9": {
+      "id": "libvim@8.10869.59@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.58",
+      "version": "8.10869.59",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.58.tgz#sha1:48d14b6ac8f7dc603fd877ef96e0121a136166d8"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.59.tgz#sha1:1402b1fd8bedbb7b344c447a3869177379fd811d"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.58@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.59@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "57801ebd99718c9ebfa748f2a52ed263",
+  "checksum": "d69f7cd39c16d9442576b6c80a471c87",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,16 +424,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.57@d41d8cd9": {
-      "id": "libvim@8.10869.57@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.57",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.57.tgz#sha1:e33e4d7d6f1531f395107322ee41e4e77c06392e"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -942,7 +937,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.57@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9f85322307d06c77239b8e487417b3f6",
+  "checksum": "f512b84a087bc1e7f23422c3a114f3a5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.58@d41d8cd9": {
-      "id": "libvim@8.10869.58@d41d8cd9",
+    "libvim@8.10869.59@d41d8cd9": {
+      "id": "libvim@8.10869.59@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.58",
+      "version": "8.10869.59",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.58.tgz#sha1:48d14b6ac8f7dc603fd877ef96e0121a136166d8"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.59.tgz#sha1:1402b1fd8bedbb7b344c447a3869177379fd811d"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.58@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.59@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "57801ebd99718c9ebfa748f2a52ed263",
+  "checksum": "d69f7cd39c16d9442576b6c80a471c87",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,16 +424,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.57@d41d8cd9": {
-      "id": "libvim@8.10869.57@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.57",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.57.tgz#sha1:e33e4d7d6f1531f395107322ee41e4e77c06392e"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -942,7 +937,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.57@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.58",
+    "libvim": "8.10869.59",
     "ocaml": "~4.7.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reasonFuzz": "*",

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
+    "libvim": "link:../libvim/src",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
     "revery": "revery-ui/revery#e646df2",
     "esy-skia": "revery-ui/esy-skia#a3785f9",

--- a/src/Feature/Extensions/Feature_Extensions.re
+++ b/src/Feature/Extensions/Feature_Extensions.re
@@ -83,10 +83,12 @@ let themeByName = (~name, model) => {
 let themesByName = (~filter: string, model) => {
   model
   |> pick((manifest: Exthost.Extension.Manifest.t) => {
-    Exthost.Extension.Contributions.(manifest.contributes.themes)
-  })
+       Exthost.Extension.Contributions.(manifest.contributes.themes)
+     })
   |> List.flatten
-  |> List.map(({label, _}: Exthost.Extension.Contributions.Theme.t) => label)
+  |> List.map(({label, _}: Exthost.Extension.Contributions.Theme.t) =>
+       label
+     )
   |> List.filter(label => Utility.StringEx.contains(filter, label));
 };
 

--- a/src/Feature/Extensions/Feature_Extensions.re
+++ b/src/Feature/Extensions/Feature_Extensions.re
@@ -80,6 +80,16 @@ let themeByName = (~name, model) => {
      );
 };
 
+let themesByName = (~filter: string, model) => {
+  model
+  |> pick((manifest: Exthost.Extension.Manifest.t) => {
+    Exthost.Extension.Contributions.(manifest.contributes.themes)
+  })
+  |> List.flatten
+  |> List.map(({label, _}: Exthost.Extension.Contributions.Theme.t) => label)
+  |> List.filter(label => Utility.StringEx.contains(filter, label));
+};
+
 module ListView = ListView;
 module DetailsView = DetailsView;
 

--- a/src/Feature/Extensions/Feature_Extensions.rei
+++ b/src/Feature/Extensions/Feature_Extensions.rei
@@ -33,6 +33,7 @@ type outmsg =
 let pick: (Exthost.Extension.Manifest.t => 'a, model) => list('a);
 
 let themeByName: (~name: string, model) => option(Contributions.Theme.t);
+let themesByName: (~filter: string, model) => list(string);
 
 let isBusy: model => bool;
 let isSearchInProgress: model => bool;

--- a/src/Feature/Theme/Feature_Theme.re
+++ b/src/Feature/Theme/Feature_Theme.re
@@ -125,6 +125,10 @@ type msg =
   | Command(command)
   | TextmateThemeLoaded(ColorTheme.variant, [@opaque] Textmate.ColorTheme.t);
 
+module Msg = {
+  let openThemePicker = Command(SelectTheme);
+};
+
 type outmsg =
   | Nothing
   | OpenThemePicker(list(theme));

--- a/src/Feature/Theme/Feature_Theme.rei
+++ b/src/Feature/Theme/Feature_Theme.rei
@@ -16,6 +16,10 @@ type msg =
   | Command(command)
   | TextmateThemeLoaded(ColorTheme.variant, [@opaque] Textmate.ColorTheme.t);
 
+module Msg: {
+  let openThemePicker: msg;
+}
+
 type outmsg =
   | Nothing
   | OpenThemePicker(list(theme));

--- a/src/Feature/Theme/Feature_Theme.rei
+++ b/src/Feature/Theme/Feature_Theme.rei
@@ -16,9 +16,7 @@ type msg =
   | Command(command)
   | TextmateThemeLoaded(ColorTheme.variant, [@opaque] Textmate.ColorTheme.t);
 
-module Msg: {
-  let openThemePicker: msg;
-}
+module Msg: {let openThemePicker: msg;};
 
 type outmsg =
   | Nothing

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -109,7 +109,10 @@ let current = (state: State.t) => {
 
   let insertSpaces = indentation.mode == Spaces;
 
-  let colorSchemeProvider = () => [||];
+  let colorSchemeProvider = () => {
+    prerr_endline ("Color scheme provider called");
+    [|"Nord"|]
+  };
 
   Vim.Context.{
     autoIndent,

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -109,9 +109,12 @@ let current = (state: State.t) => {
 
   let insertSpaces = indentation.mode == Spaces;
 
+  let colorSchemeProvider = () => [||];
+
   Vim.Context.{
     autoIndent,
     bufferId,
+    colorSchemeProvider,
     leftColumn,
     topLine,
     width,

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -109,7 +109,7 @@ let current = (state: State.t) => {
 
   let insertSpaces = indentation.mode == Spaces;
 
-  let colorSchemeProvider = (pattern) =>  {
+  let colorSchemeProvider = pattern => {
     state.extensions
     |> Feature_Extensions.themesByName(~filter=pattern)
     |> Array.of_list;

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -109,9 +109,10 @@ let current = (state: State.t) => {
 
   let insertSpaces = indentation.mode == Spaces;
 
-  let colorSchemeProvider = () => {
-    prerr_endline ("Color scheme provider called");
-    [|"Nord"|]
+  let colorSchemeProvider = (pattern) =>  {
+    state.extensions
+    |> Feature_Extensions.themesByName(~filter=pattern)
+    |> Array.of_list;
   };
 
   Vim.Context.{

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -598,9 +598,12 @@ let start =
 
         let context = Oni_Model.VimContext.current(state);
 
+        prerr_endline ("-- INPUT: BEGIN");
+
         currentTriggerKey := Some(key);
         let {cursors, topLine: newTopLine, leftColumn: newLeftColumn, _}: Vim.Context.t =
           isText ? Vim.input(~context, key) : Vim.key(~context, key);
+          prerr_endline ("-- INPUT: DONE");
         currentTriggerKey := None;
 
         // TODO: This has a sensitive timing dependency - the scroll actions need to happen first,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -191,7 +191,7 @@ let start =
         | None => dispatch(Actions.Theme(Feature_Theme.Msg.openThemePicker))
         | Some(colorScheme) =>
           dispatch(Actions.ThemeLoadByName(colorScheme))
-        },
+        }
 
       | MacroRecordingStarted({register}) =>
         dispatch(

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -29,6 +29,16 @@ let start =
   let libvimHasInitialized = ref(false);
   let currentTriggerKey = ref(None);
 
+  let colorSchemeProvider = () => {
+    getState().extensions
+    |> Feature_Extensions.pick((manifest: Exthost.Extension.Manifest.t) => {
+         Exthost.Extension.Contributions.(manifest.contributes.themes)
+       })
+    |> List.flatten
+    |> List.map(({label, _}: Exthost.Extension.Contributions.Theme.t) => label)
+    |> Array.of_list;
+  };
+
   Vim.Clipboard.setProvider(reg => {
     let state = getState();
     let yankConfig =
@@ -484,7 +494,7 @@ let start =
     Vim.CommandLine.getText()
     |> Option.iter(commandStr =>
          if (position == String.length(commandStr)) {
-           let completions = Vim.CommandLine.getCompletions();
+           let completions = Vim.CommandLine.getCompletions(~colorSchemeProvider, ());
 
            Log.debugf(m =>
              m("  got %n completions.", Array.length(completions))

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -29,7 +29,7 @@ let start =
   let libvimHasInitialized = ref(false);
   let currentTriggerKey = ref(None);
 
-  let colorSchemeProvider = (pattern) =>  {
+  let colorSchemeProvider = pattern => {
     getState().extensions
     |> Feature_Extensions.themesByName(~filter=pattern)
     |> Array.of_list;
@@ -186,10 +186,11 @@ let start =
       | SettingChanged(setting) =>
         dispatch(Actions.Vim(Feature_Vim.SettingChanged(setting)))
       | ColorSchemeChanged(maybeColorScheme) =>
-        switch(maybeColorScheme) {
-         | None => dispatch(Actions.Theme(Feature_Theme.Msg.openThemePicker));
-         | Some(colorScheme) => dispatch(Actions.ThemeLoadByName(colorScheme))
-        }
+        switch (maybeColorScheme) {
+        | None => dispatch(Actions.Theme(Feature_Theme.Msg.openThemePicker))
+        | Some(colorScheme) =>
+          dispatch(Actions.ThemeLoadByName(colorScheme))
+        },
     );
 
   let _: unit => unit =
@@ -490,7 +491,8 @@ let start =
     Vim.CommandLine.getText()
     |> Option.iter(commandStr =>
          if (position == String.length(commandStr)) {
-           let completions = Vim.CommandLine.getCompletions(~colorSchemeProvider, ());
+           let completions =
+             Vim.CommandLine.getCompletions(~colorSchemeProvider, ());
 
            Log.debugf(m =>
              m("  got %n completions.", Array.length(completions))

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -178,7 +178,12 @@ let start =
           };
         }
       | SettingChanged(setting) =>
-        dispatch(Actions.Vim(Feature_Vim.SettingChanged(setting))),
+        dispatch(Actions.Vim(Feature_Vim.SettingChanged(setting)))
+      | ColorSchemeChanged(maybeColorScheme) =>
+        maybeColorScheme
+        |> Option.iter(colorScheme => {
+          dispatch(Actions.ThemeLoadByName(colorScheme))
+        })
     );
 
   let _: unit => unit =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -190,10 +190,10 @@ let start =
       | SettingChanged(setting) =>
         dispatch(Actions.Vim(Feature_Vim.SettingChanged(setting)))
       | ColorSchemeChanged(maybeColorScheme) =>
-        maybeColorScheme
-        |> Option.iter(colorScheme => {
-          dispatch(Actions.ThemeLoadByName(colorScheme))
-        })
+        switch(maybeColorScheme) {
+         | None => dispatch(Actions.Theme(Feature_Theme.Msg.openThemePicker));
+         | Some(colorScheme) => dispatch(Actions.ThemeLoadByName(colorScheme))
+        }
     );
 
   let _: unit => unit =
@@ -608,12 +608,9 @@ let start =
 
         let context = Oni_Model.VimContext.current(state);
 
-        prerr_endline ("-- INPUT: BEGIN");
-
         currentTriggerKey := Some(key);
         let {cursors, topLine: newTopLine, leftColumn: newLeftColumn, _}: Vim.Context.t =
           isText ? Vim.input(~context, key) : Vim.key(~context, key);
-          prerr_endline ("-- INPUT: DONE");
         currentTriggerKey := None;
 
         // TODO: This has a sensitive timing dependency - the scroll actions need to happen first,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -29,13 +29,9 @@ let start =
   let libvimHasInitialized = ref(false);
   let currentTriggerKey = ref(None);
 
-  let colorSchemeProvider = () => {
+  let colorSchemeProvider = (pattern) =>  {
     getState().extensions
-    |> Feature_Extensions.pick((manifest: Exthost.Extension.Manifest.t) => {
-         Exthost.Extension.Contributions.(manifest.contributes.themes)
-       })
-    |> List.flatten
-    |> List.map(({label, _}: Exthost.Extension.Contributions.Theme.t) => label)
+    |> Feature_Extensions.themesByName(~filter=pattern)
     |> Array.of_list;
   };
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -185,7 +185,7 @@ let start =
         }
       | SettingChanged(setting) =>
         dispatch(Actions.Vim(Feature_Vim.SettingChanged(setting)))
-        
+
       | ColorSchemeChanged(maybeColorScheme) =>
         switch (maybeColorScheme) {
         | None => dispatch(Actions.Theme(Feature_Theme.Msg.openThemePicker))
@@ -199,7 +199,7 @@ let start =
             Feature_Vim.MacroRecordingStarted({register: register}),
           ),
         )
-        
+
       | MacroRecordingStopped(_) =>
         dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped)),
     );

--- a/src/reason-libvim/ColorScheme.re
+++ b/src/reason-libvim/ColorScheme.re
@@ -1,0 +1,4 @@
+module Provider = {
+    type t = unit => array(string);
+    let default = () => [||];
+};

--- a/src/reason-libvim/ColorScheme.re
+++ b/src/reason-libvim/ColorScheme.re
@@ -1,4 +1,4 @@
 module Provider = {
-    type t = unit => array(string);
-    let default = () => [||];
+    type t = string => array(string);
+    let default = (_) => [||];
 };

--- a/src/reason-libvim/ColorScheme.re
+++ b/src/reason-libvim/ColorScheme.re
@@ -1,4 +1,4 @@
 module Provider = {
-    type t = string => array(string);
-    let default = (_) => [||];
+  type t = string => array(string);
+  let default = _ => [||];
 };

--- a/src/reason-libvim/CommandLine.re
+++ b/src/reason-libvim/CommandLine.re
@@ -1,11 +1,10 @@
 type t = Types.cmdline;
 
 let getCompletions = (~colorSchemeProvider: ColorScheme.Provider.t, ()) => {
-    
- GlobalState.colorSchemeProvider := colorSchemeProvider;
- let completions = Native.vimCommandLineGetCompletions();
- GlobalState.colorSchemeProvider := ColorScheme.Provider.default;
- completions;
+  GlobalState.colorSchemeProvider := colorSchemeProvider;
+  let completions = Native.vimCommandLineGetCompletions();
+  GlobalState.colorSchemeProvider := ColorScheme.Provider.default;
+  completions;
 };
 
 let getText = Native.vimCommandLineGetText;

--- a/src/reason-libvim/CommandLine.re
+++ b/src/reason-libvim/CommandLine.re
@@ -1,6 +1,12 @@
 type t = Types.cmdline;
 
-let getCompletions = Native.vimCommandLineGetCompletions;
+let getCompletions = (~colorSchemeProvider: ColorScheme.Provider.t, ()) => {
+    
+ GlobalState.colorSchemeProvider := colorSchemeProvider;
+ let completions = Native.vimCommandLineGetCompletions();
+ GlobalState.colorSchemeProvider := ColorScheme.Provider.default;
+ completions;
+};
 
 let getText = Native.vimCommandLineGetText;
 

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -6,6 +6,7 @@ type t = {
     (~previousLine: string, ~beforePreviousLine: option(string)) =>
     AutoIndent.action,
   bufferId: int,
+  colorSchemeProvider: ColorScheme.Provider.t,
   width: int,
   height: int,
   leftColumn: int,
@@ -20,6 +21,7 @@ let current = () => {
   autoClosingPairs: AutoClosingPairs.empty,
   autoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
   bufferId: Buffer.getCurrent() |> Buffer.getId,
+  colorSchemeProvider: ColorScheme.Provider.default,
   width: Window.getWidth(),
   height: Window.getHeight(),
   leftColumn: Window.getLeftColumn(),

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -3,4 +3,5 @@ type t =
   | TabPage(TabPage.effect)
   | Format(Format.effect)
   | ModeChanged(Mode.t)
-  | SettingChanged(Setting.t);
+  | SettingChanged(Setting.t)
+  | ColorSchemeChanged(option(string));

--- a/src/reason-libvim/GlobalState.re
+++ b/src/reason-libvim/GlobalState.re
@@ -8,7 +8,7 @@
     ref(None);
   let queuedFunctions: ref(list(unit => unit)) = ref([]);
 
-  let colorSchemeProvider: ref(unit => array(string)) = ref(() => [||]);
+  let colorSchemeProvider: ref(ColorScheme.Provider.t) = ref(ColorScheme.Provider.default);
 
   let overriddenMessageHandler:
     ref(option((Types.msgPriority, string, string) => unit)) =

--- a/src/reason-libvim/GlobalState.re
+++ b/src/reason-libvim/GlobalState.re
@@ -1,15 +1,16 @@
-  let autoIndent:
-    ref(
-      option(
-        (~previousLine: string, ~beforePreviousLine: option(string)) =>
-        AutoIndent.action,
-      ),
-    ) =
-    ref(None);
-  let queuedFunctions: ref(list(unit => unit)) = ref([]);
+let autoIndent:
+  ref(
+    option(
+      (~previousLine: string, ~beforePreviousLine: option(string)) =>
+      AutoIndent.action,
+    ),
+  ) =
+  ref(None);
+let queuedFunctions: ref(list(unit => unit)) = ref([]);
 
-  let colorSchemeProvider: ref(ColorScheme.Provider.t) = ref(ColorScheme.Provider.default);
+let colorSchemeProvider: ref(ColorScheme.Provider.t) =
+  ref(ColorScheme.Provider.default);
 
-  let overriddenMessageHandler:
-    ref(option((Types.msgPriority, string, string) => unit)) =
-    ref(None);
+let overriddenMessageHandler:
+  ref(option((Types.msgPriority, string, string) => unit)) =
+  ref(None);

--- a/src/reason-libvim/GlobalState.re
+++ b/src/reason-libvim/GlobalState.re
@@ -1,0 +1,15 @@
+  let autoIndent:
+    ref(
+      option(
+        (~previousLine: string, ~beforePreviousLine: option(string)) =>
+        AutoIndent.action,
+      ),
+    ) =
+    ref(None);
+  let queuedFunctions: ref(list(unit => unit)) = ref([]);
+
+  let colorSchemeProvider: ref(unit => array(string)) = ref(() => [||]);
+
+  let overriddenMessageHandler:
+    ref(option((Types.msgPriority, string, string) => unit)) =
+    ref(None);

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -409,12 +409,12 @@ let _onSettingChanged = (setting: Setting.t) => {
 let _onColorSchemeChanged = (maybeScheme: option(string)) => {
   queue(() => {
     Event.dispatch(Effect.ColorSchemeChanged(maybeScheme), Listeners.effect)
-  })
-}
+  });
+};
 
-let _colorSchemesGet = (pattern) => {
-  (GlobalState.colorSchemeProvider^)(pattern)
-}
+let _colorSchemesGet = pattern => {
+  GlobalState.colorSchemeProvider^(pattern);
+};
 
 let init = () => {
   Callback.register("lv_clipboardGet", _clipboardGet);

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -167,10 +167,6 @@ let runWith = (~context: Context.t, f) => {
   GlobalState.autoIndent := Some(context.autoIndent);
   GlobalState.colorSchemeProvider := context.colorSchemeProvider;
 
-  prerr_endline ("Trying to call before key...");
-  let _ = context.colorSchemeProvider();
-  prerr_endline ("Trying to call before key: done");
-
   let cursors = f();
 
   GlobalState.autoIndent := None;
@@ -416,10 +412,8 @@ let _onColorSchemeChanged = (maybeScheme: option(string)) => {
   })
 }
 
-let _colorSchemesGet = () => {
-
-  prerr_endline ("Vim::_onColorSchemes get");
-  (GlobalState.colorSchemeProvider^)()
+let _colorSchemesGet = (pattern) => {
+  (GlobalState.colorSchemeProvider^)(pattern)
 }
 
 let init = () => {

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -33,24 +33,6 @@ module VisualRange = VisualRange;
 module Window = Window;
 module Yank = Yank;
 
-module GlobalState = {
-  let autoIndent:
-    ref(
-      option(
-        (~previousLine: string, ~beforePreviousLine: option(string)) =>
-        AutoIndent.action,
-      ),
-    ) =
-    ref(None);
-  let queuedFunctions: ref(list(unit => unit)) = ref([]);
-
-  let colorSchemeProvider: ref(unit => array(string)) = ref(() => [||]);
-
-  let overriddenMessageHandler:
-    ref(option((Types.msgPriority, string, string) => unit)) =
-    ref(None);
-};
-
 module Internal = {
   let nativeFormatRequestToEffect: Native.formatRequest => Format.effect =
     ({bufferId, startLine, endLine, returnCursor, formatType, lineCount}) => {

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -406,7 +406,6 @@ let _onSettingChanged = (setting: Setting.t) => {
   );
 };
 
-<<<<<<< HEAD
 let _onColorSchemeChanged = (maybeScheme: option(string)) => {
   queue(() => {
     Event.dispatch(Effect.ColorSchemeChanged(maybeScheme), Listeners.effect)
@@ -415,7 +414,8 @@ let _onColorSchemeChanged = (maybeScheme: option(string)) => {
 
 let _colorSchemesGet = pattern => {
   GlobalState.colorSchemeProvider^(pattern);
-=======
+};
+
 let _onMacroStartRecording = (register: char) => {
   queue(() => {
     Event.dispatch(
@@ -432,7 +432,6 @@ let _onMacroStopRecording = (register: char, value: option(string)) => {
       Listeners.effect,
     )
   });
->>>>>>> master
 };
 
 let init = () => {

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -179,14 +179,15 @@ let runWith = (~context: Context.t, f) => {
 
   let oldBuf = Buffer.getCurrent();
   let prevMode = Mode.current();
-  //  let prevLocation = Cursor.get();
-  //  let prevTopLine = Window.getTopLine();
-  //  let prevLeftColumn = Window.getLeftColumn();
   let prevModified = Buffer.isModified(oldBuf);
   let prevLineEndings = Buffer.getLineEndings(oldBuf);
 
   GlobalState.autoIndent := Some(context.autoIndent);
   GlobalState.colorSchemeProvider := context.colorSchemeProvider;
+
+  prerr_endline ("Trying to call before key...");
+  let _ = context.colorSchemeProvider();
+  prerr_endline ("Trying to call before key: done");
 
   let cursors = f();
 
@@ -194,10 +195,7 @@ let runWith = (~context: Context.t, f) => {
   GlobalState.colorSchemeProvider := ColorScheme.Provider.default;
 
   let newBuf = Buffer.getCurrent();
-  //  let newLocation = Cursor.get();
   let newMode = Mode.current();
-  //  let newLeftColumn = Window.getLeftColumn();
-  //  let newTopLine = Window.getTopLine();
   let newModified = Buffer.isModified(newBuf);
   let newLineEndings = Buffer.getLineEndings(newBuf);
 
@@ -436,11 +434,18 @@ let _onColorSchemeChanged = (maybeScheme: option(string)) => {
   })
 }
 
+let _colorSchemesGet = () => {
+
+  prerr_endline ("Vim::_onColorSchemes get");
+  (GlobalState.colorSchemeProvider^)()
+}
+
 let init = () => {
   Callback.register("lv_clipboardGet", _clipboardGet);
   Callback.register("lv_onBufferChanged", _onBufferChanged);
   Callback.register("lv_onAutocommand", _onAutocommand);
   Callback.register("lv_onAutoIndent", _onAutoIndent);
+  Callback.register("lv_getColorSchemesCallback", _colorSchemesGet);
   Callback.register("lv_onColorSchemeChanged", _onColorSchemeChanged);
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);
   Callback.register("lv_onFormat", _onFormat);

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -37,7 +37,7 @@ module AutoIndent: {
 
 module ColorScheme: {
   module Provider: {
-    type t = unit => array(string);
+    type t = string => array(string);
     let default: t;
   };
 };

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -35,6 +35,13 @@ module AutoIndent: {
     | DecreaseIndent;
 };
 
+module ColorScheme: {
+  module Provider: {
+    type t = unit => array(string);
+    let default: t;
+  };
+};
+
 module Context: {
   type t = {
     autoClosingPairs: AutoClosingPairs.t,
@@ -42,6 +49,7 @@ module Context: {
       (~previousLine: string, ~beforePreviousLine: option(string)) =>
       AutoIndent.action,
     bufferId: int,
+    colorSchemeProvider: ColorScheme.Provider.t,
     width: int,
     height: int,
     leftColumn: int,
@@ -343,7 +351,8 @@ module Effect: {
     | TabPage(TabPage.effect)
     | Format(Format.effect)
     | ModeChanged(Mode.t)
-    | SettingChanged(Setting.t);
+    | SettingChanged(Setting.t)
+    | ColorSchemeChanged(option(string));
 };
 
 /**

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -65,9 +65,9 @@ int onAutoIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *newLine) {
   CAMLreturnT(int, ret);
 };
 
-int getColorSchemesCallback(int *num_schemes, char_u ***schemes) {
+int getColorSchemesCallback(char_u *pat, int *num_schemes, char_u ***schemes) {
   CAMLparam0();
-  CAMLlocal1(vSchemes);
+  CAMLlocal2(vPat, vSchemes);
 
   static const value *lv_getColorSchemesCallback = NULL;
 
@@ -75,7 +75,8 @@ int getColorSchemesCallback(int *num_schemes, char_u ***schemes) {
     lv_getColorSchemesCallback = caml_named_value("lv_getColorSchemesCallback");
   }
 
-  vSchemes = caml_callback(*lv_getColorSchemesCallback, Val_unit);
+  vPat = caml_copy_string((const char*)pat);
+  vSchemes = caml_callback(*lv_getColorSchemesCallback, vPat);
 
   int len = Wosize_val(vSchemes);
   *num_schemes = len;

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -65,6 +65,54 @@ int onAutoIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *newLine) {
   CAMLreturnT(int, ret);
 };
 
+int getColorSchemesCallback(int *num_schemes, char_u ***schemes) {
+  CAMLparam0();
+  CAMLlocal1(vSchemes);
+
+  static const value *lv_getColorSchemesCallback = NULL;
+
+  if (lv_getColorSchemesCallback == NULL) {
+    lv_getColorSchemesCallback = caml_named_value("lv_getColorSchemesCallback");
+  }
+
+  vSchemes = caml_callback(*lv_getColorSchemesCallback, Val_unit);
+
+  int len = Wosize_val(vSchemes);
+  *num_schemes = len;
+  char_u **out = malloc(sizeof(char_u*) * len);
+
+  for (int i = 0; i < len; i++) {
+    const char *sz = String_val(Field(vSchemes, i));
+    out[i] = malloc((sizeof(char) * strlen(sz)) + 1); 
+    strcpy((char *)out[i], sz);
+  }
+
+  *schemes = out;
+
+  CAMLreturnT(int, OK);
+}
+
+int onColorSchemeChanged(char_u *colorscheme) {
+  CAMLparam0();
+  CAMLlocal2(vThemeStr, vThemeOpt);
+  static const value *lv_onColorSchemeChanged = NULL;
+
+  if (lv_onColorSchemeChanged == NULL) {
+    lv_onColorSchemeChanged = caml_named_value("lv_onColorSchemeChanged");
+  }
+
+  if (colorscheme == NULL) {
+    vThemeOpt = Val_none;
+  } else {
+    vThemeStr = caml_copy_string((const char *)colorscheme);
+    vThemeOpt = Val_some(vThemeStr);
+  }
+  
+  caml_callback(*lv_onColorSchemeChanged, vThemeOpt);
+  
+  CAMLreturnT(int, OK);
+};
+
 void onSettingChanged(optionSet_T *options) {
   CAMLparam0();
   CAMLlocal2(innerValue, settingValue);
@@ -488,6 +536,8 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetAutoIndentCallback(&onAutoIndent);
   vimSetBufferUpdateCallback(&onBufferChanged);
   vimSetClipboardGetCallback(&getClipboardCallback);
+  vimColorSchemeSetChangedCallback(&onColorSchemeChanged);
+  vimColorSchemeSetCompletionCallback(&getColorSchemesCallback);
   vimSetDirectoryChangedCallback(&onDirectoryChanged);
   vimSetDisplayIntroCallback(&onIntro);
   vimSetDisplayVersionCallback(&onVersion);

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e8705068b1c07ca16d0847807f801d8e",
+  "checksum": "86fc7b28d81caa9d29caea2becb8915b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,14 +424,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.58@d41d8cd9": {
-      "id": "libvim@8.10869.58@d41d8cd9",
+    "libvim@8.10869.59@d41d8cd9": {
+      "id": "libvim@8.10869.59@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.58",
+      "version": "8.10869.59",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.58.tgz#sha1:48d14b6ac8f7dc603fd877ef96e0121a136166d8"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.59.tgz#sha1:1402b1fd8bedbb7b344c447a3869177379fd811d"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.58@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.59@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8fa620422647273bc878e4c11709589d",
+  "checksum": "368d3f6713acb06a7dd481b7e96734e2",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -424,16 +424,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.57@d41d8cd9": {
-      "id": "libvim@8.10869.57@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.57",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.57.tgz#sha1:e33e4d7d6f1531f395107322ee41e4e77c06392e"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -942,7 +937,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.57@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#8cad3b0@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/test/reason-libvim/ColorSchemeTest.re
+++ b/test/reason-libvim/ColorSchemeTest.re
@@ -4,30 +4,27 @@ open Vim;
 let reset = () => Helpers.resetBuffer("test/testfile.txt");
 let input = s => ignore(Vim.input(s));
 
-
 describe("ColorScheme", ({describe, _}) => {
+  let colorSchemeChangedFilter = f =>
+    fun
+    | Effect.ColorSchemeChanged(maybeScheme) => f(maybeScheme)
+    | _ => ();
 
-  let colorSchemeChangedFilter = (f) => fun
-  | Effect.ColorSchemeChanged(maybeScheme) => f(maybeScheme)
-  | _ => ();
-
-  describe("set :colorscheme", ({ test, _}) => {
-    
+  describe("set :colorscheme", ({test, _}) => {
     test("empty", ({expect, _}) => {
       let _ = reset();
 
       let colorSchemeSets = ref([]);
       let dispose =
-        onEffect(colorSchemeChangedFilter((maybeScheme) => {
-          colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
-        }));
+        onEffect(
+          colorSchemeChangedFilter(maybeScheme => {
+            colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
+          }),
+        );
 
       let _: Context.t = command("colorscheme");
 
-//      expect.equal(
-//        colorSchemeSets^,
-//        [None]
-//      )
+      expect.equal(colorSchemeSets^, [None]);
 
       dispose();
     });
@@ -37,16 +34,15 @@ describe("ColorScheme", ({describe, _}) => {
 
       let colorSchemeSets = ref([]);
       let dispose =
-        onEffect(colorSchemeChangedFilter((maybeScheme) => {
-          colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
-        }));
+        onEffect(
+          colorSchemeChangedFilter(maybeScheme => {
+            colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
+          }),
+        );
 
       let _: Context.t = command("colorscheme abyss");
 
-      expect.equal(
-        colorSchemeSets^,
-        [Some("abyss")]
-      )
+      expect.equal(colorSchemeSets^, [Some("abyss")]);
 
       dispose();
     });
@@ -55,16 +51,15 @@ describe("ColorScheme", ({describe, _}) => {
 
       let colorSchemeSets = ref([]);
       let dispose =
-        onEffect(colorSchemeChangedFilter((maybeScheme) => {
-          colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
-        }));
+        onEffect(
+          colorSchemeChangedFilter(maybeScheme => {
+            colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
+          }),
+        );
 
       let _: Context.t = command("colorscheme Dark (with parentheses)");
 
-      expect.equal(
-        colorSchemeSets^,
-        [Some("Dark (with parentheses)")]
-      )
+      expect.equal(colorSchemeSets^, [Some("Dark (with parentheses)")]);
 
       dispose();
     });

--- a/test/reason-libvim/ColorSchemeTest.re
+++ b/test/reason-libvim/ColorSchemeTest.re
@@ -1,0 +1,72 @@
+open TestFramework;
+open Vim;
+
+let reset = () => Helpers.resetBuffer("test/testfile.txt");
+let input = s => ignore(Vim.input(s));
+
+
+describe("ColorScheme", ({describe, _}) => {
+
+  let colorSchemeChangedFilter = (f) => fun
+  | Effect.ColorSchemeChanged(maybeScheme) => f(maybeScheme)
+  | _ => ();
+
+  describe("set :colorscheme", ({ test, _}) => {
+    
+    test("empty", ({expect, _}) => {
+      let _ = reset();
+
+      let colorSchemeSets = ref([]);
+      let dispose =
+        onEffect(colorSchemeChangedFilter((maybeScheme) => {
+          colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
+        }));
+
+      let _: Context.t = command("colorscheme");
+
+//      expect.equal(
+//        colorSchemeSets^,
+//        [None]
+//      )
+
+      dispose();
+    });
+
+    test("single word", ({expect, _}) => {
+      let _ = reset();
+
+      let colorSchemeSets = ref([]);
+      let dispose =
+        onEffect(colorSchemeChangedFilter((maybeScheme) => {
+          colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
+        }));
+
+      let _: Context.t = command("colorscheme abyss");
+
+      expect.equal(
+        colorSchemeSets^,
+        [Some("abyss")]
+      )
+
+      dispose();
+    });
+    test("complex word", ({expect, _}) => {
+      let _ = reset();
+
+      let colorSchemeSets = ref([]);
+      let dispose =
+        onEffect(colorSchemeChangedFilter((maybeScheme) => {
+          colorSchemeSets := [maybeScheme, ...colorSchemeSets^]
+        }));
+
+      let _: Context.t = command("colorscheme Dark (with parentheses)");
+
+      expect.equal(
+        colorSchemeSets^,
+        [Some("Dark (with parentheses)")]
+      )
+
+      dispose();
+    });
+  });
+});

--- a/test/reason-libvim/CommandLineTest.re
+++ b/test/reason-libvim/CommandLineTest.re
@@ -7,6 +7,8 @@ let input = s => ignore(Vim.input(s));
 let key = s => ignore(Vim.key(s));
 
 describe("CommandLine", ({describe, _}) => {
+  let emptyColorSchemeProvider = () => [||];
+  let getCompletions = CommandLine.getCompletions(~colorSchemeProvider=emptyColorSchemeProvider);
   describe("getType", ({test, _}) =>
     test("simple command line", ({expect, _}) => {
       let _ = reset();
@@ -30,7 +32,7 @@ describe("CommandLine", ({describe, _}) => {
       input(":");
       input("e");
 
-      expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
+      expect.int(Array.length(getCompletions())).toBe(20);
     });
 
     test("request completions multiple times", ({expect, _}) => {
@@ -38,10 +40,10 @@ describe("CommandLine", ({describe, _}) => {
       input(":");
       input("e");
 
-      expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
-      expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
+      expect.int(Array.length(getCompletions())).toBe(20);
+      expect.int(Array.length(getCompletions())).toBe(20);
 
-      let completions = CommandLine.getCompletions();
+      let completions = getCompletions();
       expect.string(completions[0]).toEqual("earlier");
     });
 
@@ -51,7 +53,7 @@ describe("CommandLine", ({describe, _}) => {
       input("e");
       input("h");
 
-      expect.int(Array.length(CommandLine.getCompletions())).toBe(0);
+      expect.int(Array.length(getCompletions())).toBe(0);
     });
   });
 


### PR DESCRIPTION
This plumbs through the colorscheme command & completion (via https://github.com/onivim/libvim/pulls).

It provides a `colorSchemeProvider` so that libvim can know about our available colorschemes, and provides the following functionality:

- Onivim themes can be set via `:colorscheme <theme-name>`
- `:colorscheme` by itself opens up the theme picker

![2020-08-29 12 12 18](https://user-images.githubusercontent.com/13532591/91644470-237ce800-e9f1-11ea-8a24-969ebbece66b.gif)



