### PR TITLE
chore(dune): upgrade project lang to 2.5

### DIFF
--- a/assets/dune
+++ b/assets/dune
@@ -1,4 +1,4 @@
 (install
-    (section bin)
-    (package Oni2)
-    (files changelog.xml))
+ (section bin)
+ (package Oni2)
+ (files changelog.xml))

--- a/assets/images/dune
+++ b/assets/images/dune
@@ -1,4 +1,4 @@
 (install
-    (section bin)
-    (package Oni2)
-    (files logo.png logo-titlebar.png background-grid.png title-logo.png))
+ (section bin)
+ (package Oni2)
+ (files logo.png logo-titlebar.png background-grid.png title-logo.png))

--- a/assets/tutor/dune
+++ b/assets/tutor/dune
@@ -1,4 +1,4 @@
 (install
-    (section bin)
-    (package Oni2)
-    (files tutor))
+ (section bin)
+ (package Oni2)
+ (files tutor))

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "49cf8ac34f4b9ee68bdb75d9ab359e2b",
+  "checksum": "e77e22f99ed9e9a0a930e9ed15400c83",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -150,7 +150,7 @@
         "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -207,9 +207,9 @@
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lambda-term@opam:3.1.0@8adc2660",
-        "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/fpath@opam:0.7.2@3fd2da53", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/reason@3.6.2@d41d8cd9"
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.0@e0bac278" ]
@@ -961,8 +961,9 @@
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
         "@opam/ppx_deriving@opam:4.5@d89f2934",
