### PR TITLE
refactor(explorer): Use luv for populating file explorer

### DIFF
--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -1,4 +1,5 @@
 open Oni_Core;
+open Utility;
 
 module Log = (val Log.withNamespace("Oni2.Model.FileExplorer"));
 
@@ -81,51 +82,77 @@ let sortByLoweredDisplayName = (a: FsTreeNode.t, b: FsTreeNode.t) => {
    not recurse too far.
  */
 let getFilesAndFolders = (~ignored, cwd, getIcon) => {
-  let rec getDirContent = (~loadChildren=false, cwd) => {
-    let toFsTreeNode = file => {
-      let path = Filename.concat(cwd, file);
-
-      if (isDirectory(path)) {
-        let%lwt children =
-          if (loadChildren) {
-            /**
-               If resolving children for a particular directory fails
-                log the error but carry on processing other directories
-              */
-            attempt(() => getDirContent(path), ~defaultValue=[])
-            |> Lwt.map(List.sort(sortByLoweredDisplayName));
-          } else {
-            Lwt.return([]);
-          };
-
-        Lwt.return(
-          FsTreeNode.directory(path, ~icon=getIcon(path), ~children),
-        );
-      } else {
-        FsTreeNode.file(path, ~icon=getIcon(path)) |> Lwt.return;
-      };
-    };
-
-    let%lwt files =
-      Lwt_unix.files_of_directory(cwd)
-      /* Filter out the relative name for current and parent directory*/
-      |> Lwt_stream.filter(name => name != ".." && name != ".")
-      /* Remove ignored files from search */
-      |> Lwt_stream.filter(name => !List.mem(name, ignored))
-      |> Lwt_stream.to_list;
-
-    Lwt_list.map_p(toFsTreeNode, files);
-  };
-
-  attempt(() => getDirContent(cwd, ~loadChildren=true), ~defaultValue=[]);
+  Luv.File.Dirent.
+    (
+      cwd
+      |> Service_OS.Api.readdir
+      |> Lwt.map((dirents: list(Luv.File.Dirent.t)) => {
+           dirents
+           |> List.filter(({name, _}) =>
+                name != ".." && name != "." && !List.mem(name, ignored)
+              )
+           |> List.map(({name, kind}) => {
+                let path = Filename.concat(cwd, name);
+                if (kind == `FILE) {
+                  FsTreeNode.file(path, ~icon=getIcon(path));
+                } else {
+                  FsTreeNode.directory(
+                    path,
+                    ~icon=getIcon(path),
+                    ~children=[],
+                  );
+                };
+              })
+           |> List.sort(sortByLoweredDisplayName)
+         })
+    );
+    //  let rec getDirContent = (~loadChildren=false, cwd) => {
+    //    let toFsTreeNode = file => {
+    //      let path = Filename.concat(cwd, file);
+    //
+    //      if (isDirectory(path)) {
+    //        let%lwt children =
+    //          if (loadChildren) {
+    //            /**
+    //               If resolving children for a particular directory fails
+    //                log the error but carry on processing other directories
+    //              */
+    //            attempt(() => getDirContent(path), ~defaultValue=[])
+    //            |> Lwt.map(List.sort(sortByLoweredDisplayName));
+    //          } else {
+    //            Lwt.return([]);
+    //          };
+    //
+    //        Lwt.return(
+    //          FsTreeNode.directory(path, ~icon=getIcon(path), ~children),
+    //        );
+    //      } else {
+    //        FsTreeNode.file(path, ~icon=getIcon(path)) |> Lwt.return;
+    //      };
+    //    };
+    //
+    //    let%lwt files =
+    //      Lwt_unix.files_of_directory(cwd)
+    //      /* Filter out the relative name for current and parent directory*/
+    //      |> Lwt_stream.filter(name => name != ".." && name != ".")
+    //      /* Remove ignored files from search */
+    //      |> Lwt_stream.filter(name => !List.mem(name, ignored))
+    //      |> Lwt_stream.to_list;
+    //
+    //    Lwt_list.map_p(toFsTreeNode, files);
 };
+
+//  attempt(() => getDirContent(cwd, ~loadChildren=false), ~defaultValue=[]);
+//};
 
 let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
   let getIcon = getFileIcon(languageInfo, iconTheme);
-  let children =
-    getFilesAndFolders(~ignored, cwd, getIcon)
-    |> Lwt_main.run
-    |> List.sort(sortByLoweredDisplayName);
+  let childrenPromise = getFilesAndFolders(~ignored, cwd, getIcon);
+  //    |> Lwt_main.run
+  //    |> List.sort(sortByLoweredDisplayName);
 
-  FsTreeNode.directory(cwd, ~icon=getIcon(cwd), ~children, ~isOpen=true);
+  childrenPromise
+  |> Lwt.map(children => {
+       FsTreeNode.directory(cwd, ~icon=getIcon(cwd), ~children, ~isOpen=true)
+     });
 };

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -91,16 +91,20 @@ let getFilesAndFolders = (~ignored, cwd, getIcon) => {
            |> List.filter(({name, _}) =>
                 name != ".." && name != "." && !List.mem(name, ignored)
               )
-           |> List.map(({name, kind}) => {
+           |> List.filter_map(({name, kind}) => {
                 let path = Filename.concat(cwd, name);
-                if (kind == `FILE) {
-                  FsTreeNode.file(path, ~icon=getIcon(path));
-                } else {
-                  FsTreeNode.directory(
-                    path,
-                    ~icon=getIcon(path),
-                    ~children=[],
+                if (kind == `FILE || kind == `LINK) {
+                  Some(FsTreeNode.file(path, ~icon=getIcon(path)));
+                } else if (kind == `DIR) {
+                  Some(
+                    FsTreeNode.directory(
+                      path,
+                      ~icon=getIcon(path),
+                      ~children=[],
+                    ),
                   );
+                } else {
+                  None;
                 };
               })
            |> List.sort(sortByLoweredDisplayName)

--- a/src/Model/FileExplorer.re
+++ b/src/Model/FileExplorer.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Utility;
 
 module Log = (val Log.withNamespace("Oni2.Model.FileExplorer"));
 
@@ -40,25 +39,6 @@ let getFileIcon = (languageInfo, iconTheme, filePath) => {
   };
 };
 
-let isDirectory = path => Sys.file_exists(path) && Sys.is_directory(path);
-
-let logUnixError = (error, fn, arg) =>
-  Log.errorf(m => {
-    let msg = Unix.error_message(error);
-    m("%s encountered in %s called with %s", msg, fn, arg);
-  });
-
-let attempt = (~defaultValue, func) => {
-  try%lwt(func()) {
-  | Unix.Unix_error(error, fn, arg) =>
-    logUnixError(error, fn, arg);
-    Lwt.return(defaultValue);
-  | Failure(e) =>
-    Log.error(e);
-    Lwt.return(defaultValue);
-  };
-};
-
 let sortByLoweredDisplayName = (a: FsTreeNode.t, b: FsTreeNode.t) => {
   switch (a.kind, b.kind) {
   | (Directory(_), File) => (-1)
@@ -82,78 +62,38 @@ let sortByLoweredDisplayName = (a: FsTreeNode.t, b: FsTreeNode.t) => {
    not recurse too far.
  */
 let getFilesAndFolders = (~ignored, cwd, getIcon) => {
-  Luv.File.Dirent.
-    (
-      cwd
-      |> Service_OS.Api.readdir
-      |> Lwt.map((dirents: list(Luv.File.Dirent.t)) => {
-           dirents
-           |> List.filter(({name, _}) =>
-                name != ".." && name != "." && !List.mem(name, ignored)
-              )
-           |> List.filter_map(({name, kind}) => {
-                let path = Filename.concat(cwd, name);
-                if (kind == `FILE || kind == `LINK) {
-                  Some(FsTreeNode.file(path, ~icon=getIcon(path)));
-                } else if (kind == `DIR) {
-                  Some(
-                    FsTreeNode.directory(
-                      path,
-                      ~icon=getIcon(path),
-                      ~children=[],
-                    ),
-                  );
-                } else {
-                  None;
-                };
-              })
-           |> List.sort(sortByLoweredDisplayName)
-         })
-    );
-    //  let rec getDirContent = (~loadChildren=false, cwd) => {
-    //    let toFsTreeNode = file => {
-    //      let path = Filename.concat(cwd, file);
-    //
-    //      if (isDirectory(path)) {
-    //        let%lwt children =
-    //          if (loadChildren) {
-    //            /**
-    //               If resolving children for a particular directory fails
-    //                log the error but carry on processing other directories
-    //              */
-    //            attempt(() => getDirContent(path), ~defaultValue=[])
-    //            |> Lwt.map(List.sort(sortByLoweredDisplayName));
-    //          } else {
-    //            Lwt.return([]);
-    //          };
-    //
-    //        Lwt.return(
-    //          FsTreeNode.directory(path, ~icon=getIcon(path), ~children),
-    //        );
-    //      } else {
-    //        FsTreeNode.file(path, ~icon=getIcon(path)) |> Lwt.return;
-    //      };
-    //    };
-    //
-    //    let%lwt files =
-    //      Lwt_unix.files_of_directory(cwd)
-    //      /* Filter out the relative name for current and parent directory*/
-    //      |> Lwt_stream.filter(name => name != ".." && name != ".")
-    //      /* Remove ignored files from search */
-    //      |> Lwt_stream.filter(name => !List.mem(name, ignored))
-    //      |> Lwt_stream.to_list;
-    //
-    //    Lwt_list.map_p(toFsTreeNode, files);
+  Luv.File.Dirent.(
+    cwd
+    |> Service_OS.Api.readdir
+    |> Lwt.map((dirents: list(Luv.File.Dirent.t)) => {
+         dirents
+         |> List.filter(({name, _}) =>
+              name != ".." && name != "." && !List.mem(name, ignored)
+            )
+         |> List.filter_map(({name, kind}) => {
+              let path = Filename.concat(cwd, name);
+              if (kind == `FILE || kind == `LINK) {
+                Some(FsTreeNode.file(path, ~icon=getIcon(path)));
+              } else if (kind == `DIR) {
+                Some(
+                  FsTreeNode.directory(
+                    path,
+                    ~icon=getIcon(path),
+                    ~children=[],
+                  ),
+                );
+              } else {
+                None;
+              };
+            })
+         |> List.sort(sortByLoweredDisplayName)
+       })
+  );
 };
-
-//  attempt(() => getDirContent(cwd, ~loadChildren=false), ~defaultValue=[]);
-//};
 
 let getDirectoryTree = (cwd, languageInfo, iconTheme, ignored) => {
   let getIcon = getFileIcon(languageInfo, iconTheme);
   let childrenPromise = getFilesAndFolders(~ignored, cwd, getIcon);
-  //    |> Lwt_main.run
-  //    |> List.sort(sortByLoweredDisplayName);
 
   childrenPromise
   |> Lwt.map(children => {

--- a/src/Model/FileExplorer.rei
+++ b/src/Model/FileExplorer.rei
@@ -24,4 +24,5 @@ let getFileIcon:
   (Exthost.LanguageInfo.t, IconTheme.t, string) =>
   option(IconTheme.IconDefinition.t);
 let getDirectoryTree:
-  (string, Exthost.LanguageInfo.t, IconTheme.t, list(string)) => FsTreeNode.t;
+  (string, Exthost.LanguageInfo.t, IconTheme.t, list(string)) =>
+  Lwt.t(FsTreeNode.t);

--- a/src/Model/dune
+++ b/src/Model/dune
@@ -4,17 +4,17 @@
  (libraries str bigarray Revery.zed libvim lwt lwt.unix Rench Revery yojson
    ppx_deriving.runtime ppx_deriving_yojson.runtime isolinear Oni2.core
    Oni2.input Oni2.syntax Oni2.syntax_client Oni2.service.font
-   Oni2.service.file-watcher Oni2.components Oni2.feature.buffers
-   Oni2.feature.clipboard Oni2.feature.configuration Oni2.feature.contextMenu
-   Oni2.feature.exthost Oni2.feature.extensions Oni2.feature.messages
-   Oni2.feature.theme Oni2.feature.notification Oni2.feature.changelog
-   Oni2.feature.commands Oni2.feature.decorations Oni2.feature.input
-   Oni2.component.inputText Oni2.feature.search Oni2.feature.sideBar
-   Oni2.feature.syntax Oni2.feature.language_support Oni2.feature.editor
-   Oni2.feature.pane Oni2.feature.registers Oni2.feature.scm
-   Oni2.feature.sneak Oni2.feature.statusbar Oni2.feature.terminal
-   Oni2.feature.titlebar Oni2.feature.modals Oni2.feature.layout
-   Oni2.feature.vim Oni2.feature.signature_help ReasonFuzz textmate
-   Oni2.editor-core-types)
+   Oni2.service.file-watcher Oni2.service.os Oni2.components
+   Oni2.feature.buffers Oni2.feature.clipboard Oni2.feature.configuration
+   Oni2.feature.contextMenu Oni2.feature.exthost Oni2.feature.extensions
+   Oni2.feature.messages Oni2.feature.theme Oni2.feature.notification
+   Oni2.feature.changelog Oni2.feature.commands Oni2.feature.decorations
+   Oni2.feature.input Oni2.component.inputText Oni2.feature.search
+   Oni2.feature.sideBar Oni2.feature.syntax Oni2.feature.language_support
+   Oni2.feature.editor Oni2.feature.pane Oni2.feature.registers
+   Oni2.feature.scm Oni2.feature.sneak Oni2.feature.statusbar
+   Oni2.feature.terminal Oni2.feature.titlebar Oni2.feature.modals
+   Oni2.feature.layout Oni2.feature.vim Oni2.feature.signature_help
+   ReasonFuzz textmate Oni2.editor-core-types)
  (preprocess
   (pps lwt_ppx ppx_deriving_yojson ppx_deriving.show)))

--- a/src/Service/OS/Service_OS.rei
+++ b/src/Service/OS/Service_OS.rei
@@ -36,3 +36,13 @@ module Effect: {
   let statMultiple:
     (list(string), (string, Unix.stats) => 'msg) => Isolinear.Effect.t('msg);
 };
+
+module Sub: {
+  let dir:
+    (
+      ~uniqueId: string,
+      ~toMsg: result(list(Luv.File.Dirent.t), string) => 'msg,
+      string
+    ) =>
+    Isolinear.Sub.t('msg);
+};

--- a/src/Store/FileExplorerStore.re
+++ b/src/Store/FileExplorerStore.re
@@ -12,7 +12,7 @@ module Effects = {
     Isolinear.Effect.createWithDispatch(~name="explorer.load", dispatch => {
       let ignored =
         Configuration.getValue(c => c.filesExclude, configuration);
-      let tree =
+      let promise =
         FileExplorer.getDirectoryTree(
           directory,
           languageInfo,
@@ -20,7 +20,7 @@ module Effects = {
           ignored,
         );
 
-      dispatch(onComplete(tree));
+      Lwt.on_success(promise, tree => {dispatch(onComplete(tree))});
     });
   };
 };


### PR DESCRIPTION
More groundwork on the path to #528 - this is some refactoring to support changing the initial load population strategy for the file explorer, which is blocking moving the explorer to its own self-contained feature.

In addition, this moves the file population story to use libuv - and importantly, not block on File I/O. Previously, we were using `Lwt.main_run` to block and populate the directory info synchronously (in addition, we were also traversing a single layer deep inside each folder, which isn't necessary for the initial population). This is actually one bottleneck on Windows start time, at least on my machine (related to #523 ). Removing this blocking is also important for moving to subscriptions, so that we can have predictable performance and running the subscription can be lightweight.