### PR TITLE
refactor(dependency): vscode-exthost -> 1.46.0

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onivim/vscode-exthost": "1.45.6",
+    "@onivim/vscode-exthost": "1.46.0",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
     "yauzl": "^2.5.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,16 +2,16 @@
 # yarn lockfile v1
 
 
-"@onivim/vscode-exthost@1.45.6":
-  version "1.45.6"
-  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.45.6.tgz#686a8200217615e457a96453276dafe72c38778d"
-  integrity sha512-9IKvY6lO9GVIlPNsXk+JxYDjbZB1sSuZzVmQFGSDuqmu+NopdoQhedpwPR9qOiqIgUEiDRAWRZwqjX3WuVld+g==
+"@onivim/vscode-exthost@1.46.0":
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.46.0.tgz#37500b8b14210173ea7829e898399472c5f39fa6"
+  integrity sha512-8zabMYbG0NgjEMMGvP4QrjjkbjulZOe8x6WgkY4gUGOGq1lPYO+yQhxdjcIptXmOOLWhMw2Nu5k9Mt7uDY1itw==
   dependencies:
     graceful-fs "4.2.3"
     iconv-lite "0.5.0"
-    minimist "^1.2.5"
+    minimist "^1.2.0"
     native-watchdog "1.3.0"
-    node-pty "^0.10.0-beta2"
+    node-pty "^0.10.0-beta8"
     semver-umd "^5.5.5"
     spdlog "^0.11.1"
     vscode-proxy-agent "^0.5.2"
@@ -115,7 +115,7 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -142,7 +142,7 @@ native-watchdog@1.3.0:
   resolved "https://registry.yarnpkg.com/native-watchdog/-/native-watchdog-1.3.0.tgz#88cee94c9dc766b85c8506eda14c8bd8c9618e27"
   integrity sha512-WOjGRNGkYZ5MXsntcvCYrKtSYMaewlbCFplbcUVo9bE80LPVt8TAVFHYWB8+a6fWCGYheq21+Wtt6CJrUaCJhw==
 
-node-pty@^0.10.0-beta2:
+node-pty@^0.10.0-beta8:
   version "0.10.0-beta9"
   resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.10.0-beta9.tgz#e5a795f9b53948346803cb71bac4ffc02e7909f0"
   integrity sha512-Qm6uSH30FUcAhJ9s76C+lgvTsOW2cHUbkIGjCdOVCL0c7S4DxsmKBRgjcr+guUK9d9KwfuZHeSjXYWjpJFPe4w==

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1724,13 +1724,7 @@ module Request: {
       Lwt.t(SuggestResult.t);
 
     let resolveCompletionItem:
-      (
-        ~handle: int,
-        ~resource: Uri.t,
-        ~position: OneBasedPosition.t,
-        ~chainedCacheId: ChainedCacheId.t,
-        Client.t
-      ) =>
+      (~handle: int, ~chainedCacheId: ChainedCacheId.t, Client.t) =>
       Lwt.t(SuggestItem.t);
 
     let provideDocumentHighlights:

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -1223,6 +1223,7 @@ module StatusBar = {
           colorJson,
           alignmentJson,
           priorityJson,
+          _accessibilityInfoJson,
         ]),
       ) =>
       open Base.Result.Let_syntax;

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -281,13 +281,7 @@ module LanguageFeatures = {
   };
 
   let resolveCompletionItem =
-      (
-        ~handle: int,
-        ~resource: Uri.t,
-        ~position: OneBasedPosition.t,
-        ~chainedCacheId: ChainedCacheId.t,
-        client,
-      ) => {
+      (~handle: int, ~chainedCacheId: ChainedCacheId.t, client) => {
     Client.request(
       ~decoder=SuggestItem.Dto.decode,
       ~usesCancellationToken=true,
@@ -296,8 +290,6 @@ module LanguageFeatures = {
       ~args=
         `List([
           `Int(handle),
-          Uri.to_yojson(resource),
-          OneBasedPosition.to_yojson(position),
           chainedCacheId |> Json.Encode.encode_value(ChainedCacheId.encode),
         ]),
       client,

--- a/src/Exthost/SuggestItem.re
+++ b/src/Exthost/SuggestItem.re
@@ -135,9 +135,15 @@ module Dto = {
         let label = field.required("a", string);
 
         let kind =
-          field.required("b", int)
-          |> CompletionKind.ofInt
-          |> Option.value(~default=CompletionKind.Method);
+          field.withDefault(
+            "b",
+            CompletionKind.Property,
+            int
+            |> map(i =>
+                 CompletionKind.ofInt(i)
+                 |> Option.value(~default=CompletionKind.Property)
+               ),
+          );
 
         let detail = field.optional("c", string);
         let documentation = field.optional("d", MarkdownString.decode);

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -797,16 +797,13 @@ let sub = (~client, model) => {
 
          model.handleToSession
          |> IntMap.find_opt(handle)
-         |> OptionEx.flatMap(
-              ({supportsResolve, buffer, location, _}: Session.t) =>
+         |> OptionEx.flatMap(({supportsResolve, _}: Session.t) =>
               if (supportsResolve) {
                 focusedItem.item.chainedCacheId
                 |> Option.map(chainedCacheId => {
                      Service_Exthost.Sub.completionItem(
                        ~handle,
                        ~chainedCacheId,
-                       ~buffer,
-                       ~position=location,
                        ~toMsg=
                          fun
                          | Ok(suggestItem) =>

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -133,8 +133,6 @@ module Sub: {
     (
       ~handle: int,
       ~chainedCacheId: Exthost.ChainedCacheId.t,
-      ~buffer: Oni_Core.Buffer.t,
-      ~position: EditorCoreTypes.CharacterPosition.t,
       ~toMsg: result(Exthost.SuggestItem.t, string) => 'a,
       Exthost.Client.t
     ) =>

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -307,7 +307,7 @@ let create = (~config, ~extensions, ~setup: Setup.t) => {
 
   let initData =
     InitData.create(
-      ~version="1.44.5", // TODO: How to keep in sync with bundled version?
+      ~version="1.46.0", // TODO: How to keep in sync with bundled version?
       ~parentPid,
       ~logsLocation,
       ~logFile,


### PR DESCRIPTION
This picks up the vscode-exthost@1.46.0, and implements several API changes:
- Additional argument for StatusBar `$setEntry` 
- Streamlined `$resolveCompletionItem` API
- Optional `CompletionKind` for suggestitems