### PR TITLE
fix(vim): Fix ':set rnu' default

### DIFF
--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -123,7 +123,7 @@ module VimSettings = {
 
       let justRelative =
         fun
-        | Some(true) => Some(`RelativeOnly)
+        | Some(true) => Some(`Relative)
         | Some(false) => Some(`Off)
         | None => None;
 


### PR DESCRIPTION
__Issue:__ When using `:set rnu`, the current line number doesn't show - this is a bit misleading, given that our default is to show absolute line numbers.

__Fix:__ Change the default when _only_ `:set rnu` is used to show the absolute line number for the current line. This can be disabled by additional running `:set nonumber` if desired.