### PR TITLE
docs: Add 'Edit' button on all pages

### DIFF
--- a/docs/website/siteConfig.js
+++ b/docs/website/siteConfig.js
@@ -25,6 +25,7 @@ const siteConfig = {
   tagline: 'Modal Editing from the Future',
   url: 'https://your-docusaurus-test-site.com', // Your website URL
   baseUrl: '/', // Base URL for your project */
+  editUrl: 'https://github.com/onivim/oni2/edit/master/docs/docs/',
   // For github.io type URLs, you would set the url and baseUrl like:
   //   url: 'https://facebook.github.io',
   //   baseUrl: '/test-site/',


### PR DESCRIPTION
I really like @eleijonmarck 's idea in #2473 / #2480 to have an Edit button - this just implements it in a slightly different way - apparently Docusaurus has an `editUrl` property: https://docusaurus.io/docs/en/site-config#editurl-string

When populated, you get a nice `Edit` button at the top of the page:

![image](https://user-images.githubusercontent.com/13532591/93687136-3e7ecd00-fa70-11ea-80bb-46bf090cb782.png)
