### PR TITLE
docs: tips for users coming from vim and vscode

### DIFF
--- a/docs/docs/getting-started/vim-tips.md
+++ b/docs/docs/getting-started/vim-tips.md
@@ -1,0 +1,45 @@
+# Tips for users coming from Vim
+
+### How do I get the tabs to behave as they do in Vim?
+
+Add these settings to your configuration:
+
+```
+  "oni.layout.singleTabMode": true,
+  "oni.layout.layoutTabPosition": "top",
+```
+
+### How do I replicate my vimrc?
+
+Using the
+[`"experimental.viml"`](https://onivim.github.io/docs/configuration/settings#experimental)
+setting you can already successfully run many VimL commands like keybindings.
+But it is experimental for good reason. Many commands do not work, and there's
+no overview of what does and does not work.
+
+This setting will eventually be replaced with a mechanism that will support a
+larger and more well-defined subset of VimL. See
+[this issue](https://github.com/onivim/oni2/issues/150) for details.
+
+### How do I bind to Vim motions and commands using Oni's natvie keybinding configuration?
+
+Ex commands are supported by prefixing the command with `:` as you would when
+typing it in Normal mode. For example:
+
+```
+  {"key": "kk", "command": ":split", "when": "editorTextFocus"},
+  {"key": "<C-D>", "command": ":d 2", "when": "insertMode"}
+```
+
+There's currently no support for creating native keybindings for Vim motions.
+For now, pelase use VimL keybindings with the
+[`"experimental.viml"`](https://onivim.github.io/docs/configuration/settings#experimental)
+setting.
+
+<!--
+
+### How to format on save?
+
+By running the format comamnd with `autocmd`. Help, vim people?
+
+-->

--- a/docs/docs/getting-started/vscode-tips.md
+++ b/docs/docs/getting-started/vscode-tips.md
@@ -36,4 +36,13 @@ Note: If closing the last open file, this will also close the editor.
 
 ### How do I search the current file?
 
-In Normal mode, type `/` then the pattern 
+In Normal mode, type `/` to search forwards from the cursor, or `?` to search
+backwards, followed by the pattern to search for.
+
+Vim uses a peculiar regex-like syntax for patterns. See
+[the documentation](http://vimdoc.sourceforge.net/htmldoc/pattern.html) for
+details.
+
+### How do I clear the search highlights?
+
+In Normal mode, type `:nohlsearch`, or the short form `:noh`.

--- a/docs/docs/getting-started/vscode-tips.md
+++ b/docs/docs/getting-started/vscode-tips.md
@@ -1,0 +1,39 @@
+### Tips for users coming from Visual Studio Code
+
+If you come from Visual Studio Code, Onivim's appearance will hopefully have you
+feeling right at home. It's behaviour might be a bit unfamiliar though, so here's
+a few tips tips to help you along:
+
+### How do I change the working directory?
+
+In Normal mode, type `:cd <dir>`.
+
+### How do I create a new file?
+
+In Normal mode, type `:e <filename>`.
+
+Note that this will eventually be possible to accomplish interactively using the
+file explorer with either the keyboard or mouse.
+
+### How do I create a new directory?
+
+In Normal mode, type `:!mkdir <dir>`.
+
+`:!` can be used to execute arbitrary commands, but has very limited feedback.
+
+Note that this is a temporary stopgap. It will eventually be possible to
+accomplish this interactively in the file explorer with either keyboard or mouse.
+
+### How do I save a file?
+
+In Normal mode, type `:w` to save or `:w <filename>` to save to a specific file.
+
+### How do I close a file?
+
+In Normal mode, type `:q`.
+
+Note: If closing the last open file, this will also close the editor.
+
+### How do I search the current file?
+
+In Normal mode, type `/` then the pattern 

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -4,6 +4,8 @@
       "getting-started/why-onivim",
       "getting-started/installation",
       "getting-started/vim-differences",
+      "getting-started/vim-tips",
+      "getting-started/vscode-tips",
       "getting-started/modal-editing-101"
     ],
     "Basic Usage": [


### PR DESCRIPTION
This adds two new pages in the "Getting Started" with tips for vim and vscode users. Kind of a FAQ but targeted towards specific user groups. I also think these will make it easier to contribute documentation as the format lends itself well to adding self-contained tips.