### PR TITLE
feat(vim): Initial ':vimcompatible' setting implementation

### DIFF
--- a/src/Core/Config.re
+++ b/src/Core/Config.re
@@ -148,8 +148,19 @@ module Schema = {
       };
     };
 
-    let vim = (name, converter: VimSetting.t => 'a, resolver) => {
-      name |> toVimSettingOpt(resolver) |> Option.map(converter);
+    let getVimCompatibilitySetting = (resolver, maybeDefault) => {
+      maybeDefault
+      |> OptionEx.flatMap((default) => {
+        switch (toVimSettingOpt(resolver, "vimcompatible")) {
+        | Some(VimSetting.Int(1)) => maybeDefault
+        | _ => None
+        };
+      });
+    };
+
+    let vim = (~compatibilityDefault=?, name, converter: VimSetting.t => 'a, resolver) => {
+      name |> toVimSettingOpt(resolver) |> Option.map(converter)
+      |> OptionEx.or_(getVimCompatibilitySetting(resolver, compatibilityDefault))
     };
 
     let vim2 =

--- a/src/Core/Config.re
+++ b/src/Core/Config.re
@@ -150,17 +150,27 @@ module Schema = {
 
     let getVimCompatibilitySetting = (resolver, maybeDefault) => {
       maybeDefault
-      |> OptionEx.flatMap((default) => {
-        switch (toVimSettingOpt(resolver, "vimcompatible")) {
-        | Some(VimSetting.Int(1)) => maybeDefault
-        | _ => None
-        };
-      });
+      |> OptionEx.flatMap(default => {
+           switch (toVimSettingOpt(resolver, "vimcompatible")) {
+           | Some(VimSetting.Int(1)) => Some(default)
+           | _ => None
+           }
+         });
     };
 
-    let vim = (~compatibilityDefault=?, name, converter: VimSetting.t => 'a, resolver) => {
-      name |> toVimSettingOpt(resolver) |> Option.map(converter)
-      |> OptionEx.or_(getVimCompatibilitySetting(resolver, compatibilityDefault))
+    let vim =
+        (
+          ~compatibilityDefault=?,
+          name,
+          converter: VimSetting.t => 'a,
+          resolver,
+        ) => {
+      name
+      |> toVimSettingOpt(resolver)
+      |> Option.map(converter)
+      |> OptionEx.or_(
+           getVimCompatibilitySetting(resolver, compatibilityDefault),
+         );
     };
 
     let vim2 =

--- a/src/Core/Config.rei
+++ b/src/Core/Config.rei
@@ -73,7 +73,9 @@ module Schema: {
     // [vim(~compatible, settingName, converter)] specifies a vim
     // setting. The optional [compatible] value will be used if the
     // setting itself is not set, but `set vimcompatible` is active.
-    let vim: (~compatibilityDefault: 'a=?, string, VimSetting.t => 'a) => vimSetting('a);
+    let vim:
+      (~compatibilityDefault: 'a=?, string, VimSetting.t => 'a) =>
+      vimSetting('a);
     let vim2:
       (
         string,
@@ -93,7 +95,9 @@ module Schema: {
   let string: codec(string);
   let list: codec('a) => codec(list('a));
 
-  let vim: (~compatibilityDefault: 'a=?, string, VimSetting.t => 'a) => vimSetting('a);
+  let vim:
+    (~compatibilityDefault: 'a=?, string, VimSetting.t => 'a) =>
+    vimSetting('a);
   let vim2:
     (
       string,

--- a/src/Core/Config.rei
+++ b/src/Core/Config.rei
@@ -70,7 +70,10 @@ module Schema: {
     let custom:
       (~decode: Json.decoder('a), ~encode: Json.encoder('a)) => codec('a);
 
-    let vim: (string, VimSetting.t => 'a) => vimSetting('a);
+    // [vim(~compatible, settingName, converter)] specifies a vim
+    // setting. The optional [compatible] value will be used if the
+    // setting itself is not set, but `set vimcompatible` is active.
+    let vim: (~compatibilityDefault: 'a=?, string, VimSetting.t => 'a) => vimSetting('a);
     let vim2:
       (
         string,
@@ -90,7 +93,7 @@ module Schema: {
   let string: codec(string);
   let list: codec('a) => codec(list('a));
 
-  let vim: (string, VimSetting.t => 'a) => vimSetting('a);
+  let vim: (~compatibilityDefault: 'a=?, string, VimSetting.t => 'a) => vimSetting('a);
   let vim2:
     (
       string,

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -83,14 +83,14 @@ module CustomDecoders: {
 module VimSettings = {
   open VimSetting.Schema;
   let smoothScroll =
-    vim("smoothscroll", scrollSetting => {
+    vim("smoothscroll", ~compatibilityDefault=false, scrollSetting => {
       scrollSetting
       |> VimSetting.decode_value_opt(bool)
       |> Option.value(~default=false)
     });
 
   let minimap =
-    vim("minimap", scrollSetting => {
+    vim("minimap", ~compatibilityDefault=false, scrollSetting => {
       scrollSetting
       |> VimSetting.decode_value_opt(bool)
       |> Option.value(~default=false)

--- a/src/Feature/Layout/Configuration.re
+++ b/src/Feature/Layout/Configuration.re
@@ -48,14 +48,42 @@ module Codec: {
     );
 };
 
+module VimSettings = {
+  open Config.Schema;
+  open VimSetting.Schema;
+
+  let singleTabMode =
+    vim(
+      "__singletabmode", // We don't have a vim setting for this, today.
+      ~compatibilityDefault=true,
+      _setting =>
+      false
+    );
+
+  let layoutTabPosition =
+    vim(
+      "__layouttabposition", // No vim setting for this, either...
+      ~compatibilityDefault=`top,
+      _setting =>
+      `top
+    );
+};
+
 let showLayoutTabs =
   setting("oni.layout.showLayoutTabs", Codec.showLayoutTabs, ~default=`smart);
 
 let layoutTabPosition =
   setting(
+    ~vim=VimSettings.layoutTabPosition,
     "oni.layout.layoutTabPosition",
     Codec.layoutTabPosition,
     ~default=`bottom,
   );
 
-let singleTabMode = setting("oni.layout.singleTabMode", bool, ~default=false);
+let singleTabMode =
+  setting(
+    ~vim=VimSettings.singleTabMode,
+    "oni.layout.singleTabMode",
+    bool,
+    ~default=false,
+  );

--- a/src/Feature/Layout/Configuration.re
+++ b/src/Feature/Layout/Configuration.re
@@ -50,7 +50,6 @@ module Codec: {
 
 module VimSettings = {
   open Config.Schema;
-  open VimSetting.Schema;
 
   let singleTabMode =
     vim(


### PR DESCRIPTION
__Issue:__ For users coming from Vim, Onivim's set of defaults are not optimal and there are a bunch of features that may not be desirable. It'd be better to be able to have a quick way to set vim-like defaults, and then opt-in to additional functionality if desired.

__Fix:__ Introduce a `vimcompatible` setting - this defaults to `off`, but if `:set vimcompatible` is run, it will default to using layout-tabs, positioning them on top, and turning off some features like smooth scroll and minimap.