### PR TITLE
feat(extensions/#2332): Add XML extension

### DIFF
--- a/extensions/xml/cgmanifest.json
+++ b/extensions/xml/cgmanifest.json
@@ -1,0 +1,18 @@
+{
+	"registrations": [
+		{
+			"component": {
+				"type": "git",
+				"git": {
+					"name": "atom/language-xml",
+					"repositoryUrl": "https://github.com/atom/language-xml",
+					"commitHash": "7bc75dfe779ad5b35d9bf4013d9181864358cb49"
+				}
+			},
+			"license": "MIT",
+			"description": "The files syntaxes/xml.json and syntaxes/xsl.json were derived from the Atom package https://github.com/atom/language-xml which were originally converted from the TextMate bundle https://github.com/textmate/xml.tmbundle.",
+			"version": "0.35.2"
+		}
+	],
+	"version": 1
+}

--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -1,0 +1,99 @@
+{
+	"name": "xml",
+	"displayName": "%displayName%",
+	"description": "%description%",
+	"version": "1.0.0",
+	"publisher": "vscode",
+	"license": "MIT",
+	"engines": { "vscode": "*" },
+	"contributes": {
+		"languages": [{
+			"id": "xml",
+			"extensions": [
+				".xml",
+				".xsd",
+				".ascx",
+				".atom",
+				".axml",
+				".bpmn",
+				".cpt",
+				".csl",
+				".csproj",
+				".csproj.user",
+				".dita",
+				".ditamap",
+				".dtd",
+        ".ent",
+        ".mod",
+				".dtml",
+				".fsproj",
+				".fxml",
+				".iml",
+				".isml",
+				".jmx",
+				".launch",
+				".menu",
+				".mxml",
+				".nuspec",
+				".opml",
+				".owl",
+				".proj",
+				".props",
+				".pt",
+				".publishsettings",
+				".pubxml",
+				".pubxml.user",
+				".rbxlx",
+				".rbxmx",
+				".rdf",
+				".rng",
+				".rss",
+				".shproj",
+				".storyboard",
+				".svg",
+				".targets",
+				".tld",
+				".tmx",
+				".vbproj",
+				".vbproj.user",
+				".vcxproj",
+				".vcxproj.filters",
+				".wsdl",
+				".wxi",
+				".wxl",
+				".wxs",
+				".xaml",
+				".xbl",
+				".xib",
+				".xlf",
+				".xliff",
+				".xpdl",
+				".xul",
+				".xoml"
+			],
+			"firstLine" : "(\\<\\?xml.*)|(\\<svg)|(\\<\\!doctype\\s+svg)",
+			"aliases": [ "XML", "xml" ],
+			"configuration": "./xml.language-configuration.json"
+		}, {
+			"id": "xsl",
+			"extensions": [
+				".xsl",
+				".xslt"
+			],
+			"aliases": [ "XSL", "xsl" ],
+			"configuration": "./xsl.language-configuration.json"
+		}],
+		"grammars": [{
+			"language": "xml",
+			"scopeName": "text.xml",
+			"path": "./syntaxes/xml.tmLanguage.json"
+		}, {
+			"language": "xsl",
+			"scopeName": "text.xml.xsl",
+			"path": "./syntaxes/xsl.tmLanguage.json"
+		}]
+	},
+	"scripts": {
+		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-xml grammars/xml.cson ./syntaxes/xml.tmLanguage.json grammars/xsl.cson ./syntaxes/xsl.tmLanguage.json"
+	}
+}

--- a/extensions/xml/package.nls.json
+++ b/extensions/xml/package.nls.json
@@ -1,0 +1,4 @@
+{
+	"displayName": "XML Language Basics",
+	"description": "Provides syntax highlighting and bracket matching in XML files."
+}

--- a/extensions/xml/syntaxes/xml.tmLanguage.json
+++ b/extensions/xml/syntaxes/xml.tmLanguage.json
@@ -1,0 +1,387 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/atom/language-xml/blob/master/grammars/xml.cson",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/atom/language-xml/commit/7bc75dfe779ad5b35d9bf4013d9181864358cb49",
+	"name": "XML",
+	"scopeName": "text.xml",
+	"patterns": [
+		{
+			"begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "entity.name.tag.xml"
+				}
+			},
+			"end": "(\\?>)",
+			"name": "meta.tag.preprocessor.xml",
+			"patterns": [
+				{
+					"match": " ([a-zA-Z-]+)",
+					"name": "entity.other.attribute-name.xml"
+				},
+				{
+					"include": "#doublequotedString"
+				},
+				{
+					"include": "#singlequotedString"
+				}
+			]
+		},
+		{
+			"begin": "(<!)(DOCTYPE)\\s+([:a-zA-Z_][:a-zA-Z0-9_.-]*)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "keyword.other.doctype.xml"
+				},
+				"3": {
+					"name": "variable.language.documentroot.xml"
+				}
+			},
+			"end": "\\s*(>)",
+			"name": "meta.tag.sgml.doctype.xml",
+			"patterns": [
+				{
+					"include": "#internalSubset"
+				}
+			]
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "entity.name.tag.xml"
+				},
+				"3": {
+					"name": "entity.name.tag.namespace.xml"
+				},
+				"4": {
+					"name": "punctuation.separator.namespace.xml"
+				},
+				"5": {
+					"name": "entity.name.tag.localname.xml"
+				}
+			},
+			"end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"3": {
+					"name": "entity.name.tag.xml"
+				},
+				"4": {
+					"name": "entity.name.tag.namespace.xml"
+				},
+				"5": {
+					"name": "punctuation.separator.namespace.xml"
+				},
+				"6": {
+					"name": "entity.name.tag.localname.xml"
+				},
+				"7": {
+					"name": "punctuation.definition.tag.xml"
+				}
+			},
+			"name": "meta.tag.no-content.xml",
+			"patterns": [
+				{
+					"include": "#tagStuff"
+				}
+			]
+		},
+		{
+			"begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "entity.name.tag.namespace.xml"
+				},
+				"3": {
+					"name": "entity.name.tag.xml"
+				},
+				"4": {
+					"name": "punctuation.separator.namespace.xml"
+				},
+				"5": {
+					"name": "entity.name.tag.localname.xml"
+				}
+			},
+			"end": "(/?>)",
+			"name": "meta.tag.xml",
+			"patterns": [
+				{
+					"include": "#tagStuff"
+				}
+			]
+		},
+		{
+			"include": "#entity"
+		},
+		{
+			"include": "#bare-ampersand"
+		},
+		{
+			"begin": "<%@",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.embedded.begin.xml"
+				}
+			},
+			"end": "%>",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.embedded.end.xml"
+				}
+			},
+			"name": "source.java-props.embedded.xml",
+			"patterns": [
+				{
+					"match": "page|include|taglib",
+					"name": "keyword.other.page-props.xml"
+				}
+			]
+		},
+		{
+			"begin": "<%[!=]?(?!--)",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.embedded.begin.xml"
+				}
+			},
+			"end": "(?!--)%>",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.embedded.end.xml"
+				}
+			},
+			"name": "source.java.embedded.xml",
+			"patterns": [
+				{
+					"include": "source.java"
+				}
+			]
+		},
+		{
+			"begin": "<!\\[CDATA\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.xml"
+				}
+			},
+			"end": "]]>",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.xml"
+				}
+			},
+			"name": "string.unquoted.cdata.xml"
+		}
+	],
+	"repository": {
+		"EntityDecl": {
+			"begin": "(<!)(ENTITY)\\s+(%\\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\\s+(?:SYSTEM|PUBLIC)\\s+)?",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "keyword.other.entity.xml"
+				},
+				"3": {
+					"name": "punctuation.definition.entity.xml"
+				},
+				"4": {
+					"name": "variable.language.entity.xml"
+				},
+				"5": {
+					"name": "keyword.other.entitytype.xml"
+				}
+			},
+			"end": "(>)",
+			"patterns": [
+				{
+					"include": "#doublequotedString"
+				},
+				{
+					"include": "#singlequotedString"
+				}
+			]
+		},
+		"bare-ampersand": {
+			"match": "&",
+			"name": "invalid.illegal.bad-ampersand.xml"
+		},
+		"doublequotedString": {
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.xml"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.xml"
+				}
+			},
+			"name": "string.quoted.double.xml",
+			"patterns": [
+				{
+					"include": "#entity"
+				},
+				{
+					"include": "#bare-ampersand"
+				}
+			]
+		},
+		"entity": {
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.constant.xml"
+				},
+				"3": {
+					"name": "punctuation.definition.constant.xml"
+				}
+			},
+			"match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+			"name": "constant.character.entity.xml"
+		},
+		"internalSubset": {
+			"begin": "(\\[)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.constant.xml"
+				}
+			},
+			"end": "(\\])",
+			"name": "meta.internalsubset.xml",
+			"patterns": [
+				{
+					"include": "#EntityDecl"
+				},
+				{
+					"include": "#parameterEntity"
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		},
+		"parameterEntity": {
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.constant.xml"
+				},
+				"3": {
+					"name": "punctuation.definition.constant.xml"
+				}
+			},
+			"match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
+			"name": "constant.character.parameter-entity.xml"
+		},
+		"singlequotedString": {
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.xml"
+				}
+			},
+			"end": "'",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.xml"
+				}
+			},
+			"name": "string.quoted.single.xml",
+			"patterns": [
+				{
+					"include": "#entity"
+				},
+				{
+					"include": "#bare-ampersand"
+				}
+			]
+		},
+		"tagStuff": {
+			"patterns": [
+				{
+					"captures": {
+						"1": {
+							"name": "entity.other.attribute-name.namespace.xml"
+						},
+						"2": {
+							"name": "entity.other.attribute-name.xml"
+						},
+						"3": {
+							"name": "punctuation.separator.namespace.xml"
+						},
+						"4": {
+							"name": "entity.other.attribute-name.localname.xml"
+						}
+					},
+					"match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*="
+				},
+				{
+					"include": "#doublequotedString"
+				},
+				{
+					"include": "#singlequotedString"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"begin": "<%--",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.xml"
+						},
+						"end": "--%>",
+						"name": "comment.block.xml"
+					}
+				},
+				{
+					"begin": "<!--",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.xml"
+						}
+					},
+					"end": "-->",
+					"name": "comment.block.xml",
+					"patterns": [
+						{
+							"begin": "--(?!>)",
+							"captures": {
+								"0": {
+									"name": "invalid.illegal.bad-comments-or-CDATA.xml"
+								}
+							}
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/extensions/xml/syntaxes/xsl.tmLanguage.json
+++ b/extensions/xml/syntaxes/xsl.tmLanguage.json
@@ -1,0 +1,94 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/atom/language-xml/blob/master/grammars/xsl.cson",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/atom/language-xml/commit/507de2ee7daca60cf02e9e21fbeb92bbae73e280",
+	"name": "XSL",
+	"scopeName": "text.xml.xsl",
+	"patterns": [
+		{
+			"begin": "(<)(xsl)((:))(template)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.xml"
+				},
+				"2": {
+					"name": "entity.name.tag.namespace.xml"
+				},
+				"3": {
+					"name": "entity.name.tag.xml"
+				},
+				"4": {
+					"name": "punctuation.separator.namespace.xml"
+				},
+				"5": {
+					"name": "entity.name.tag.localname.xml"
+				}
+			},
+			"end": "(>)",
+			"name": "meta.tag.xml.template",
+			"patterns": [
+				{
+					"captures": {
+						"1": {
+							"name": "entity.other.attribute-name.namespace.xml"
+						},
+						"2": {
+							"name": "entity.other.attribute-name.xml"
+						},
+						"3": {
+							"name": "punctuation.separator.namespace.xml"
+						},
+						"4": {
+							"name": "entity.other.attribute-name.localname.xml"
+						}
+					},
+					"match": " (?:([-_a-zA-Z0-9]+)((:)))?([a-zA-Z-]+)"
+				},
+				{
+					"include": "#doublequotedString"
+				},
+				{
+					"include": "#singlequotedString"
+				}
+			]
+		},
+		{
+			"include": "text.xml"
+		}
+	],
+	"repository": {
+		"doublequotedString": {
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.xml"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.xml"
+				}
+			},
+			"name": "string.quoted.double.xml"
+		},
+		"singlequotedString": {
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.xml"
+				}
+			},
+			"end": "'",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.xml"
+				}
+			},
+			"name": "string.quoted.single.xml"
+		}
+	}
+}

