### PR TITLE
docs: fix release steps

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -78,7 +78,7 @@ node install-node-deps.js
 
 ### Inline Unit Tests
 
-- `esy @test inline`
+- `esy '@test' inline`
 
 ### Check build
 
@@ -100,8 +100,8 @@ We use auto formatting tool, you might want to run it before you commit changes
 
 To create a release build, run:
 
-- `esy x Oni2 -f --checkhealth`
-- `esy @release create`
+- `esy '@release' run -f --checkhealth`
+- `esy '@release' create`
 
 This will create a `_release` folder at the root with the application bundle inside.
 


### PR DESCRIPTION
Just updates the release step, since the release is now in its own sandbox, you need to run Oni2 in that sandbox once for the binary to exist, to be copied for the release.

Arguably, the scripts should be a little smarter about this (i.e. check, error, say "Run `esy ....`).