+        "@opam/ocamlformat@opam:0.15.0@8e036963",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/logs@opam:0.7.0@1d03143e",
@@ -1212,10 +1213,40 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+      ]
+    },
+    "@opam/uuseg@opam:13.0.0@f60712a7": {
+      "id": "@opam/uuseg@opam:13.0.0@f60712a7",
+      "name": "@opam/uuseg",
+      "version": "opam:13.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a0/a07a97fff61da604614ea8da0547ef6a#md5:a07a97fff61da604614ea8da0547ef6a",
+          "archive:https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz#md5:a07a97fff61da604614ea8da0547ef6a"
+        ],
+        "opam": {
+          "name": "uuseg",
+          "version": "13.0.0",
+          "path": "bench.esy.lock/opam/uuseg.13.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uucp@opam:13.0.0@e9b515e0", "@opam/topkg@opam:1.0.2@3c5942ad",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uucp@opam:13.0.0@e9b515e0"
       ]
     },
     "@opam/uucp@opam:13.0.0@e9b515e0": {
@@ -1240,6 +1271,7 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -1368,7 +1400,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -1376,7 +1408,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/stdlib-shims@opam:0.1.0@8c116481": {
@@ -1423,12 +1455,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/sexplib0@opam:v0.14.0@ddeb6438": {
@@ -1859,13 +1891,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_optcomp@opam:v0.14.0@d77a04c2": {
@@ -1888,13 +1920,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_let@opam:v0.14.0@eb9b93e0": {
@@ -1916,12 +1948,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_js_style@opam:v0.14.0@10b020a8": {
@@ -1944,13 +1976,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d": {
@@ -1973,13 +2005,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_here@opam:v0.14.0@5ccc1c01": {
@@ -2001,12 +2033,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_hash@opam:v0.14.0@8e9618e4": {
@@ -2030,14 +2062,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_enumerate@opam:v0.14.0@63db8245": {
@@ -2059,12 +2091,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d": {
@@ -2180,12 +2212,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_cold@opam:v0.14.0@345dec7c": {
@@ -2207,12 +2239,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_base@opam:v0.14.0@b4702ed9": {
@@ -2276,7 +2308,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -2285,7 +2317,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9": {
@@ -2307,6 +2339,39 @@
         "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@opam/base-bigarray@opam:base@b03491b0"
+      ]
+    },
+    "@opam/odoc@opam:1.5.1@52a58c0b": {
+      "id": "@opam/odoc@opam:1.5.1@52a58c0b",
+      "name": "@opam/odoc",
+      "version": "opam:1.5.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/ea/ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f",
+          "archive:https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+        ],
+        "opam": {
+          "name": "odoc",
+          "version": "1.5.1",
+          "path": "bench.esy.lock/opam/odoc.1.5.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8"
       ]
     },
     "@opam/octavius@opam:1.2.2@b328d1f1": {
@@ -2360,6 +2425,51 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/ocamlformat@opam:0.15.0@8e036963": {
+      "id": "@opam/ocamlformat@opam:0.15.0@8e036963",
+      "name": "@opam/ocamlformat",
+      "version": "opam:0.15.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/26/263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005",
+          "archive:https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+        ],
+        "opam": {
+          "name": "ocamlformat",
+          "version": "0.15.0",
+          "path": "bench.esy.lock/opam/ocamlformat.0.15.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
@@ -2730,12 +2840,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
@@ -2759,14 +2869,14 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2787,15 +2897,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt@opam:4.5.0@677655b4": {
-      "id": "@opam/lwt@opam:4.5.0@677655b4",
+    "@opam/lwt@opam:4.5.0@542100aa": {
+      "id": "@opam/lwt@opam:4.5.0@542100aa",
       "name": "@opam/lwt",
       "version": "opam:4.5.0",
       "source": {
@@ -2892,7 +3002,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2920,7 +3031,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2930,7 +3041,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b"
       ]
@@ -2982,14 +3093,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/jane-street-headers@opam:v0.14.0@59432b6a": {
@@ -3062,8 +3173,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/fpath@opam:0.7.2@45477b93": {
-      "id": "@opam/fpath@opam:0.7.2@45477b93",
+    "@opam/fpath@opam:0.7.2@3fd2da53": {
+      "id": "@opam/fpath@opam:0.7.2@3fd2da53",
       "name": "@opam/fpath",
       "version": "opam:0.7.2",
       "source": {
@@ -3133,6 +3244,7 @@
         "@opam/seq@opam:base@d8d7de1d",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3495,6 +3607,28 @@
       ],
       "devDependencies": []
     },
+    "@opam/cmdliner@opam:1.0.4@93208aac": {
+      "id": "@opam/cmdliner@opam:1.0.4@93208aac",
+      "name": "@opam/cmdliner",
+      "version": "opam:1.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fe/fe2213d0bc63b1e10a2d0aa66d2fc8d9#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9",
+          "archive:http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+        ],
+        "opam": {
+          "name": "cmdliner",
+          "version": "1.0.4",
+          "path": "bench.esy.lock/opam/cmdliner.1.0.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
+    },
     "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
       "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
@@ -3571,7 +3705,7 @@
         "@opam/rresult@opam:0.6.0@4b185e72",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8",
@@ -3579,7 +3713,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8"
@@ -3736,8 +3870,8 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "@opam/base@opam:v0.14.0@b8817fc1": {
-      "id": "@opam/base@opam:v0.14.0@b8817fc1",
+    "@opam/base@opam:v0.14.0@8bc55fce": {
+      "id": "@opam/base@opam:v0.14.0@8bc55fce",
       "name": "@opam/base",
       "version": "opam:v0.14.0",
       "source": {

--- a/bench.esy.lock/opam/base.v0.14.0/opam
+++ b/bench.esy.lock/opam/base.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"             {>= "4.07.0"}
+  "ocaml"             {>= "4.07.0" & < "4.12"}
   "sexplib0"          {>= "v0.14" & < "v0.15"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"

--- a/bench.esy.lock/opam/cmdliner.1.0.4/opam
+++ b/bench.esy.lock/opam/cmdliner.1.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+depends:[ "ocaml" {>= "4.03.0"} ]
+build: [[ make "all" "PREFIX=%{prefix}%" ]]
+install:
+[[make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%" ]
+ [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"  ]]
+
+synopsis: """Declarative definition of command line interfaces for OCaml"""
+description: """\
+
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+"""
+url {
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz"
+checksum: "fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+}

--- a/bench.esy.lock/opam/fpath.0.7.2/opam
+++ b/bench.esy.lock/opam/fpath.0.7.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fpath/issues"
 tags: [ "file" "system" "path" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.12"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/bench.esy.lock/opam/lwt.4.5.0/opam
+++ b/bench.esy.lock/opam/lwt.4.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.12"}
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/bench.esy.lock/opam/ocamlformat.0.15.0/opam
+++ b/bench.esy.lock/opam/ocamlformat.0.15.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.12"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "e9e70f4d3aea202ec8ea4afd7ccb828b36822799"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz"
+  checksum: [
+    "sha256=263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+    "sha512=2bc0b826567fa71201031a730568b822938c66c56da47b05b8896b68439da3d0a8b9bc552fa5cacab95bf9192a1b6e583655fd90095aa686daa91cd2bdf4725a"
+  ]
+}

--- a/bench.esy.lock/opam/odoc.1.5.1/opam
+++ b/bench.esy.lock/opam/odoc.1.5.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune"
+  "fpath"
+  "ocaml" {>= "4.02.0" & < "4.12"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz"
+  checksum: [
+    "sha256=ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+    "sha512=b2d12277d61e1e52354128d459d2ad49bea24a4d46db89790769c2843c4b00beaee3ea7d0215211079174c0bd893de6bf52dcbb71e46622728be7491d91058b2"
+  ]
+}

--- a/bench.esy.lock/opam/uuseg.13.0.0/opam
+++ b/bench.esy.lock/opam/uuseg.13.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.03.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uucp" {>= "13.0.0" & < "14.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+checksum: "a07a97fff61da604614ea8da0547ef6a"
+}

--- a/bench/dune
+++ b/bench/dune
@@ -1,7 +1,6 @@
 (executable
-    (name OniBench)
-    (public_name OniBench)
-    (modules OniBench)
-    (libraries OniBench.lib OniBench.treesitter)
-    (package OniBench)
-)
+ (name OniBench)
+ (public_name OniBench)
+ (modules OniBench)
+ (libraries OniBench.lib OniBench.treesitter)
+ (package OniBench))

--- a/bench/lib/dune
+++ b/bench/lib/dune
@@ -1,7 +1,8 @@
 (library
-    (name OniBenchLib)
-    (public_name OniBench.lib)
-    (ocamlopt_flags -linkall)
-    (preprocess (pps brisk-reconciler.ppx))
-    (libraries Oni2.core Oni2.feature.editor Oni2.store Oni2.syntax Oni2.ui reperf.lib textmate)
-)
+ (name OniBenchLib)
+ (public_name OniBench.lib)
+ (ocamlopt_flags -linkall)
+ (preprocess
+  (pps brisk-reconciler.ppx))
+ (libraries Oni2.core Oni2.feature.editor Oni2.store Oni2.syntax Oni2.ui
+   reperf.lib textmate))

--- a/bench/reason-treesitter/dune
+++ b/bench/reason-treesitter/dune
@@ -1,11 +1,10 @@
 (library
-    (name TreeSitterBenchLib)
-    (public_name OniBench.treesitter)
-    (ocamlopt_flags -linkall)
-    (libraries treesitter reperf.lib)
-)
+ (name TreeSitterBenchLib)
+ (public_name OniBench.treesitter)
+ (ocamlopt_flags -linkall)
+ (libraries treesitter reperf.lib))
 
 (install
-    (section bin)
-    (package OniBench)
-    (files canada.json sqlite3.c))
+ (section bin)
+ (package OniBench)
+ (files canada.json sqlite3.c))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,2 @@
-(lang dune 1.6)
-(using fmt 1.0 (enabled_for reason))
+(lang dune 2.5)
 (using menhir 2.0)

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "49cf8ac34f4b9ee68bdb75d9ab359e2b",
+  "checksum": "e77e22f99ed9e9a0a930e9ed15400c83",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -150,7 +150,7 @@
         "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -207,9 +207,9 @@
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lambda-term@opam:3.1.0@8adc2660",
-        "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/fpath@opam:0.7.2@3fd2da53", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/reason@3.6.2@d41d8cd9"
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.0@e0bac278" ]
@@ -960,8 +960,9 @@
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
         "@opam/ppx_deriving@opam:4.5@d89f2934",
+        "@opam/ocamlformat@opam:0.15.0@8e036963",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/logs@opam:0.7.0@1d03143e",
@@ -1211,10 +1212,40 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+      ]
+    },
+    "@opam/uuseg@opam:13.0.0@f60712a7": {
+      "id": "@opam/uuseg@opam:13.0.0@f60712a7",
+      "name": "@opam/uuseg",
+      "version": "opam:13.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a0/a07a97fff61da604614ea8da0547ef6a#md5:a07a97fff61da604614ea8da0547ef6a",
+          "archive:https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz#md5:a07a97fff61da604614ea8da0547ef6a"
+        ],
+        "opam": {
+          "name": "uuseg",
+          "version": "13.0.0",
+          "path": "esy.lock/opam/uuseg.13.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uucp@opam:13.0.0@e9b515e0", "@opam/topkg@opam:1.0.2@3c5942ad",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uucp@opam:13.0.0@e9b515e0"
       ]
     },
     "@opam/uucp@opam:13.0.0@e9b515e0": {
@@ -1239,6 +1270,7 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -1367,7 +1399,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -1375,7 +1407,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/stdlib-shims@opam:0.1.0@8c116481": {
@@ -1422,12 +1454,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/sexplib0@opam:v0.14.0@ddeb6438": {
@@ -1858,13 +1890,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_optcomp@opam:v0.14.0@d77a04c2": {
@@ -1887,13 +1919,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_let@opam:v0.14.0@eb9b93e0": {
@@ -1915,12 +1947,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_js_style@opam:v0.14.0@10b020a8": {
@@ -1943,13 +1975,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d": {
@@ -1972,13 +2004,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_here@opam:v0.14.0@5ccc1c01": {
@@ -2000,12 +2032,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_hash@opam:v0.14.0@8e9618e4": {
@@ -2029,14 +2061,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_enumerate@opam:v0.14.0@63db8245": {
@@ -2058,12 +2090,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d": {
@@ -2179,12 +2211,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_cold@opam:v0.14.0@345dec7c": {
@@ -2206,12 +2238,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_base@opam:v0.14.0@b4702ed9": {
@@ -2275,7 +2307,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -2284,7 +2316,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9": {
@@ -2306,6 +2338,39 @@
         "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@opam/base-bigarray@opam:base@b03491b0"
+      ]
+    },
+    "@opam/odoc@opam:1.5.1@52a58c0b": {
+      "id": "@opam/odoc@opam:1.5.1@52a58c0b",
+      "name": "@opam/odoc",
+      "version": "opam:1.5.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/ea/ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f",
+          "archive:https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+        ],
+        "opam": {
+          "name": "odoc",
+          "version": "1.5.1",
+          "path": "esy.lock/opam/odoc.1.5.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8"
       ]
     },
     "@opam/octavius@opam:1.2.2@b328d1f1": {
@@ -2359,6 +2424,51 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/ocamlformat@opam:0.15.0@8e036963": {
+      "id": "@opam/ocamlformat@opam:0.15.0@8e036963",
+      "name": "@opam/ocamlformat",
+      "version": "opam:0.15.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/26/263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005",
+          "archive:https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+        ],
+        "opam": {
+          "name": "ocamlformat",
+          "version": "0.15.0",
+          "path": "esy.lock/opam/ocamlformat.0.15.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
@@ -2729,12 +2839,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
@@ -2758,14 +2868,14 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2786,15 +2896,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt@opam:4.5.0@677655b4": {
-      "id": "@opam/lwt@opam:4.5.0@677655b4",
+    "@opam/lwt@opam:4.5.0@542100aa": {
+      "id": "@opam/lwt@opam:4.5.0@542100aa",
       "name": "@opam/lwt",
       "version": "opam:4.5.0",
       "source": {
@@ -2891,7 +3001,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2919,7 +3030,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2929,7 +3040,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b"
       ]
@@ -2981,14 +3092,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/jane-street-headers@opam:v0.14.0@59432b6a": {
@@ -3061,8 +3172,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/fpath@opam:0.7.2@45477b93": {
-      "id": "@opam/fpath@opam:0.7.2@45477b93",
+    "@opam/fpath@opam:0.7.2@3fd2da53": {
+      "id": "@opam/fpath@opam:0.7.2@3fd2da53",
       "name": "@opam/fpath",
       "version": "opam:0.7.2",
       "source": {
@@ -3132,6 +3243,7 @@
         "@opam/seq@opam:base@d8d7de1d",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3494,6 +3606,28 @@
       ],
       "devDependencies": []
     },
+    "@opam/cmdliner@opam:1.0.4@93208aac": {
+      "id": "@opam/cmdliner@opam:1.0.4@93208aac",
+      "name": "@opam/cmdliner",
+      "version": "opam:1.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fe/fe2213d0bc63b1e10a2d0aa66d2fc8d9#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9",
+          "archive:http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+        ],
+        "opam": {
+          "name": "cmdliner",
+          "version": "1.0.4",
+          "path": "esy.lock/opam/cmdliner.1.0.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
+    },
     "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
       "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
@@ -3570,7 +3704,7 @@
         "@opam/rresult@opam:0.6.0@4b185e72",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8",
@@ -3578,7 +3712,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8"
@@ -3735,8 +3869,8 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "@opam/base@opam:v0.14.0@b8817fc1": {
-      "id": "@opam/base@opam:v0.14.0@b8817fc1",
+    "@opam/base@opam:v0.14.0@8bc55fce": {
+      "id": "@opam/base@opam:v0.14.0@8bc55fce",
       "name": "@opam/base",
       "version": "opam:v0.14.0",
       "source": {

--- a/esy.lock/opam/base.v0.14.0/opam
+++ b/esy.lock/opam/base.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"             {>= "4.07.0"}
+  "ocaml"             {>= "4.07.0" & < "4.12"}
   "sexplib0"          {>= "v0.14" & < "v0.15"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"

--- a/esy.lock/opam/cmdliner.1.0.4/opam
+++ b/esy.lock/opam/cmdliner.1.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+depends:[ "ocaml" {>= "4.03.0"} ]
+build: [[ make "all" "PREFIX=%{prefix}%" ]]
+install:
+[[make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%" ]
+ [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"  ]]
+
+synopsis: """Declarative definition of command line interfaces for OCaml"""
+description: """\
+
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+"""
+url {
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz"
+checksum: "fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+}

--- a/esy.lock/opam/fpath.0.7.2/opam
+++ b/esy.lock/opam/fpath.0.7.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fpath/issues"
 tags: [ "file" "system" "path" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.12"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/esy.lock/opam/lwt.4.5.0/opam
+++ b/esy.lock/opam/lwt.4.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.12"}
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/esy.lock/opam/ocamlformat.0.15.0/opam
+++ b/esy.lock/opam/ocamlformat.0.15.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.12"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "e9e70f4d3aea202ec8ea4afd7ccb828b36822799"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz"
+  checksum: [
+    "sha256=263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+    "sha512=2bc0b826567fa71201031a730568b822938c66c56da47b05b8896b68439da3d0a8b9bc552fa5cacab95bf9192a1b6e583655fd90095aa686daa91cd2bdf4725a"
+  ]
+}

--- a/esy.lock/opam/odoc.1.5.1/opam
+++ b/esy.lock/opam/odoc.1.5.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune"
+  "fpath"
+  "ocaml" {>= "4.02.0" & < "4.12"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz"
+  checksum: [
+    "sha256=ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+    "sha512=b2d12277d61e1e52354128d459d2ad49bea24a4d46db89790769c2843c4b00beaee3ea7d0215211079174c0bd893de6bf52dcbb71e46622728be7491d91058b2"
+  ]
+}

--- a/esy.lock/opam/uuseg.13.0.0/opam
+++ b/esy.lock/opam/uuseg.13.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.03.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uucp" {>= "13.0.0" & < "14.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+checksum: "a07a97fff61da604614ea8da0547ef6a"
+}

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,132 +1,57 @@
 (executables
-    (names InsertModeTest
-           ClipboardInsertModePasteMultiLineTest
-           ClipboardInsertModePasteSingleLineTest
-           ClipboardInsertModePasteEmptyTest
-           ClipboardNormalModePasteTest
-           ClipboardYankTest
-           ClipboardxpTest
-           ClipboardyypTest
-           CopyActiveFilepathToClipboardTest
-           EchoNotificationTest
-           EditorFontFromPathTest
-           EditorFontValidTest
-           EditorUtf8Test
-           ExCommandKeybindingTest
-           ExCommandKeybindingWithArgsTest
-           ExtConfigurationChangedTest
-           ExtHostBufferOpenTest
-           ExtHostBufferUpdatesTest
-           ExtHostCompletionTest
-           ExtHostDefinitionTest
-           FileWatcherTest
-           KeybindingsInvalidJsonTest
-           KeySequenceJJTest
-           InputIgnoreTest
-           LanguageCssTest
-           LanguageTypeScriptTest
-           LineEndingsLFTest
-           LineEndingsCRLFTest
-           QuickOpenEventuallyCompletesTest
-           SearchShowClearHighlightsTest
-           SyntaxServer
-           SyntaxServerCloseTest
-           SyntaxServerMessageExceptionTest
-           SyntaxServerParentPidTest
-           SyntaxServerParentPidCorrectTest
-           SyntaxServerReadExceptionTest
-           Regression1671Test
-           Regression2349EnewTest
-           RegressionCommandLineNoCompletionTest
-           RegressionFontFallbackTest
-           RegressionFileModifiedIndicationTest
-           RegressionNonExistentDirectory
-           RegressionVspEmptyInitialBufferTest
-           RegressionVspEmptyExistingBufferTest
-           SCMGitTest
-           SyntaxHighlightTextMateTest
-           SyntaxHighlightTreesitterTest
-           AddRemoveSplitTest
-           TerminalSetPidTitleTest
-           TerminalConfigurationTest
-           TypingBatchedTest
-           TypingUnbatchedTest
-           VimlConfigurationTest
-           ZenModeSingleFileModeTest
-           ZenModeSplitTest
-    )
-    (libraries
-        Oni_CLI
-        Oni_IntegrationTestLib
-        reason-native-crash-utils.asan
-))
+ (names InsertModeTest ClipboardInsertModePasteMultiLineTest
+   ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
+   ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
+   ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
+   EditorFontFromPathTest EditorFontValidTest EditorUtf8Test
+   ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
+   ExtConfigurationChangedTest ExtHostBufferOpenTest ExtHostBufferUpdatesTest
+   ExtHostCompletionTest ExtHostDefinitionTest FileWatcherTest
+   KeybindingsInvalidJsonTest KeySequenceJJTest InputIgnoreTest
+   LanguageCssTest LanguageTypeScriptTest LineEndingsLFTest
+   LineEndingsCRLFTest QuickOpenEventuallyCompletesTest
+   SearchShowClearHighlightsTest SyntaxServer SyntaxServerCloseTest
+   SyntaxServerMessageExceptionTest SyntaxServerParentPidTest
+   SyntaxServerParentPidCorrectTest SyntaxServerReadExceptionTest
+   Regression1671Test Regression2349EnewTest
+   RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
+   RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
+   RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
+   SCMGitTest SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
+   AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
+   TypingBatchedTest TypingUnbatchedTest VimlConfigurationTest
+   ZenModeSingleFileModeTest ZenModeSplitTest)
+ (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
-    (section bin)
-    (package OniIntegrationTests)
-    (files 
-        run-tests.sh
-        InsertModeTest.exe
-        ClipboardInsertModePasteMultiLineTest.exe
-        ClipboardInsertModePasteSingleLineTest.exe
-        ClipboardInsertModePasteEmptyTest.exe
-        ClipboardNormalModePasteTest.exe
-        ClipboardYankTest.exe
-        ClipboardxpTest.exe
-        ClipboardyypTest.exe
-        CopyActiveFilepathToClipboardTest.exe
-        EchoNotificationTest.exe
-        EditorFontFromPathTest.exe
-        EditorFontValidTest.exe
-        EditorUtf8Test.exe
-        ExCommandKeybindingTest.exe
-        ExCommandKeybindingWithArgsTest.exe
-        ExtConfigurationChangedTest.exe
-        ExtHostBufferOpenTest.exe
-        ExtHostBufferUpdatesTest.exe
-        ExtHostCompletionTest.exe
-        ExtHostDefinitionTest.exe
-        FileWatcherTest.exe
-        KeybindingsInvalidJsonTest.exe
-        KeySequenceJJTest.exe
-        InputIgnoreTest.exe
-        LanguageCssTest.exe
-        LanguageTypeScriptTest.exe
-        LineEndingsCRLFTest.exe
-        LineEndingsLFTest.exe
-        QuickOpenEventuallyCompletesTest.exe
-        Regression1671Test.exe
-        Regression2349EnewTest.exe
-        RegressionCommandLineNoCompletionTest.exe
-        RegressionFileModifiedIndicationTest.exe
-        RegressionFontFallbackTest.exe
-        RegressionVspEmptyInitialBufferTest.exe
-        RegressionNonExistentDirectory.exe
-        RegressionVspEmptyExistingBufferTest.exe
-        SCMGitTest.exe
-        SearchShowClearHighlightsTest.exe
-        SyntaxHighlightTextMateTest.exe
-        SyntaxHighlightTreesitterTest.exe
-        SyntaxServer.exe
-        SyntaxServerCloseTest.exe
-        SyntaxServerMessageExceptionTest.exe
-        SyntaxServerParentPidTest.exe
-        SyntaxServerParentPidCorrectTest.exe
-        SyntaxServerReadExceptionTest.exe
-        TerminalSetPidTitleTest.exe
-        TerminalConfigurationTest.exe
-        AddRemoveSplitTest.exe
-        TypingBatchedTest.exe
-        TypingUnbatchedTest.exe
-        VimlConfigurationTest.exe
-        ZenModeSingleFileModeTest.exe
-        ZenModeSplitTest.exe
-        large-c-file.c
-        lsan.supp
-        some-test-file.json
-        some-test-file.txt
-        test.crlf
-        test.lf
-        utf8.txt
-        utf8-test-file.htm
-))
+ (section bin)
+ (package OniIntegrationTests)
+ (files run-tests.sh InsertModeTest.exe
+   ClipboardInsertModePasteMultiLineTest.exe
+   ClipboardInsertModePasteSingleLineTest.exe
+   ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
+   ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
+   CopyActiveFilepathToClipboardTest.exe EchoNotificationTest.exe
+   EditorFontFromPathTest.exe EditorFontValidTest.exe EditorUtf8Test.exe
+   ExCommandKeybindingTest.exe ExCommandKeybindingWithArgsTest.exe
+   ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
+   ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
+   ExtHostDefinitionTest.exe FileWatcherTest.exe
+   KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
+   LanguageCssTest.exe LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe
+   LineEndingsLFTest.exe QuickOpenEventuallyCompletesTest.exe
+   Regression1671Test.exe Regression2349EnewTest.exe
+   RegressionCommandLineNoCompletionTest.exe
+   RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
+   RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe
+   RegressionVspEmptyExistingBufferTest.exe SCMGitTest.exe
+   SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
+   SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
+   SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
+   SyntaxServerParentPidTest.exe SyntaxServerParentPidCorrectTest.exe
+   SyntaxServerReadExceptionTest.exe TerminalSetPidTitleTest.exe
+   TerminalConfigurationTest.exe AddRemoveSplitTest.exe TypingBatchedTest.exe
+   TypingUnbatchedTest.exe VimlConfigurationTest.exe
+   ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe large-c-file.c
+   lsan.supp some-test-file.json some-test-file.txt test.crlf test.lf
+   utf8.txt utf8-test-file.htm))

--- a/integration_test/lib/dune
+++ b/integration_test/lib/dune
@@ -1,5 +1,7 @@
 (library
-    (name Oni_IntegrationTestLib)
-    (modules (:standard))
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show))
-    (libraries Oni2.feature.terminal Oni2.store Oni2.model Oni2.core Oni2.syntax_server))
+ (name Oni_IntegrationTestLib)
+ (modules (:standard))
+ (preprocess
+  (pps brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show))
+ (libraries Oni2.feature.terminal Oni2.store Oni2.model Oni2.core
+   Oni2.syntax_server))

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "49cf8ac34f4b9ee68bdb75d9ab359e2b",
+  "checksum": "e77e22f99ed9e9a0a930e9ed15400c83",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -150,7 +150,7 @@
         "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -207,9 +207,9 @@
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lambda-term@opam:3.1.0@8adc2660",
-        "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/fpath@opam:0.7.2@3fd2da53", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/reason@3.6.2@d41d8cd9"
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.0@e0bac278" ]
@@ -960,8 +960,9 @@
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
         "@opam/ppx_deriving@opam:4.5@d89f2934",
+        "@opam/ocamlformat@opam:0.15.0@8e036963",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/logs@opam:0.7.0@1d03143e",
@@ -1211,10 +1212,40 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+      ]
+    },
+    "@opam/uuseg@opam:13.0.0@f60712a7": {
+      "id": "@opam/uuseg@opam:13.0.0@f60712a7",
+      "name": "@opam/uuseg",
+      "version": "opam:13.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a0/a07a97fff61da604614ea8da0547ef6a#md5:a07a97fff61da604614ea8da0547ef6a",
+          "archive:https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz#md5:a07a97fff61da604614ea8da0547ef6a"
+        ],
+        "opam": {
+          "name": "uuseg",
+          "version": "13.0.0",
+          "path": "integrationtest.esy.lock/opam/uuseg.13.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uucp@opam:13.0.0@e9b515e0", "@opam/topkg@opam:1.0.2@3c5942ad",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uucp@opam:13.0.0@e9b515e0"
       ]
     },
     "@opam/uucp@opam:13.0.0@e9b515e0": {
@@ -1239,6 +1270,7 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -1367,7 +1399,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -1375,7 +1407,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/stdlib-shims@opam:0.1.0@8c116481": {
@@ -1422,12 +1454,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/sexplib0@opam:v0.14.0@ddeb6438": {
@@ -1858,13 +1890,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_optcomp@opam:v0.14.0@d77a04c2": {
@@ -1887,13 +1919,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_let@opam:v0.14.0@eb9b93e0": {
@@ -1915,12 +1947,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_js_style@opam:v0.14.0@10b020a8": {
@@ -1943,13 +1975,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d": {
@@ -1972,13 +2004,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_here@opam:v0.14.0@5ccc1c01": {
@@ -2000,12 +2032,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_hash@opam:v0.14.0@8e9618e4": {
@@ -2029,14 +2061,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_enumerate@opam:v0.14.0@63db8245": {
@@ -2058,12 +2090,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d": {
@@ -2179,12 +2211,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_cold@opam:v0.14.0@345dec7c": {
@@ -2206,12 +2238,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_base@opam:v0.14.0@b4702ed9": {
@@ -2275,7 +2307,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -2284,7 +2316,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9": {
@@ -2306,6 +2338,39 @@
         "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@opam/base-bigarray@opam:base@b03491b0"
+      ]
+    },
+    "@opam/odoc@opam:1.5.1@52a58c0b": {
+      "id": "@opam/odoc@opam:1.5.1@52a58c0b",
+      "name": "@opam/odoc",
+      "version": "opam:1.5.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/ea/ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f",
+          "archive:https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+        ],
+        "opam": {
+          "name": "odoc",
+          "version": "1.5.1",
+          "path": "integrationtest.esy.lock/opam/odoc.1.5.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8"
       ]
     },
     "@opam/octavius@opam:1.2.2@b328d1f1": {
@@ -2359,6 +2424,51 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/ocamlformat@opam:0.15.0@8e036963": {
+      "id": "@opam/ocamlformat@opam:0.15.0@8e036963",
+      "name": "@opam/ocamlformat",
+      "version": "opam:0.15.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/26/263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005",
+          "archive:https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+        ],
+        "opam": {
+          "name": "ocamlformat",
+          "version": "0.15.0",
+          "path": "integrationtest.esy.lock/opam/ocamlformat.0.15.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
@@ -2730,12 +2840,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
@@ -2759,14 +2869,14 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2787,15 +2897,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt@opam:4.5.0@677655b4": {
-      "id": "@opam/lwt@opam:4.5.0@677655b4",
+    "@opam/lwt@opam:4.5.0@542100aa": {
+      "id": "@opam/lwt@opam:4.5.0@542100aa",
       "name": "@opam/lwt",
       "version": "opam:4.5.0",
       "source": {
@@ -2892,7 +3002,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2920,7 +3031,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2930,7 +3041,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b"
       ]
@@ -2982,14 +3093,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/jane-street-headers@opam:v0.14.0@59432b6a": {
@@ -3062,8 +3173,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/fpath@opam:0.7.2@45477b93": {
-      "id": "@opam/fpath@opam:0.7.2@45477b93",
+    "@opam/fpath@opam:0.7.2@3fd2da53": {
+      "id": "@opam/fpath@opam:0.7.2@3fd2da53",
       "name": "@opam/fpath",
       "version": "opam:0.7.2",
       "source": {
@@ -3133,6 +3244,7 @@
         "@opam/seq@opam:base@d8d7de1d",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3495,6 +3607,28 @@
       ],
       "devDependencies": []
     },
+    "@opam/cmdliner@opam:1.0.4@93208aac": {
+      "id": "@opam/cmdliner@opam:1.0.4@93208aac",
+      "name": "@opam/cmdliner",
+      "version": "opam:1.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fe/fe2213d0bc63b1e10a2d0aa66d2fc8d9#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9",
+          "archive:http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+        ],
+        "opam": {
+          "name": "cmdliner",
+          "version": "1.0.4",
+          "path": "integrationtest.esy.lock/opam/cmdliner.1.0.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
+    },
     "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
       "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
@@ -3571,7 +3705,7 @@
         "@opam/rresult@opam:0.6.0@4b185e72",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8",
@@ -3579,7 +3713,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8"
@@ -3736,8 +3870,8 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "@opam/base@opam:v0.14.0@b8817fc1": {
-      "id": "@opam/base@opam:v0.14.0@b8817fc1",
+    "@opam/base@opam:v0.14.0@8bc55fce": {
+      "id": "@opam/base@opam:v0.14.0@8bc55fce",
       "name": "@opam/base",
       "version": "opam:v0.14.0",
       "source": {

--- a/integrationtest.esy.lock/opam/base.v0.14.0/opam
+++ b/integrationtest.esy.lock/opam/base.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"             {>= "4.07.0"}
+  "ocaml"             {>= "4.07.0" & < "4.12"}
   "sexplib0"          {>= "v0.14" & < "v0.15"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"

--- a/integrationtest.esy.lock/opam/cmdliner.1.0.4/opam
+++ b/integrationtest.esy.lock/opam/cmdliner.1.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+depends:[ "ocaml" {>= "4.03.0"} ]
+build: [[ make "all" "PREFIX=%{prefix}%" ]]
+install:
+[[make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%" ]
+ [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"  ]]
+
+synopsis: """Declarative definition of command line interfaces for OCaml"""
+description: """\
+
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+"""
+url {
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz"
+checksum: "fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+}

--- a/integrationtest.esy.lock/opam/fpath.0.7.2/opam
+++ b/integrationtest.esy.lock/opam/fpath.0.7.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fpath/issues"
 tags: [ "file" "system" "path" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.12"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/integrationtest.esy.lock/opam/lwt.4.5.0/opam
+++ b/integrationtest.esy.lock/opam/lwt.4.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.12"}
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/integrationtest.esy.lock/opam/ocamlformat.0.15.0/opam
+++ b/integrationtest.esy.lock/opam/ocamlformat.0.15.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.12"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "e9e70f4d3aea202ec8ea4afd7ccb828b36822799"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz"
+  checksum: [
+    "sha256=263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+    "sha512=2bc0b826567fa71201031a730568b822938c66c56da47b05b8896b68439da3d0a8b9bc552fa5cacab95bf9192a1b6e583655fd90095aa686daa91cd2bdf4725a"
+  ]
+}

--- a/integrationtest.esy.lock/opam/odoc.1.5.1/opam
+++ b/integrationtest.esy.lock/opam/odoc.1.5.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune"
+  "fpath"
+  "ocaml" {>= "4.02.0" & < "4.12"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz"
+  checksum: [
+    "sha256=ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+    "sha512=b2d12277d61e1e52354128d459d2ad49bea24a4d46db89790769c2843c4b00beaee3ea7d0215211079174c0bd893de6bf52dcbb71e46622728be7491d91058b2"
+  ]
+}

--- a/integrationtest.esy.lock/opam/uuseg.13.0.0/opam
+++ b/integrationtest.esy.lock/opam/uuseg.13.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.03.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uucp" {>= "13.0.0" & < "14.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+checksum: "a07a97fff61da604614ea8da0547ef6a"
+}

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "@opam/lwt": "*",
     "@opam/markup": "^0.8.2",
     "@opam/ocamlbuild": "*",
+    "@opam/ocamlformat": "^0.15.0",
     "@opam/ppx_deriving": "*",
     "@opam/ppx_deriving_yojson": "*",
     "@opam/ppx_inline_test": "v0.14.1",

--- a/src/CLI/dune
+++ b/src/CLI/dune
@@ -1,10 +1,7 @@
 (library
-    (name Oni_CLI)
-    (public_name Oni2.cli)
-    (inline_tests)
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test))
-    (libraries 
-        Oni2.core
-        Revery
-        ppx_deriving.runtime
-    ))
+ (name Oni_CLI)
+ (public_name Oni2.cli)
+ (inline_tests)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test))
+ (libraries Oni2.core Revery ppx_deriving.runtime))

--- a/src/Components/dune
+++ b/src/Components/dune
@@ -1,23 +1,9 @@
 (library
-    (name Oni_Components)
-    (public_name Oni2.components)
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show))
-    (libraries 
-        str
-        bigarray
-        Revery.zed
-        lwt
-        lwt.unix
-        Oni2.core
-        Oni2.input
-        Oni2.syntax
-        Oni2.exthost
-        Oni2.service.font
-        Oni2.service.net
-        Oni2.feature.sneak
-        Oni2.feature.theme
-        Rench
-        Revery
-        Oni2.editor-core-types
-        isolinear
-    ))
+ (name Oni_Components)
+ (public_name Oni2.components)
+ (preprocess
+  (pps brisk-reconciler.ppx ppx_deriving.show))
+ (libraries str bigarray Revery.zed lwt lwt.unix Oni2.core Oni2.input
+   Oni2.syntax Oni2.exthost Oni2.service.font Oni2.service.net
+   Oni2.feature.sneak Oni2.feature.theme Rench Revery Oni2.editor-core-types
+   isolinear))

--- a/src/Core/Kernel/dune
+++ b/src/Core/Kernel/dune
@@ -1,12 +1,7 @@
 (library
-    (name Kernel)
-    (public_name Oni2.core.kernel)
-    (libraries 
-        yojson
-        ppx_deriving.runtime
-        ppx_deriving_yojson.runtime
-        Revery.zed
-        threads
-        Oni2.editor-core-types
-        timber)
-    (preprocess (pps lwt_ppx ppx_deriving_yojson ppx_deriving.show)))
+ (name Kernel)
+ (public_name Oni2.core.kernel)
+ (libraries yojson ppx_deriving.runtime ppx_deriving_yojson.runtime
+   Revery.zed threads Oni2.editor-core-types timber)
+ (preprocess
+  (pps lwt_ppx ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Core/Utility/dune
+++ b/src/Core/Utility/dune
@@ -1,14 +1,7 @@
 (library
-    (name Utility)
-    (public_name Oni2.core.utility)
-    (libraries 
-        Oni2.core.kernel
-        libvim
-        oniguruma
-        str
-        luv
-        lwt
-        Revery
-        timber)
-    (inline_tests)
-    (preprocess (pps lwt_ppx ppx_inline_test)))
+ (name Utility)
+ (public_name Oni2.core.utility)
+ (libraries Oni2.core.kernel libvim oniguruma str luv lwt Revery timber)
+ (inline_tests)
+ (preprocess
+  (pps lwt_ppx ppx_inline_test)))

--- a/src/Core/WhenExpr/dune
+++ b/src/Core/WhenExpr/dune
@@ -1,5 +1,6 @@
 (library
-    (name WhenExpr)
-    (public_name Oni2.core.whenExpr)
-    (preprocess (pps ppx_deriving.show))
-    (libraries Oni2.core.kernel re timber oniguruma))
+ (name WhenExpr)
+ (public_name Oni2.core.whenExpr)
+ (preprocess
+  (pps ppx_deriving.show))
+ (libraries Oni2.core.kernel re timber oniguruma))

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -1,26 +1,15 @@
 (rule
-    (targets BuildInfo.re)
-    (deps (:generator ../gen_buildinfo/generator.exe))
-    (action (run %{generator}))
-)
+ (targets BuildInfo.re)
+ (deps
+  (:generator ../gen_buildinfo/generator.exe))
+ (action
+  (run %{generator})))
 
 (library
-    (name Oni_Core)
-    (public_name Oni2.core)
-    (libraries 
-        Oni2.core.kernel
-        Oni2.core.utility
-        Oni2.core.whenExpr
-        isolinear
-        Rench
-        Revery
-        yojson
-        ppx_deriving.runtime
-        ppx_deriving_yojson.runtime
-        Oni2.editor-core-types
-        timber
-        ReasonFuzz
-        decoders-yojson
-        angstrom
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show)))
+ (name Oni_Core)
+ (public_name Oni2.core)
+ (libraries Oni2.core.kernel Oni2.core.utility Oni2.core.whenExpr isolinear
+   Rench Revery yojson ppx_deriving.runtime ppx_deriving_yojson.runtime
+   Oni2.editor-core-types timber ReasonFuzz decoders-yojson angstrom)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Exthost/Extension/dune
+++ b/src/Exthost/Extension/dune
@@ -1,6 +1,8 @@
 (library
-    (name Exthost_Extension)
-    (public_name Oni2.exthost.extension)
-    (inline_tests)
-    (libraries Oni2.core Oni2.core.whenExpr Rench luv re timber yojson decoders-yojson)
-    (preprocess (pps ppx_deriving.show ppx_deriving_yojson ppx_inline_test)))
+ (name Exthost_Extension)
+ (public_name Oni2.exthost.extension)
+ (inline_tests)
+ (libraries Oni2.core Oni2.core.whenExpr Rench luv re timber yojson
+   decoders-yojson)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving_yojson ppx_inline_test)))

--- a/src/Exthost/Protocol/dune
+++ b/src/Exthost/Protocol/dune
@@ -1,5 +1,7 @@
 (library
-    (name Exthost_Protocol)
-    (public_name Oni2.exthost.protocol)
-    (libraries luv Oni2.exthost.extension Oni2.exthost.transport Oni2.core yojson decoders-yojson)
-    (preprocess (pps ppx_deriving.show ppx_deriving_yojson)))
+ (name Exthost_Protocol)
+ (public_name Oni2.exthost.protocol)
+ (libraries luv Oni2.exthost.extension Oni2.exthost.transport Oni2.core
+   yojson decoders-yojson)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving_yojson)))

--- a/src/Exthost/Transport/dune
+++ b/src/Exthost/Transport/dune
@@ -1,5 +1,6 @@
 (library
-    (name Exthost_Transport)
-    (public_name Oni2.exthost.transport)
-    (libraries timber luv yojson decoders-yojson)
-    (preprocess (pps ppx_deriving.show ppx_deriving_yojson)))
+ (name Exthost_Transport)
+ (public_name Oni2.exthost.transport)
+ (libraries timber luv yojson decoders-yojson)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving_yojson)))

