### PR TITLE
fix(command-line/#2477): Fix completion keybindings in ':' command line

### DIFF
--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -5,6 +5,12 @@ let menus = (~isFocused) => {
     // TODO: This should be factored to a feature...
     isFocused
       ? Quickmenu.[
+          bool(
+            "commandLineFocus",
+            fun
+            | Some({variant: Wildmenu(_), _}) => true
+            | _ => false,
+          ),
           bool("listFocus", model => model != None),
           bool("inQuickOpen", model => model != None),
           bool(
@@ -12,6 +18,13 @@ let menus = (~isFocused) => {
             fun
             | Some({variant: EditorsPicker, _}) => true
             | _ => false,
+          ),
+          bool(
+            "textInputFocus",
+            fun
+            | Some({variant: EditorsPicker, _}) => false
+            | Some(_) => true
+            | None => false,
           ),
           bool(
             "textInputFocus",
@@ -145,7 +158,7 @@ let all = (state: State.t) => {
     paneContextKeys |> map(({pane, _}: State.t) => pane),
     Feature_LanguageSupport.Contributions.contextKeys
     |> map(({languageSupport, _}: State.t) => languageSupport),
-    menus(~isFocused=focus == Focus.Quickmenu)
+    menus(~isFocused=focus == Focus.Quickmenu || focus == Focus.Wildmenu)
     |> map((state: State.t) => state.quickmenu),
     editors(~isFocused=focus == Focus.Editor),
     other,

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -27,13 +27,6 @@ let menus = (~isFocused) => {
             | None => false,
           ),
           bool(
-            "textInputFocus",
-            fun
-            | Some({variant: EditorsPicker, _}) => false
-            | Some(_) => true
-            | None => false,
-          ),
-          bool(
             "quickmenuCursorEnd",
             fun
             | Some({inputText, _})


### PR DESCRIPTION
__Issue:__ Various keybindings for triggering and interacting with command-line completion (control+n, tab, arrows) were not working as expected.

__Defect:__ The quick menu context keys, to engage the appropriate key bindings, were not enabled when the command line was open.

__Fix:__ Hook up the command-line context keys.

Fixes #2477 
Fixes #2485 

Longer-term - we should pivot the 'Quickmenu' model, such that it doesn't need to be aware of every menu. We could instead make the menu component stand-alone (like input/vimlist/vimtree), and supply context keys. This would make implementing a more dynamic menu, like one with more details in the completion info, doable.

