### PR TITLE
fix(explorer/#528): #528 - Part 1 - Initial vim navigation for Explorer

### DIFF
--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -9,7 +9,7 @@ type model('item) = {
   rowHeight: int,
   items: array('item),
   hovered: option(int),
-  focused: int,
+  selected: int,
   viewportHeight: int,
   viewportWidth: int,
   multiplier: int,
@@ -24,7 +24,7 @@ let create = (~rowHeight) => {
   rowHeight,
   items: [||],
   hovered: None,
-  focused: 0,
+  selected: 0,
   multiplier: 0,
   viewportHeight: 1,
   viewportWidth: 1,
@@ -36,21 +36,18 @@ let isScrollAnimated = ({isScrollAnimated, _}) => isScrollAnimated;
 
 let findIndex = (f, {items, _}) => {
   let len = Array.length(items);
-  let rec loop = (idx) => {
+  let rec loop = idx =>
     if (idx >= len) {
-      None
+      None;
+    } else if (f(items[idx])) {
+      Some(idx);
     } else {
-      if (f(items[idx])) {
-        Some(idx)
-      } else {
-        loop(idx + 1);
-      }
-    }
-  };
+      loop(idx + 1);
+    };
   loop(0);
 };
 
-let focusedIndex = ({focused, _}) => focused;
+let selectedIndex = ({selected, _}) => selected;
 
 let resetMultiplier = model => {...model, multiplier: 0};
 
@@ -114,8 +111,8 @@ let showBottomScrollShadow = ({items, scrollY, rowHeight, viewportHeight, _}) =>
 
 // UPDATE
 
-let ensureFocusedVisible = model => {
-  let yPosition = float(model.focused * model.rowHeight);
+let ensureSelectedVisible = model => {
+  let yPosition = float(model.selected * model.rowHeight);
 
   let rowHeightF = float(model.rowHeight);
   let viewportHeightF = float(model.viewportHeight);
@@ -132,18 +129,18 @@ let ensureFocusedVisible = model => {
   {...model, scrollY: scrollY'};
 };
 
-let setFocus = (~focus, model) => {
+let setSelected = (~selected, model) => {
   let count = model.items |> Array.length;
-  let focus' =
-    if (focus < 0) {
+  let selected' =
+    if (selected < 0) {
       0;
-    } else if (focus >= count) {
+    } else if (selected >= count) {
       count - 1;
     } else {
-      focus;
+      selected;
     };
 
-  {...model, focused: focus'} |> ensureFocusedVisible;
+  {...model, selected: selected'} |> ensureSelectedVisible;
 };
 
 let setScrollY = (~scrollY, model) => {
@@ -159,68 +156,74 @@ let setScrollY = (~scrollY, model) => {
 let enableScrollAnimation = model => {...model, isScrollAnimated: true};
 let disableScrollAnimation = model => {...model, isScrollAnimated: false};
 
-let scrollFocusToTop = (model) => {
-   model
-   |> setScrollY(~scrollY=float(model.focused * model.rowHeight))
-   |> enableScrollAnimation;
+let scrollSelectedToTop = model => {
+  model
+  |> setScrollY(~scrollY=float(model.selected * model.rowHeight))
+  |> enableScrollAnimation;
 };
 
-let scrollFocusToBottom = (model) => {
-      model
-      |> setScrollY(
-           ~scrollY=
-             float(
-               model.focused
-               * model.rowHeight
-               - (model.viewportHeight - model.rowHeight),
-             ),
-         )
-      |> enableScrollAnimation;
+let scrollSelectedToBottom = model => {
+  model
+  |> setScrollY(
+       ~scrollY=
+         float(
+           model.selected
+           * model.rowHeight
+           - (model.viewportHeight - model.rowHeight),
+         ),
+     )
+  |> enableScrollAnimation;
 };
 
-let scrollFocusToCenter = (model) => {
-      model
-      |> setScrollY(
-           ~scrollY=
-             float(
-               model.focused
-               * model.rowHeight
-               - (model.viewportHeight - model.rowHeight)
-               / 2,
-             ),
-         )
-      |> enableScrollAnimation;
+let scrollSelectedToCenter = model => {
+  model
+  |> setScrollY(
+       ~scrollY=
+         float(
+           model.selected
+           * model.rowHeight
+           - (model.viewportHeight - model.rowHeight)
+           / 2,
+         ),
+     )
+  |> enableScrollAnimation;
 };
 
 let scrollTo = (~index, ~alignment, model) => {
-  let model' = model |> setFocus(~focus=index);
+  let model' = model |> setSelected(~selected=index);
   switch (alignment) {
-  | `Top => model' |> scrollFocusToTop
-  | `Bottom => model' |> scrollFocusToBottom
-  | `Center => model' |> scrollFocusToCenter
-  | `Reveal => model' |> ensureFocusedVisible
-  }
+  | `Top => model' |> scrollSelectedToTop
+  | `Bottom => model' |> scrollSelectedToBottom
+  | `Center => model' |> scrollSelectedToCenter
+  | `Reveal => model' |> ensureSelectedVisible
+  };
 };
 
 let update = (msg, model) => {
   switch (msg) {
   | Command(CursorToTop) => (
-      model |> setFocus(~focus=0) |> enableScrollAnimation |> resetMultiplier,
+      model
+      |> setSelected(~selected=0)
+      |> enableScrollAnimation
+      |> resetMultiplier,
       Nothing,
     )
 
   | Command(CursorToBottom) =>
-    let focus =
+    let selected =
       model.multiplier == 0
         ? Array.length(model.items) - 1 : model.multiplier;
     (
-      model |> setFocus(~focus) |> enableScrollAnimation |> resetMultiplier,
+      model
+      |> setSelected(~selected)
+      |> enableScrollAnimation
+      |> resetMultiplier,
       Nothing,
     );
 
   | Command(CursorUp) => (
       model
-      |> setFocus(~focus=model.focused - getMultiplier(model))
+      |> setSelected(~selected=model.selected - getMultiplier(model))
       |> enableScrollAnimation
       |> resetMultiplier,
       Nothing,
@@ -228,7 +231,7 @@ let update = (msg, model) => {
 
   | Command(CursorDown) => (
       model
-      |> setFocus(~focus=model.focused + getMultiplier(model))
+      |> setSelected(~selected=model.selected + getMultiplier(model))
       |> enableScrollAnimation
       |> resetMultiplier,
       Nothing,
@@ -240,32 +243,26 @@ let update = (msg, model) => {
     )
 
   | Command(ScrollCursorTop) => (
-      model
-      |> scrollFocusToTop
-      |> resetMultiplier,
+      model |> scrollSelectedToTop |> resetMultiplier,
       Nothing,
     )
 
   | Command(ScrollCursorBottom) => (
-      model
-      |> scrollFocusToBottom
-      |> resetMultiplier,
+      model |> scrollSelectedToBottom |> resetMultiplier,
       Nothing,
     )
 
   | Command(ScrollCursorCenter) => (
-      model
-      |> scrollFocusToCenter
-      |> resetMultiplier,
+      model |> scrollSelectedToCenter |> resetMultiplier,
       Nothing,
     )
 
   | Command(Select) =>
     let isValidFocus =
-      model.focused >= 0 && model.focused < Array.length(model.items);
+      model.selected >= 0 && model.selected < Array.length(model.items);
 
     if (isValidFocus) {
-      (model, Selected({index: model.focused}));
+      (model, Selected({index: model.selected}));
     } else {
       (model, Nothing);
     };
@@ -274,7 +271,7 @@ let update = (msg, model) => {
     let isValidIndex = index >= 0 && index < Array.length(model.items);
 
     if (isValidIndex) {
-      (model |> setFocus(~focus=index), Selected({index: index}));
+      (model |> setSelected(~selected=index), Selected({index: index}));
     } else {
       (model, Nothing);
     };
@@ -357,6 +354,8 @@ module Keybindings = {
       {key: "<S-G>", command: Commands.g.id, condition: commandCondition},
       {key: "j", command: Commands.j.id, condition: commandCondition},
       {key: "k", command: Commands.k.id, condition: commandCondition},
+      {key: "<DOWN>", command: Commands.j.id, condition: commandCondition},
+      {key: "<UP>", command: Commands.k.id, condition: commandCondition},
       {key: "<CR>", command: Commands.enter.id, condition: commandCondition},
       {key: "zz", command: Commands.zz.id, condition: commandCondition},
       {key: "zb", command: Commands.zb.id, condition: commandCondition},
@@ -464,10 +463,12 @@ module View = {
   let renderHelper =
       (
         ~items,
+        ~focusIndex,
         ~hovered,
-        ~focused,
+        ~selected,
         ~hoverBg,
         ~focusBg,
+        ~selectedBg,
         ~onMouseClick,
         ~onMouseOver,
         ~onMouseOut,
@@ -494,13 +495,15 @@ module View = {
         let rowY = (i - startRow) * rowHeight;
         let offset = rowY - startY;
         let isHovered = hovered == Some(i);
-        let isFocused = focused == i;
+        let isSelected = selected == i;
 
         let bg =
-          if (isFocused) {
-            focusBg;
+          if (isSelected) {
+            selectedBg;
           } else if (isHovered) {
             hoverBg;
+          } else if (focusIndex == Some(i)) {
+            focusBg;
           } else {
             Revery.Colors.transparentWhite;
           };
@@ -514,7 +517,7 @@ module View = {
              ~availableWidth=viewportWidth,
              ~index=i,
              ~hovered=hovered == Some(i),
-             ~focused=focused == i,
+             ~selected=selected == i,
              items[i],
            )}
         </Clickable>;
@@ -526,6 +529,7 @@ module View = {
   let make:
     (
       ~isActive: bool,
+      ~focusedIndex: option(int),
       ~theme: ColorTheme.Colors.t,
       ~model: model('item),
       ~dispatch: msg => unit,
@@ -533,14 +537,14 @@ module View = {
                  ~availableWidth: int,
                  ~index: int,
                  ~hovered: bool,
-                 ~focused: bool,
+                 ~selected: bool,
                  'item
                ) =>
                Revery.UI.element,
       unit
     ) =>
     _ =
-    (~isActive, ~theme, ~model, ~dispatch, ~render, ()) => {
+    (~isActive, ~focusedIndex, ~theme, ~model, ~dispatch, ~render, ()) => {
       component(hooks => {
         let {rowHeight, viewportWidth, viewportHeight, _} = model;
 
@@ -607,16 +611,22 @@ module View = {
           };
         };
         let hoverBg = Colors.List.hoverBackground.from(theme);
+        let selectedBg =
+          isActive
+            ? Colors.List.activeSelectionBackground.from(theme)
+            : Colors.List.inactiveSelectionBackground.from(theme);
         let focusBg =
           isActive
             ? Colors.List.focusBackground.from(theme)
             : Colors.List.inactiveFocusBackground.from(theme);
         let items =
           renderHelper(
-            ~focused=model.focused,
+            ~focusIndex=focusedIndex,
+            ~selected=model.selected,
             ~hovered=model.hovered,
             ~items=model.items,
             ~hoverBg,
+            ~selectedBg,
             ~focusBg,
             ~onMouseOver,
             ~onMouseOut,

--- a/src/Components/VimList/Component_VimList.rei
+++ b/src/Components/VimList/Component_VimList.rei
@@ -31,6 +31,10 @@ let update: (msg, model('item)) => (model('item), outmsg);
 
 let set: (array('item), model('item)) => model('item);
 
+let findIndex: ('item => bool, model('item)) => option(int);
+
+let scrollTo: (~index: int, ~alignment: [> | `Top | `Bottom | `Center | `Reveal], model('item)) => model('item);
+
 // CONTRIBUTIONS
 
 module Contributions: {

--- a/src/Components/VimList/Component_VimList.rei
+++ b/src/Components/VimList/Component_VimList.rei
@@ -17,7 +17,7 @@ type model('item);
 let create: (~rowHeight: int) => model('item);
 
 let get: (int, model('item)) => option('item);
-let focusedIndex: model('item) => int;
+let selectedIndex: model('item) => int;
 
 let count: model('item) => int;
 
@@ -33,7 +33,13 @@ let set: (array('item), model('item)) => model('item);
 
 let findIndex: ('item => bool, model('item)) => option(int);
 
-let scrollTo: (~index: int, ~alignment: [> | `Top | `Bottom | `Center | `Reveal], model('item)) => model('item);
+let scrollTo:
+  (
+    ~index: int,
+    ~alignment: [< | `Top | `Bottom | `Center | `Reveal],
+    model('item)
+  ) =>
+  model('item);
 
 // CONTRIBUTIONS
 
@@ -49,6 +55,7 @@ module View: {
   let make:
     (
       ~isActive: bool,
+      ~focusedIndex: option(int),
       ~theme: ColorTheme.Colors.t,
       ~model: model('item),
       ~dispatch: msg => unit,
@@ -56,7 +63,7 @@ module View: {
                  ~availableWidth: int,
                  ~index: int,
                  ~hovered: bool,
-                 ~focused: bool,
+                 ~selected: bool,
                  'item
                ) =>
                Revery.UI.element,

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -109,6 +109,20 @@ type model('node, 'leaf) = {
 
 let count = ({treeAsList, _}) => Component_VimList.count(treeAsList);
 
+let findIndex = (f, {treeAsList, _}) => {
+  let pred = fun
+  | Node({ expanded, indentation, data}) => f(
+    Node({expanded, indentation, data: data.inner})
+  )
+  | Leaf(_) as leaf => f(leaf);
+
+  Component_VimList.findIndex(pred, treeAsList);
+};
+
+let scrollTo = (~index, ~alignment, ({treeAsList, _}) => {
+  Component_VimList.scrollTo(~index, ~alignment, treeAsList);
+};
+
 let create = (~rowHeight) => {
   expansionContext: ExpansionContext.initial,
   activeIndentRange: None,

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -48,6 +48,10 @@ let set:
   ) =>
   model('node, 'leaf);
 
+let findIndex: (nodeOrLeaf('node, 'leaf) => bool, model('node, 'leaf)) => option(int);
+
+let scrollTo: (~index: int, ~alignment: [> | `Top | `Bottom | `Center | `Reveal], model('node, 'leaf)) => model('node, 'leaf);
+
 // CONTRIBUTIONS
 
 module Contributions: {

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -48,9 +48,16 @@ let set:
   ) =>
   model('node, 'leaf);
 
-let findIndex: (nodeOrLeaf('node, 'leaf) => bool, model('node, 'leaf)) => option(int);
+let findIndex:
+  (nodeOrLeaf('node, 'leaf) => bool, model('node, 'leaf)) => option(int);
 
-let scrollTo: (~index: int, ~alignment: [> | `Top | `Bottom | `Center | `Reveal], model('node, 'leaf)) => model('node, 'leaf);
+let scrollTo:
+  (
+    ~index: int,
+    ~alignment: [< | `Top | `Bottom | `Center | `Reveal],
+    model('node, 'leaf)
+  ) =>
+  model('node, 'leaf);
 
 // CONTRIBUTIONS
 
@@ -65,6 +72,7 @@ module View: {
   let make:
     (
       ~isActive: bool,
+      ~focusedIndex: option(int),
       ~theme: ColorTheme.Colors.t,
       ~model: model('node, 'leaf),
       ~dispatch: msg => unit,
@@ -72,7 +80,7 @@ module View: {
                  ~availableWidth: int,
                  ~index: int,
                  ~hovered: bool,
-                 ~focused: bool,
+                 ~selected: bool,
                  nodeOrLeaf('node, 'leaf)
                ) =>
                Revery.UI.element,

--- a/src/Core/Tree.re
+++ b/src/Core/Tree.re
@@ -13,6 +13,11 @@ let node = (~expanded=true, ~children=[], data) => {
   Node({expanded, children, data});
 };
 
+let children =
+  fun
+  | Node({children, _}) => children
+  | Leaf(_) => [];
+
 let fold = (f, acc, tree) => {
   let rec loop = (current, node) => {
     let newAcc = f(current, node);

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -122,8 +122,7 @@ let setFocus = (maybePath, model) =>
     }
   | _ => {...model, focus: None}
   };
-let setScrollOffset = (scrollOffset, model) => {...model, scrollOffset};
-
+  
 let replaceNode = (node, model: model) =>
   switch (model.tree) {
   | Some(tree) =>
@@ -274,15 +273,6 @@ let update = (~configuration, ~languageInfo, ~iconTheme, msg, model) => {
   | KeyboardInput(_) =>
     // Anything to be brought back here?
     (model, Nothing)
-
-  | NodeClicked(node) => (
-      model
-      |> setFocus(Some(FsTreeNode.getPath(node)))
-      |> selectNode(~languageInfo, ~configuration, ~iconTheme, node),
-      Nothing,
-    )
-
-  | ScrollOffsetChanged(offset) => (setScrollOffset(offset, model), Nothing)
 
   | Tree(treeMsg) =>
     let (treeView, outmsg) =

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -103,7 +103,9 @@ type outmsg =
   | OpenFile(string)
   | GrabFocus;
 
-let setTree = (tree, model) => {...model, tree: Some(tree)};
+let setTree = (tree, model) => {
+...model, tree: Some(tree),
+};
 
 let setActive = (maybePath, model) => {...model, active: maybePath};
 
@@ -299,6 +301,12 @@ let update = (~configuration, ~languageInfo, ~iconTheme, msg, model) => {
     OptionEx.zip(model.focus, model.tree)
     |> OptionEx.flatMap(handleKey)
     |> Option.value(~default=(model, Nothing));
+
+    | Tree(treeMsg) =>
+      let (treeView, _outmsg) = Component_VimTree.update(treeMsg,
+      model.treeView);
+
+      ({...model, treeView}, Nothing)
   };
 };
 

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -288,10 +288,25 @@ let update = (~configuration, ~languageInfo, ~iconTheme, msg, model) => {
   | ScrollOffsetChanged(offset) => (setScrollOffset(offset, model), Nothing)
 
   | Tree(treeMsg) =>
-    let (treeView, _outmsg) =
+    let (treeView, outmsg) =
       Component_VimTree.update(treeMsg, model.treeView);
 
-    ({...model, treeView}, Nothing);
+    let eff = switch (outmsg) {
+    | Expanded(node) =>
+        Effect(
+            Effects.load(
+              node.path,
+              languageInfo,
+              iconTheme,
+              configuration,
+              ~onComplete=newNode =>
+              NodeLoaded(newNode)
+            ),
+          );
+    | Collapsed(_) => Nothing
+    | _ => Nothing
+    };
+    ({...model, treeView}, eff);
   };
 };
 

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -104,7 +104,15 @@ type outmsg =
   | OpenFile(string)
   | GrabFocus;
 
-let setTree = (tree, model) => {...model, tree: Some(tree)};
+let setTree = (tree, model) => {
+
+  let uniqueId = (data: FsTreeNode.metadata) => data.path;
+  let treeView = Component_VimTree.set(~uniqueId, [tree], model.treeView);
+
+{...model, tree: Some(tree), 
+treeView,
+};
+};
 
 let setActive = (maybePath, model) => {...model, active: maybePath};
 

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -320,3 +320,27 @@ let sub = (~configuration, ~languageInfo, ~iconTheme, {rootPath, _}) => {
 
   Service_OS.Sub.dir(~uniqueId="FileExplorerSideBar", ~toMsg, rootPath);
 };
+
+module Contributions = {
+  open WhenExpr.ContextKeys.Schema;
+
+  let commands = (~isFocused) => {
+    !isFocused
+      ? []
+      : 
+        (
+          Component_VimTree.Contributions.commands
+          |> List.map(Oni_Core.Command.map(msg => Tree(msg)))
+        );
+  };
+
+  let contextKeys = (~isFocused) => {
+    let vimTreeKeys =
+      isFocused ? Component_VimTree.Contributions.contextKeys : [];
+
+    [
+      vimTreeKeys |> fromList |> map(_ => ()),
+    ]
+    |> unionMany;
+  };
+};

--- a/src/Feature/Explorer/Feature_Explorer.rei
+++ b/src/Feature/Explorer/Feature_Explorer.rei
@@ -54,6 +54,7 @@ let sub:
 module View: {
   let make:
     (
+      ~isFocused: bool,
       ~model: model,
       ~decorations: Feature_Decorations.model,
       ~theme: ColorTheme.Colors.t,
@@ -62,4 +63,9 @@ module View: {
       unit
     ) =>
     Revery.UI.element;
+};
+
+module Contributions: {
+  let commands: (~isFocused: bool) => list(Command.t(msg));
+  let contextKeys: (~isFocused: bool) => WhenExpr.ContextKeys.Schema.t(model);
 };

--- a/src/Feature/Explorer/FileTreeView.re
+++ b/src/Feature/Explorer/FileTreeView.re
@@ -111,6 +111,7 @@ let nodeView =
 
 let make =
     (
+      ~isFocused,
       ~scrollOffset,
       ~tree: FsTreeNode.t,
       ~treeView:
@@ -127,7 +128,7 @@ let make =
   //let onScrollOffsetChange = offset => dispatch(ScrollOffsetChanged(offset));
   <View style=Styles.container>
     <Component_VimTree.View
-      isActive=true
+      isActive=isFocused
       theme
       model=treeView
       dispatch={msg => dispatch(Tree(msg))}

--- a/src/Feature/Explorer/FileTreeView.re
+++ b/src/Feature/Explorer/FileTreeView.re
@@ -48,7 +48,6 @@ module Styles = {
         }
       },
     ),
-    marginLeft(10),
     // Minor adjustment to align with seti-icon
     marginTop(4),
     textWrap(TextWrapping.NoWrap),
@@ -66,6 +65,7 @@ let setiIcon = (~icon, ~fontSize, ~fg, ()) => {
       // Minor adjustment to center vertically
       marginTop(-2),
       marginLeft(-4),
+      marginRight(10),
     ]
     fontFamily={Revery.Font.Family.fromFile("seti.ttf")}
     fontSize={fontSize *. 2.}
@@ -112,6 +112,7 @@ let nodeView =
 let make =
     (
       ~isFocused,
+      ~focusedIndex,
       ~treeView:
          Component_VimTree.model(FsTreeNode.metadata, FsTreeNode.metadata),
       ~active: option(string),
@@ -125,10 +126,17 @@ let make =
   <View style=Styles.container>
     <Component_VimTree.View
       isActive=isFocused
+      focusedIndex
       theme
       model=treeView
       dispatch={msg => dispatch(Tree(msg))}
-      render={(~availableWidth as _, ~index as _, ~hovered as _, ~focused, item) => {
+      render={(
+        ~availableWidth as _,
+        ~index as _,
+        ~hovered as _,
+        ~selected,
+        item,
+      ) => {
         open FsTreeNode;
         let (icon, data) =
           switch (item) {
@@ -150,7 +158,7 @@ let make =
           Feature_Decorations.getDecorations(~path=data.path, decorations);
         <nodeView
           icon
-          isFocus=focused
+          isFocus=selected
           isActive={Some(data.path) == active}
           font
           theme

--- a/src/Feature/Explorer/FileTreeView.re
+++ b/src/Feature/Explorer/FileTreeView.re
@@ -112,13 +112,9 @@ let nodeView =
 let make =
     (
       ~isFocused,
-      ~scrollOffset,
-      ~tree: FsTreeNode.t,
       ~treeView:
          Component_VimTree.model(FsTreeNode.metadata, FsTreeNode.metadata),
       ~active: option(string),
-      ~focus: option(string),
-      ~onNodeClick,
       ~theme,
       ~decorations: Feature_Decorations.model,
       ~font: UiFont.t,
@@ -132,7 +128,7 @@ let make =
       theme
       model=treeView
       dispatch={msg => dispatch(Tree(msg))}
-      render={(~availableWidth, ~index as _, ~hovered as _, ~focused, item) => {
+      render={(~availableWidth as _, ~index as _, ~hovered as _, ~focused, item) => {
         open FsTreeNode;
         let (icon, data) =
           switch (item) {

--- a/src/Feature/Explorer/FsTreeNode.re
+++ b/src/Feature/Explorer/FsTreeNode.re
@@ -136,7 +136,7 @@ let updateNodesInPath =
     switch (pathHashes) {
     | [hash, ...rest] when hash == getHash(node) =>
       switch (node) {
-      | Tree.Node({children, data, _}) as cur =>
+      | Tree.Node({children, _}) as cur =>
         let newChildren = List.map(loop(rest), children);
         switch (updater(cur)) {
         | Tree.Node(data) => Tree.Node({...data, children: newChildren})
@@ -154,7 +154,7 @@ let updateNodesInPath =
 
 let toggleOpen =
   fun
-  | Tree.Node({expanded as prev, _} as node) =>
+  | Tree.Node({expanded: prev, _} as node) =>
     Tree.Node({...node, expanded: !prev})
   | leaf => leaf;
 

--- a/src/Feature/Explorer/FsTreeNode.re
+++ b/src/Feature/Explorer/FsTreeNode.re
@@ -2,65 +2,48 @@ open Oni_Core;
 open Utility;
 
 [@deriving show({with_path: false})]
-type t = {
+type metadata = {
   path: string,
   displayName: string,
   hash: int, // hash of basename, so only comparable locally
   icon: option([@opaque] IconTheme.IconDefinition.t),
-  kind,
-  expandedSubtreeSize: int,
-}
+};
 
-and kind =
-  | Directory({
-      isOpen: bool,
-      children: [@opaque] list(t),
-    })
-  | File;
+[@deriving show({with_path: false})]
+type t = Tree.t(metadata, metadata);
 
 let _hash = Hashtbl.hash;
 let _pathHashes = (~base, path) =>
   path |> Path.toRelative(~base) |> Path.explode |> List.map(_hash);
 
-let rec countExpandedSubtree =
-  fun
-  | Directory({isOpen: true, children}) =>
-    List.fold_left(
-      (acc, child) => acc + countExpandedSubtree(child.kind),
-      1,
-      children,
-    )
-
-  | _ => 1;
-
 let file = (path, ~icon) => {
   let basename = Filename.basename(path);
 
-  {
-    path,
-    hash: _hash(basename),
-    displayName: basename,
-    icon,
-    kind: File,
-    expandedSubtreeSize: 1,
-  };
+  Tree.leaf({path, hash: _hash(basename), displayName: basename, icon});
 };
 
 let directory = (~isOpen=false, path, ~icon, ~children) => {
-  let kind = Directory({isOpen, children});
   let basename = Filename.basename(path);
 
-  {
-    path,
-    hash: _hash(basename),
-    displayName: basename,
-    icon,
-    kind,
-    expandedSubtreeSize: countExpandedSubtree(kind),
-  };
+  Tree.node(
+    ~expanded=isOpen,
+    ~children,
+    {path, hash: _hash(basename), displayName: basename, icon},
+  );
 };
 
-let equals = (a, b) => a.hash == b.hash && a.path == b.path;
+let get = f =>
+  fun
+  | Tree.Node({data, _})
+  | Tree.Leaf(data) => f(data);
+
+let icon = get(({icon, _}) => icon);
+let getHash = get(({hash, _}) => hash);
+let getPath = get(({path, _}) => path);
+let displayName = get(({displayName, _}) => displayName);
+
+let equals = (a, b) =>
+  getHash(a) == getHash(b) && getPath(a) == getPath(b);
 
 let findNodesByPath = (path, tree) => {
   let rec loop = (focusedNodes, children, pathHashes) =>
@@ -77,12 +60,8 @@ let findNodesByPath = (path, tree) => {
         };
 
       | [node, ...children] =>
-        if (node.hash == hash) {
-          let children =
-            switch (node.kind) {
-            | Directory({children, _}) => children
-            | File => []
-            };
+        if (getHash(node) == hash) {
+          let children = Tree.children(node);
           loop([node, ...focusedNodes], children, rest);
         } else {
           loop(focusedNodes, children, pathHashes);
@@ -90,10 +69,10 @@ let findNodesByPath = (path, tree) => {
       }
     };
 
-  switch (tree.kind) {
-  | Directory({children, _}) =>
-    loop([tree], children, _pathHashes(~base=tree.path, path))
-  | File => `Failed
+  switch (tree) {
+  | Node({children, _}) =>
+    loop([tree], children, _pathHashes(~base=getPath(tree), path))
+  | Leaf(_) => `Failed
   };
 };
 
@@ -106,12 +85,8 @@ let findByPath = (path, tree) => {
       | [] => None
 
       | [node, ...children] =>
-        if (node.hash == hash) {
-          let children =
-            switch (node.kind) {
-            | Directory({children, _}) => children
-            | File => []
-            };
+        if (getHash(node) == hash) {
+          let children = Tree.children(node);
           loop(node, children, rest);
         } else {
           loop(node, children, pathHashes);
@@ -119,209 +94,88 @@ let findByPath = (path, tree) => {
       }
     };
 
-  switch (tree.kind) {
-  | Directory({children, _}) =>
-    loop(tree, children, _pathHashes(~base=tree.path, path))
-  | File => None
-  };
-};
-
-let prevExpandedNode = (path, tree) =>
-  switch (findNodesByPath(path, tree)) {
-  | `Success(nodePath) =>
-    switch (List.rev(nodePath)) {
-    // Has a parent, and therefore also siblings
-    | [focus, {kind: Directory({children, _}), _} as parent, ..._] =>
-      let children = children |> Array.of_list;
-      let index = children |> ArrayEx.findIndex(equals(focus));
-
-      switch (index) {
-      // is first child
-      | Some(index) when index == 0 => Some(parent)
-
-      | Some(index) =>
-        switch (children[index - 1]) {
-        // is open directory with at least one child
-        | {
-            kind: Directory({isOpen: true, children: [_, ..._] as children}),
-            _,
-          } =>
-          let children = children |> Array.of_list;
-          let lastChild = children[Array.length(children) - 1];
-          Some(lastChild);
-
-        | prev => Some(prev)
-        }
-
-      | None => None // is not a child of its parent (?!)
-      };
-    | _ => None // has neither parent or siblings
-    }
-  | `Partial(_)
-  | `Failed => None // path does not exist in this ree
-  };
-
-let nextExpandedNode = (path, tree) =>
-  switch (findNodesByPath(path, tree)) {
-  | `Success(nodePath) =>
-    let rec loop = revNodePath =>
-      switch (revNodePath) {
-      | [
-          focus,
-          ...[{kind: Directory({children, _}), _}, ..._] as ancestors,
-        ] =>
-        let children = children |> Array.of_list;
-        let index = children |> ArrayEx.findIndex(equals(focus));
-
-        switch (index) {
-        // is last child
-        | Some(index) when index == Array.length(children) - 1 =>
-          loop(ancestors)
-
-        | Some(index) =>
-          let next = children[index + 1];
-          Some(next);
-
-        | None => None // is not a child of its parent (?!)
-        };
-      | _ => None // has neither parent or siblings
-      };
-
-    switch (List.rev(nodePath)) {
-    // Focus is open directory with at least one child
-    | [
-        {kind: Directory({isOpen: true, children: [firstChild, ..._]}), _},
-        ..._,
-      ] =>
-      Some(firstChild)
-    | revNodePath => loop(revNodePath)
-    };
-
-  | `Partial(_)
-  | `Failed => None // path does not exist in this tree
-  };
-
-// Counts the number of expanded nodes before the node specified by the given path
-let expandedIndex = (path, tree) => {
-  let rec loop = (node, pathHashes) =>
-    switch (pathHashes) {
-    | [] => `Found(0)
-    | [hash, ...pathTail] =>
-      if (node.hash != hash) {
-        `NotFound(node.expandedSubtreeSize);
-      } else {
-        switch (node.kind) {
-        | Directory({isOpen: false, _})
-        | File => `Found(0)
-
-        | Directory({isOpen: true, children}) =>
-          let rec loopChildren = (count, children) =>
-            switch (children) {
-            | [] => `NotFound(count)
-            | [child, ...childTail] =>
-              switch (loop(child, pathTail)) {
-              | `Found(subtreeCount) => `Found(count + subtreeCount)
-              | `NotFound(subtreeCount) =>
-                loopChildren(count + subtreeCount, childTail)
-              }
-            };
-
-          loopChildren(1, children);
-        };
-      }
-    };
-
-  switch (loop(tree, _pathHashes(~base=Filename.dirname(tree.path), path))) {
-  | `Found(count) => Some(count)
-  | `NotFound(_) => None
+  switch (tree) {
+  | Tree.Node({children, _}) =>
+    loop(tree, children, _pathHashes(~base=getPath(tree), path))
+  | Tree.Leaf(_) => None
   };
 };
 
 let replace = (~replacement, tree) => {
   let rec loop = (pathHashes, node) =>
     switch (pathHashes) {
-    | [hash] when hash == node.hash => replacement
+    | [hash] when hash == getHash(node) => replacement
 
-    | [hash, ...rest] when hash == node.hash =>
-      switch (node.kind) {
-      | Directory({children, _} as dir) =>
+    | [hash, ...rest] when hash == getHash(node) =>
+      switch (node) {
+      | Tree.Node({children, _} as dir) =>
         let newChildren = List.map(loop(rest), children);
-        let kind = Directory({...dir, children: newChildren});
-
-        {...node, kind, expandedSubtreeSize: countExpandedSubtree(kind)};
-
-      | File => node
+        Tree.Node({...dir, children: newChildren});
+      | Tree.Leaf(_) => node
       }
 
     | _ => node
     };
 
   loop(
-    _pathHashes(~base=Filename.dirname(tree.path), replacement.path),
+    _pathHashes(
+      ~base=Filename.dirname(getPath(tree)),
+      getPath(replacement),
+    ),
     tree,
   );
 };
 
-let updateNodesInPath = (updater, path, tree) => {
-  let rec loop = (pathHashes, node) =>
+let updateNodesInPath =
+    (
+      updater: Tree.t(metadata, metadata) => Tree.t(metadata, metadata),
+      path,
+      tree,
+    ) => {
+  let rec loop = (pathHashes, node: Tree.t(metadata, metadata)) =>
     switch (pathHashes) {
-    | [hash, ...rest] when hash == node.hash =>
-      switch (node.kind) {
-      | Directory({children, _} as dir) =>
+    | [hash, ...rest] when hash == getHash(node) =>
+      switch (node) {
+      | Tree.Node({children, data, _}) as cur =>
         let newChildren = List.map(loop(rest), children);
-        let newNode =
-          updater({
-            ...node,
-            kind: Directory({...dir, children: newChildren}),
-          });
-
-        {
-          ...newNode,
-          expandedSubtreeSize: countExpandedSubtree(newNode.kind),
+        switch (updater(cur)) {
+        | Tree.Node(data) => Tree.Node({...data, children: newChildren})
+        | Tree.Leaf(_) as leaf => leaf
         };
 
-      | File => updater(node)
+      | Tree.Leaf(_) as leaf => updater(leaf)
       }
 
     | _ => node
     };
 
-  loop(_pathHashes(~base=Filename.dirname(tree.path), path), tree);
+  loop(_pathHashes(~base=Filename.dirname(getPath(tree)), path), tree);
 };
 
 let toggleOpen =
   fun
-  | {kind: Directory({isOpen, children}), _} as node => {
-      let kind = Directory({isOpen: !isOpen, children});
-
-      {...node, kind, expandedSubtreeSize: countExpandedSubtree(kind)};
-    }
-  | node => node;
+  | Tree.Node({expanded as prev, _} as node) =>
+    Tree.Node({...node, expanded: !prev})
+  | leaf => leaf;
 
 let setOpen =
   fun
-  | {kind: Directory({children, _}), _} as node => {
-      let kind = Directory({isOpen: true, children});
-
-      {...node, kind, expandedSubtreeSize: countExpandedSubtree(kind)};
-    }
-  | node => node;
+  | Tree.Node(node) => Tree.Node({...node, expanded: true})
+  | leaf => leaf;
 
 module Model = {
   type nonrec t = t;
 
   let children = node =>
-    switch (node.kind) {
-    | Directory({children, _}) => children
-    | File => []
+    switch (node) {
+    | Tree.Node({children, _}) => children
+    | Tree.Leaf(_) => []
     };
 
   let kind = node =>
-    switch (node.kind) {
-    | Directory({isOpen: true, _}) => `Node(`Open)
-    | Directory({isOpen: false, _}) => `Node(`Closed)
-    | File => `Leaf
+    switch (node) {
+    | Tree.Node({expanded: true, _}) => `Node(`Open)
+    | Tree.Node({expanded: false, _}) => `Node(`Closed)
+    | Tree.Leaf(_) => `Leaf
     };
-
-  let expandedSubtreeSize = node => node.expandedSubtreeSize;
 };

--- a/src/Feature/Explorer/FsTreeNode.rei
+++ b/src/Feature/Explorer/FsTreeNode.rei
@@ -1,23 +1,15 @@
 open Oni_Core;
 
-[@deriving show]
-type t =
-  pri {
-    path: string,
-    displayName: string,
-    hash: int, // hash of basename, so only comparable locally
-    icon: option(IconTheme.IconDefinition.t),
-    kind,
-    expandedSubtreeSize: int,
-  }
+[@deriving show({with_path: false})]
+type metadata = {
+  path: string,
+  displayName: string,
+  hash: int, // hash of basename, so only comparable locally
+  icon: option([@opaque] IconTheme.IconDefinition.t),
+};
 
-and kind =
-  pri
-    | Directory({
-        isOpen: bool,
-        children: list(t),
-      })
-    | File;
+[@deriving show({with_path: false})]
+type t = Tree.t(metadata, metadata);
 
 let file: (string, ~icon: option(IconTheme.IconDefinition.t)) => t;
 let directory:
@@ -29,14 +21,13 @@ let directory:
   ) =>
   t;
 
+let icon: t => option(IconTheme.IconDefinition.t);
+let getPath: t => string;
+let displayName: t => string;
+
 let findNodesByPath:
   (string, t) => [ | `Success(list(t)) | `Partial(t) | `Failed];
 let findByPath: (string, t) => option(t);
-
-let prevExpandedNode: (string, t) => option(t);
-let nextExpandedNode: (string, t) => option(t);
-
-let expandedIndex: (string, t) => option(int);
 
 let replace: (~replacement: t, t) => t;
 let updateNodesInPath: (t => t, string, t) => t;
@@ -50,5 +41,4 @@ module Model: {
 
   let children: t => list(t);
   let kind: t => [ | `Node([ | `Open | `Closed]) | `Leaf];
-  let expandedSubtreeSize: t => int;
 };

--- a/src/Feature/Explorer/Model.re
+++ b/src/Feature/Explorer/Model.re
@@ -7,8 +7,6 @@ type msg =
   | TreeLoadError(string)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)
-  | NodeClicked(FsTreeNode.t)
-  | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
   | KeyboardInput(string)
   | Tree(Component_VimTree.msg);
 

--- a/src/Feature/Explorer/Model.re
+++ b/src/Feature/Explorer/Model.re
@@ -42,3 +42,19 @@ let setRoot = (~rootPath, model) => {
   active: None,
   focus: None,
 };
+
+let getIndex = (path, model) => {
+  Component_VimTree.(
+    findIndex(
+      fun
+      | Node({data, _})
+      | Leaf({data, _}) => FsTreeNode.(data.path) == path,
+      model.treeView,
+    )
+  );
+};
+
+let getFocusedIndex = model => {
+  model.active
+  |> Oni_Core.Utility.OptionEx.flatMap(path => getIndex(path, model));
+};

--- a/src/Feature/Explorer/Model.re
+++ b/src/Feature/Explorer/Model.re
@@ -17,11 +17,10 @@ module Msg = {
   let activeFileChanged = maybePath => ActiveFilePathChanged(maybePath);
 };
 
-
 type model = {
   rootPath: string,
   tree: option(FsTreeNode.t),
-  treeView: Component_VimTree.model(FsTreeNode.t, FsTreeNode.t),
+  treeView: Component_VimTree.model(FsTreeNode.metadata, FsTreeNode.metadata),
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(string), // path

--- a/src/Feature/Explorer/Model.re
+++ b/src/Feature/Explorer/Model.re
@@ -9,16 +9,19 @@ type msg =
   | FocusNodeLoaded(FsTreeNode.t)
   | NodeClicked(FsTreeNode.t)
   | ScrollOffsetChanged([ | `Start(float) | `Middle(float) | `Reveal(int)])
-  | KeyboardInput(string);
+  | KeyboardInput(string)
+  | Tree(Component_VimTree.msg);
 
 module Msg = {
   let keyPressed = key => KeyboardInput(key);
   let activeFileChanged = maybePath => ActiveFilePathChanged(maybePath);
 };
 
+
 type model = {
   rootPath: string,
   tree: option(FsTreeNode.t),
+  treeView: Component_VimTree.model(FsTreeNode.t, FsTreeNode.t),
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(string), // path
@@ -28,6 +31,7 @@ type model = {
 let initial = (~rootPath) => {
   rootPath,
   tree: None,
+  treeView: Component_VimTree.create(~rowHeight=20),
   isOpen: true,
   scrollOffset: `Start(0.),
   active: None,

--- a/src/Feature/Explorer/View.re
+++ b/src/Feature/Explorer/View.re
@@ -1,19 +1,22 @@
 open Revery.UI;
 
 let make =
-    (~isFocused: bool,~model, ~decorations, ~theme, ~font, ~dispatch: Model.msg => unit, ()) => {
+    (
+      ~isFocused: bool,
+      ~model,
+      ~decorations,
+      ~theme,
+      ~font,
+      ~dispatch: Model.msg => unit,
+      (),
+    ) => {
   switch ((model: Model.model)) {
-  | {tree: Some(tree), treeView, active, focus, scrollOffset, _} =>
-    let onNodeClick = node => dispatch(NodeClicked(node));
+  | {tree: Some(_), treeView, active, _} =>
 
     <FileTreeView
       isFocused
-      scrollOffset
       decorations
       active
-      focus
-      onNodeClick
-      tree
       treeView
       theme
       font

--- a/src/Feature/Explorer/View.re
+++ b/src/Feature/Explorer/View.re
@@ -12,9 +12,10 @@ let make =
     ) => {
   switch ((model: Model.model)) {
   | {tree: Some(_), treeView, active, _} =>
-
+    let focusedIndex = Model.getFocusedIndex(model);
     <FileTreeView
       isFocused
+      focusedIndex
       decorations
       active
       treeView

--- a/src/Feature/Explorer/View.re
+++ b/src/Feature/Explorer/View.re
@@ -1,12 +1,13 @@
 open Revery.UI;
 
 let make =
-    (~model, ~decorations, ~theme, ~font, ~dispatch: Model.msg => unit, ()) => {
+    (~isFocused: bool,~model, ~decorations, ~theme, ~font, ~dispatch: Model.msg => unit, ()) => {
   switch ((model: Model.model)) {
   | {tree: Some(tree), treeView, active, focus, scrollOffset, _} =>
     let onNodeClick = node => dispatch(NodeClicked(node));
 
     <FileTreeView
+      isFocused
       scrollOffset
       decorations
       active

--- a/src/Feature/Explorer/View.re
+++ b/src/Feature/Explorer/View.re
@@ -3,7 +3,7 @@ open Revery.UI;
 let make =
     (~model, ~decorations, ~theme, ~font, ~dispatch: Model.msg => unit, ()) => {
   switch ((model: Model.model)) {
-  | {tree: Some(tree), active, focus, scrollOffset, _} =>
+  | {tree: Some(tree), treeView, active, focus, scrollOffset, _} =>
     let onNodeClick = node => dispatch(NodeClicked(node));
 
     <FileTreeView
@@ -13,6 +13,7 @@ let make =
       focus
       onNodeClick
       tree
+      treeView
       theme
       font
       dispatch

--- a/src/Feature/Explorer/dune
+++ b/src/Feature/Explorer/dune
@@ -1,7 +1,7 @@
 (library
  (name Feature_Explorer)
  (public_name Oni2.feature.explorer)
- (libraries Oni2.core Oni2.exthost Oni2.feature.decorations
+ (libraries Oni2.component.vimTree Oni2.core Oni2.exthost Oni2.feature.decorations
    Oni2.feature.theme Oni2.components Revery isolinear)
  (preprocess
   (pps ppx_let lwt_ppx ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Explorer/dune
+++ b/src/Feature/Explorer/dune
@@ -1,7 +1,8 @@
 (library
  (name Feature_Explorer)
  (public_name Oni2.feature.explorer)
- (libraries Oni2.component.vimTree Oni2.core Oni2.exthost Oni2.feature.decorations
-   Oni2.feature.theme Oni2.components Revery isolinear)
+ (libraries Oni2.component.vimTree Oni2.core Oni2.exthost
+   Oni2.feature.decorations Oni2.feature.theme Oni2.components Revery
+   isolinear)
  (preprocess
   (pps ppx_let lwt_ppx ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Pane/DiagnosticsPaneView.re
+++ b/src/Feature/Pane/DiagnosticsPaneView.re
@@ -55,6 +55,7 @@ let make =
     } else {
       <Component_VimTree.View
         isActive=isFocused
+        focusedIndex=None
         theme
         model=diagnosticsList
         dispatch
@@ -62,7 +63,7 @@ let make =
           ~availableWidth,
           ~index as _,
           ~hovered as _,
-          ~focused as _,
+          ~selected as _,
           item,
         ) =>
           switch (item) {

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -294,6 +294,7 @@ let make =
       />
       <Component_VimTree.View
         isActive={isFocused && model.focus == ResultsPane}
+        focusedIndex=None
         theme
         model={model.resultsTree}
         dispatch={msg => dispatch(ResultsList(msg))}
@@ -301,7 +302,7 @@ let make =
           ~availableWidth,
           ~index as _,
           ~hovered as _,
-          ~focused as _,
+          ~selected as _,
           item,
         ) =>
           switch (item) {

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -472,6 +472,18 @@ module List = {
       "list.activeSelectionForeground",
       {dark: hex("#FFF"), light: hex("#FFF"), hc: unspecified},
     );
+
+  let inactiveSelectionBackground =
+    define(
+      "list.inactiveSelectionBackground",
+      all(ref(activeSelectionBackground) |> transparent(0.25)),
+    );
+  let inactiveSelectionForeground =
+    define(
+      "list.inactiveSelectionForeground",
+      all(ref(activeSelectionForeground)),
+    );
+
   let hoverBackground =
     define(
       "list.hoverBackground",

--- a/src/Model/CommandManager.re
+++ b/src/Model/CommandManager.re
@@ -25,6 +25,13 @@ let current = state => {
     )
     |> Command.Lookup.fromList
     |> Command.Lookup.map(msg => Actions.Search(msg)),
+    Feature_Explorer.Contributions.commands(
+      ~isFocused={
+        focus == Focus.FileExplorer;
+      },
+    )
+    |> Command.Lookup.fromList
+    |> Command.Lookup.map(msg => Actions.FileExplorer(msg)),
     Feature_Pane.Contributions.commands(
       ~isFocused={
         focus == Focus.Pane;

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -122,6 +122,11 @@ let all = (state: State.t) => {
   // by Feature_SideBar.contextKeys.
   let scmContextKeys =
     Feature_SCM.Contributions.contextKeys(~isFocused=focus == Focus.SCM);
+    
+  let explorerContextKeys =
+    Feature_Explorer.Contributions.contextKeys(
+      ~isFocused=focus == Focus.FileExplorer,
+    );
 
   let extensionContextKeys =
     Feature_Extensions.Contributions.contextKeys(
@@ -144,6 +149,7 @@ let all = (state: State.t) => {
       ~isFocused=focus == Focus.InsertRegister,
     )
     |> map(({registers, _}: State.t) => registers),
+    explorerContextKeys |> map(({fileExplorer, _}: State.t) => fileExplorer),
     sideBarContext |> fromList |> map(({sideBar, _}: State.t) => sideBar),
     scmContextKeys |> map(({scm, _}: State.t) => scm),
     extensionContextKeys |> map(({extensions, _}: State.t) => extensions),

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -122,7 +122,7 @@ let all = (state: State.t) => {
   // by Feature_SideBar.contextKeys.
   let scmContextKeys =
     Feature_SCM.Contributions.contextKeys(~isFocused=focus == Focus.SCM);
-    
+
   let explorerContextKeys =
     Feature_Explorer.Contributions.contextKeys(
       ~isFocused=focus == Focus.FileExplorer,

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -73,6 +73,7 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
     | FileExplorer =>
       let dispatch = msg => dispatch(Actions.FileExplorer(msg));
       <Feature_Explorer.View
+        isFocused={FocusManager.current(state) == Focus.FileExplorer}
         decorations={state.decorations}
         model={state.fileExplorer}
         theme


### PR DESCRIPTION
This brings in the the vim-navigable-tree introduced in #2492 , and wires it up to the file explorer:

![2020-09-23 12 32 08](https://user-images.githubusercontent.com/13532591/94060762-51a7da80-fd99-11ea-9a89-ea22e074595e.gif)

This supports some initial vim-style navigation, like j/k/zz/zb/zt. 

There are a few additional gestures I'd like to support, to be able to resolve (soon) #528 :
- Implement a search (hook up `/`, `?`, `n`, `N`) experience
- Implement cut/copy/paste (`yy`, `dd`, `pp`).