--- a/src/Exthost/dune
+++ b/src/Exthost/dune
@@ -1,6 +1,9 @@
 (library
-    (name Exthost)
-    (inline_tests)
-    (libraries timber base Oni2.core Oni2.core.kernel Oni2.exthost.extension Oni2.exthost.protocol Oni2.exthost.transport luv Oni2.service.os Oni2.service.net yojson decoders-yojson)
-    (preprocess (pps ppx_let ppx_deriving.show ppx_deriving_yojson ppx_inline_test))
-    (public_name Oni2.exthost))
+ (name Exthost)
+ (inline_tests)
+ (libraries timber base Oni2.core Oni2.core.kernel Oni2.exthost.extension
+   Oni2.exthost.protocol Oni2.exthost.transport luv Oni2.service.os
+   Oni2.service.net yojson decoders-yojson)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving_yojson ppx_inline_test))
+ (public_name Oni2.exthost))

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -1,12 +1,7 @@
 (library
-    (name Feature_Buffers)
-    (public_name Oni2.feature.buffers)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.service.exthost
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Buffers)
+ (public_name Oni2.feature.buffers)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.service.exthost Revery
+   isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Changelog/dune
+++ b/src/Feature/Changelog/dune
@@ -1,12 +1,7 @@
 (library
-    (name Feature_Changelog)
-    (public_name Oni2.feature.changelog)
-    (libraries
-      Oni2.core
-      Oni2.components
-      Oni2.feature.theme
-      Oni2.service.os
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Changelog)
+ (public_name Oni2.feature.changelog)
+ (libraries Oni2.core Oni2.components Oni2.feature.theme Oni2.service.os
+   Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Clipboard/dune
+++ b/src/Feature/Clipboard/dune
@@ -1,11 +1,7 @@
 (library
-    (name Feature_Clipboard)
-    (public_name Oni2.feature.clipboard)
-    (libraries 
-      Oni2.core
-      isolinear
-      base
-      Oni2.feature.commands
-      Oni2.service.clipboard
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Feature_Clipboard)
+ (public_name Oni2.feature.clipboard)
+ (libraries Oni2.core isolinear base Oni2.feature.commands
+   Oni2.service.clipboard)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Feature/Commands/dune
+++ b/src/Feature/Commands/dune
@@ -1,9 +1,6 @@
 (library
-    (name Feature_Commands)
-    (public_name Oni2.feature.commands)
-    (libraries 
-      Oni2.core
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Feature_Commands)
+ (public_name Oni2.feature.commands)
+ (libraries Oni2.core isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Feature/Configuration/dune
+++ b/src/Feature/Configuration/dune
@@ -1,11 +1,6 @@
 (library
-    (name Feature_Configuration)
-    (public_name Oni2.feature.configuration)
-    (libraries 
-      Oni2.core
-      Oni2.exthost
-      Oni2.feature.vim
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Feature_Configuration)
+ (public_name Oni2.feature.configuration)
+ (libraries Oni2.core Oni2.exthost Oni2.feature.vim isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Feature/ContextMenu/dune
+++ b/src/Feature/ContextMenu/dune
@@ -1,9 +1,6 @@
 (library
-    (name Feature_ContextMenu)
-    (public_name Oni2.feature.contextMenu)
-    (libraries
-      Oni2.core
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_ContextMenu)
+ (public_name Oni2.feature.contextMenu)
+ (libraries Oni2.core Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Editor/dune
+++ b/src/Feature/Editor/dune
@@ -1,20 +1,10 @@
 (library
-    (name Feature_Editor)
-    (public_name Oni2.feature.editor)
-    (inline_tests)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.components
-      Oni2.exthost
-      Oni2.syntax
-      Oni2.feature.scm
-      Oni2.feature.theme
-      Oni2.feature.language_support
-      Oni2.feature.syntax
-      Oni2.service.font
-      Oni2.service.os
-      Revery
-      libvim
-    )
-    (preprocess (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))
+ (name Feature_Editor)
+ (public_name Oni2.feature.editor)
+ (inline_tests)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.components Oni2.exthost
+   Oni2.syntax Oni2.feature.scm Oni2.feature.theme
+   Oni2.feature.language_support Oni2.feature.syntax Oni2.service.font
+   Oni2.service.os Revery libvim)
+ (preprocess
+  (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Extensions/dune
+++ b/src/Feature/Extensions/dune
@@ -1,16 +1,9 @@
 (library
-    (name Feature_Extensions)
-    (public_name Oni2.feature.extensions)
-    (inline_tests)
-    (libraries
-      Oni2.core
-      Oni2.components
-      Oni2.exthost
-      Oni2.feature.inputText
-      Oni2.service.extensions
-      Oni2.service.exthost
-      Oni2.feature.sneak
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))
+ (name Feature_Extensions)
+ (public_name Oni2.feature.extensions)
+ (inline_tests)
+ (libraries Oni2.core Oni2.components Oni2.exthost Oni2.feature.inputText
+   Oni2.service.extensions Oni2.service.exthost Oni2.feature.sneak Revery
+   isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Exthost/dune
+++ b/src/Feature/Exthost/dune
@@ -1,15 +1,7 @@
 (library
-    (name Feature_Exthost)
-    (public_name Oni2.feature.exthost)
-    (libraries
-      Oni2.core
-      Oni2.components
-      Oni2.exthost
-      Oni2.feature.buffers
-      Oni2.feature.editor
-      Oni2.service.exthost
-      Oni2.service.vim
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Exthost)
+ (public_name Oni2.feature.exthost)
+ (libraries Oni2.core Oni2.components Oni2.exthost Oni2.feature.buffers
+   Oni2.feature.editor Oni2.service.exthost Oni2.service.vim Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/ImagePreview/dune
+++ b/src/Feature/ImagePreview/dune
@@ -1,13 +1,7 @@
 (library
-    (name Feature_ImagePreview)
-    (public_name Oni2.feature.imagePreview)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.feature.theme
-      Oni2.components
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_ImagePreview)
+ (public_name Oni2.feature.imagePreview)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.feature.theme
+   Oni2.components Revery isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/InputText/dune
+++ b/src/Feature/InputText/dune
@@ -1,12 +1,7 @@
 (library
-    (name Feature_InputText)
-    (public_name Oni2.feature.inputText)
-    (inline_tests)
-    (libraries
-      Oni2.core
-      Oni2.components
-      Revery
-      isolinear
-      Oni2.feature.sneak
-    )
-    (preprocess (pps ppx_inline_test ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_InputText)
+ (public_name Oni2.feature.inputText)
+ (inline_tests)
+ (libraries Oni2.core Oni2.components Revery isolinear Oni2.feature.sneak)
+ (preprocess
+  (pps ppx_inline_test ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/LanguageSupport/dune
+++ b/src/Feature/LanguageSupport/dune
@@ -1,17 +1,9 @@
 (library
-    (name Feature_LanguageSupport)
-    (public_name Oni2.feature.language_support)
-    (inline_tests)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.syntax
-      Oni2.feature.commands
-      Oni2.feature.inputText
-      Oni2.service.exthost
-      Oni2.service.font
-      Oni2.service.vim
-      Oni2.input
-      uucp
-    )
-    (preprocess (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))
+ (name Feature_LanguageSupport)
+ (public_name Oni2.feature.language_support)
+ (inline_tests)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.syntax
+   Oni2.feature.commands Oni2.feature.inputText Oni2.service.exthost
+   Oni2.service.font Oni2.service.vim Oni2.input uucp)
+ (preprocess
+  (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Layout/dune
+++ b/src/Feature/Layout/dune
@@ -1,15 +1,8 @@
 (library
-    (name Feature_Layout)
-    (public_name Oni2.feature.layout)
-    (inline_tests)
-    (libraries 
-      Oni2.core
-      isolinear
-      base
-      Oni2.components
-      Oni2.feature.sneak
-      Oni2.feature.commands
-      Oni2.feature.theme
-      Oni2.feature.editor
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))
+ (name Feature_Layout)
+ (public_name Oni2.feature.layout)
+ (inline_tests)
+ (libraries Oni2.core isolinear base Oni2.components Oni2.feature.sneak
+   Oni2.feature.commands Oni2.feature.theme Oni2.feature.editor)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Menus/dune
+++ b/src/Feature/Menus/dune
@@ -1,12 +1,7 @@
 (library
-    (name Feature_Menus)
-    (public_name Oni2.feature.menus)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.core.whenExpr
-      Oni2.feature.commands
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Feature_Menus)
+ (public_name Oni2.feature.menus)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.core.whenExpr
+   Oni2.feature.commands isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Feature/Messages/dune
+++ b/src/Feature/Messages/dune
@@ -1,13 +1,7 @@
 (library
-    (name Feature_Messages)
-    (public_name Oni2.feature.messages)
-    (libraries 
-      Oni2.core
-      Oni2.exthost
-      Oni2.feature.notification
-      Oni2.feature.sneak
-      Oni2.feature.theme
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Messages)
+ (public_name Oni2.feature.messages)
+ (libraries Oni2.core Oni2.exthost Oni2.feature.notification
+   Oni2.feature.sneak Oni2.feature.theme isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Modals/dune
+++ b/src/Feature/Modals/dune
@@ -1,12 +1,7 @@
 (library
-    (name Feature_Modals)
-    (public_name Oni2.feature.modals)
-    (libraries 
-      Oni2.core
-      Oni2.components
-      Oni2.service.vim
-      Oni2.feature.theme
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Modals)
+ (public_name Oni2.feature.modals)
+ (libraries Oni2.core Oni2.components Oni2.service.vim Oni2.feature.theme
+   Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Notification/dune
+++ b/src/Feature/Notification/dune
@@ -1,13 +1,7 @@
-
 (library
-    (name Feature_Notification)
-    (public_name Oni2.feature.notification)
-    (libraries 
-      Oni2.core
-      Oni2.components
-      Oni2.feature.theme
-      isolinear
-      base
-      Revery
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Notification)
+ (public_name Oni2.feature.notification)
+ (libraries Oni2.core Oni2.components Oni2.feature.theme isolinear base
+   Revery)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Pane/dune
+++ b/src/Feature/Pane/dune
@@ -1,12 +1,7 @@
 (library
-    (name Feature_Pane)
-    (public_name Oni2.feature.pane)
-    (libraries 
-      Oni2.core
-      Oni2.components
-      Oni2.feature.theme
-      isolinear
-      base
-      Revery
-    )
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show)))
+ (name Feature_Pane)
+ (public_name Oni2.feature.pane)
+ (libraries Oni2.core Oni2.components Oni2.feature.theme isolinear base
+   Revery)
+ (preprocess
+  (pps brisk-reconciler.ppx ppx_deriving.show)))

--- a/src/Feature/Registers/dune
+++ b/src/Feature/Registers/dune
@@ -1,16 +1,8 @@
 (library
-    (name Feature_Registers)
-    (public_name Oni2.feature.registers)
-    (libraries 
-      Oni2.core
-      Oni2.exthost
-      isolinear
-      base
-      libvim
-      Oni2.feature.commands
-      Oni2.feature.inputText
-      Oni2.feature.theme
-      Oni2.service.font
-      Oni2.service.vim
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Registers)
+ (public_name Oni2.feature.registers)
+ (libraries Oni2.core Oni2.exthost isolinear base libvim
+   Oni2.feature.commands Oni2.feature.inputText Oni2.feature.theme
+   Oni2.service.font Oni2.service.vim)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/SCM/dune
+++ b/src/Feature/SCM/dune
@@ -1,15 +1,8 @@
 (library
-    (name Feature_SCM)
-    (public_name Oni2.feature.scm)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.feature.inputText
-      Oni2.feature.theme
-      Oni2.components
-      Oni2.service.exthost
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_SCM)
+ (public_name Oni2.feature.scm)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.feature.inputText
+   Oni2.feature.theme Oni2.components Oni2.service.exthost Revery isolinear
+   base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Search/dune
+++ b/src/Feature/Search/dune
@@ -1,13 +1,7 @@
 (library
-    (name Feature_Search)
-    (public_name Oni2.feature.search)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.components
-      Oni2.service.font
-      Oni2.feature.inputText
-      Oni2.feature.theme
-      Revery
-    )
-    (preprocess (pps ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Search)
+ (public_name Oni2.feature.search)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.components
+   Oni2.service.font Oni2.feature.inputText Oni2.feature.theme Revery)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/SideBar/dune
+++ b/src/Feature/SideBar/dune
@@ -1,14 +1,7 @@
 (library
-    (name Feature_SideBar)
-    (public_name Oni2.feature.sideBar)
-    (libraries 
-      Oni2.core
-      Oni2.components
-      Oni2.feature.extensions
-      Oni2.feature.scm
-      Oni2.feature.theme
-      isolinear
-      base
-      Revery
-    )
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show)))
+ (name Feature_SideBar)
+ (public_name Oni2.feature.sideBar)
+ (libraries Oni2.core Oni2.components Oni2.feature.extensions
+   Oni2.feature.scm Oni2.feature.theme isolinear base Revery)
+ (preprocess
+  (pps brisk-reconciler.ppx ppx_deriving.show)))

--- a/src/Feature/SignatureHelp/dune
+++ b/src/Feature/SignatureHelp/dune
@@ -1,14 +1,8 @@
 (library
-    (name Feature_SignatureHelp)
-    (public_name Oni2.feature.signature_help)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.syntax
-      Oni2.feature.commands
-      Oni2.feature.editor
-      Oni2.components
-      Oni2.service.exthost
-      uucp
-    )
-    (preprocess (pps ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_SignatureHelp)
+ (public_name Oni2.feature.signature_help)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.syntax
+   Oni2.feature.commands Oni2.feature.editor Oni2.components
+   Oni2.service.exthost uucp)
+ (preprocess
+  (pps ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Sneak/dune
+++ b/src/Feature/Sneak/dune
@@ -1,13 +1,7 @@
 (library
-    (name Feature_Sneak)
-    (public_name Oni2.feature.sneak)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.feature.commands
-      Oni2.feature.theme
-      isolinear
-      Revery
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Sneak)
+ (public_name Oni2.feature.sneak)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.feature.commands
+   Oni2.feature.theme isolinear Revery base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Snippets/dune
+++ b/src/Feature/Snippets/dune
@@ -1,13 +1,8 @@
 (library
-    (name Feature_Snippets)
-    (public_name Oni2.feature.snippets)
-    (inline_tests)
-    (libraries
-      Oni2.core
-      Oni2.components
-      Oni2.feature.theme
-      Oni2.service.os
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))
+ (name Feature_Snippets)
+ (public_name Oni2.feature.snippets)
+ (inline_tests)
+ (libraries Oni2.core Oni2.components Oni2.feature.theme Oni2.service.os
+   Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/StatusBar/dune
+++ b/src/Feature/StatusBar/dune
@@ -1,19 +1,9 @@
 (library
-    (name Feature_StatusBar)
-    (public_name Oni2.feature.statusbar)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.feature.contextMenu
-      Oni2.feature.editor
-      Oni2.feature.language_support
-      Oni2.feature.notification
-      Oni2.feature.scm
-      Oni2.feature.theme
-      Oni2.components
-      Oni2.service.exthost
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_StatusBar)
+ (public_name Oni2.feature.statusbar)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.feature.contextMenu
+   Oni2.feature.editor Oni2.feature.language_support
+   Oni2.feature.notification Oni2.feature.scm Oni2.feature.theme
+   Oni2.components Oni2.service.exthost Revery isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Syntax/dune
+++ b/src/Feature/Syntax/dune
@@ -1,15 +1,7 @@
 (library
-    (name Feature_Syntax)
-    (public_name Oni2.feature.syntax)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.components
-      Oni2.syntax
-      Oni2.syntax_client
-      Oni2.service.syntax
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Syntax)
+ (public_name Oni2.feature.syntax)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.components Oni2.syntax
+   Oni2.syntax_client Oni2.service.syntax Revery isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Terminal/dune
+++ b/src/Feature/Terminal/dune
@@ -1,15 +1,8 @@
 (library
-    (name Feature_Terminal)
-    (public_name Oni2.feature.terminal)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.components
-      Oni2.service.terminal
-      Oni2.feature.commands
-      Revery
-      revery-terminal.lib
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_Terminal)
+ (public_name Oni2.feature.terminal)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.components
+   Oni2.service.terminal Oni2.feature.commands Revery revery-terminal.lib
+   isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Theme/dune
+++ b/src/Feature/Theme/dune
@@ -1,14 +1,7 @@
 (library
-    (name Feature_Theme)
-    (public_name Oni2.feature.theme)
-    (libraries 
-      Oni2.core
-      Revery
-      isolinear
-      base
-      textmate
-      libvim
-      Oni2.exthost
-      Oni2.feature.commands
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Feature_Theme)
+ (public_name Oni2.feature.theme)
+ (libraries Oni2.core Revery isolinear base textmate libvim Oni2.exthost
+   Oni2.feature.commands)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Feature/TitleBar/dune
+++ b/src/Feature/TitleBar/dune
@@ -1,14 +1,7 @@
 (library
-    (name Feature_TitleBar)
-    (public_name Oni2.feature.titlebar)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.feature.contextMenu
-      Oni2.feature.theme
-      Oni2.components
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))
+ (name Feature_TitleBar)
+ (public_name Oni2.feature.titlebar)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.feature.contextMenu
+   Oni2.feature.theme Oni2.components Revery isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Vim/dune
+++ b/src/Feature/Vim/dune
@@ -1,13 +1,7 @@
 (library
-    (name Feature_Vim)
-    (public_name Oni2.feature.vim)
-    (inline_tests)
-    (libraries
-      libvim
-      Oni2.core
-      Oni2.service.vim
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show brisk-reconciler.ppx
-    ppx_inline_test)))
+ (name Feature_Vim)
+ (public_name Oni2.feature.vim)
+ (inline_tests)
+ (libraries libvim Oni2.core Oni2.service.vim Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Input/dune
+++ b/src/Input/dune
@@ -1,17 +1,7 @@
 (library
-    (name Oni_Input)
-    (public_name Oni2.input)
-    (libraries 
-        str
-        bigarray
-        reason-sdl2
-        Revery.zed
-        lwt
-        lwt.unix
-        Oni2.core
-        Oni2.core.whenExpr
-        Oni2.editor-input
-        Rench
-        Revery
-    )
-    (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))
+ (name Oni_Input)
+ (public_name Oni2.input)
+ (libraries str bigarray reason-sdl2 Revery.zed lwt lwt.unix Oni2.core
+   Oni2.core.whenExpr Oni2.editor-input Rench Revery)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Model/dune
+++ b/src/Model/dune
@@ -1,56 +1,19 @@
 (library
-    (name Oni_Model)
-    (public_name Oni2.model)
-    (libraries
-        str
-        bigarray
-        Revery.zed
-        libvim
-        lwt
-        lwt.unix
-        Rench
-        Revery
-        yojson
-        ppx_deriving.runtime
-        ppx_deriving_yojson.runtime
-        isolinear
-        Oni2.core
-        Oni2.input
-        Oni2.syntax
-        Oni2.syntax_client
-        Oni2.service.font
-        Oni2.service.file-watcher
-        Oni2.components
-        Oni2.feature.buffers
-        Oni2.feature.clipboard
-        Oni2.feature.configuration
-        Oni2.feature.contextMenu
-        Oni2.feature.exthost
-        Oni2.feature.extensions
-        Oni2.feature.messages
-        Oni2.feature.theme
-        Oni2.feature.notification
-        Oni2.feature.changelog
-        Oni2.feature.commands
-        Oni2.feature.inputText
-        Oni2.feature.search
-        Oni2.feature.sideBar
-        Oni2.feature.syntax
-        Oni2.feature.language_support
-        Oni2.feature.editor
-        Oni2.feature.pane
-        Oni2.feature.registers
-        Oni2.feature.scm
-        Oni2.feature.sneak
-        Oni2.feature.statusbar
-        Oni2.feature.terminal
-        Oni2.feature.titlebar
-        Oni2.feature.modals
-        Oni2.feature.layout
-        Oni2.feature.vim
-        Oni2.feature.signature_help
-        ReasonFuzz
-        textmate
-        Oni2.editor-core-types
-    )
-    (preprocess (pps lwt_ppx ppx_deriving_yojson ppx_deriving.show)))
+ (name Oni_Model)
+ (public_name Oni2.model)
+ (libraries str bigarray Revery.zed libvim lwt lwt.unix Rench Revery yojson
+   ppx_deriving.runtime ppx_deriving_yojson.runtime isolinear Oni2.core
+   Oni2.input Oni2.syntax Oni2.syntax_client Oni2.service.font
+   Oni2.service.file-watcher Oni2.components Oni2.feature.buffers
+   Oni2.feature.clipboard Oni2.feature.configuration Oni2.feature.contextMenu
+   Oni2.feature.exthost Oni2.feature.extensions Oni2.feature.messages
+   Oni2.feature.theme Oni2.feature.notification Oni2.feature.changelog
+   Oni2.feature.commands Oni2.feature.inputText Oni2.feature.search
+   Oni2.feature.sideBar Oni2.feature.syntax Oni2.feature.language_support
+   Oni2.feature.editor Oni2.feature.pane Oni2.feature.registers
+   Oni2.feature.scm Oni2.feature.sneak Oni2.feature.statusbar
+   Oni2.feature.terminal Oni2.feature.titlebar Oni2.feature.modals
+   Oni2.feature.layout Oni2.feature.vim Oni2.feature.signature_help
+   ReasonFuzz textmate Oni2.editor-core-types)
+ (preprocess
+  (pps lwt_ppx ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Service/Clipboard/dune
+++ b/src/Service/Clipboard/dune
@@ -1,10 +1,6 @@
 (library
-    (name Service_Clipboard)
-    (public_name Oni2.service.clipboard)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Revery
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Clipboard)
+ (public_name Oni2.service.clipboard)
+ (libraries Oni2.editor-core-types Oni2.core Revery isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Extensions/dune
+++ b/src/Service/Extensions/dune
@@ -1,14 +1,7 @@
 (library
-    (name Service_Extensions)
-    (public_name Oni2.service.extensions)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.exthost
-      Oni2.service.net
-      Oni2.service.os
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Extensions)
+ (public_name Oni2.service.extensions)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.exthost Oni2.service.net
+   Oni2.service.os Revery isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Exthost/dune
+++ b/src/Service/Exthost/dune
@@ -1,10 +1,6 @@
 (library
-    (name Service_Exthost)
-    (public_name Oni2.service.exthost)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.exthost
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Exthost)
+ (public_name Oni2.service.exthost)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.exthost isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/FileWatcher/dune
+++ b/src/Service/FileWatcher/dune
@@ -1,9 +1,6 @@
 (library
-    (name Service_FileWatcher)
-    (public_name Oni2.service.file-watcher)
-    (libraries 
-      Oni2.core
-      isolinear
-      luv
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_FileWatcher)
+ (public_name Oni2.service.file-watcher)
+ (libraries Oni2.core isolinear luv)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Font/dune
+++ b/src/Service/Font/dune
@@ -1,13 +1,7 @@
 (library
-    (name Service_Font)
-    (public_name Oni2.service.font)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Revery
-      isolinear
-      base
-      lru
-      reason-skia
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Font)
+ (public_name Oni2.service.font)
+ (libraries Oni2.editor-core-types Oni2.core Revery isolinear base lru
+   reason-skia)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Net/dune
+++ b/src/Service/Net/dune
@@ -1,13 +1,8 @@
 (library
-    (name Service_Net)
-    (public_name Oni2.service.net)
-    (inline_tests)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.service.os
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show ppx_inline_test)))
+ (name Service_Net)
+ (public_name Oni2.service.net)
+ (inline_tests)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.service.os Revery isolinear
+   base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_inline_test)))

--- a/src/Service/OS/dune
+++ b/src/Service/OS/dune
@@ -1,11 +1,6 @@
 (library
-    (name Service_OS)
-    (public_name Oni2.service.os)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Revery
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_OS)
+ (public_name Oni2.service.os)
+ (libraries Oni2.editor-core-types Oni2.core Revery isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Syntax/dune
+++ b/src/Service/Syntax/dune
@@ -1,11 +1,7 @@
 (library
-    (name Service_Syntax)
-    (public_name Oni2.service.syntax)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.syntax
-      Oni2.syntax_client
-      Revery
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Syntax)
+ (public_name Oni2.service.syntax)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.syntax Oni2.syntax_client
+   Revery)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Terminal/dune
+++ b/src/Service/Terminal/dune
@@ -1,14 +1,7 @@
 (library
-    (name Service_Terminal)
-    (public_name Oni2.service.terminal)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.exthost
-      Revery
-      revery-terminal.lib
-      revery-terminal.vterm
-      isolinear
-      base
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Terminal)
+ (public_name Oni2.service.terminal)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.exthost Revery
+   revery-terminal.lib revery-terminal.vterm isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Service/Vim/dune
+++ b/src/Service/Vim/dune
@@ -1,10 +1,6 @@
 (library
-    (name Service_Vim)
-    (public_name Oni2.service.vim)
-    (libraries 
-      Oni2.editor-core-types
-      Oni2.core
-      Oni2.service.font
-      isolinear
-    )
-    (preprocess (pps ppx_let ppx_deriving.show)))
+ (name Service_Vim)
+ (public_name Oni2.service.vim)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.service.font isolinear)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/Store/dune
+++ b/src/Store/dune
@@ -1,47 +1,17 @@
 (library
-    (name Oni_Store)
-    (public_name Oni2.store)
-    (libraries
-        Rench
-        Revery
-        yojson
-        ppx_deriving.runtime
-        ppx_deriving_yojson.runtime
-        Oni2.core
-        Oni2.core.whenExpr
-        Oni2.editor-input
-        Oni2.model
-        Oni2.input
-        Oni2.syntax_client
-        Oni2.service.extensions
-        Oni2.service.font
-        Oni2.service.file-watcher
-        Oni2.service.syntax
-        Oni2.service.terminal
-        Oni2.service.vim
-        Oni2.components
-        Oni2.ui
-        Oni2.feature.buffers
-        Oni2.feature.clipboard
-        Oni2.feature.commands
-        Oni2.feature.contextMenu
-        Oni2.feature.extensions
-        Oni2.feature.exthost
-        Oni2.feature.language_support
-        Oni2.feature.menus
-        Oni2.feature.notification
-        Oni2.feature.theme
-        Oni2.feature.registers
-        Oni2.feature.snippets
-        Oni2.feature.statusbar
-        Oni2.feature.terminal
-        Oni2.feature.modals
-        Oni2.feature.vim
-        Oni2.feature.signature_help
-        Oni2.feature.editor
-        isolinear
-        libvim
-        textmate
-        treesitter
-    )
-    (preprocess (pps ppx_let brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show)))
+ (name Oni_Store)
+ (public_name Oni2.store)
+ (libraries Rench Revery yojson ppx_deriving.runtime
+   ppx_deriving_yojson.runtime Oni2.core Oni2.core.whenExpr Oni2.editor-input
+   Oni2.model Oni2.input Oni2.syntax_client Oni2.service.extensions
+   Oni2.service.font Oni2.service.file-watcher Oni2.service.syntax
+   Oni2.service.terminal Oni2.service.vim Oni2.components Oni2.ui
+   Oni2.feature.buffers Oni2.feature.clipboard Oni2.feature.commands
+   Oni2.feature.contextMenu Oni2.feature.extensions Oni2.feature.exthost
+   Oni2.feature.language_support Oni2.feature.menus Oni2.feature.notification
+   Oni2.feature.theme Oni2.feature.registers Oni2.feature.snippets
+   Oni2.feature.statusbar Oni2.feature.terminal Oni2.feature.modals
+   Oni2.feature.vim Oni2.feature.signature_help Oni2.feature.editor isolinear
+   libvim textmate treesitter)
+ (preprocess
+  (pps ppx_let brisk-reconciler.ppx ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Syntax/dune
+++ b/src/Syntax/dune
@@ -1,19 +1,7 @@
 (library
-    (name Oni_Syntax)
-    (public_name Oni2.syntax)
-    (libraries 
-        str
-        bigarray
-        Revery.zed
-        lwt
-        lwt.unix
-        yojson
-        ppx_deriving.runtime
-        Oni2.core
-        Oni2.exthost
-        Rench
-        Revery
-        textmate
-        treesitter
-    )
-    (preprocess (pps ppx_deriving.show)))
+ (name Oni_Syntax)
+ (public_name Oni2.syntax)
+ (libraries str bigarray Revery.zed lwt lwt.unix yojson ppx_deriving.runtime
+   Oni2.core Oni2.exthost Rench Revery textmate treesitter)
+ (preprocess
+  (pps ppx_deriving.show)))

--- a/src/Syntax_Client/dune
+++ b/src/Syntax_Client/dune
@@ -1,19 +1,5 @@
 (library
-    (name Oni_Syntax_Client)
-    (public_name Oni2.syntax_client)
-    (libraries 
-        str
-        bigarray
-        Revery.zed
-        luv
-        lwt
-        lwt.unix
-        yojson
-        Oni2.core
-        Oni2.syntax
-        Rench
-        Revery
-        textmate
-        treesitter
-        Oni2.exthost
-    ))
+ (name Oni_Syntax_Client)
+ (public_name Oni2.syntax_client)
+ (libraries str bigarray Revery.zed luv lwt lwt.unix yojson Oni2.core
+   Oni2.syntax Rench Revery textmate treesitter Oni2.exthost))

--- a/src/Syntax_Server/dune
+++ b/src/Syntax_Server/dune
@@ -1,20 +1,5 @@
 (library
-    (name Oni_Syntax_Server)
-    (public_name Oni2.syntax_server)
-    (libraries 
-        str
-        bigarray
-        Revery.zed
-        luv
-        lwt
-        lwt.unix
-        yojson
-        Oni2.core
-        Oni2.syntax
-        Oni2.model
-        Rench
-        Revery
-        textmate
-        treesitter
-        Oni2.exthost
-    ))
+ (name Oni_Syntax_Server)
+ (public_name Oni2.syntax_server)
+ (libraries str bigarray Revery.zed luv lwt lwt.unix yojson Oni2.core
+   Oni2.syntax Oni2.model Rench Revery textmate treesitter Oni2.exthost))

--- a/src/UI/dune
+++ b/src/UI/dune
@@ -1,32 +1,12 @@
 (library
-    (name Oni_UI)
-    (public_name Oni2.ui)
-    (preprocess (pps brisk-reconciler.ppx ppx_deriving.show))
-    (libraries 
-        str
-        bigarray
-        luv
-        lwt
-        lwt.unix
-        Oni2.core
-        Oni2.model
-        Oni2.feature.theme
-        Oni2.components
-        Oni2.feature.notification
-        Oni2.feature.search
-        Oni2.feature.editor
-        Oni2.feature.imagePreview
-        Oni2.feature.sideBar
-        Oni2.feature.scm
-        Oni2.feature.modals
-        Oni2.feature.layout
-        Oni2.feature.changelog
-        Oni2.feature.statusbar
-        Oni2.feature.titlebar
-        Rench
-        Revery
-        Revery.zed
-        revery-terminal.lib
-        Oni2.editor-core-types
-        ppx_deriving.runtime
-    ))
+ (name Oni_UI)
+ (public_name Oni2.ui)
+ (preprocess
+  (pps brisk-reconciler.ppx ppx_deriving.show))
+ (libraries str bigarray luv lwt lwt.unix Oni2.core Oni2.model
+   Oni2.feature.theme Oni2.components Oni2.feature.notification
+   Oni2.feature.search Oni2.feature.editor Oni2.feature.imagePreview
+   Oni2.feature.sideBar Oni2.feature.scm Oni2.feature.modals
+   Oni2.feature.layout Oni2.feature.changelog Oni2.feature.statusbar
+   Oni2.feature.titlebar Rench Revery Revery.zed revery-terminal.lib
+   Oni2.editor-core-types ppx_deriving.runtime))

--- a/src/bin_editor/dune
+++ b/src/bin_editor/dune
@@ -1,31 +1,10 @@
 (executable
-    (name Oni2_editor)
-    (package Oni2)
-    (public_name Oni2_editor)
-    (libraries
-        bigarray
-        Revery.zed
-        luv
-        lwt
-        lwt.unix
-        oniguruma
-        Oni2.cli
-        Oni2.core
-        Oni2.model
-        Oni2.service.extensions
-        Oni2.service.net
-        Oni2.store
-        Oni2.syntax_client
-        Oni2.syntax_server
-        Oni2.ui
-        reason-sdl2
-        reason-harfbuzz
-        fp
-        dir.lib
-    )
-    (preprocess (
-        pps
-        lwt_ppx
-        brisk-reconciler.ppx
-    ))
-)
+ (name Oni2_editor)
+ (package Oni2)
+ (public_name Oni2_editor)
+ (libraries bigarray Revery.zed luv lwt lwt.unix oniguruma Oni2.cli Oni2.core
+   Oni2.model Oni2.service.extensions Oni2.service.net Oni2.store
+   Oni2.syntax_client Oni2.syntax_server Oni2.ui reason-sdl2 reason-harfbuzz
+   fp dir.lib)
+ (preprocess
+  (pps lwt_ppx brisk-reconciler.ppx)))

--- a/src/bin_launcher/dune
+++ b/src/bin_launcher/dune
@@ -1,6 +1,5 @@
 (executable
-    (name Oni2)
-    (package Oni2)
-    (public_name Oni2)
-    (libraries unix str)
-)
+ (name Oni2)
+ (package Oni2)
+ (public_name Oni2)
+ (libraries unix str))

--- a/src/editor-core-types/dune
+++ b/src/editor-core-types/dune
@@ -1,4 +1,5 @@
 (library
-    (name EditorCoreTypes)
-    (public_name Oni2.editor-core-types)
-    (preprocess (pps ppx_deriving.show)))
+ (name EditorCoreTypes)
+ (public_name Oni2.editor-core-types)
+ (preprocess
+  (pps ppx_deriving.show)))

--- a/src/editor-input/dune
+++ b/src/editor-input/dune
@@ -1,10 +1,11 @@
 (ocamllex
-    (modules Matcher_lexer))
+ (modules Matcher_lexer))
 
 (menhir
-    (modules Matcher_parser))
+ (modules Matcher_parser))
 
 (library
-    (name EditorInput)
-    (public_name Oni2.editor-input)
-    (preprocess (pps ppx_deriving.show)))
+ (name EditorInput)
+ (public_name Oni2.editor-input)
+ (preprocess
+  (pps ppx_deriving.show)))

--- a/src/gen_buildinfo/dune
+++ b/src/gen_buildinfo/dune
@@ -1,3 +1,3 @@
 (executable
-	(name generator)
-	(libraries unix yojson))
+ (name generator)
+ (libraries unix yojson))

--- a/src/reason-libvim/config/dune
+++ b/src/reason-libvim/config/dune
@@ -1,3 +1,3 @@
 (executable
-    (name discover)
-    (libraries dune.configurator))
+ (name discover)
+ (libraries dune.configurator))

--- a/src/reason-libvim/dune
+++ b/src/reason-libvim/dune
@@ -1,20 +1,25 @@
 (library
-    (name vim)
-    (public_name libvim)
-    (library_flags (:include flags.sexp))
-    (c_flags (:include c_flags.sexp))
-    (c_names bindings)
-    (cxx_flags (:include cxx_flags.sexp))
-    (preprocess (pps ppx_deriving.show))
-    (libraries
-        base
-        Oni2.editor-core-types
-        timber
-        Revery.zed
-        ppx_deriving.runtime
-))
+ (name vim)
+ (public_name libvim)
+ (library_flags
+  (:include flags.sexp))
+ (foreign_stubs
+  (language c)
+  (flags
+   (:include c_flags.sexp))
+  (names bindings))
+ (foreign_stubs
+  (language cxx)
+  (flags
+   (:include c_flags.sexp)))
+ (preprocess
+  (pps ppx_deriving.show))
+ (libraries base Oni2.editor-core-types timber Revery.zed
+   ppx_deriving.runtime))
 
 (rule
-    (targets c_flags.sexp cxx_flags.sexp flags.sexp)
-    (deps (:discover config/discover.exe))
-    (action (run %{discover})))
+ (targets c_flags.sexp cxx_flags.sexp flags.sexp)
+ (deps
+  (:discover config/discover.exe))
+ (action
+  (run %{discover})))

--- a/src/reason-oniguruma/config/dune
+++ b/src/reason-oniguruma/config/dune
@@ -1,3 +1,3 @@
 (executable
-    (name discover)
-    (libraries dune.configurator))
+ (name discover)
+ (libraries dune.configurator))

--- a/src/reason-oniguruma/dune
+++ b/src/reason-oniguruma/dune
@@ -1,12 +1,21 @@
 (library
-    (name oniguruma)
-    (public_name textmate.oniguruma)
-    (library_flags (:include flags.sexp))
-    (c_flags (:include c_flags.sexp))
-    (c_names bindings)
-    (cxx_flags (:include cxx_flags.sexp)))
+ (name oniguruma)
+ (public_name textmate.oniguruma)
+ (library_flags
+  (:include flags.sexp))
+ (foreign_stubs
+  (language c)
+  (flags
+   (:include c_flags.sexp))
+  (names bindings))
+ (foreign_stubs
+  (language cxx)
+  (flags
+   (:include cxx_flags.sexp))))
 
 (rule
-    (targets c_flags.sexp cxx_flags.sexp flags.sexp)
-    (deps (:discover config/discover.exe))
-    (action (run %{discover})))
+ (targets c_flags.sexp cxx_flags.sexp flags.sexp)
+ (deps
+  (:discover config/discover.exe))
+ (action
+  (run %{discover})))

--- a/src/reason-textmate/dune
+++ b/src/reason-textmate/dune
@@ -1,6 +1,6 @@
 (library
-    (name textmate)
-    (public_name textmate)
-    (libraries str oniguruma yojson Rench markup Oni2.core)
-    (preprocess (pps ppx_let ppx_deriving.show)))
-
+ (name textmate)
+ (public_name textmate)
+ (libraries str oniguruma yojson Rench markup Oni2.core)
+ (preprocess
+  (pps ppx_let ppx_deriving.show)))

--- a/src/reason-tree-sitter/config/dune
+++ b/src/reason-tree-sitter/config/dune
@@ -1,3 +1,3 @@
 (executable
-    (name discover)
-    (libraries dune.configurator))
+ (name discover)
+ (libraries dune.configurator))

--- a/src/reason-tree-sitter/dune
+++ b/src/reason-tree-sitter/dune
@@ -1,13 +1,22 @@
 (library
-    (name treesitter)
-    (public_name treesitter)
-    (library_flags (:include flags.sexp))
-    (c_flags (:include c_flags.sexp))
-    (c_names bindings)
-    (cxx_flags (:include cxx_flags.sexp))
-    (libraries Oni2.editor-core-types))
+ (name treesitter)
+ (public_name treesitter)
+ (library_flags
+  (:include flags.sexp))
+ (foreign_stubs
+  (language c)
+  (flags
+   (:include c_flags.sexp))
+  (names bindings))
+ (foreign_stubs
+  (language cxx)
+  (flags
+   (:include cxx_flags.sexp)))
+ (libraries Oni2.editor-core-types))
 
 (rule
-    (targets c_flags.sexp cxx_flags.sexp flags.sexp)
-    (deps (:discover config/discover.exe))
-    (action (run %{discover})))
+ (targets c_flags.sexp cxx_flags.sexp flags.sexp)
+ (deps
+  (:discover config/discover.exe))
+ (action
+  (run %{discover})))

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ba4551a9a94e2ce7312ceb804a79099c",
+  "checksum": "bdba9efdc1b3e10cb070038018f5b30b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -150,7 +150,7 @@
         "@opam/ppx_deriving@opam:4.5@d89f2934",
         "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9",
         "@opam/markup@opam:0.8.2@87975241",
