### PR TITLE
fix(ux): Missing fontFamily setting on new <Text /> components

### DIFF
--- a/src/Components/FileItemView.re
+++ b/src/Components/FileItemView.re
@@ -101,6 +101,7 @@ module View = {
         <Text
           style={Styles.fileText(~theme)}
           text=filename
+          fontFamily={uiFont.family}
           fontSize={uiFont.size}
           fontWeight=Revery.Font.Weight.SemiBold
         />
@@ -110,6 +111,7 @@ module View = {
           <Text
             style={Styles.directoryText(~theme)}
             text=dirname
+            fontFamily={uiFont.family}
             fontSize={uiFont.size}
             fontWeight=Revery.Font.Weight.Light
           />

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -183,7 +183,7 @@ module View = {
                   ~documentSymbols:
                      option(Feature_LanguageSupport.DocumentSymbols.t),
                   ~theme,
-                  ~font,
+                  ~font: UiFont.t,
                   ~dispatch: msg => unit,
                   (),
                 ) => {
@@ -229,6 +229,8 @@ module View = {
           <Text
             text={symbolData.name}
             style=Style.[color(foregroundColor)]
+            fontFamily={font.family}
+            fontSize={font.size}
           />
         </View>
       </Oni_Components.Tooltip>;
@@ -239,6 +241,8 @@ module View = {
         <Text
           text="No symbols available for active buffer."
           style=Style.[color(foregroundColor)]
+          fontFamily={font.family}
+          fontSize={font.size}
         />
       </View>;
 


### PR DESCRIPTION
__Issue:__ In some of the new UI - like the `<FileItemView />` used in search and diagnostics, and the symbol view - a `fontFamily` wasn't set, so this would fall back to a default system font in those new pieces of UI, which isn't desirable - which can either cause a mismatching font to show, or not display at all.

__Defect:__ Missed setting the `fontFamily` parameter on these new elements.

__Fix:__ Set the missing properties.

As a next step, it may make sense to have an `<OniText font />` component, that takes a `UiFont.t` as a required parameter, so it isn't missed elsewhere.