### PR TITLE
fix(explorer): Initial population is not showing icons

### DIFF
--- a/src/Components/FileIcon.re
+++ b/src/Components/FileIcon.re
@@ -1,0 +1,38 @@
+open Oni_Core;
+open Revery;
+open Revery.UI;
+
+let getFileIcon = (~languageInfo, ~iconTheme, filePath) => {
+  Exthost.LanguageInfo.getLanguageFromFilePath(languageInfo, filePath)
+  |> Oni_Core.IconTheme.getIconForFile(iconTheme, filePath);
+};
+
+let setiIcon = (~icon, ~fontSize, ~fg, ()) => {
+  <Text
+    text={FontIcon.codeToIcon(icon)}
+    style=Style.[
+      color(fg),
+      width(int_of_float(fontSize *. 1.5)),
+      height(int_of_float(fontSize *. 1.75)),
+      textWrap(TextWrapping.NoWrap),
+      // Minor adjustment to center vertically
+      marginTop(-2),
+      marginLeft(-4),
+      marginRight(10),
+    ]
+    fontFamily={Revery.Font.Family.fromFile("seti.ttf")}
+    fontSize={fontSize *. 2.}
+  />;
+};
+
+let make = (~font: UiFont.t, ~iconTheme, ~languageInfo, ~path, ()) => {
+  switch (getFileIcon(~iconTheme, ~languageInfo, path)) {
+  | None => React.empty
+  | Some((icon: IconTheme.IconDefinition.t)) =>
+    <setiIcon
+      fontSize={font.size}
+      fg={icon.fontColor}
+      icon={icon.fontCharacter}
+    />
+  };
+};

--- a/src/Feature/Explorer/Feature_Explorer.rei
+++ b/src/Feature/Explorer/Feature_Explorer.rei
@@ -29,25 +29,12 @@ type outmsg =
   | GrabFocus;
 
 let update:
-  (
-    ~configuration: Oni_Core.Configuration.t,
-    ~languageInfo: Exthost.LanguageInfo.t,
-    ~iconTheme: Oni_Core.IconTheme.t,
-    msg,
-    model
-  ) =>
-  (model, outmsg);
+  (~configuration: Oni_Core.Configuration.t, msg, model) => (model, outmsg);
 
 // SUBSCRIPTION
 
 let sub:
-  (
-    ~configuration: Oni_Core.Configuration.t,
-    ~languageInfo: Exthost.LanguageInfo.t,
-    ~iconTheme: Oni_Core.IconTheme.t,
-    model
-  ) =>
-  Isolinear.Sub.t(msg);
+  (~configuration: Oni_Core.Configuration.t, model) => Isolinear.Sub.t(msg);
 
 // VIEW
 