-        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_ppx@opam:2.0.1@e6a764a0", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
@@ -207,9 +207,9 @@
       "dependencies": [
         "refmterr@3.3.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/lambda-term@opam:3.1.0@8adc2660",
-        "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/fpath@opam:0.7.2@3fd2da53", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/reason@3.6.2@d41d8cd9"
       ],
       "devDependencies": [ "@opam/dune@opam:2.5.0@e0bac278" ]
@@ -961,8 +961,9 @@
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d",
         "@opam/ppx_deriving@opam:4.5@d89f2934",
+        "@opam/ocamlformat@opam:0.15.0@8e036963",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/markup@opam:0.8.2@87975241", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/luv@github:bryphe/luv:luv.opam#207d3f6@d41d8cd9",
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/logs@opam:0.7.0@1d03143e",
@@ -1212,10 +1213,40 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+      ]
+    },
+    "@opam/uuseg@opam:13.0.0@f60712a7": {
+      "id": "@opam/uuseg@opam:13.0.0@f60712a7",
+      "name": "@opam/uuseg",
+      "version": "opam:13.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a0/a07a97fff61da604614ea8da0547ef6a#md5:a07a97fff61da604614ea8da0547ef6a",
+          "archive:https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz#md5:a07a97fff61da604614ea8da0547ef6a"
+        ],
+        "opam": {
+          "name": "uuseg",
+          "version": "13.0.0",
+          "path": "test.esy.lock/opam/uuseg.13.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uucp@opam:13.0.0@e9b515e0", "@opam/topkg@opam:1.0.2@3c5942ad",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uucp@opam:13.0.0@e9b515e0"
       ]
     },
     "@opam/uucp@opam:13.0.0@e9b515e0": {
@@ -1240,6 +1271,7 @@
         "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
@@ -1368,7 +1400,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -1376,7 +1408,7 @@
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/stdlib-shims@opam:0.1.0@8c116481": {
@@ -1423,12 +1455,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/sexplib0@opam:v0.14.0@ddeb6438": {
@@ -1859,13 +1891,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_optcomp@opam:v0.14.0@d77a04c2": {
@@ -1888,13 +1920,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_let@opam:v0.14.0@eb9b93e0": {
@@ -1916,12 +1948,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_js_style@opam:v0.14.0@10b020a8": {
@@ -1944,13 +1976,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/octavius@opam:1.2.2@b328d1f1",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d": {
@@ -1973,13 +2005,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
         "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_here@opam:v0.14.0@5ccc1c01": {
@@ -2001,12 +2033,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_hash@opam:v0.14.0@8e9618e4": {
@@ -2030,14 +2062,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
         "@opam/ppx_sexp_conv@opam:v0.14.1@a205b550",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_enumerate@opam:v0.14.0@63db8245": {
@@ -2059,12 +2091,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_deriving_yojson@opam:3.5.3@253e094d": {
@@ -2180,12 +2212,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_cold@opam:v0.14.0@345dec7c": {
@@ -2207,12 +2239,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ppx_base@opam:v0.14.0@b4702ed9": {
@@ -2276,7 +2308,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -2285,7 +2317,7 @@
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/omd@github:ocaml/omd:omd.opam#1535e3c@d41d8cd9": {
@@ -2307,6 +2339,39 @@
         "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@opam/base-bigarray@opam:base@b03491b0"
+      ]
+    },
+    "@opam/odoc@opam:1.5.1@52a58c0b": {
+      "id": "@opam/odoc@opam:1.5.1@52a58c0b",
+      "name": "@opam/odoc",
+      "version": "opam:1.5.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/ea/ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f",
+          "archive:https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz#sha256:ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+        ],
+        "opam": {
+          "name": "odoc",
+          "version": "1.5.1",
+          "path": "test.esy.lock/opam/odoc.1.5.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
+        "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/astring@opam:0.8.5@1300cee8"
       ]
     },
     "@opam/octavius@opam:1.2.2@b328d1f1": {
@@ -2360,6 +2425,51 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/ocamlformat@opam:0.15.0@8e036963": {
+      "id": "@opam/ocamlformat@opam:0.15.0@8e036963",
+      "name": "@opam/ocamlformat",
+      "version": "opam:0.15.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/26/263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005",
+          "archive:https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz#sha256:263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+        ],
+        "opam": {
+          "name": "ocamlformat",
+          "version": "0.15.0",
+          "path": "test.esy.lock/opam/ocamlformat.0.15.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/uuseg@opam:13.0.0@f60712a7",
+        "@opam/stdio@opam:v0.14.0@a624e254", "@opam/re@opam:1.9.0@d4d5e13d",
+        "@opam/odoc@opam:1.5.1@52a58c0b",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/fpath@opam:0.7.2@3fd2da53",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
@@ -2730,12 +2840,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_ppx@opam:2.0.1@e6a764a0": {
@@ -2759,14 +2869,14 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.4.0@32d1a414",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -2787,15 +2897,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/lwt@opam:4.5.0@677655b4": {
-      "id": "@opam/lwt@opam:4.5.0@677655b4",
+    "@opam/lwt@opam:4.5.0@542100aa": {
+      "id": "@opam/lwt@opam:4.5.0@542100aa",
       "name": "@opam/lwt",
       "version": "opam:4.5.0",
       "source": {
@@ -2892,7 +3002,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/topkg@opam:1.0.2@3c5942ad",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:4.5.0@677655b4", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/lwt@opam:4.5.0@542100aa", "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2920,7 +3031,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2930,7 +3041,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@542100aa",
         "@opam/dune@opam:2.5.0@e0bac278",
         "@opam/camomile@opam:1.0.2@40411a6b"
       ]
@@ -2982,14 +3093,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1",
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
         "@opam/ppx_assert@opam:v0.14.0@877b5900",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@b8817fc1"
+        "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
     "@opam/jane-street-headers@opam:v0.14.0@59432b6a": {
@@ -3062,8 +3173,8 @@
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/fpath@opam:0.7.2@45477b93": {
-      "id": "@opam/fpath@opam:0.7.2@45477b93",
+    "@opam/fpath@opam:0.7.2@3fd2da53": {
+      "id": "@opam/fpath@opam:0.7.2@3fd2da53",
       "name": "@opam/fpath",
       "version": "opam:0.7.2",
       "source": {
@@ -3133,6 +3244,7 @@
         "@opam/seq@opam:base@d8d7de1d",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -3495,6 +3607,28 @@
       ],
       "devDependencies": []
     },
+    "@opam/cmdliner@opam:1.0.4@93208aac": {
+      "id": "@opam/cmdliner@opam:1.0.4@93208aac",
+      "name": "@opam/cmdliner",
+      "version": "opam:1.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fe/fe2213d0bc63b1e10a2d0aa66d2fc8d9#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9",
+          "archive:http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz#md5:fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+        ],
+        "opam": {
+          "name": "cmdliner",
+          "version": "1.0.4",
+          "path": "test.esy.lock/opam/cmdliner.1.0.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
+    },
     "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
       "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
       "name": "@opam/charInfo_width",
@@ -3571,7 +3705,7 @@
         "@opam/rresult@opam:0.6.0@4b185e72",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8",
@@ -3579,7 +3713,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/rresult@opam:0.6.0@4b185e72",
-        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@45477b93",
+        "@opam/logs@opam:0.7.0@1d03143e", "@opam/fpath@opam:0.7.2@3fd2da53",
         "@opam/fmt@opam:0.8.8@01c3a23c",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/astring@opam:0.8.5@1300cee8"
@@ -3736,8 +3870,8 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "@opam/base@opam:v0.14.0@b8817fc1": {
-      "id": "@opam/base@opam:v0.14.0@b8817fc1",
+    "@opam/base@opam:v0.14.0@8bc55fce": {
+      "id": "@opam/base@opam:v0.14.0@8bc55fce",
       "name": "@opam/base",
       "version": "opam:v0.14.0",
       "source": {

--- a/test.esy.lock/opam/base.v0.14.0/opam
+++ b/test.esy.lock/opam/base.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"             {>= "4.07.0"}
+  "ocaml"             {>= "4.07.0" & < "4.12"}
   "sexplib0"          {>= "v0.14" & < "v0.15"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"

--- a/test.esy.lock/opam/cmdliner.1.0.4/opam
+++ b/test.esy.lock/opam/cmdliner.1.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+depends:[ "ocaml" {>= "4.03.0"} ]
+build: [[ make "all" "PREFIX=%{prefix}%" ]]
+install:
+[[make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%" ]
+ [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"  ]]
+
+synopsis: """Declarative definition of command line interfaces for OCaml"""
+description: """\
+
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+"""
+url {
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz"
+checksum: "fe2213d0bc63b1e10a2d0aa66d2fc8d9"
+}

--- a/test.esy.lock/opam/fpath.0.7.2/opam
+++ b/test.esy.lock/opam/fpath.0.7.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fpath/issues"
 tags: [ "file" "system" "path" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.12"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/test.esy.lock/opam/lwt.4.5.0/opam
+++ b/test.esy.lock/opam/lwt.4.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.12"}
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/test.esy.lock/opam/ocamlformat.0.15.0/opam
+++ b/test.esy.lock/opam/ocamlformat.0.15.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.12"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "e9e70f4d3aea202ec8ea4afd7ccb828b36822799"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz"
+  checksum: [
+    "sha256=263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+    "sha512=2bc0b826567fa71201031a730568b822938c66c56da47b05b8896b68439da3d0a8b9bc552fa5cacab95bf9192a1b6e583655fd90095aa686daa91cd2bdf4725a"
+  ]
+}

--- a/test.esy.lock/opam/odoc.1.5.1/opam
+++ b/test.esy.lock/opam/odoc.1.5.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune"
+  "fpath"
+  "ocaml" {>= "4.02.0" & < "4.12"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/1.5.1/odoc-1.5.1.tbz"
+  checksum: [
+    "sha256=ea14721344e2aab6b63f2884782d37e94a1ed8ab91147a1c08a29710d99d354f"
+    "sha512=b2d12277d61e1e52354128d459d2ad49bea24a4d46db89790769c2843c4b00beaee3ea7d0215211079174c0bd893de6bf52dcbb71e46622728be7491d91058b2"
+  ]
+}

--- a/test.esy.lock/opam/uuseg.13.0.0/opam
+++ b/test.esy.lock/opam/uuseg.13.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.03.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uucp" {>= "13.0.0" & < "14.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+checksum: "a07a97fff61da604614ea8da0547ef6a"
+}

--- a/test/Cli/dune
+++ b/test/Cli/dune
@@ -1,13 +1,7 @@
 (library
-    (name Oni_Cli_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries
-        Oni2.cli
-        Oni2.core
-        Oni_Core_Test
-        rely.lib
-        luv
-        Oni2.editor-core-types
-        unix
-    ))
+ (name Oni_Cli_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.cli Oni2.core Oni_Core_Test rely.lib luv
+   Oni2.editor-core-types unix))

--- a/test/Core/Utility/dune
+++ b/test/Core/Utility/dune
@@ -1,5 +1,6 @@
 (library
-    (name Oni_Core_Utility_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries base Oni2.core rely.lib Oni2.editor-core-types))
+ (name Oni_Core_Utility_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries base Oni2.core rely.lib Oni2.editor-core-types))

--- a/test/Core/WhenExpr/dune
+++ b/test/Core/WhenExpr/dune
@@ -1,5 +1,6 @@
 (library
-    (name Oni_Core_WhenExpr_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries Oni2.core.whenExpr rely.lib console.lib))
+ (name Oni_Core_WhenExpr_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core.whenExpr rely.lib console.lib))

--- a/test/Core/dune
+++ b/test/Core/dune
@@ -1,13 +1,7 @@
 (library
-    (name Oni_Core_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries
-        Oni2.core
-        Oni_Core_Utility_Test
-        Oni_Core_WhenExpr_Test
-        fp
-        rely.lib
-        luv
-        Oni2.editor-core-types
-    ))
+ (name Oni_Core_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core Oni_Core_Utility_Test Oni_Core_WhenExpr_Test fp
+   rely.lib luv Oni2.editor-core-types))

--- a/test/Exthost/Transport/dune
+++ b/test/Exthost/Transport/dune
@@ -1,6 +1,7 @@
 (library
-    (name Exthost_Transport_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib Oni2.exthost Exthost_TestLib)
-)
+ (name Exthost_Transport_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib Oni2.exthost Exthost_TestLib))

--- a/test/Exthost/dune
+++ b/test/Exthost/dune
@@ -1,6 +1,7 @@
 (library
-    (name Exthost_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib Oni2.exthost Exthost_TestLib)
-)
+ (name Exthost_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib Oni2.exthost Exthost_TestLib))

--- a/test/Exthost/lib/dune
+++ b/test/Exthost/lib/dune
@@ -1,6 +1,7 @@
 (library
-    (name Exthost_TestLib)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib Oni2.exthost)
-)
+ (name Exthost_TestLib)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib Oni2.exthost))

--- a/test/Feature/Editor/dune
+++ b/test/Feature/Editor/dune
@@ -1,5 +1,7 @@
 (library
-    (name Feature_Editor_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries Oni2.core Oni2.feature.editor Oni_Core_Test rely.lib Oni2.editor-core-types))
+ (name Feature_Editor_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core Oni2.feature.editor Oni_Core_Test rely.lib
+   Oni2.editor-core-types))

--- a/test/Feature/LanguageSupport/dune
+++ b/test/Feature/LanguageSupport/dune
@@ -1,5 +1,7 @@
 (library
-    (name Feature_LanguageSupport_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries Oni2.core Oni2.feature.language_support rely.lib Oni2.editor-core-types))
+ (name Feature_LanguageSupport_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core Oni2.feature.language_support rely.lib
+   Oni2.editor-core-types))

--- a/test/Input/dune
+++ b/test/Input/dune
@@ -1,10 +1,6 @@
 (library
-    (name Oni_Input_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries
-        Oni_Core_Test
-        Oni2.input
-        Oni2.core.whenExpr
-        rely.lib
-    ))
+ (name Oni_Input_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni_Core_Test Oni2.input Oni2.core.whenExpr rely.lib))

--- a/test/Model/dune
+++ b/test/Model/dune
@@ -1,5 +1,7 @@
 (library
-    (name Oni_Model_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries libvim Oni2.core Oni2.model Oni_Core_Test rely.lib Oni2.editor-core-types))
+ (name Oni_Model_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries libvim Oni2.core Oni2.model Oni_Core_Test rely.lib
+   Oni2.editor-core-types))

