### PR TITLE
feat(keybindings): execute keybinding starting with : as ex command

### DIFF
--- a/integration_test/ExCommandKeybindingTest.re
+++ b/integration_test/ExCommandKeybindingTest.re
@@ -1,0 +1,49 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+open Actions;
+
+let keybindings =
+  Some(
+    {|
+[
+  {"key": "kk", "command": ":split", "when": "editorTextFocus"}
+]
+|},
+  );
+
+runTest(
+  ~keybindings,
+  ~name="ExCommandKeybindingTest",
+  (dispatch, wait, _) => {
+    let input = key => {
+      let keyPress =
+        EditorInput.KeyPress.{
+          scancode: Sdl2.Scancode.ofName(key),
+          keycode: Sdl2.Keycode.ofName(key),
+          modifiers: EditorInput.Modifiers.none,
+        };
+      let time = Revery.Time.now();
+
+      dispatch(KeyDown(keyPress, time));
+      //dispatch(TextInput(key));
+      dispatch(KeyUp(keyPress, time));
+    };
+
+    wait(~name="Initial sanity check", (state: State.t) => {
+      let splitCount =
+        state.layout |> Feature_Layout.visibleEditors |> List.length;
+
+      splitCount == 1;
+    });
+
+    input("k");
+    input("k");
+
+    wait(~name="Wait for split to be created", (state: State.t) => {
+      let splitCount =
+        state.layout |> Feature_Layout.visibleEditors |> List.length;
+
+      splitCount == 2;
+    });
+  },
+);

--- a/integration_test/ExCommandKeybindingWithArgsTest.re
+++ b/integration_test/ExCommandKeybindingWithArgsTest.re
@@ -1,0 +1,61 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+open Actions;
+
+let keybindings =
+  Some(
+    {|
+[
+  {"key": "kk", "command": ":d 2", "when": "editorTextFocus"}
+]
+|},
+  );
+
+runTest(
+  ~keybindings,
+  ~name="ExCommandKeybindingTest",
+  (dispatch, wait, _) => {
+    let input = key => {
+      let keyPress =
+        EditorInput.KeyPress.{
+          scancode: Sdl2.Scancode.ofName(key),
+          keycode: Sdl2.Keycode.ofName(key),
+          modifiers: EditorInput.Modifiers.none,
+        };
+      let time = Revery.Time.now();
+
+      dispatch(KeyDown(keyPress, time));
+      //dispatch(TextInput(key));
+      dispatch(KeyUp(keyPress, time));
+    };
+
+    let testFile = getAssetPath("some-test-file.txt");
+    dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+    wait(~name="Verify buffer is loaded", (state: State.t) =>
+      switch (Selectors.getActiveBuffer(state)) {
+      | Some(buffer) =>
+        Buffer.getShortFriendlyName(buffer) == Some("some-test-file.txt")
+      | None => false
+      }
+    );
+
+    wait(~name="Verify initial line count", (state: State.t) =>
+      switch (Selectors.getActiveBuffer(state)) {
+      | Some(buffer) => Buffer.getNumberOfLines(buffer) == 3
+      | None => false
+      }
+    );
+
+    input("k");
+    input("k");
+
+    wait(~name="Wait for split to be created", (state: State.t) =>
+      switch (Selectors.getActiveBuffer(state)) {
+      | Some(buffer) => Buffer.getNumberOfLines(buffer) == 1
+      | None => false
+      }
+    );
+  },
+);

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -13,6 +13,7 @@
            EditorFontValidTest
            EditorUtf8Test
            ExCommandKeybindingTest
+           ExCommandKeybindingWithArgsTest
            ExtConfigurationChangedTest
            ExtHostBufferOpenTest
            ExtHostBufferUpdatesTest
@@ -79,6 +80,7 @@
         EditorFontValidTest.exe
         EditorUtf8Test.exe
         ExCommandKeybindingTest.exe
+        ExCommandKeybindingWithArgsTest.exe
         ExtConfigurationChangedTest.exe
         ExtHostBufferOpenTest.exe
         ExtHostBufferUpdatesTest.exe

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -12,6 +12,7 @@
            EditorFontFromPathTest
            EditorFontValidTest
            EditorUtf8Test
+           ExCommandKeybindingTest
            ExtConfigurationChangedTest
            ExtHostBufferOpenTest
            ExtHostBufferUpdatesTest
@@ -77,6 +78,7 @@
         EditorFontFromPathTest.exe
         EditorFontValidTest.exe
         EditorUtf8Test.exe
+        ExCommandKeybindingTest.exe
         ExtConfigurationChangedTest.exe
         ExtHostBufferOpenTest.exe
         ExtHostBufferUpdatesTest.exe

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -539,6 +539,11 @@ let start = maybeKeyBindingsFilePath => {
       }
     );
 
+  let executeExCommandEffect = command =>
+    Isolinear.Effect.create(~name="keybindings.executeExCommand", () =>
+      ignore(Vim.command(command): Vim.Context.t)
+    );
+
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
     | Actions.Init => (state, loadKeyBindingsEffect(true))
@@ -552,14 +557,21 @@ let start = maybeKeyBindingsFilePath => {
       )
 
     | KeybindingInvoked({command}) =>
-      switch (Command.Lookup.get(command, State.commands(state))) {
-      | Some((command: Command.t(_))) => (
+      if (command |> Utility.StringEx.startsWith(~prefix=":")) {
+        (
           state,
-          executeCommandEffect(command.msg),
-        )
-      | None =>
-        Log.errorf(m => m("Unknown command: %s", command));
-        (state, Isolinear.Effect.none);
+          executeExCommandEffect(Base.String.drop_prefix(command, 1)),
+        );
+      } else {
+        switch (Command.Lookup.get(command, State.commands(state))) {
+        | Some((command: Command.t(_))) => (
+            state,
+            executeCommandEffect(command.msg),
+          )
+        | None =>
+          Log.errorf(m => m("Unknown command: %s", command));
+          (state, Isolinear.Effect.none);
+        };
       }
 
     | _ => (state, Isolinear.Effect.none)


### PR DESCRIPTION
A simple change that allows keybindings to invoke ex commands directly, and could address quite a few of the requests in #1423. The downside of doing this instead of implementing proper commands is of course that they won't be discoverable through the command palette, but this doesn't prevent proper commands to be added either, so I think it might be a nice convenient stop-gap solution to unblock people at least.

Example:

```
  {key: "kk", command: ":split", when: "editorTextFocus"}
```

Let me know if you think this is a viable approach @bryphe, then I'll add a few integration tests before it's merged.

Fixes #807 