### PR TITLE
fix(completion): Improve sorting behavior

### DIFF
--- a/src/Core/Filter.re
+++ b/src/Core/Filter.re
@@ -12,6 +12,8 @@ type result('a) = {
   highlight: list((int, int)),
 };
 
+let result = item => {item, highlight: []};
+
 let map = (f, result) => {
   item: f(result.item),
   highlight: result.highlight,

--- a/src/Core/Filter.rei
+++ b/src/Core/Filter.rei
@@ -9,6 +9,8 @@ type result('a) = {
   highlight: list((int, int)),
 };
 
+let result: 'a => result('a);
+
 let map: ('a => 'b, result('a)) => result('b);
 
 let rank:

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -270,6 +270,8 @@ module SuggestItem: {
     [@deriving show]
     type t;
 
+    let none: t;
+
     let matches: (~rule: rule, t) => bool;
   };
   module SuggestRange: {

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -1,0 +1,34 @@
+open Exthost;
+
+[@deriving show]
+type t = {
+  chainedCacheId: option(ChainedCacheId.t),
+  handle: int,
+  label: string,
+  kind: CompletionKind.t,
+  detail: option(string),
+  documentation: option(MarkdownString.t),
+  insertText: string,
+  insertTextRules: SuggestItem.InsertTextRules.t,
+  sortText: string,
+  suggestRange: option(SuggestItem.SuggestRange.t),
+  commitCharacters: list(string),
+  additionalTextEdits: list(Edit.SingleEditOperation.t),
+  command: option(Command.t),
+};
+
+let create = (~handle, item: SuggestItem.t) => {
+  chainedCacheId: item.chainedCacheId,
+  handle,
+  label: item.label,
+  kind: item.kind,
+  detail: item.detail,
+  documentation: item.documentation,
+  insertText: item |> SuggestItem.insertText,
+  insertTextRules: item.insertTextRules,
+  sortText: item |> SuggestItem.sortText,
+  suggestRange: item.suggestRange,
+  commitCharacters: item.commitCharacters,
+  additionalTextEdits: item.additionalTextEdits,
+  command: item.command,
+};

--- a/src/Feature/LanguageSupport/CompletionItemSorter.re
+++ b/src/Feature/LanguageSupport/CompletionItemSorter.re
@@ -1,0 +1,64 @@
+open Oni_Core;
+
+let compare =
+    (a: Filter.result(CompletionItem.t), b: Filter.result(CompletionItem.t)) => {
+  // First, use the sortText, if available
+  let sortValue = String.compare(a.item.sortText, b.item.sortText);
+  if (sortValue == 0) {
+    let aLen = String.length(a.item.label);
+    let bLen = String.length(b.item.label);
+    if (aLen == bLen) {
+      String.compare(a.item.label, b.item.label);
+    } else {
+      aLen - bLen;
+    };
+  } else {
+    sortValue;
+  };
+};
+
+let%test_module "compare" =
+  (module
+   {
+     let create = (~label, ~sortText) => {
+       CompletionItem.{
+         chainedCacheId: None,
+         handle: 0,
+         label,
+         kind: Exthost.CompletionKind.Method,
+         detail: None,
+         documentation: None,
+         insertText: label,
+         insertTextRules: Exthost.SuggestItem.InsertTextRules.none,
+         sortText,
+         suggestRange: None,
+         commitCharacters: [],
+         additionalTextEdits: [],
+         command: None,
+       }
+       |> Filter.result;
+     };
+
+     let%test "sortText takes precedence" = {
+       let sortTextZ = create(~label="abc", ~sortText="z");
+       let sortTextA = create(~label="def", ~sortText="a");
+
+       [sortTextZ, sortTextA]
+       |> List.sort(compare) == [sortTextA, sortTextZ];
+     };
+
+     let%test "falls back to label" = {
+       let abc = create(~label="abc", ~sortText="a");
+       let def = create(~label="def", ~sortText="a");
+
+       [def, abc] |> List.sort(compare) == [abc, def];
+     };
+
+     let%test "when falling back to label, prefer shorter result" = {
+       let toString = create(~label="toString", ~sortText="a");
+       let toLocaleString = create(~label="toLocaleString", ~sortText="a");
+
+       [toLocaleString, toString]
+       |> List.sort(compare) == [toString, toLocaleString];
+     };
+   });


### PR DESCRIPTION
__Issue:__ When `sortText` is not provided, the completion ordering could be un-intuitive.

For example:

![image](https://user-images.githubusercontent.com/13532591/93522038-c1275100-f8e5-11ea-870d-dee22ac98cef.png)

In this case, the expectation would be that `toString` is prioritized.

__Defect:__ When `sortText` is not available, we fall back to `label` alphabetical sort.

__Fix:__ In the short-term, we can consider the length as well - with fuzzy matching, shorter matches have a higher percent match, so it's more intuitive and useful:

![image](https://user-images.githubusercontent.com/13532591/93522291-16636280-f8e6-11ea-8e67-bf0e086a18eb.png)

The fuzzy-finding work in #1566 will also accomodate this, so once that's in, we can use the fuzzy-filter score as the fall.

In addition, add test cases, so that we can catalog, document, and continue to improve the sorting behavior.