--- a/test/Service/Extensions/dune
+++ b/test/Service/Extensions/dune
@@ -1,6 +1,8 @@
 (library
-    (name Service_Extensions_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (preprocess (pps ppx_deriving_yojson ppx_deriving.show))
-    (libraries Oni2.exthost Oni2.service.extensions Oni_Core_Test rely.lib))
+ (name Service_Extensions_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.show))
+ (libraries Oni2.exthost Oni2.service.extensions Oni_Core_Test rely.lib))

--- a/test/Service/Net/dune
+++ b/test/Service/Net/dune
@@ -1,5 +1,7 @@
 (library
-    (name Service_Net_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries Oni2.core Oni2.service.net Oni_Core_Test rely.lib Oni2.editor-core-types))
+ (name Service_Net_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core Oni2.service.net Oni_Core_Test rely.lib
+   Oni2.editor-core-types))

--- a/test/Service/OS/dune
+++ b/test/Service/OS/dune
@@ -1,5 +1,7 @@
 (library
-    (name Service_OS_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries Oni2.core Oni2.service.os Oni_Core_Test rely.lib Oni2.editor-core-types))
+ (name Service_OS_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core Oni2.service.os Oni_Core_Test rely.lib
+   Oni2.editor-core-types))

--- a/test/Syntax/dune
+++ b/test/Syntax/dune
@@ -1,5 +1,6 @@
 (library
-    (name Oni_Syntax_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries libvim Oni2.core Oni2.syntax Oni2.model Oni_Core_Test rely.lib))
+ (name Oni_Syntax_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries libvim Oni2.core Oni2.syntax Oni2.model Oni_Core_Test rely.lib))

