### PR TITLE
fix(ux): Fix several UX issues around the bottom-pane

### DIFF
--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -37,4 +37,6 @@ let inactiveWindowOpacity =
     ~default=0.75,
   );
 
-let contributions = [inactiveWindowOpacity.spec];
+let animation = setting("ui.animation", bool, ~default=true);
+
+let contributions = [inactiveWindowOpacity.spec, animation.spec];

--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -54,6 +54,7 @@ let setDiagnostics: (Feature_Diagnostics.model, model) => model;
 module View: {
   let make:
     (
+      ~key: Brisk_reconciler.Key.t=?,
       ~config: Config.resolver,
       ~isFocused: bool,
       ~theme: Oni_Core.ColorTheme.Colors.t,


### PR DESCRIPTION
__Issue:__ There were a couple problems with the bottom pane:
1) When opening, diagnostics is a more convenient default, but it defaults to opening notifications
2) Clicking the 'close' x in the corner doesn't have an effect when focused
3) Opening can be jarring

__Fix:__
1) Update the default selected pane. This way, when using `<C-w><C-j>` to open the bottom pane, diagnostics will be fixed. 
2) Fix the close behavior to release focus as well
3) Add a subtle animation on opening, and wire up a new config flag to disable it (`ui.animation`) - we can use this config flag to disable smooth scroll elsewhere, too.