### PR TITLE
fix(ux): Indent guide incorrect in vimlist/vimtree

### DIFF
--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -92,6 +92,7 @@ module ExpansionContext = {
 
 [@deriving show]
 type activeIndentRange = {
+  level: int,
   start: int,
   stop: int,
 };
@@ -152,14 +153,27 @@ let calculateIndentGuides = model => {
   let selectedIndex = model.treeAsList |> Component_VimList.selectedIndex;
 
   let count = model.treeAsList |> Component_VimList.count;
-  let rec travel = (~direction, ~iteration, idx) =>
+  let rec travel = (~indentationLevel, ~direction, ~iteration, idx) =>
     if (idx + direction <= 0 || idx + direction >= count || iteration > 250) {
       idx;
     } else {
       switch (Component_VimList.get(idx + direction, model.treeAsList)) {
       | Some(ViewLeaf(_)) =>
-        travel(~direction, ~iteration=iteration + 1, idx + direction)
-      | Some(ViewNode(_)) => idx
+        travel(
+          ~indentationLevel,
+          ~direction,
+          ~iteration=iteration + 1,
+          idx + direction,
+        )
+      | Some(ViewNode({indentationLevel: indent, _}))
+          when indent < indentationLevel => idx
+      | Some(ViewNode(_)) =>
+        travel(
+          ~indentationLevel,
+          ~direction,
+          ~iteration=iteration + 1,
+          idx + direction,
+        )
       | None => idx
       };
     };
@@ -169,20 +183,37 @@ let calculateIndentGuides = model => {
     |> Component_VimList.get(selectedIndex)
     |> OptionEx.flatMap(item => {
          switch (item) {
-         | TreeList.ViewNode(_) => None
-         | TreeList.ViewLeaf(_) =>
-           let start = travel(~direction=-1, ~iteration=0, selectedIndex);
-           let stop = travel(~direction=1, ~iteration=0, selectedIndex);
-           Some({start, stop});
+         | TreeList.ViewNode({indentationLevel, _})
+         | TreeList.ViewLeaf({indentationLevel, _}) =>
+           let start =
+             travel(
+               ~indentationLevel,
+               ~direction=-1,
+               ~iteration=0,
+               selectedIndex,
+             );
+           let stop =
+             travel(
+               ~indentationLevel,
+               ~direction=1,
+               ~iteration=0,
+               selectedIndex,
+             );
+           Some({level: indentationLevel, start, stop});
          }
        });
   {...model, activeIndentRange};
 };
 
-let isActiveIndent = (index, model) => {
+let activeLevel = (index, model) => {
   model.activeIndentRange
-  |> Option.map(range => {index >= range.start && index <= range.stop})
-  |> Option.value(~default=false);
+  |> OptionEx.flatMap(range =>
+       if (index >= range.start && index <= range.stop) {
+         Some(range.level);
+       } else {
+         None;
+       }
+     );
 };
 
 let updateTreeList = (treesWithId, expansionContext, model) => {
@@ -298,12 +329,13 @@ module View = {
     />;
   };
 
-  let indent = (~level, ~width, ~height, ~color) => {
-    List.init(level, _ =>
+  let indent =
+      (~activeLevel, ~level, ~width, ~height, ~inactiveColor, ~activeColor) => {
+    List.init(level, i =>
       indentGuide(
         ~horizontalSize=width,
         ~verticalSize=height,
-        ~strokeColor=color,
+        ~strokeColor=Some(i + 1) == activeLevel ? activeColor : inactiveColor,
       )
     );
   };
@@ -323,12 +355,14 @@ module View = {
     let activeIndentColor = Colors.List.activeIndentGuide.from(theme);
     let inactiveIndentColor = Colors.List.inactiveIndentGuide.from(theme);
 
-    let makeIndent = (~isActive, level) => {
+    let makeIndent = (~activeLevel, level) => {
       indent(
+        ~activeLevel,
         ~level,
         ~width=indentWidth,
         ~height=indentHeight,
-        ~color=isActive ? activeIndentColor : inactiveIndentColor,
+        ~inactiveColor=inactiveIndentColor,
+        ~activeColor=activeIndentColor,
       )
       |> React.listToElement;
     };
@@ -345,7 +379,7 @@ module View = {
           switch (item) {
           | TreeList.ViewLeaf({indentationLevel, data}) => [
               makeIndent(
-                ~isActive=isActiveIndent(index, model),
+                ~activeLevel=activeLevel(index, model),
                 indentationLevel,
               ),
               render(
@@ -366,7 +400,10 @@ module View = {
               );
 
             [
-              makeIndent(~isActive=false, indentationLevel),
+              makeIndent(
+                ~activeLevel=activeLevel(index, model),
+                indentationLevel,
+              ),
               icon,
               render(
                 ~availableWidth,


### PR DESCRIPTION
__Issue:__ The active indent guide calculation is incorrect:

![image](https://user-images.githubusercontent.com/13532591/94613117-ece8f600-0258-11eb-9d50-523910385d36.png)

__Defect:__ There were two issues:
1) All indent levels were highlighted
2) Parent nodes at the same indentation level were not considered

__Fix:__ 
1) Only highlight active level
2) Consider nodes at the same or greater indentation level