--- a/test/UI/dune
+++ b/test/UI/dune
@@ -1,5 +1,6 @@
 (library
-    (name Oni_UI_Test)
-    (library_flags (-linkall -g))
-    (modules (:standard))
-    (libraries Oni2.core Oni2.ui rely.lib))
+ (name Oni_UI_Test)
+ (library_flags
+  (-linkall -g))
+ (modules (:standard))
+ (libraries Oni2.core Oni2.ui rely.lib))

--- a/test/dune
+++ b/test/dune
@@ -1,159 +1,93 @@
 (executable
-    (name OniUnitTestRunner)
-    (public_name OniUnitTestRunner)
-    (modules OniUnitTestRunner)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Oni_Cli_Test
-        Oni_Core_Test
-        Oni_Input_Test
-        Oni_Model_Test
-        Oni_UI_Test
-        Oni_Syntax_Test
-        Feature_Editor_Test
-        Feature_LanguageSupport_Test
-        Service_Extensions_Test
-        Service_Net_Test
-        Service_OS_Test
-        EditorCoreTypes_Test
-        EditorInput_Test
-        Exthost_Transport_Test
-        Exthost_Test
-        Libvim_Test
-        Oniguruma_Test
-        Textmate_Test
-        TreeSitter_Test
-        reason-native-crash-utils.asan
-            ))
+ (name OniUnitTestRunner)
+ (public_name OniUnitTestRunner)
+ (modules OniUnitTestRunner)
+ (package OniUnitTestRunner)
+ (libraries yojson Oni_Cli_Test Oni_Core_Test Oni_Input_Test Oni_Model_Test
+   Oni_UI_Test Oni_Syntax_Test Feature_Editor_Test
+   Feature_LanguageSupport_Test Service_Extensions_Test Service_Net_Test
+   Service_OS_Test EditorCoreTypes_Test EditorInput_Test
+   Exthost_Transport_Test Exthost_Test Libvim_Test Oniguruma_Test
+   Textmate_Test TreeSitter_Test reason-native-crash-utils.asan))
 
 (executable
-    (name OniUnitTestRunnerServiceExtensions)
-    (public_name OniUnitTestRunnerServiceExtensions)
-    (modules OniUnitTestRunnerServiceExtensions)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Service_Extensions_Test)
-            )
-    
-(executable
-    (name OniUnitTestRunnerServiceNet)
-    (public_name OniUnitTestRunnerServiceNet)
-    (modules OniUnitTestRunnerServiceNet)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Service_Net_Test
-            ))
+ (name OniUnitTestRunnerServiceExtensions)
+ (public_name OniUnitTestRunnerServiceExtensions)
+ (modules OniUnitTestRunnerServiceExtensions)
+ (package OniUnitTestRunner)
+ (libraries yojson Service_Extensions_Test))
 
 (executable
-    (name OniUnitTestRunnerCLI)
-    (public_name OniUnitTestRunnerCLI)
-    (modules OniUnitTestRunnerCLI)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Oni_Cli_Test
-            ))
+ (name OniUnitTestRunnerServiceNet)
+ (public_name OniUnitTestRunnerServiceNet)
+ (modules OniUnitTestRunnerServiceNet)
+ (package OniUnitTestRunner)
+ (libraries yojson Service_Net_Test))
 
 (executable
-    (name OniUnitTestRunnerCore)
-    (public_name OniUnitTestRunnerCore)
-    (modules OniUnitTestRunnerCore)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Oni_Core_Test
-            ))
+ (name OniUnitTestRunnerCLI)
+ (public_name OniUnitTestRunnerCLI)
+ (modules OniUnitTestRunnerCLI)
+ (package OniUnitTestRunner)
+ (libraries yojson Oni_Cli_Test))
 
 (executable
-    (name OniUnitTestRunnerInput)
-    (public_name OniUnitTestRunnerInput)
-    (modules OniUnitTestRunnerInput)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Oni_Core_Test
-        Oni_Input_Test
-            ))
+ (name OniUnitTestRunnerCore)
+ (public_name OniUnitTestRunnerCore)
+ (modules OniUnitTestRunnerCore)
+ (package OniUnitTestRunner)
+ (libraries yojson Oni_Core_Test))
 
 (executable
-    (name OniUnitTestRunnerModel)
-    (public_name OniUnitTestRunnerModel)
-    (modules OniUnitTestRunnerModel)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Oni_Core_Test
-        Oni_Model_Test
-            ))
+ (name OniUnitTestRunnerInput)
+ (public_name OniUnitTestRunnerInput)
+ (modules OniUnitTestRunnerInput)
+ (package OniUnitTestRunner)
+ (libraries yojson Oni_Core_Test Oni_Input_Test))
 
 (executable
-    (name OniUnitTestRunnerUI)
-    (public_name OniUnitTestRunnerUI)
-    (modules OniUnitTestRunnerUI)
-    (package OniUnitTestRunner)
-    (libraries 
-        Oni_Core_Test
-        Oni_UI_Test))
+ (name OniUnitTestRunnerModel)
+ (public_name OniUnitTestRunnerModel)
+ (modules OniUnitTestRunnerModel)
+ (package OniUnitTestRunner)
+ (libraries yojson Oni_Core_Test Oni_Model_Test))
 
 (executable
-    (name OniUnitTestRunnerExtHost)
-    (public_name OniUnitTestRunnerExtHost)
-    (modules OniUnitTestRunnerExtHost)
-    (package OniUnitTestRunner)
-    (libraries 
-        Oni_Core_Test
-        Exthost_Transport_Test
-        Exthost_Test))
+ (name OniUnitTestRunnerUI)
+ (public_name OniUnitTestRunnerUI)
+ (modules OniUnitTestRunnerUI)
+ (package OniUnitTestRunner)
+ (libraries Oni_Core_Test Oni_UI_Test))
 
 (executable
-    (name OniUnitTestRunnerLibvim)
-    (public_name OniUnitTestRunnerLibvim)
-    (modules OniUnitTestRunnerLibvim)
-    (package OniUnitTestRunner)
-    (libraries 
-        Oni_Core_Test
-        Libvim_Test
-        reason-native-crash-utils.asan
-        ))
+ (name OniUnitTestRunnerExtHost)
+ (public_name OniUnitTestRunnerExtHost)
+ (modules OniUnitTestRunnerExtHost)
+ (package OniUnitTestRunner)
+ (libraries Oni_Core_Test Exthost_Transport_Test Exthost_Test))
 
 (executable
-    (name OniUnitTestRunnerTextmate)
-    (public_name OniUnitTestRunnerTextmate)
-    (modules OniUnitTestRunnerTextmate)
-    (package OniUnitTestRunner)
-    (libraries 
-        Oni_Core_Test
-        Textmate_Test
-        reason-native-crash-utils.asan
-        ))
+ (name OniUnitTestRunnerLibvim)
+ (public_name OniUnitTestRunnerLibvim)
+ (modules OniUnitTestRunnerLibvim)
+ (package OniUnitTestRunner)
+ (libraries Oni_Core_Test Libvim_Test reason-native-crash-utils.asan))
 
 (executable
-    (name OniUnitTestRunnerCI)
-    (public_name OniUnitTestRunnerCI)
-    (modules OniUnitTestRunnerCI)
-    (package OniUnitTestRunner)
-    (libraries
-        yojson
-        Oni_Cli_Test
-        Oni_Core_Test
-        Oni_Input_Test
-        Oni_Syntax_Test
-        Oni_Model_Test
-        Feature_Editor_Test
-        Feature_LanguageSupport_Test
-        Service_Extensions_Test
-        Service_Net_Test
-        Service_OS_Test
-        EditorCoreTypes_Test
-        EditorInput_Test
-        Exthost_Transport_Test
-        Exthost_Test
-        Libvim_Test
-        Oniguruma_Test
-        Textmate_Test
-        TreeSitter_Test
-        reason-native-crash-utils.asan
-            ))
+ (name OniUnitTestRunnerTextmate)
+ (public_name OniUnitTestRunnerTextmate)
+ (modules OniUnitTestRunnerTextmate)
+ (package OniUnitTestRunner)
+ (libraries Oni_Core_Test Textmate_Test reason-native-crash-utils.asan))
+
+(executable
+ (name OniUnitTestRunnerCI)
+ (public_name OniUnitTestRunnerCI)
+ (modules OniUnitTestRunnerCI)
+ (package OniUnitTestRunner)
+ (libraries yojson Oni_Cli_Test Oni_Core_Test Oni_Input_Test Oni_Syntax_Test
+   Oni_Model_Test Feature_Editor_Test Feature_LanguageSupport_Test
+   Service_Extensions_Test Service_Net_Test Service_OS_Test
+   EditorCoreTypes_Test EditorInput_Test Exthost_Transport_Test Exthost_Test
+   Libvim_Test Oniguruma_Test Textmate_Test TreeSitter_Test
+   reason-native-crash-utils.asan))

