### PR TITLE
docs(typo): change editorFocus to editorTextFocus

### DIFF
--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -115,7 +115,7 @@ Common contexts with VSCode:
 
 | Context Name | True When | 
 | --- | --- |
-| `editorFocus` | An editor has focus |
+| `editorTextFocus` | An editor has focus |
 | `textInputFocus` | A text input area has focus |
 | `terminalFocus` | A terminal has focus |
 | `suggestWidgetVisible` | The suggest widget (auto-completion) is visible |


### PR DESCRIPTION
Fixes a typo in the documentation