### PR TITLE
fix(ux-windows/#2526): strip \r when pasting text with CTRL+V

### DIFF
--- a/src/Feature/Clipboard/Feature_Clipboard.re
+++ b/src/Feature/Clipboard/Feature_Clipboard.re
@@ -44,7 +44,14 @@ let update = (msg, model) => {
   | PasteClipboardEmpty => (model, Nothing)
   | PasteClipboardText({text}) =>
     let (isMultiLine, lines) = StringEx.splitLines(text);
-    (model, Pasted({isMultiLine, lines, rawText: text}));
+    (
+      model,
+      Pasted({
+        isMultiLine,
+        lines,
+        rawText: StringEx.removeWindowsNewLines(text),
+      }),
+    );
   };
 };
 


### PR DESCRIPTION
Fixes #2526