### PR TITLE
docs: fix titles and typos on tips pages

### DIFF
--- a/docs/docs/getting-started/vim-tips.md
+++ b/docs/docs/getting-started/vim-tips.md
@@ -1,4 +1,8 @@
-# Tips for users coming from Vim
+---
+id: vim-tips
+title: Tips for users coming from Vim
+sidebar_label: Tips for Vim Users
+---
 
 ### How do I get the tabs to behave as they do in Vim?
 
@@ -9,7 +13,7 @@ Add these settings to your configuration:
   "oni.layout.layoutTabPosition": "top",
 ```
 
-### How do I replicate my vimrc?
+### How do I replicate my .vimrc?
 
 Using the
 [`"experimental.viml"`](https://onivim.github.io/docs/configuration/settings#experimental)
@@ -21,7 +25,7 @@ This setting will eventually be replaced with a mechanism that will support a
 larger and more well-defined subset of VimL. See
 [this issue](https://github.com/onivim/oni2/issues/150) for details.
 
-### How do I bind to Vim motions and commands using Oni's natvie keybinding configuration?
+### How do I bind to Vim motions and commands using Oni's native keybinding configuration?
 
 Ex commands are supported by prefixing the command with `:` as you would when
 typing it in Normal mode. For example:
@@ -32,7 +36,7 @@ typing it in Normal mode. For example:
 ```
 
 There's currently no support for creating native keybindings for Vim motions.
-For now, pelase use VimL keybindings with the
+For now, please use VimL keybindings with the
 [`"experimental.viml"`](https://onivim.github.io/docs/configuration/settings#experimental)
 setting.
 

--- a/docs/docs/getting-started/vscode-tips.md
+++ b/docs/docs/getting-started/vscode-tips.md
@@ -1,6 +1,6 @@
 ---
 id: vscode-tips
-title: Tips for users coming from Visual Studo Code
+title: Tips for users coming from Visual Studio Code
 sidebar_label: Tips for VSCode Users
 ---
 

--- a/docs/docs/getting-started/vscode-tips.md
+++ b/docs/docs/getting-started/vscode-tips.md
@@ -1,7 +1,11 @@
-### Tips for users coming from Visual Studio Code
+---
+id: vscode-tips
+title: Tips for users coming from Visual Studo Code
+sidebar_label: Tips for VSCode Users
+---
 
 If you come from Visual Studio Code, Onivim's appearance will hopefully have you
-feeling right at home. It's behaviour might be a bit unfamiliar though, so here's
+feeling right at home. Its behaviour might be a bit unfamiliar though, so here's
 a few tips tips to help you along:
 
 ### How do I change the working directory?
@@ -12,8 +16,8 @@ In Normal mode, type `:cd <dir>`.
 
 In Normal mode, type `:e <filename>`.
 
-Note that this will eventually be possible to accomplish interactively using the
-file explorer with either the keyboard or mouse.
+Note that it will eventually be possible to accomplish this interactively using
+the file explorer with either the keyboard or mouse.
 
 ### How do I create a new directory?
 
@@ -45,4 +49,4 @@ details.
 
 ### How do I clear the search highlights?
 
-In Normal mode, type `:nohlsearch`, or the short form `:noh`.
+In Normal mode, type `:nohlsearch`, or its short form `:noh`.


### PR DESCRIPTION
Fixes for #2475. I didn't realize the titles had to be in a special preface format. Also fixes a few typos found in a second reading.