### PR TITLE
refactor(dependency): vscode-exthost -> 1.47.1

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onivim/vscode-exthost": "1.46.0",
+    "@onivim/vscode-exthost": "1.47.1000",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
     "yauzl": "^2.5.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@onivim/vscode-exthost@1.46.0":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.46.0.tgz#37500b8b14210173ea7829e898399472c5f39fa6"
-  integrity sha512-8zabMYbG0NgjEMMGvP4QrjjkbjulZOe8x6WgkY4gUGOGq1lPYO+yQhxdjcIptXmOOLWhMw2Nu5k9Mt7uDY1itw==
+"@onivim/vscode-exthost@1.47.1000":
+  version "1.47.1000"
+  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.47.1000.tgz#05eb8a07b6f0a4945b713d11609877992e7f9e0f"
+  integrity sha512-XY1uZtAPpPSFkG5JiKVIUc+8nOZYsX9DJ7zypKJqPaJb8elbhj0MRRjmV0pknUBT5OtFhRCgOMm+g5zaWleuRg==
   dependencies:
     graceful-fs "4.2.3"
-    iconv-lite "0.5.0"
+    iconv-lite-umd "0.6.7"
     minimist "^1.2.0"
     native-watchdog "1.3.0"
     node-pty "^0.10.0-beta8"
-    semver-umd "^5.5.5"
+    semver-umd "^5.5.7"
     spdlog "^0.11.1"
     vscode-proxy-agent "^0.5.2"
 
@@ -96,12 +96,10 @@ https-proxy-agent@^2.2.3:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-iconv-lite@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.5.0.tgz#59cdde0a2a297cc2aeb0c6445a195ee89f127550"
-  integrity sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
+iconv-lite-umd@0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/iconv-lite-umd/-/iconv-lite-umd-0.6.7.tgz#ee437e34b30f15dc00ec93ea65065e672770777c"
+  integrity sha512-DT90zb7wL1B3I6DmYUMcfJeVdY19XigzDj5AtXbXEw9Jfi0+AVAxfn7ytvY7Xhr+GFn7nd7hPonapC37oo7iAQ==
 
 ip@1.1.5:
   version "1.1.5"
@@ -154,15 +152,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-"safer-buffer@>= 2.1.2 < 3":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-semver-umd@^5.5.5:
-  version "5.5.6"
-  resolved "https://registry.yarnpkg.com/semver-umd/-/semver-umd-5.5.6.tgz#1d185bbd2caec825c564b54907cd09e14083f228"
-  integrity sha512-6ARYXVi4Y4VO5HfyCjT/6xyykBtJwEXSGQ8ON4UPQSFOjZUDsbAE0J614QcBBsLTTyQMEqvsXN804vAqpydjzw==
+semver-umd@^5.5.7:
+  version "5.5.7"
+  resolved "https://registry.yarnpkg.com/semver-umd/-/semver-umd-5.5.7.tgz#966beb5e96c7da6fbf09c3da14c2872d6836c528"
+  integrity sha512-XgjPNlD0J6aIc8xoTN6GQGwWc2Xg0kq8NzrqMVuKG/4Arl6ab1F8+Am5Y/XKKCR+FceFr2yN/Uv5ZJBhRyRqKg==
 
 smart-buffer@^4.1.0:
   version "4.1.0"

