### PR TITLE
fix(ux/#2449): Windows - Title bar not draggable from icon / text

### DIFF
--- a/src/Feature/TitleBar/Feature_TitleBar.re
+++ b/src/Feature/TitleBar/Feature_TitleBar.re
@@ -250,9 +250,7 @@ module Styles = {
       marginHorizontal(16),
     ];
 
-    let icon = [
-      pointerEvents(`Ignore)
-    ];
+    let icon = [pointerEvents(`Ignore)];
 
     let title = (~isFocused, ~theme) => [
       pointerEvents(`Ignore),
@@ -429,9 +427,12 @@ module View = {
         mouseBehavior=Draggable
         style={Styles.Windows.container(~isFocused, ~theme)}>
         <View mouseBehavior=Draggable style=Styles.Windows.iconAndTitle>
-          <Image 
+          <Image
             style=Styles.Windows.icon
-            src={`File("./logo-titlebar.png")} width=18 height=18 />
+            src={`File("./logo-titlebar.png")}
+            width=18
+            height=18
+          />
           <Text
             style={Styles.Windows.title(~isFocused, ~theme)}
             fontFamily={font.family}

--- a/src/Feature/TitleBar/Feature_TitleBar.re
+++ b/src/Feature/TitleBar/Feature_TitleBar.re
@@ -250,7 +250,12 @@ module Styles = {
       marginHorizontal(16),
     ];
 
+    let icon = [
+      pointerEvents(`Ignore)
+    ];
+
     let title = (~isFocused, ~theme) => [
+      pointerEvents(`Ignore),
       flexGrow(0),
       marginLeft(16),
       marginTop(2),
@@ -424,7 +429,9 @@ module View = {
         mouseBehavior=Draggable
         style={Styles.Windows.container(~isFocused, ~theme)}>
         <View mouseBehavior=Draggable style=Styles.Windows.iconAndTitle>
-          <Image src={`File("./logo-titlebar.png")} width=18 height=18 />
+          <Image 
+            style=Styles.Windows.icon
+            src={`File("./logo-titlebar.png")} width=18 height=18 />
           <Text
             style={Styles.Windows.title(~isFocused, ~theme)}
             fontFamily={font.family}


### PR DESCRIPTION
__Issue:__ If initiating a drag on Windows by clicking on the title bar icon or title bar text, nothing would happen. Clicking empty space would work as expected, though.

__Defect:__ The icon / text elements were stealing the mouse event.

__Fix:__ Use ```pointerEvents(`ignore)``` to prevent the mouse event from being blocked.

Fixes #2449 