### PR TITLE
feat(ux): Yank highlights

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -76,6 +76,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.smoothScroll` __(_bool_ default: `true`)__ - When `true`, smoothly scroll the editor when the viewport is adjusted due to a cursor motion.
 
+- `editor.yankHighlightAnimation` __(_bool_ default: `true`)__ - When `true`, briefly highlight yanks on the editor surface.
+
 - `editor.zenMode.singleFile` __(_bool_ default: `true`)__ - When `true`, the Onivim will automatically enter zen mode when started up with a single file. Zen mode hides most of the UI until disabled via the command pallette.
 
 - `editor.zenMode.hideTabs` __(_bool_ default: `true`)__ - When `true`, the Onivim will hide the buffer tabs from the user whilst in zen mode. Zen mode can be toggled in the command pallette, or automatically enabled with the `editor.zenMode.singleFile` configuration option.

--- a/src/Feature/Editor/CursorView.re
+++ b/src/Feature/Editor/CursorView.re
@@ -22,7 +22,7 @@ let%component make =
               ) => {
   let%hook () = React.Hooks.effect(Always, () => None);
 
-  let ({pixelX, pixelY}: Editor.pixelPosition, characterWidth) =
+  let ({x: pixelX, y: pixelY}: PixelPosition.t, characterWidth) =
     Editor.bufferCharacterPositionToPixel(~position=cursorPosition, editor);
 
   let originalX = pixelX;

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -300,7 +300,7 @@ let ruler = (~context, ~color, x) =>
   );
 
 let lineHighlight = (~context, ~color, lineIdx: EditorCoreTypes.LineNumber.t) => {
-  let ({x: pixelY, _}: PixelPosition.t, _) =
+  let ({y: pixelY, _}: PixelPosition.t, _) =
     Editor.bufferBytePositionToPixel(
       ~position=BytePosition.{line: lineIdx, byte: ByteIndex.zero},
       context.editor,

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -135,18 +135,13 @@ let utf8Text = drawUtf8Text;
 
 let underline =
     (~context, ~color=Revery.Colors.black, range: CharacterRange.t) => {
-  //  let line = Index.toZeroBased(r.start.line);
-  //  let start = Index.toZeroBased(r.start.column);
-  //  let endLine = Index.toZeroBased(r.stop.line);
-  //  let endC = Index.toZeroBased(r.stop.column);
-
-  let ({pixelY: startPixelY, pixelX: startPixelX}: Editor.pixelPosition, _) =
+  let ({y: startPixelY, x: startPixelX}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(
       ~position=range.start,
       context.editor,
     );
 
-  let ({pixelX: stopPixelX, _}: Editor.pixelPosition, _) =
+  let ({x: stopPixelX, _}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(
       ~position=range.stop,
       context.editor,
@@ -174,10 +169,10 @@ let rangeCharacter =
   //  let endC = Index.toZeroBased(r.stop.column);
   //  let endLine = Index.toZeroBased(r.stop.line);
 
-  let ({pixelY: startPixelY, pixelX: startPixelX}: Editor.pixelPosition, _) =
+  let ({y: startPixelY, x: startPixelX}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(~position=r.start, context.editor);
 
-  let ({pixelX: stopPixelX, _}: Editor.pixelPosition, _) =
+  let ({x: stopPixelX, _}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(~position=r.stop, context.editor);
 
   let lineHeight = Editor.lineHeightInPixels(context.editor);
@@ -196,15 +191,11 @@ let rangeCharacter =
 let rangeByte =
     (~context, ~padding=0., ~color=Revery.Colors.black, r: ByteRange.t) => {
   let doublePadding = padding *. 2.;
-  //  let line = Index.toZeroBased(r.start.line);
-  //  let start = Index.toZeroBased(r.start.column);
-  //  let endC = Index.toZeroBased(r.stop.column);
-  //  let endLine = Index.toZeroBased(r.stop.line);
 
-  let ({pixelY: startPixelY, pixelX: startPixelX}: Editor.pixelPosition, _) =
+  let ({y: startPixelY, x: startPixelX}: PixelPosition.t, _) =
     Editor.bufferBytePositionToPixel(~position=r.start, context.editor);
 
-  let ({pixelX: stopPixelX, _}: Editor.pixelPosition, _) =
+  let ({x: stopPixelX, _}: PixelPosition.t, _) =
     Editor.bufferBytePositionToPixel(~position=r.stop, context.editor);
 
   let lineHeight = Editor.lineHeightInPixels(context.editor);
@@ -219,35 +210,6 @@ let rangeByte =
     ~color,
   );
 };
-
-//let rangeByte =
-//    (~context, ~padding=0., ~color=Revery.Colors.black, r: ByteRange.t) => {
-//  let doublePadding = padding *. 2.;
-//
-//  let ({pixelY: startPixelY, pixelX: startPixelX}: Editor.pixelPosition, _) =
-//    Editor.bufferBytePositionToPixel(
-//      ~position=r.start,
-//      context.editor,
-//    );
-//
-//  let ({pixelX: stopPixelX, _}: Editor.pixelPosition, _) =
-//    Editor.bufferBytePositionToPixel(
-//      ~position=r.stop,
-//      context.editor,
-//    );
-//
-//  let lineHeight = Editor.lineHeightInPixels(context.editor);
-//  let characterWidth = Editor.characterWidthInPixels(context.editor);
-//
-//  drawRect(
-//    ~context,
-//    ~x=startPixelX,
-//    ~y=startPixelY,
-//    ~height=lineHeight +. doublePadding,
-//    ~width=max(stopPixelX -. startPixelX, characterWidth),
-//    ~color,
-//  );
-//};
 
 let tabPaint = Skia.Paint.make();
 Skia.Paint.setTextEncoding(tabPaint, GlyphId);
@@ -265,7 +227,7 @@ let token = (~context, ~line, ~colors: Colors.t, token: BufferViewTokenizer.t) =
     );
   let fontMetrics = Revery.Font.getMetrics(font, context.fontSize);
 
-  let ({pixelY, pixelX}: Editor.pixelPosition, _) =
+  let ({y: pixelY, x: pixelX}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(
       ~position=CharacterPosition.{line, character: token.startIndex},
       context.editor,
@@ -338,7 +300,7 @@ let ruler = (~context, ~color, x) =>
   );
 
 let lineHighlight = (~context, ~color, lineIdx: EditorCoreTypes.LineNumber.t) => {
-  let ({pixelY, _}: Editor.pixelPosition, _) =
+  let ({x: pixelY, _}: PixelPosition.t, _) =
     Editor.bufferBytePositionToPixel(
       ~position=BytePosition.{line: lineIdx, byte: ByteIndex.zero},
       context.editor,

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -11,15 +11,16 @@ module GlobalState = {
   };
 };
 
-type pixelPosition = {
-  pixelX: float,
-  pixelY: float,
-};
-
 type viewLine = {
   contents: BufferLine.t,
   byteOffset: int,
   characterOffset: int,
+};
+
+[@deriving show]
+type yankHighlight = {
+  key: [@opaque] Brisk_reconciler.Key.t,
+  pixelRanges: list(PixelRange.t),
 };
 
 [@deriving show]
@@ -44,6 +45,7 @@ type t = {
   selection: [@opaque] option(VisualRange.t),
   pixelWidth: int,
   pixelHeight: int,
+  yankHighlight: option(yankHighlight),
 };
 
 let key = ({key, _}) => key;
@@ -85,7 +87,7 @@ let bufferBytePositionToPixel =
   let lineCount = EditorBuffer.numberOfLines(buffer);
   let line = position.line |> EditorCoreTypes.LineNumber.toZeroBased;
   if (line < 0 || line >= lineCount) {
-    ({pixelX: 0., pixelY: 0.}, 0.);
+    ({x: 0., y: 0.}: PixelPosition.t, 0.);
   } else {
     let bufferLine = buffer |> EditorBuffer.line(line);
 
@@ -97,8 +99,14 @@ let bufferBytePositionToPixel =
 
     let pixelY = lineHeightInPixels(editor) *. float(line) -. scrollY +. 0.5;
 
-    ({pixelX, pixelY}, width);
+    ({x: pixelX, y: pixelY}: PixelPosition.t, width);
   };
+};
+
+let yankHighlight = ({yankHighlight, _}) => yankHighlight;
+let setYankHighlight = (~yankHighlight, editor) => {
+  ...editor,
+  yankHighlight: Some(yankHighlight),
 };
 
 let viewLine = (editor, lineNumber) => {
@@ -112,7 +120,7 @@ let bufferCharacterPositionToPixel =
   let lineCount = EditorBuffer.numberOfLines(buffer);
   let line = position.line |> EditorCoreTypes.LineNumber.toZeroBased;
   if (line < 0 || line >= lineCount) {
-    ({pixelX: 0., pixelY: 0.}, 0.);
+    ({x: 0., y: 0.}: PixelPosition.t, 0.);
   } else {
     let (cursorOffset, width) =
       buffer
@@ -123,7 +131,7 @@ let bufferCharacterPositionToPixel =
 
     let pixelY = lineHeightInPixels(editor) *. float(line) -. scrollY +. 0.5;
 
-    ({pixelX, pixelY}, width);
+    ({x: pixelX, y: pixelY}: PixelPosition.t, width);
   };
 };
 
@@ -155,6 +163,16 @@ let create = (~config, ~buffer, ()) => {
     selection: None,
     pixelWidth: 1,
     pixelHeight: 1,
+    yankHighlight:
+      Some({
+        key: Brisk_reconciler.Key.create(),
+        pixelRanges: [
+          PixelRange.create(
+            ~start=PixelPosition.{x: 50., y: 50.},
+            ~stop=PixelPosition.{x: 150., y: 150.},
+          ),
+        ],
+      }),
   };
 };
 
@@ -434,7 +452,7 @@ let exposePrimaryCursor = editor => {
     let {pixelHeight, scrollX, scrollY, _} = editor;
     let pixelHeight = float(pixelHeight);
 
-    let ({pixelX, pixelY}, _width) =
+    let ({x: pixelX, y: pixelY}: PixelPosition.t, _width) =
       bufferBytePositionToPixel(~position=primaryCursor, editor);
 
     let scrollOffX = getCharacterWidth(editor) *. 2.;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -163,16 +163,7 @@ let create = (~config, ~buffer, ()) => {
     selection: None,
     pixelWidth: 1,
     pixelHeight: 1,
-    yankHighlight:
-      Some({
-        key: Brisk_reconciler.Key.create(),
-        pixelRanges: [
-          PixelRange.create(
-            ~start=PixelPosition.{x: 50., y: 50.},
-            ~stop=PixelPosition.{x: 150., y: 150.},
-          ),
-        ],
-      }),
+    yankHighlight: None,
   };
 };
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -4,11 +4,6 @@ open Oni_Core;
 [@deriving show]
 type t;
 
-type pixelPosition = {
-  pixelX: float,
-  pixelY: float,
-};
-
 type scrollbarMetrics = {
   visible: bool,
   thumbSize: int,
@@ -19,6 +14,11 @@ type viewLine = {
   contents: BufferLine.t,
   byteOffset: int,
   characterOffset: int,
+};
+
+type yankHighlight = {
+  key: Brisk_reconciler.Key.t,
+  pixelRanges: list(PixelRange.t),
 };
 
 let create: (~config: Config.resolver, ~buffer: EditorBuffer.t, unit) => t;
@@ -45,6 +45,9 @@ let getVerticalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getCursors: t => list(BytePosition.t);
 let setCursors: (~cursors: list(BytePosition.t), t) => t;
+
+let yankHighlight: t => option(yankHighlight);
+let setYankHighlight: (~yankHighlight: yankHighlight, t) => t;
 
 let isMinimapEnabled: t => bool;
 let setMinimapEnabled: (~enabled: bool, t) => t;
@@ -111,9 +114,9 @@ let byteRangeToCharacterRange: (ByteRange.t, t) => option(CharacterRange.t);
 
 // They return both the pixel position, as well as the character width of the target character.
 let bufferBytePositionToPixel:
-  (~position: BytePosition.t, t) => (pixelPosition, float);
+  (~position: BytePosition.t, t) => (PixelPosition.t, float);
 let bufferCharacterPositionToPixel:
-  (~position: CharacterPosition.t, t) => (pixelPosition, float);
+  (~position: CharacterPosition.t, t) => (PixelPosition.t, float);
 
 // PROJECTION
 

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -162,6 +162,8 @@ let smoothScroll =
   );
 
 let tabSize = setting("editor.tabSize", int, ~default=4);
+let yankHighlightAnimation =
+  setting("editor.yankHighlightAnimation", bool, ~default=true);
 
 module Hover = {
   let enabled = setting("editor.hover.enabled", bool, ~default=true);
@@ -220,6 +222,7 @@ let contributions = [
   scrollShadow.spec,
   smoothScroll.spec,
   tabSize.spec,
+  yankHighlightAnimation.spec,
   Hover.enabled.spec,
   Hover.delay.spec,
   Minimap.enabled.spec,

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -291,7 +291,7 @@ let%component make =
 
     maybeHover
     |> Option.map(((position: CharacterPosition.t, sections)) => {
-         let ({pixelX, pixelY}: Editor.pixelPosition, _) =
+         let ({x: pixelX, y: pixelY}: PixelPosition.t, _) =
            Editor.bufferCharacterPositionToPixel(~position, editor);
          let popupX = pixelX +. gutterWidth |> int_of_float;
          let popupTopY = pixelY |> int_of_float;

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -60,6 +60,7 @@ let minimap =
       ~colors,
       ~dispatch,
       ~matchingPairs,
+      ~maybeYankHighlights,
       ~bufferSyntaxHighlights,
       ~selectionRanges,
       ~showMinimapSlider,
@@ -95,6 +96,7 @@ let minimap =
       dispatch
       width=minimapPixelWidth
       height=pixelHeight
+      maybeYankHighlights
       count
       diagnostics=diagnosticsMap
       getTokensForLine={getTokensForLine(
@@ -178,6 +180,8 @@ let%component make =
     lastDimensions := Some((width, height));
     onEditorSizeChanged(editorId, width, height);
   };
+
+  let maybeYankHighlights = editor |> Editor.yankHighlight;
 
   let colors =
     backgroundColor
@@ -329,6 +333,7 @@ let%component make =
       diagnosticsMap
       selectionRanges
       matchingPairs
+      maybeYankHighlights
       bufferHighlights
       languageSupport
       bufferSyntaxHighlights
@@ -350,6 +355,7 @@ let%component make =
            colors
            dispatch
            matchingPairs
+           maybeYankHighlights
            bufferSyntaxHighlights
            selectionRanges
            showMinimapSlider={Config.Minimap.showSlider.get(config)}

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -181,7 +181,9 @@ let%component make =
     onEditorSizeChanged(editorId, width, height);
   };
 
-  let maybeYankHighlights = editor |> Editor.yankHighlight;
+  let showYankHighlightAnimation = Config.yankHighlightAnimation.get(config);
+  let maybeYankHighlights =
+    showYankHighlightAnimation ? editor |> Editor.yankHighlight : None;
 
   let colors =
     backgroundColor

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -27,7 +27,7 @@ let renderLineNumber =
     );
   let fontMetrics = Revery.Font.getMetrics(font, context.fontSize);
   let isActiveLine = lineNumber == cursorLine;
-  let ({pixelY: yOffset, _}: Editor.pixelPosition, _) =
+  let ({y: yOffset, _}: PixelPosition.t, _) =
     Editor.bufferBytePositionToPixel(
       ~position=
         BytePosition.{

--- a/src/Feature/Editor/IndentLineRenderer.re
+++ b/src/Feature/Editor/IndentLineRenderer.re
@@ -89,7 +89,7 @@ let render =
 
   let editor = context.editor;
   let bufferPositionToPixel = lineIdx => {
-    let ({pixelX, pixelY}: Editor.pixelPosition, _) =
+    let ({x: pixelX, y: pixelY}: PixelPosition.t, _) =
       Editor.bufferBytePositionToPixel(
         ~position=
           BytePosition.{

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -116,6 +116,7 @@ let%component make =
                 ~height: int,
                 ~count,
                 ~diagnostics,
+                ~maybeYankHighlights: option(Editor.yankHighlight),
                 ~getTokensForLine: int => list(BufferViewTokenizer.t),
                 ~selection:
                    Hashtbl.t(
@@ -231,6 +232,33 @@ let%component make =
   let sliderBackground =
     isHovering
       ? colors.minimapSliderHoverBackground : colors.minimapSliderBackground;
+
+  // Convert an editor surface pixel range (post-scroll) to a
+  // minimap pixel range. For now, this just has per-line fidelity.
+  let mapPixelRange = ({start, stop}: PixelRange.t) => {
+    let editorPixelYToMinimapPixelY = pixelY => {
+      let scaleFactor = rowHeight /. Editor.lineHeightInPixels(editor);
+      pixelY *. scaleFactor +. thumbTop;
+    };
+
+    PixelRange.{
+      start: PixelPosition.{x: 0., y: editorPixelYToMinimapPixelY(start.y)},
+      stop:
+        PixelPosition.{
+          x: float(width),
+          y: editorPixelYToMinimapPixelY(stop.y),
+        },
+    };
+  };
+
+  let yankHighlightElement =
+    maybeYankHighlights
+    |> Option.map(({key, pixelRanges}: Editor.yankHighlight) => {
+         let pixelRanges = pixelRanges |> List.map(mapPixelRange);
+
+         <YankHighlights key pixelRanges />;
+       })
+    |> Option.value(~default=React.empty);
 
   <View
     style={Styles.container(backgroundColor)}
@@ -456,5 +484,6 @@ let%component make =
         );
       }}
     />
+    yankHighlightElement
   </View>;
 };

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -256,7 +256,7 @@ let%component make =
     |> Option.map(({key, pixelRanges}: Editor.yankHighlight) => {
          let pixelRanges = pixelRanges |> List.map(mapPixelRange);
 
-         <YankHighlights key pixelRanges />;
+         <YankHighlights key colors pixelRanges />;
        })
     |> Option.value(~default=React.empty);
 

--- a/src/Feature/Editor/OverlaysView.re
+++ b/src/Feature/Editor/OverlaysView.re
@@ -58,7 +58,7 @@ let make =
       ~editorFont: Service_Font.font,
       (),
     ) => {
-  let ({pixelX, pixelY}: Editor.pixelPosition, _) =
+  let ({x: pixelX, y: pixelY}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(~position=cursorPosition, editor);
 
   let cursorPixelY = pixelY |> int_of_float;

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -55,6 +55,7 @@ let%component make =
                 ~languageSupport,
                 ~bufferSyntaxHighlights,
                 ~bottomVisibleLine,
+                ~maybeYankHighlights,
                 ~mode,
                 ~isActiveSplit,
                 ~gutterWidth,
@@ -158,10 +159,12 @@ let%component make =
   let pixelHeight = Editor.visiblePixelHeight(editor);
 
   let yankHighlightElement =
-    editor
-    |> Editor.yankHighlight
+    maybeYankHighlights
     |> Option.map((highlights: Editor.yankHighlight) =>
-         <YankHighlights key={highlights.key} highlights />
+         <YankHighlights
+           key={highlights.key}
+           pixelRanges={highlights.pixelRanges}
+         />
        )
     |> Option.value(~default=React.empty);
 

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -161,10 +161,7 @@ let%component make =
     editor
     |> Editor.yankHighlight
     |> Option.map((highlights: Editor.yankHighlight) =>
-         <YankHighlights
-           key={highlights.key}
-           highlights
-         />
+         <YankHighlights key={highlights.key} highlights />
        )
     |> Option.value(~default=React.empty);
 

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -163,6 +163,7 @@ let%component make =
     |> Option.map((highlights: Editor.yankHighlight) =>
          <YankHighlights
            key={highlights.key}
+           colors
            pixelRanges={highlights.pixelRanges}
          />
        )

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -157,6 +157,17 @@ let%component make =
   let pixelWidth = Editor.visiblePixelWidth(editor);
   let pixelHeight = Editor.visiblePixelHeight(editor);
 
+  let yankHighlightElement =
+    editor
+    |> Editor.yankHighlight
+    |> Option.map((highlights: Editor.yankHighlight) =>
+         <YankHighlights
+           key={highlights.key}
+           highlights
+         />
+       )
+    |> Option.value(~default=React.empty);
+
   <View
     onBoundingBoxChanged={bbox => maybeBbox := Some(bbox)}
     style={Styles.bufferViewClipped(
@@ -232,6 +243,7 @@ let%component make =
         };
       }}
     />
+    yankHighlightElement
     <CursorView
       config
       editor

--- a/src/Feature/Editor/YankHighlights.re
+++ b/src/Feature/Editor/YankHighlights.re
@@ -28,8 +28,8 @@ module Animations = {
     );
 };
 
-let%component make = (~highlights: Editor.yankHighlight, ()) => {
-  let ranges = highlights.pixelRanges;
+let%component make = (~pixelRanges: list(PixelRange.t), ()) => {
+  let ranges = pixelRanges;
 
   let%hook (opacity, _animationState, _reset) =
     Hooks.animation(Animations.fadeIn, ~active=true);

--- a/src/Feature/Editor/YankHighlights.re
+++ b/src/Feature/Editor/YankHighlights.re
@@ -28,11 +28,7 @@ module Animations = {
     );
 };
 
-let%component make =
-              (
-                ~highlights: Editor.yankHighlight,
-                (),
-              ) => {
+let%component make = (~highlights: Editor.yankHighlight, ()) => {
   let ranges = highlights.pixelRanges;
 
   let%hook (opacity, _animationState, _reset) =

--- a/src/Feature/Editor/YankHighlights.re
+++ b/src/Feature/Editor/YankHighlights.re
@@ -1,4 +1,5 @@
 open EditorCoreTypes;
+module EditorColors = Colors;
 open Revery.UI;
 
 open Oni_Core;
@@ -23,16 +24,19 @@ module Animations = {
     Revery.UI.Animation.(
       animate(Revery.Time.milliseconds(250))
       |> ease(Easing.easeIn)
-      |> tween(0.2, 0.0)
+      |> tween(0.6, 0.0)
       |> delay(Revery.Time.milliseconds(0))
     );
 };
 
-let%component make = (~pixelRanges: list(PixelRange.t), ()) => {
+let%component make =
+              (~colors: EditorColors.t, ~pixelRanges: list(PixelRange.t), ()) => {
   let ranges = pixelRanges;
 
   let%hook (opacity, _animationState, _reset) =
     Hooks.animation(Animations.fadeIn, ~active=true);
+
+  let bg = colors.selectionBackground;
 
   let elements =
     ranges
@@ -44,7 +48,7 @@ let%component make = (~pixelRanges: list(PixelRange.t), ()) => {
              left(range.start.x |> int_of_float),
              width(range.stop.x -. range.start.x |> int_of_float),
              height(range.stop.y -. range.start.y |> int_of_float),
-             backgroundColor(Revery.Colors.yellow),
+             backgroundColor(bg),
            ]
          />
        })

--- a/src/Feature/Editor/YankHighlights.re
+++ b/src/Feature/Editor/YankHighlights.re
@@ -1,0 +1,58 @@
+open EditorCoreTypes;
+open Revery.UI;
+
+open Oni_Core;
+
+module Log = (val Log.withNamespace("Oni2.UI.EditorSurface"));
+
+module Styles = {
+  open Style;
+
+  let overlay = [
+    pointerEvents(`Ignore),
+    position(`Absolute),
+    top(0),
+    left(0),
+    right(0),
+    bottom(0),
+  ];
+};
+
+module Animations = {
+  let fadeIn =
+    Revery.UI.Animation.(
+      animate(Revery.Time.milliseconds(250))
+      |> ease(Easing.easeIn)
+      |> tween(0.2, 0.0)
+      |> delay(Revery.Time.milliseconds(0))
+    );
+};
+
+let%component make =
+              (
+                ~highlights: Editor.yankHighlight,
+                (),
+              ) => {
+  let ranges = highlights.pixelRanges;
+
+  let%hook (opacity, _animationState, _reset) =
+    Hooks.animation(Animations.fadeIn, ~active=true);
+
+  let elements =
+    ranges
+    |> List.map((range: PixelRange.t) => {
+         <View
+           style=Style.[
+             position(`Absolute),
+             top(range.start.y |> int_of_float),
+             left(range.start.x |> int_of_float),
+             width(range.stop.x -. range.start.x |> int_of_float),
+             height(range.stop.y -. range.start.y |> int_of_float),
+             backgroundColor(Revery.Colors.yellow),
+           ]
+         />
+       })
+    |> React.listToElement;
+
+  <View style=Styles.overlay> <Opacity opacity> elements </Opacity> </View>;
+};