--- a/test/Exthost/TerminalServiceTest.re
+++ b/test/Exthost/TerminalServiceTest.re
@@ -8,34 +8,34 @@ let waitForProcessExit =
   | _ => false;
 
 describe("TerminalServiceTest", ({test, _}) => {
-// With 1.47.1, our no-op process isn't even started, so there is no exit for it.
-//  test("noop process should give process exited", _ => {
-//    Test.startWithExtensions([])
-//    |> Test.waitForReady
-//    |> Test.withClient(
-//         Request.TerminalService.spawnExtHostProcess(
-//           ~id=0,
-//           ~shellLaunchConfig=
-//             ShellLaunchConfig.{
-//               executable: "noop",
-//               arguments: [],
-//               name: "noop",
-//             },
-//           ~activeWorkspaceRoot=Uri.fromPath(Sys.getcwd()),
-//           ~cols=10,
-//           ~rows=10,
-//           ~isWorkspaceShellAllowed=true,
-//         ),
-//       )
-//    |> Test.waitForMessage(
-//         ~name="TerminalService.SendProcessExit",
-//         waitForProcessExit,
-//       )
-//    |> Test.terminate
-//    |> Test.waitForProcessClosed
-//  });
-
+  // With 1.47.1, our no-op process isn't even started, so there is no exit for it.
+  //  test("noop process should give process exited", _ => {
+  //    Test.startWithExtensions([])
+  //    |> Test.waitForReady
+  //    |> Test.withClient(
+  //         Request.TerminalService.spawnExtHostProcess(
+  //           ~id=0,
+  //           ~shellLaunchConfig=
+  //             ShellLaunchConfig.{
+  //               executable: "noop",
+  //               arguments: [],
+  //               name: "noop",
+  //             },
+  //           ~activeWorkspaceRoot=Uri.fromPath(Sys.getcwd()),
+  //           ~cols=10,
+  //           ~rows=10,
+  //           ~isWorkspaceShellAllowed=true,
+  //         ),
+  //       )
+  //    |> Test.waitForMessage(
+  //         ~name="TerminalService.SendProcessExit",
+  //         waitForProcessExit,
+  //       )
+  //    |> Test.terminate
+  //  });
   test("valid process should send data and title", _ => {
+    //    |> Test.waitForProcessClosed
+
     let shellLaunchConfig =
       Sys.win32
         ? ShellLaunchConfig.{
@@ -84,5 +84,5 @@ describe("TerminalServiceTest", ({test, _}) => {
        )
     |> Test.terminate
     |> Test.waitForProcessClosed;
-  });
+  })
 });

--- a/test/Exthost/TerminalServiceTest.re
+++ b/test/Exthost/TerminalServiceTest.re
@@ -8,31 +8,32 @@ let waitForProcessExit =
   | _ => false;
 
 describe("TerminalServiceTest", ({test, _}) => {
-  test("noop process should give process exited", _ => {
-    Test.startWithExtensions([])
-    |> Test.waitForReady
-    |> Test.withClient(
-         Request.TerminalService.spawnExtHostProcess(
-           ~id=0,
-           ~shellLaunchConfig=
-             ShellLaunchConfig.{
-               executable: "noop",
-               arguments: [],
-               name: "noop",
-             },
-           ~activeWorkspaceRoot=Uri.fromPath(Sys.getcwd()),
-           ~cols=10,
-           ~rows=10,
-           ~isWorkspaceShellAllowed=true,
-         ),
-       )
-    |> Test.waitForMessage(
-         ~name="TerminalService.SendProcessExit",
-         waitForProcessExit,
-       )
-    |> Test.terminate
-    |> Test.waitForProcessClosed
-  });
+// With 1.47.1, our no-op process isn't even started, so there is no exit for it.
+//  test("noop process should give process exited", _ => {
+//    Test.startWithExtensions([])
+//    |> Test.waitForReady
+//    |> Test.withClient(
+//         Request.TerminalService.spawnExtHostProcess(
+//           ~id=0,
+//           ~shellLaunchConfig=
+//             ShellLaunchConfig.{
+//               executable: "noop",
+//               arguments: [],
+//               name: "noop",
+//             },
+//           ~activeWorkspaceRoot=Uri.fromPath(Sys.getcwd()),
+//           ~cols=10,
+//           ~rows=10,
+//           ~isWorkspaceShellAllowed=true,
+//         ),
+//       )
+//    |> Test.waitForMessage(
+//         ~name="TerminalService.SendProcessExit",
+//         waitForProcessExit,
+//       )
+//    |> Test.terminate
+//    |> Test.waitForProcessClosed
+//  });
 
   test("valid process should send data and title", _ => {
     let shellLaunchConfig =


### PR DESCRIPTION
Upgrade to vscode-exthost -> 1.47.1. Needs an update to the test case, as our 'noop-process' test behaves differently with the new terminal service handling logic.