### PR TITLE
fix(exthost/#2282): Fix URI serialization on Windows

### DIFF
--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -70,30 +70,6 @@ type t = {
   authority: [@default None] option(string),
 };
 
-let encode = uri =>
-  Json.Encode.(
-    obj([
-      ("$mid", Json.Encode.int(1)), // Magic marshaling id for Uri
-      ("scheme", uri.scheme |> Scheme.encode),
-      ("path", uri.path |> string),
-      ("query", uri.query |> nullable(string)),
-      ("authority", uri.authority |> nullable(string)),
-    ])
-  );
-
-let decode = {
-  Json.Decode.(
-    obj(({field, _}) =>
-      {
-        scheme: field.required("scheme", Scheme.decode),
-        path: field.required("path", string),
-        query: field.optional("query", string),
-        authority: field.optional("authority", string),
-      }
-    )
-  );
-};
-
 module Internal = {
   let isDriveLetter = (candidate: Char.t) => {
     let aCode = Char.code('A');
@@ -157,7 +133,16 @@ let fromScheme = (~scheme: Scheme.t, ~authority=?, ~query=?, path: string) => {
 };
 
 let fromMemory = path => fromScheme(~scheme=Scheme.Memory, path);
-let fromPath = path => fromScheme(~scheme=Scheme.File, path);
+let fromPath = path => {
+
+  // On Windows - we need to normalize backward slashes to forward slashes,
+  // to be in sync with the logic from vscode:
+  // https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/base/common/uri.ts#L306
+  // Also see: https://github.com/onivim/oni2/issues/2282
+  let backSlashRegex = Str.regexp("\\\\");
+  let normalizePath = p => Str.global_replace(backSlashRegex, "/", p);
+  fromScheme(~scheme=Scheme.File, normalizePath(path));
+};
 
 let toString = ({scheme, authority, path, query}: t) => {
   let schemeStr = Scheme.toString(scheme);
@@ -195,3 +180,27 @@ let toFileSystemPath = (uri: t) => {
 };
 
 let getScheme = (uri: t) => uri.scheme;
+
+let encode = uri =>
+  Json.Encode.(
+    obj([
+      ("$mid", Json.Encode.int(1)), // Magic marshaling id for Uri
+      ("scheme", uri.scheme |> Scheme.encode),
+      ("path", uri.path |> string),
+      ("query", uri.query |> nullable(string)),
+      ("authority", uri.authority |> nullable(string)),
+    ])
+  );
+
+let decode = {
+  Json.Decode.(
+    obj(({field, _}) =>
+      {
+        scheme: field.required("scheme", Scheme.decode),
+        path: field.required("path", string),
+        query: field.optional("query", string),
+        authority: field.optional("authority", string),
+      }
+    )
+  );
+};

--- a/src/Core/Uri.re
+++ b/src/Core/Uri.re
@@ -134,14 +134,13 @@ let fromScheme = (~scheme: Scheme.t, ~authority=?, ~query=?, path: string) => {
 
 let fromMemory = path => fromScheme(~scheme=Scheme.Memory, path);
 let fromPath = path => {
-
   // On Windows - we need to normalize backward slashes to forward slashes,
   // to be in sync with the logic from vscode:
   // https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/base/common/uri.ts#L306
   // Also see: https://github.com/onivim/oni2/issues/2282
-  let backSlashRegex = Str.regexp("\\\\");
-  let normalizePath = p => Str.global_replace(backSlashRegex, "/", p);
-  fromScheme(~scheme=Scheme.File, normalizePath(path));
+  let path = Sys.win32 ? Utility.Path.normalizeBackSlashes(path) : path;
+
+  fromScheme(~scheme=Scheme.File, path);
 };
 
 let toString = ({scheme, authority, path, query}: t) => {

--- a/src/Core/Utility/Path.re
+++ b/src/Core/Utility/Path.re
@@ -14,6 +14,11 @@ let hasTrailingSeparator = path => {
   };
 };
 
+let normalizeBackSlashes = {
+  let backSlashRegex = Str.regexp("\\\\");
+  path => Str.global_replace(backSlashRegex, "/", path);
+};
+
 let toRelative = (~base, path) => {
   let base = hasTrailingSeparator(base) ? base : base ++ Filename.dir_sep;
   Str.replace_first(Str.regexp_string(base), "", path);

--- a/src/Core/Utility/ResultEx.re
+++ b/src/Core/Utility/ResultEx.re
@@ -23,3 +23,7 @@ let tap = f =>
       ok;
     }
   | Error(_) as err => err;
+
+let value = (~default) => fun
+| Ok(v) => v
+| Error(_) => default;

--- a/src/Core/Utility/ResultEx.re
+++ b/src/Core/Utility/ResultEx.re
@@ -24,6 +24,7 @@ let tap = f =>
     }
   | Error(_) as err => err;
 
-let value = (~default) => fun
-| Ok(v) => v
-| Error(_) => default;
+let value = (~default) =>
+  fun
+  | Ok(v) => v
+  | Error(_) => default;

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -1240,7 +1240,7 @@ module StatusBar = {
       let%bind alignmentNumber =
         alignmentJson |> Internal.decode_value(Decode.int);
       let alignment = alignmentNumber |> intToAlignment;
-      let%bind priority = priorityJson |> Internal.decode_value(Decode.int);
+      let%bind priority = priorityJson |> Internal.decode_value(nullable(Decode.int)) |> Result.map(Option.value(~default=0));
       Ok(
         SetEntry({
           id,

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -1240,7 +1240,10 @@ module StatusBar = {
       let%bind alignmentNumber =
         alignmentJson |> Internal.decode_value(Decode.int);
       let alignment = alignmentNumber |> intToAlignment;
-      let%bind priority = priorityJson |> Internal.decode_value(nullable(Decode.int)) |> Result.map(Option.value(~default=0));
+      let%bind priority =
+        priorityJson
+        |> Internal.decode_value(nullable(Decode.int))
+        |> Result.map(Option.value(~default=0));
       Ok(
         SetEntry({
           id,

--- a/test/Core/UriTests.re
+++ b/test/Core/UriTests.re
@@ -28,7 +28,13 @@ describe("Uri", ({describe, _}) => {
     test("adds slash for windows-style path", ({expect, _}) => {
       let uri = Uri.fromPath("C:/test");
       expect.string(Uri.toString(uri)).toEqual("file:///c:/test");
-    })
+    });
+    if (Sys.win32) {
+      test("#2282 - Windows: backward slashes should get normalized to forward slashes", ({expect, _}) => {
+        let uri = Uri.fromPath("C:\\hello-rust\\src\\main.rs");
+      expect.string(Uri.toString(uri)).toEqual("file:///c:/hello-rust/src/main.rs");
+      });
+    }
   });
   describe("toFileSystemPath", ({test, _}) => {
     test("round-trip windows-style path", ({expect, _}) => {

--- a/test/Core/UriTests.re
+++ b/test/Core/UriTests.re
@@ -30,11 +30,15 @@ describe("Uri", ({describe, _}) => {
       expect.string(Uri.toString(uri)).toEqual("file:///c:/test");
     });
     if (Sys.win32) {
-      test("#2282 - Windows: backward slashes should get normalized to forward slashes", ({expect, _}) => {
+      test(
+        "#2282 - Windows: backward slashes should get normalized to forward slashes",
+        ({expect, _}) => {
         let uri = Uri.fromPath("C:\\hello-rust\\src\\main.rs");
-      expect.string(Uri.toString(uri)).toEqual("file:///c:/hello-rust/src/main.rs");
+        expect.string(Uri.toString(uri)).toEqual(
+          "file:///c:/hello-rust/src/main.rs",
+        );
       });
-    }
+    };
   });
   describe("toFileSystemPath", ({test, _}) => {
     test("round-trip windows-style path", ({expect, _}) => {

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -3,6 +3,7 @@ open Exthost_Extension;
 open Exthost;
 open Exthost_TestLib;
 open Oni_Core;
+open Oni_Core.Utility;
 
 module Log = (val Timber.Log.withNamespace("Test"));
 
@@ -92,7 +93,7 @@ let startWithExtensions =
       ~onError=errorHandler,
       (),
     )
-    |> ResultEx.tap_error(msg => prerr_endline(msg))
+    |> ResultEx.tapError(msg => prerr_endline(msg))
     |> Result.get_ok;
 
   let processHasExited = ref(false);

--- a/test/Exthost/lib/Node.re
+++ b/test/Exthost/lib/Node.re
@@ -1,4 +1,5 @@
 open Oni_Core;
+open Oni_Core.Utility;
 module Log = (val Timber.Log.withNamespace("ExtHost.TestLib.Node"));
 
 let spawn = (~env=[], ~onExit, args) => {
@@ -27,6 +28,6 @@ let spawn = (~env=[], ~onExit, args) => {
     nodeFullPath,
     [nodeFullPath, ...args],
   )
-  |> ResultEx.tap_error(msg => prerr_endline(Luv.Error.strerror(msg)))
+  |> ResultEx.tapError(msg => prerr_endline(Luv.Error.strerror(msg)))
   |> Result.get_ok;
 };

--- a/test/Exthost/lib/ResultEx.re
+++ b/test/Exthost/lib/ResultEx.re
@@ -1,7 +1,0 @@
-let tap_error = f =>
-  fun
-  | Ok(_) as v => v
-  | Error(msg) as v => {
-      f(msg);
-      v;
-    };


### PR DESCRIPTION
__Issue:__ The `matklad.rust-analyzer` extension wasn't working on Windows... an error dialog would come up after every request, making the extension unusable.

__Defect:__ Our logic for serializing URLs wasn't correct. VSCode normalizes back-slashes to forward slashes, and we weren't doing that: https://github.com/onivim/vscode-exthost/blob/c7df89c1cf0087ca5decaf8f6d4c0fd0257a8b7a/src/vs/base/common/uri.ts#L306

This meant, for a path like `D:\hello-rust\src\main.rs` we were sending a URL like this:
```file:///d%3A%5Chello-rust%5Csrc%5Cmain.rs```

When we should be sending one like this:
```file:///d%3A/hello-rust/src/main.rs```

__Fix:__ Add backslash normalization.

There was also an issue where the status bar `$setEntry` API wasn't being deserialized properly - we were expecting `priority` always to have a value, but the rust-analyzer LSP was sending null. In that case, I set it to fallback to a priority of 0.

Fixes #2282 
![image](https://user-images.githubusercontent.com/13532591/92049895-80a1d200-ed40-11ea-9071-3642f78fbfbc.png)