--- a/test/editor-core-types/dune
+++ b/test/editor-core-types/dune
@@ -1,6 +1,8 @@
 (library
-    (name EditorCoreTypes_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries Oni2.editor-core-types rely.lib)
-    (modules (:standard)))
+ (name EditorCoreTypes_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries Oni2.editor-core-types rely.lib)
+ (modules (:standard)))

--- a/test/editor-input/dune
+++ b/test/editor-input/dune
@@ -1,6 +1,8 @@
 (library
-    (name EditorInput_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries Oni2.editor-input rely.lib)
-    (modules (:standard)))
+ (name EditorInput_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries Oni2.editor-input rely.lib)
+ (modules (:standard)))

--- a/test/reason-libvim/dune
+++ b/test/reason-libvim/dune
@@ -1,9 +1,10 @@
 (library
-    (name Libvim_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib libvim)
-)
+ (name Libvim_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib libvim))
 
 (install
  (section bin)

--- a/test/reason-oniguruma/dune
+++ b/test/reason-oniguruma/dune
@@ -1,6 +1,7 @@
 (library
-    (name Oniguruma_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib oniguruma)
-)
+ (name Oniguruma_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib oniguruma))

--- a/test/reason-textmate/bin/dune
+++ b/test/reason-textmate/bin/dune
@@ -1,9 +1,5 @@
 (executables
-    (names TextmateCli)
-    (package OniUnitTestRunner)
-    (public_names TextmateCli)
-    (libraries
-        Oni2.core
-        Oni2.core.utility
-        textmate)
-)
+ (names TextmateCli)
+ (package OniUnitTestRunner)
+ (public_names TextmateCli)
+ (libraries Oni2.core Oni2.core.utility textmate))

