### PR TITLE
fix(ux/windows): Long path / folder names can overflow

### DIFF
--- a/src/Components/Accordion/Component_Accordion.re
+++ b/src/Components/Accordion/Component_Accordion.re
@@ -39,6 +39,8 @@ module Styles = {
 
   let title = (~theme) => [
     color(Colors.SideBarSectionHeader.foreground.from(theme)),
+    textWrap(Revery.TextWrapping.NoWrap),
+    overflow(`Hidden),
   ];
 
   let countContainer = (~theme) => [

--- a/src/Feature/TitleBar/Feature_TitleBar.re
+++ b/src/Feature/TitleBar/Feature_TitleBar.re
@@ -246,6 +246,9 @@ module Styles = {
       flexDirection(`Row),
       alignItems(`Center),
       marginHorizontal(16),
+      flexGrow(1),
+      flexShrink(1),
+      overflow(`Hidden),
     ];
 
     let icon = [pointerEvents(`Ignore)];
@@ -266,9 +269,10 @@ module Styles = {
           : Colors.inactiveForeground.from(theme),
       ),
       textWrap(TextWrapping.NoWrap),
+      textOverflow(`Ellipsis),
     ];
 
-    let buttons = [flexDirection(`Row), alignItems(`Center)];
+    let buttons = [flexDirection(`Row), flexGrow(0), flexShrink(0), alignItems(`Center)];
 
     module Button = {
       let container = [

--- a/src/Feature/TitleBar/Feature_TitleBar.re
+++ b/src/Feature/TitleBar/Feature_TitleBar.re
@@ -272,7 +272,12 @@ module Styles = {
       textOverflow(`Ellipsis),
     ];
 
-    let buttons = [flexDirection(`Row), flexGrow(0), flexShrink(0), alignItems(`Center)];
+    let buttons = [
+      flexDirection(`Row),
+      flexGrow(0),
+      flexShrink(0),
+      alignItems(`Center),
+    ];
 
     module Button = {
       let container = [


### PR DESCRIPTION
While investigating #2501 testing w/ long paths - there were cases where a long path name could overflow (and kick out the titlebar buttons).

This fixes a couple long-path overflow cases in the accordion and titlebar.