--- a/extensions/xml/xml.language-configuration.json
+++ b/extensions/xml/xml.language-configuration.json
@@ -1,0 +1,34 @@
+{
+	"comments": {
+		"blockComment": [ "<!--", "-->" ]
+	},
+	"brackets": [
+		["<!--", "-->"],
+		["<", ">"],
+		["{", "}"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "'", "close": "'", "notIn": ["string"] },
+		{ "open": "<!--", "close": "-->", "notIn": [ "comment", "string" ]},
+		{ "open": "<![CDATA[", "close": "]]>", "notIn": [ "comment", "string" ]}
+	],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" }
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*<!--\\s*#region\\b.*-->",
+			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+		}
+	}
+}

--- a/extensions/xml/xsl.language-configuration.json
+++ b/extensions/xml/xsl.language-configuration.json
@@ -1,0 +1,20 @@
+{
+	"comments": {
+		"lineComment": "",
+		"blockComment": ["<!--", "-->"]
+	},
+	"brackets": [
+		["<", ">"]
+	]
+
+	// enhancedBrackets: [{
+	// 	tokenType: 'tag.tag-$1.xml',
+	// 	openTrigger: '>',
+	// 	open: /<(\w[\w\d]*)([^\/>]*(?!\/)>)[^<>]*$/i,
+	// 	closeComplete: '</$1>',
+	// 	closeTrigger: '>',
+	// 	close: /<\/(\w[\w\d]*)\s*>$/i
+	// }],
+
+	// autoClosingPairs:  [['\'', '\''], ['"', '"'] ]
+}


### PR DESCRIPTION
We've had several requests for XML syntax highlighting. We still need a good automated way to pull extensions from VSCode - but in the meantime, I'll bring over the XML extension.

With this extension, XML syntax highlighting is available out of box:
![image](https://user-images.githubusercontent.com/13532591/92166326-4b9f8900-eded-11ea-923d-cb09ac994cd1.png)

Fixes #2332 