### PR TITLE
fix(pane/#2408): Toggle Problems Pane not working

### DIFF
--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -3,6 +3,7 @@
  *
  * Feature for the bottom pane, hosting notifications, diagnostics, etc.
  */
+open Oni_Core;
 
 [@deriving show({with_path: false})]
 type pane =
@@ -25,6 +26,11 @@ module Msg: {
 type model;
 
 let update: (msg, model) => (model, outmsg);
+
+module Contributions: {
+  let commands: list(Command.t(msg));
+  let keybindings: list(Oni_Input.Keybindings.keybinding);
+};
 
 let initial: model;
 

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -21,15 +21,6 @@ let copyFilePath =
     CopyActiveFilepathToClipboard,
   );
 
-let acceptSelectedSuggestion =
-  register("acceptSelectedSuggestion", Command("acceptSelectedSuggestion"));
-
-let selectPrevSuggestion =
-  register("selectPrevSuggestion", Command("selectPrevSuggestion"));
-
-let selectNextSuggestion =
-  register("selectNextSuggestion", Command("selectNextSuggestion"));
-
 let undo = register("undo", Command("undo"));
 let redo = register("redo", Command("redo"));
 
@@ -272,17 +263,6 @@ module Workbench = {
         register(
           "workbench.action.files.save",
           Command("workbench.action.files.save"),
-        );
-    };
-  };
-  module Actions = {
-    module View = {
-      let problems =
-        register(
-          ~category="View",
-          ~title="Toggle Problems (Errors, Warnings)",
-          "workbench.actions.view.problems",
-          Command("workbench.actions.view.problems"),
         );
     };
   };

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -209,267 +209,260 @@ let start = maybeKeyBindingsFilePath => {
           command: Feature_Sneak.Commands.stop.id,
           condition: "sneakMode" |> WhenExpr.parse,
         },