@@ -55,6 +42,8 @@ module View: {
   let make:
     (
       ~isFocused: bool,
+      ~iconTheme: IconTheme.t,
+      ~languageInfo: Exthost.LanguageInfo.t,
       ~model: model,
       ~decorations: Feature_Decorations.model,
       ~theme: ColorTheme.Colors.t,

--- a/src/Feature/Explorer/FileTreeView.re
+++ b/src/Feature/Explorer/FileTreeView.re
@@ -109,9 +109,13 @@ let nodeView =
   </Tooltip>;
 };
 
+let getFileIcon = Model.getFileIcon;
+
 let make =
     (
       ~isFocused,
+      ~iconTheme,
+      ~languageInfo,
       ~focusedIndex,
       ~treeView:
          Component_VimTree.model(FsTreeNode.metadata, FsTreeNode.metadata),
@@ -122,7 +126,6 @@ let make =
       ~dispatch: Model.msg => unit,
       (),
     ) => {
-  //let onScrollOffsetChange = offset => dispatch(ScrollOffsetChanged(offset));
   <View style=Styles.container>
     <Component_VimTree.View
       isActive=isFocused
@@ -142,7 +145,7 @@ let make =
           switch (item) {
           | Component_VimTree.Node({data, _}) => (React.empty, data)
           | Component_VimTree.Leaf({data, _}) => (
-              switch (data.icon) {
+              switch (getFileIcon(~iconTheme, ~languageInfo, data.path)) {
               | None => React.empty
               | Some((icon: IconTheme.IconDefinition.t)) =>
                 <setiIcon

--- a/src/Feature/Explorer/FileTreeView.re
+++ b/src/Feature/Explorer/FileTreeView.re
@@ -145,15 +145,12 @@ let make =
           switch (item) {
           | Component_VimTree.Node({data, _}) => (React.empty, data)
           | Component_VimTree.Leaf({data, _}) => (
-              switch (getFileIcon(~iconTheme, ~languageInfo, data.path)) {
-              | None => React.empty
-              | Some((icon: IconTheme.IconDefinition.t)) =>
-                <setiIcon
-                  fontSize={font.size}
-                  fg={icon.fontColor}
-                  icon={icon.fontCharacter}
-                />
-              },
+              <Oni_Components.FileIcon
+                font
+                iconTheme
+                languageInfo
+                path={data.path}
+              />,
               data,
             )
           };

--- a/src/Feature/Explorer/FileTreeView.re
+++ b/src/Feature/Explorer/FileTreeView.re
@@ -54,24 +54,6 @@ module Styles = {
   ];
 };
 
-let setiIcon = (~icon, ~fontSize, ~fg, ()) => {
-  <Text
-    text={FontIcon.codeToIcon(icon)}
-    style=Style.[
-      color(fg),
-      width(int_of_float(fontSize *. 1.5)),
-      height(int_of_float(fontSize *. 1.75)),
-      textWrap(TextWrapping.NoWrap),
-      // Minor adjustment to center vertically
-      marginTop(-2),
-      marginLeft(-4),
-      marginRight(10),
-    ]
-    fontFamily={Revery.Font.Family.fromFile("seti.ttf")}
-    fontSize={fontSize *. 2.}
-  />;
-};
-
 let nodeView =
     (
       ~isFocus,

--- a/src/Feature/Explorer/FsTreeNode.re
+++ b/src/Feature/Explorer/FsTreeNode.re
@@ -5,8 +5,7 @@ open Utility;
 type metadata = {
   path: string,
   displayName: string,
-  hash: int, // hash of basename, so only comparable locally
-  icon: option([@opaque] IconTheme.IconDefinition.t),
+  hash: int // hash of basename, so only comparable locally
 };
 
 [@deriving show({with_path: false})]
@@ -16,19 +15,19 @@ let _hash = Hashtbl.hash;
 let _pathHashes = (~base, path) =>
   path |> Path.toRelative(~base) |> Path.explode |> List.map(_hash);
 
-let file = (path, ~icon) => {
+let file = path => {
   let basename = Filename.basename(path);
 
-  Tree.leaf({path, hash: _hash(basename), displayName: basename, icon});
+  Tree.leaf({path, hash: _hash(basename), displayName: basename});
 };
 
-let directory = (~isOpen=false, path, ~icon, ~children) => {
+let directory = (~isOpen=false, path, ~children) => {
   let basename = Filename.basename(path);
 
   Tree.node(
     ~expanded=isOpen,
     ~children,
-    {path, hash: _hash(basename), displayName: basename, icon},
+    {path, hash: _hash(basename), displayName: basename},
   );
 };
 
@@ -37,7 +36,6 @@ let get = f =>
   | Tree.Node({data, _})
   | Tree.Leaf(data) => f(data);
 
-let icon = get(({icon, _}) => icon);
 let getHash = get(({hash, _}) => hash);
 let getPath = get(({path, _}) => path);
 let displayName = get(({displayName, _}) => displayName);

--- a/src/Feature/Explorer/FsTreeNode.rei
+++ b/src/Feature/Explorer/FsTreeNode.rei
@@ -4,24 +4,15 @@ open Oni_Core;
 type metadata = {
   path: string,
   displayName: string,
-  hash: int, // hash of basename, so only comparable locally
-  icon: option([@opaque] IconTheme.IconDefinition.t),
+  hash: int // hash of basename, so only comparable locally
 };
 
 [@deriving show({with_path: false})]
 type t = Tree.t(metadata, metadata);
 
-let file: (string, ~icon: option(IconTheme.IconDefinition.t)) => t;
-let directory:
-  (
-    ~isOpen: bool=?,
-    string,
-    ~icon: option(IconTheme.IconDefinition.t),
-    ~children: list(t)
-  ) =>
-  t;
+let file: string => t;
+let directory: (~isOpen: bool=?, string, ~children: list(t)) => t;
 
-let icon: t => option(IconTheme.IconDefinition.t);
 let getPath: t => string;
 let displayName: t => string;
 

--- a/src/Feature/Explorer/Model.re
+++ b/src/Feature/Explorer/Model.re
@@ -43,6 +43,11 @@ let setRoot = (~rootPath, model) => {
   focus: None,
 };
 
+let getFileIcon = (~languageInfo, ~iconTheme, filePath) => {
+  Exthost.LanguageInfo.getLanguageFromFilePath(languageInfo, filePath)
+  |> Oni_Core.IconTheme.getIconForFile(iconTheme, filePath);
+};
+
 let getIndex = (path, model) => {
   Component_VimTree.(
     findIndex(

--- a/src/Feature/Explorer/View.re
+++ b/src/Feature/Explorer/View.re
@@ -3,6 +3,8 @@ open Revery.UI;
 let make =
     (
       ~isFocused: bool,
+      ~iconTheme,
+      ~languageInfo,
       ~model,
       ~decorations,
       ~theme,
@@ -15,6 +17,8 @@ let make =
     let focusedIndex = Model.getFocusedIndex(model);
     <FileTreeView
       isFocused
+      iconTheme
+      languageInfo
       focusedIndex
       decorations
       active

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -826,6 +826,7 @@ module Pane = {
     ];
 
     let item = [
+      flexDirection(`Row),
       paddingVertical(2),
       marginLeft(6),
       cursor(MouseCursors.pointer),
@@ -837,6 +838,8 @@ module Pane = {
         ~provider: Provider.t,
         ~resource: Resource.t,
         ~theme,
+        ~iconTheme,
+        ~languageInfo,
         ~font: UiFont.t,
         ~workingDirectory,
         (),
@@ -852,6 +855,7 @@ module Pane = {
     let displayName = Path.toRelative(~base, path);
 
     <View style=Styles.item>
+      <Oni_Components.FileIcon font iconTheme languageInfo path />
       <Text
         style={Styles.text(~theme)}
         text=displayName
@@ -865,6 +869,8 @@ module Pane = {
       (
         ~provider,
         ~group: ResourceGroup.t,
+        ~iconTheme,
+        ~languageInfo,
         ~theme,
         ~isFocused: bool,
         ~font: UiFont.t,
@@ -883,7 +889,15 @@ module Pane = {
           ~selected as _,
           item,
         ) => {
-      <itemView provider resource=item theme font workingDirectory />;
+      <itemView
+        provider
+        resource=item
+        iconTheme
+        languageInfo
+        theme
+        font
+        workingDirectory
+      />;
     };
     <Component_Accordion.VimList
       title=label
@@ -906,6 +920,8 @@ module Pane = {
                   ~model,
                   ~workingDirectory,
                   ~isFocused,
+                  ~iconTheme,
+                  ~languageInfo,
                   ~theme,
                   ~font: UiFont.t,
                   ~dispatch,
@@ -948,6 +964,8 @@ module Pane = {
               group
               dispatch
               isFocused={isFocused && isGroupFocused(group, model.focus)}
+              iconTheme
+              languageInfo
               theme
               font
               workingDirectory

--- a/src/Feature/SCM/Feature_SCM.rei
+++ b/src/Feature/SCM/Feature_SCM.rei
@@ -96,6 +96,8 @@ module Pane: {
       ~model: model,
       ~workingDirectory: string,
       ~isFocused: bool,
+      ~iconTheme: Oni_Core.IconTheme.t,
+      ~languageInfo: Exthost.LanguageInfo.t,
       ~theme: ColorTheme.Colors.t,
       ~font: UiFont.t,
       ~dispatch: msg => unit,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -267,8 +267,6 @@ let update =
     let (model, outmsg) =
       Feature_Explorer.update(
         ~configuration=state.configuration,
-        ~languageInfo=state.languageInfo,
-        ~iconTheme=state.iconTheme,
         msg,
         state.fileExplorer,
       );

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -306,8 +306,6 @@ let start =
     let fileExplorerSub =
       Feature_Explorer.sub(
         ~configuration=state.configuration,
-        ~languageInfo=state.languageInfo,
-        ~iconTheme=state.iconTheme,
         state.fileExplorer,
       )
       |> Isolinear.Sub.map(msg => Model.Actions.FileExplorer(msg));

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -74,6 +74,8 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
       let dispatch = msg => dispatch(Actions.FileExplorer(msg));
       <Feature_Explorer.View
         isFocused={FocusManager.current(state) == Focus.FileExplorer}
+        languageInfo={state.languageInfo}
+        iconTheme={state.iconTheme}
         decorations={state.decorations}
         model={state.fileExplorer}
         theme
@@ -82,14 +84,6 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
       />;
 
     | SCM =>
-      //        dispatch(
-
-      //            Oni_Core.Uri.toFileSystemPath(resource.uri),
-
-      //            None,
-
-      //        );
-
       <Feature_SCM.Pane
         model={state.scm}
         workingDirectory={state.workspace.workingDirectory}
@@ -98,10 +92,6 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
         font
         dispatch={msg => dispatch(Actions.SCM(msg))}
       />
-    //          ),
-    //            None,
-    //          Actions.OpenFileByPath(
-    //      let onItemClick = (resource: Feature_SCM.Resource.t) =>
 
     | Search =>
       let dispatch = msg =>

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -88,6 +88,8 @@ let%component make = (~theme, ~state: State.t, ~dispatch, ()) => {
         model={state.scm}
         workingDirectory={state.workspace.workingDirectory}
         isFocused={FocusManager.current(state) == Focus.SCM}
+        languageInfo={state.languageInfo}
+        iconTheme={state.iconTheme}
         theme
         font
         dispatch={msg => dispatch(Actions.SCM(msg))}


### PR DESCRIPTION
__Issue:__ After refactoring the file explorer population to be asynchronous, there was a regression, in that the initial explorer items don't have file icons:
![image](https://user-images.githubusercontent.com/13532591/94214905-c8270400-fe8f-11ea-98f0-358aa64e2bff.png)

__Defect:__ The `languageInfo` and `iconTheme` were not yet populated at the time the initial load came back.

__Fix:__ Defer the icon resolution to rendering, which will always be up-to-date. In addition, re-use the `<FileIcon />` component to show icons for SCM, too:
![image](https://user-images.githubusercontent.com/13532591/94215000-10462680-fe90-11ea-9ddc-eafb914ff6b9.png)
