### PR TITLE
fix(windows/#2445): Packaging - Windows executables not getting proper icon

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -84,7 +84,7 @@ const updateIcon = (rcedit, exe, iconFile) => {
     process.env = {
         PATH: process.env.PATH,
     }
-    fs.chmodSync(exe, 0755);
+    fs.chmodSync(exe, 0755)
     rcedit(exe, {
         icon: iconFile,
     })

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -84,6 +84,7 @@ const updateIcon = (rcedit, exe, iconFile) => {
     process.env = {
         PATH: process.env.PATH,
     }
+    fs.chmodSync(exe, 0755);
     rcedit(exe, {
         icon: iconFile,
     })
@@ -290,9 +291,9 @@ if (process.platform == "linux") {
     fs.copySync(iconFile, path.join(platformReleaseDirectory, "oni2.ico"))
     fs.copySync(eulaFile, path.join(platformReleaseDirectory, "EULA.md"))
     fs.copySync(thirdPartyFile, path.join(platformReleaseDirectory, "ThirdPartyLicenses.txt"))
-    fs.copySync(curBin, platformReleaseDirectory, { deference: true })
-    fs.copySync(extensionsSourceDirectory, extensionsDestDirectory, { deference: true })
-    fs.copySync(nodeScriptSourceDirectory, nodeScriptDestDirectory, { deference: true })
+    fs.copySync(curBin, platformReleaseDirectory, { dereference: true })
+    fs.copySync(extensionsSourceDirectory, extensionsDestDirectory, { dereference: true })
+    fs.copySync(nodeScriptSourceDirectory, nodeScriptDestDirectory, { dereference: true })
     fs.removeSync(path.join(platformReleaseDirectory, "setup.json"))
 
     // Now that we've copied set the app icon up correctly.


### PR DESCRIPTION
__Issue:__ As described in #2445 - the windows executables aren't getting proper app icons.

__Defect:__ We use a tool called [`rcedit`](..) to handle embedding icons in our executables.

However, on our private packaging pipeline, we're getting this error:
```
(node:8744) UnhandledPromiseRejectionWarning: Error: rcedit.exe failed with exit code 1. Fatal error: Unable to commit changes
    at ChildProcess.<anonymous> (C:\Users\VssAdministrator\.esy\source\i\rcedit__2.0.0__0ca922f4\lib\rcedit.js:69:16)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Socket.<anonymous> (internal/child_process.js:430:11)
    at Socket.emit (events.js:210:5)
    at Pipe.<anonymous> (net.js:658:12)
```

Luckily, it also reproduced on my Windows machine. It turns out the executables, for some reason, don't have the write permission set, which causes `rcedit` to fail when trying to back the icon.

__Fix:__ Set writable permissions prior to running `rcedit`.

Fixes #2445 