-        {
-          key: "<S-C-M>",
-          command: Commands.Workbench.Actions.View.problems.id,
-          condition: WhenExpr.Value(True),
-        },
-        {
-          key: "<D-S-M>",
-          command: Commands.Workbench.Actions.View.problems.id,
-          condition: isMacCondition,
-        },
-        {
-          key: "<D-W>",
-          command: Feature_Layout.Commands.closeActiveEditor.id,
-          condition: isMacCondition,
-        },
-        {
-          key: "<C-PAGEDOWN>",
-          command: Feature_Layout.Commands.nextEditor.id,
-          condition: WhenExpr.Value(True),
-        },
-        {
-          key: "<D-S-]>",
-          command: Feature_Layout.Commands.nextEditor.id,
-          condition: isMacCondition,
-        },
-        {
-          key: "<C-PAGEUP>",
-          command: Feature_Layout.Commands.previousEditor.id,
-          condition: WhenExpr.Value(True),
-        },
-        {
-          key: "<D-S-[>",
-          command: Feature_Layout.Commands.previousEditor.id,
-          condition: isMacCondition,
-        },
-        {
-          key: "<D-=>",
-          command: "workbench.action.zoomIn",
-          condition: isMacCondition,
-        },
-        {
-          key: "<C-=>",
-          command: "workbench.action.zoomIn",
-          condition: WhenExpr.Value(True),
-        },
-        {
-          key: "<D-->",
-          command: "workbench.action.zoomOut",
-          condition: isMacCondition,
-        },
-        {
-          key: "<C-->",
-          command: "workbench.action.zoomOut",
-          condition: WhenExpr.Value(True),
-        },
-        {
-          key: "<D-0>",
-          command: "workbench.action.zoomReset",
-          condition: isMacCondition,
-        },
-        {
-          key: "<C-0>",
-          command: "workbench.action.zoomReset",
-          condition: WhenExpr.Value(True),
-        },
-        // TERMINAL
-        // Binding to open normal mode
-        {
-          key: "<C-\\><C-N>",
-          command: Feature_Terminal.Commands.Oni.normalMode.id,
-          condition: "terminalFocus && insertMode" |> WhenExpr.parse,
-        },
-        // Bindings to go from normal / visual mode -> insert mode
-        {
-          key: "o",
-          command: Feature_Terminal.Commands.Oni.insertMode.id,
-          condition:
-            "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
-        },
-        {
-          key: "<S-O>",
-          command: Feature_Terminal.Commands.Oni.insertMode.id,
-          condition:
-            "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
-        },
-        {
-          key: "Shift+a",
-          command: Feature_Terminal.Commands.Oni.insertMode.id,
-          condition:
-            "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
-        },
-        {
-          key: "a",
-          command: Feature_Terminal.Commands.Oni.insertMode.id,
-          condition:
-            "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
-        },
-        {
-          key: "i",
-          command: Feature_Terminal.Commands.Oni.insertMode.id,
-          condition:
-            "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
-        },
-        {
-          key: "Shift+i",
-          command: Feature_Terminal.Commands.Oni.insertMode.id,
-          condition:
-            "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
-        },
-        //LAYOUT
-        {
-          key: "<C-W>H",
-          command: Feature_Layout.Commands.moveLeft.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-H>",
-          command: Feature_Layout.Commands.moveLeft.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><LEFT>",
-          command: Feature_Layout.Commands.moveLeft.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>L",
-          command: Feature_Layout.Commands.moveRight.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-L>",
-          command: Feature_Layout.Commands.moveRight.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-S>",
-          command: Feature_Layout.Commands.splitHorizontal.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>S",
-          command: Feature_Layout.Commands.splitHorizontal.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-V>",
-          command: Feature_Layout.Commands.splitVertical.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>V",
-          command: Feature_Layout.Commands.splitVertical.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><RIGHT>",
-          command: Feature_Layout.Commands.moveRight.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>K",
-          command: Feature_Layout.Commands.moveUp.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-K>",
-          command: Feature_Layout.Commands.moveUp.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><UP>",
-          command: Feature_Layout.Commands.moveUp.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>J",
-          command: Feature_Layout.Commands.moveDown.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-J>",
-          command: Feature_Layout.Commands.moveDown.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><DOWN>",
-          command: Feature_Layout.Commands.moveDown.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>R",
-          command: Feature_Layout.Commands.rotateForward.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-R>",
-          command: Feature_Layout.Commands.rotateForward.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><C-S-R>", // TODO: Does not work, blocked by bug in editor-input
-          command: Feature_Layout.Commands.rotateBackward.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>-",
-          command: Feature_Layout.Commands.decreaseVerticalSize.id,
-          condition: windowCommandCondition,
-        },
-        //      TODO: Does not work, blocked by bug in editor-input
-        //      {
-        //        key: "<C-W>+",
-        //        command: Feature_Layout.Commands.increaseVerticalSize.id,
-        //        condition: "!insertMode" |> WhenExpr.parse
-        //      },
-        {
-          key: "<C-W><S-,>", // TODO: Does not work and should be `<`, but blocked by bugs in editor-input,
-          command: Feature_Layout.Commands.increaseHorizontalSize.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W><S-.>", // TODO: Does not work and should be `>`, but blocked by bugs in editor-input
-          command: Feature_Layout.Commands.decreaseHorizontalSize.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<C-W>=",
-          command: Feature_Layout.Commands.resetSizes.id,
-          condition: windowCommandCondition,
-        },
-        // TODO: Fails to parse
-        // {
-        //   key: "<C-W>_",
-        //   command: Feature_Layout.Commands.maximizeVertical.id,
-        //   condition: windowCommandCondition,
-        // },
-        // TODO: Fails to parse
-        // {
-        //   key: "<C-W>|",
-        //   command: Feature_Layout.Commands.maximizeHorizontal.id,
-        //   condition: windowCommandCondition,
-        // },
-        {
-          key: "<C-W>o",
-          command: Feature_Layout.Commands.toggleMaximize.id,
-          condition: windowCommandCondition,
-        },
-        {
-          key: "<A-DOWN>",
-          command: Feature_SignatureHelp.Commands.incrementSignature.id,
-          condition:
-            "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
-        },
-        {
-          key: "<A-UP>",
-          command: Feature_SignatureHelp.Commands.decrementSignature.id,
-          condition:
-            "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
-        },
-      ];
+      ]
+    @ Feature_Pane.Contributions.keybindings
+    @ [
+      {
+        key: "<D-W>",
+        command: Feature_Layout.Commands.closeActiveEditor.id,
+        condition: isMacCondition,
+      },
+      {
+        key: "<C-PAGEDOWN>",
+        command: Feature_Layout.Commands.nextEditor.id,
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-S-]>",
+        command: Feature_Layout.Commands.nextEditor.id,
+        condition: isMacCondition,
+      },
+      {
+        key: "<C-PAGEUP>",
+        command: Feature_Layout.Commands.previousEditor.id,
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-S-[>",
+        command: Feature_Layout.Commands.previousEditor.id,
+        condition: isMacCondition,
+      },
+      {
+        key: "<D-=>",
+        command: "workbench.action.zoomIn",
+        condition: isMacCondition,
+      },
+      {
+        key: "<C-=>",
+        command: "workbench.action.zoomIn",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-->",
+        command: "workbench.action.zoomOut",
+        condition: isMacCondition,
+      },
+      {
+        key: "<C-->",
+        command: "workbench.action.zoomOut",
+        condition: WhenExpr.Value(True),
+      },
+      {
+        key: "<D-0>",
+        command: "workbench.action.zoomReset",
+        condition: isMacCondition,
+      },
+      {
+        key: "<C-0>",
+        command: "workbench.action.zoomReset",
+        condition: WhenExpr.Value(True),
+      },
+      // TERMINAL
+      // Binding to open normal mode
+      {
+        key: "<C-\\><C-N>",
+        command: Feature_Terminal.Commands.Oni.normalMode.id,
+        condition: "terminalFocus && insertMode" |> WhenExpr.parse,
+      },
+      // Bindings to go from normal / visual mode -> insert mode
+      {
+        key: "o",
+        command: Feature_Terminal.Commands.Oni.insertMode.id,
+        condition:
+          "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
+      },
+      {
+        key: "<S-O>",
+        command: Feature_Terminal.Commands.Oni.insertMode.id,
+        condition:
+          "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
+      },
+      {
+        key: "Shift+a",
+        command: Feature_Terminal.Commands.Oni.insertMode.id,
+        condition:
+          "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
+      },
+      {
+        key: "a",
+        command: Feature_Terminal.Commands.Oni.insertMode.id,
+        condition:
+          "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
+      },
+      {
+        key: "i",
+        command: Feature_Terminal.Commands.Oni.insertMode.id,
+        condition:
+          "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
+      },
+      {
+        key: "Shift+i",
+        command: Feature_Terminal.Commands.Oni.insertMode.id,
+        condition:
+          "terminalFocus && normalMode || visualMode" |> WhenExpr.parse,
+      },
+      //LAYOUT
+      {
+        key: "<C-W>H",
+        command: Feature_Layout.Commands.moveLeft.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-H>",
+        command: Feature_Layout.Commands.moveLeft.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><LEFT>",
+        command: Feature_Layout.Commands.moveLeft.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>L",
+        command: Feature_Layout.Commands.moveRight.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-L>",
+        command: Feature_Layout.Commands.moveRight.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-S>",
+        command: Feature_Layout.Commands.splitHorizontal.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>S",
+        command: Feature_Layout.Commands.splitHorizontal.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-V>",
+        command: Feature_Layout.Commands.splitVertical.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>V",
+        command: Feature_Layout.Commands.splitVertical.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><RIGHT>",
+        command: Feature_Layout.Commands.moveRight.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>K",
+        command: Feature_Layout.Commands.moveUp.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-K>",
+        command: Feature_Layout.Commands.moveUp.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><UP>",
+        command: Feature_Layout.Commands.moveUp.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>J",
+        command: Feature_Layout.Commands.moveDown.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-J>",
+        command: Feature_Layout.Commands.moveDown.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><DOWN>",
+        command: Feature_Layout.Commands.moveDown.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>R",
+        command: Feature_Layout.Commands.rotateForward.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-R>",
+        command: Feature_Layout.Commands.rotateForward.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><C-S-R>", // TODO: Does not work, blocked by bug in editor-input
+        command: Feature_Layout.Commands.rotateBackward.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>-",
+        command: Feature_Layout.Commands.decreaseVerticalSize.id,
+        condition: windowCommandCondition,
+      },
+      //      TODO: Does not work, blocked by bug in editor-input
+      //      {
+      //        key: "<C-W>+",
+      //        command: Feature_Layout.Commands.increaseVerticalSize.id,
+      //        condition: "!insertMode" |> WhenExpr.parse
+      //      },
+      {
+        key: "<C-W><S-,>", // TODO: Does not work and should be `<`, but blocked by bugs in editor-input,
+        command: Feature_Layout.Commands.increaseHorizontalSize.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W><S-.>", // TODO: Does not work and should be `>`, but blocked by bugs in editor-input
+        command: Feature_Layout.Commands.decreaseHorizontalSize.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<C-W>=",
+        command: Feature_Layout.Commands.resetSizes.id,
+        condition: windowCommandCondition,
+      },
+      // TODO: Fails to parse
+      // {
+      //   key: "<C-W>_",
+      //   command: Feature_Layout.Commands.maximizeVertical.id,
+      //   condition: windowCommandCondition,
+      // },
+      // TODO: Fails to parse
+      // {
+      //   key: "<C-W>|",
+      //   command: Feature_Layout.Commands.maximizeHorizontal.id,
+      //   condition: windowCommandCondition,
+      // },
+      {
+        key: "<C-W>o",
+        command: Feature_Layout.Commands.toggleMaximize.id,
+        condition: windowCommandCondition,
+      },
+      {
+        key: "<A-DOWN>",
+        command: Feature_SignatureHelp.Commands.incrementSignature.id,
+        condition:
+          "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
+      },
+      {
+        key: "<A-UP>",
+        command: Feature_SignatureHelp.Commands.decrementSignature.id,
+        condition:
+          "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
+      },
+    ];
 
   let getKeybindingsFile = () => {
     Filesystem.getOrCreateConfigFile(

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -440,6 +440,8 @@ let start =
     |> List.map(Core.Command.map(msg => Model.Actions.Registers(msg))),
     Feature_LanguageSupport.Contributions.commands
     |> List.map(Core.Command.map(msg => Model.Actions.LanguageSupport(msg))),
+    Feature_Pane.Contributions.commands
+    |> List.map(Core.Command.map(msg => Model.Actions.Pane(msg))),
   ]
   |> List.flatten
   |> registerCommands(~dispatch);


### PR DESCRIPTION
__Issue:__ The toggle-problems-pane command (bound to Control+Shift+M/Command+Shift+M) wasn't working. The command and key-binding had no effect.

__Defect:__ The 'workbench.actions.view.problems' command wasn't actually wired up to our action.

__Fix:__ 
- Move the 'workbench.actions.view.problems' to a contributed command from the Pane feature
- Move the Control+Shift+M / Command+Shift+M bindings to contributed keybindings from the Pane feature
- Wire up the logic for showing / hiding the problems pane.

Fixes #2408 - still need to wire up vim-style navigation to it, though (in the spirit for #528)