--- a/test/reason-textmate/dune
+++ b/test/reason-textmate/dune
@@ -1,16 +1,14 @@
 (library
-    (name Textmate_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib textmate)
-    (preprocess (pps ppx_deriving_yojson))
-)
+ (name Textmate_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib textmate)
+ (preprocess
+  (pps ppx_deriving_yojson)))
 
 (install
-    (section bin)
-    (package OniUnitTestRunner)
-    (files
-        json.json
-        haskell.tmLanguage
-        lua.tmLanguage
-))
+ (section bin)
+ (package OniUnitTestRunner)
+ (files json.json haskell.tmLanguage lua.tmLanguage))

--- a/test/reason-tree-sitter/dune
+++ b/test/reason-tree-sitter/dune
@@ -1,6 +1,7 @@
 (library
-    (name TreeSitter_Test)
-    (flags (:standard (-w -39)))
-    (ocamlopt_flags -linkall -g)
-    (libraries rely.lib treesitter)
-)
+ (name TreeSitter_Test)
+ (flags
+  (:standard
+   (-w -39)))
+ (ocamlopt_flags -linkall -g)
+ (libraries rely.lib treesitter))


### PR DESCRIPTION
- Allows us to tie native libs to `bin_editor` (mostly important for Sparkle)
- The docs are more aligned with what we're using
- Automatic formatting of `dune` files