--- a/src/Feature/SignatureHelp/Feature_SignatureHelp.re
+++ b/src/Feature/SignatureHelp/Feature_SignatureHelp.re
@@ -628,7 +628,7 @@ module View = {
         }
       )
       |> Option.map((characterPosition: CharacterPosition.t) => {
-           let ({pixelX, pixelY}: Feature_Editor.Editor.pixelPosition, _) =
+           let ({x: pixelX, y: pixelY}: PixelPosition.t, _) =
              Feature_Editor.Editor.bufferCharacterPositionToPixel(
                ~position=characterPosition,
                editor,

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -180,6 +180,7 @@ type t =
     })
   | Vim(Feature_Vim.msg)
   | TabPage(Vim.TabPage.effect)
+  | Yank({range: [@opaque] VisualRange.t})
   | Noop
 and command = {
   commandCategory: option(string),

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -882,8 +882,23 @@ let update =
     | Some(buffer) =>
       let byteRanges = Selection.getRanges(range, buffer);
 
+      let cursorLine =
+        activeEditor
+        |> Editor.getPrimaryCursor
+        |> (
+          ({line, _}: CharacterPosition.t) =>
+            line |> EditorCoreTypes.LineNumber.toZeroBased
+        );
+
+      let maxDelta = 400;
+
       let pixelRanges =
         byteRanges
+        |> List.filter(({start, _}: ByteRange.t) => {
+             let lineNumber =
+               start.line |> EditorCoreTypes.LineNumber.toZeroBased;
+             abs(lineNumber - cursorLine) < maxDelta;
+           })
         |> List.map(({start, stop}: ByteRange.t) => {
              let (pixelStart, _) =
                Editor.bufferBytePositionToPixel(

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -869,6 +869,60 @@ let update =
 
     ({...state, signatureHelp, languageSupport: languageSupport'}, shEffect);
 
+  | Yank({range}) =>
+    open EditorCoreTypes;
+    open Feature_Editor;
+
+    let activeEditor = state.layout |> Feature_Layout.activeEditor;
+    let activeEditorId = activeEditor |> Editor.getId;
+    let maybeBuffer = Selectors.getActiveBuffer(state);
+
+    switch (maybeBuffer) {
+    | None => (state, Isolinear.Effect.none)
+    | Some(buffer) =>
+      let byteRanges = Selection.getRanges(range, buffer);
+
+      let pixelRanges =
+        byteRanges
+        |> List.map(({start, stop}: ByteRange.t) => {
+             let (pixelStart, _) =
+               Editor.bufferBytePositionToPixel(
+                 ~position=start,
+                 activeEditor,
+               );
+
+             let (pixelStop, _) =
+               Editor.bufferBytePositionToPixel(~position=stop, activeEditor);
+             let lineHeightInPixels =
+               activeEditor |> Editor.lineHeightInPixels;
+             let range =
+               PixelRange.create(
+                 ~start=pixelStart,
+                 ~stop={
+                   x: pixelStop.x,
+                   y: pixelStart.y +. lineHeightInPixels,
+                 },
+               );
+             range;
+           });
+      let layout' =
+        state.layout
+        |> Feature_Layout.map(editor =>
+             if (Editor.getId(editor) == activeEditorId) {
+               Editor.setYankHighlight(
+                 ~yankHighlight={
+                   key: Brisk_reconciler.Key.create(),
+                   pixelRanges,
+                 },
+                 editor,
+               );
+             } else {
+               editor;
+             }
+           );
+      ({...state, layout: layout'}, Isolinear.Effect.none);
+    };
+
   | Vim(msg) =>
     let wasInInsertMode = Feature_Vim.mode(state.vim) == Vim.Mode.Insert;
     let (vim, outmsg) = Feature_Vim.update(msg, state.vim);

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -200,8 +200,47 @@ let start =
     });
 
   let _: unit => unit =
-    Vim.onYank(({lines, register, operator, yankType, _}) => {
+    Vim.onYank(
+      (
+        {
+          lines,
+          register,
+          operator,
+          yankType,
+          startLine,
+          startColumn,
+          endLine,
+          endColumn,
+        },
+      ) => {
       let state = getState();
+
+      if (operator == Vim.Yank.Yank) {
+        let visualType =
+          switch (yankType) {
+          | Block => Vim.Types.Block
+          | Line => Vim.Types.Line
+          | Char => Vim.Types.Character
+          };
+
+        let range =
+          ByteRange.{
+            start:
+              BytePosition.{
+                line: LineNumber.ofOneBased(startLine),
+                byte: ByteIndex.ofInt(startColumn),
+              },
+            stop:
+              BytePosition.{
+                line: LineNumber.ofOneBased(endLine),
+                byte: ByteIndex.ofInt(endColumn),
+              },
+          };
+        let visualRange =
+          Oni_Core.VisualRange.create(~mode=visualType, range);
+        dispatch(Actions.Yank({range: visualRange}));
+      };
+
       let yankConfig =
         Selectors.getActiveConfigurationValue(state, c =>
           c.vimUseSystemClipboard

--- a/src/editor-core-types/PixelPosition.re
+++ b/src/editor-core-types/PixelPosition.re
@@ -1,0 +1,7 @@
+[@deriving show]
+type t = {
+  x: float,
+  y: float,
+};
+
+let zero = {x: 0., y: 0.};

--- a/src/editor-core-types/PixelPosition.rei
+++ b/src/editor-core-types/PixelPosition.rei
@@ -1,0 +1,7 @@
+[@deriving show]
+type t = {
+  x: float,
+  y: float,
+};
+
+let zero: t;

--- a/src/editor-core-types/PixelRange.re
+++ b/src/editor-core-types/PixelRange.re
@@ -1,0 +1,9 @@
+[@deriving show]
+type t = {
+  start: PixelPosition.t,
+  stop: PixelPosition.t,
+};
+
+let zero = {start: PixelPosition.zero, stop: PixelPosition.zero};
+
+let create = (~start, ~stop) => {start, stop};

--- a/src/editor-core-types/PixelRange.rei
+++ b/src/editor-core-types/PixelRange.rei
@@ -1,0 +1,9 @@
+[@deriving show]
+type t = {
+  start: PixelPosition.t,
+  stop: PixelPosition.t,
+};
+
+let zero: t;
+
+let create: (~start: PixelPosition.t, ~stop: PixelPosition.t) => t;


### PR DESCRIPTION
This implements a visualization when yanking text (a revamp of #986, using our new editor pixel conversion APIs on the editor surface):

![2020-08-29 16 01 59](https://user-images.githubusercontent.com/13532591/91647575-140d9700-ea11-11ea-9b45-51cb326ae2c0.gif)

__TODO:__

- [x] Configuration setting: `editor.yankHighlightAnimation`
- [x] Add linewise visualization on minimap
