### PR TITLE
fix(crash): Remove usages of rench; replace with path utilities

### DIFF
--- a/src/Core/IconTheme.re
+++ b/src/Core/IconTheme.re
@@ -5,6 +5,7 @@
  */
 
 open Kernel;
+module CoreUtility = Utility;
 open Revery;
 
 module FontSource = {
@@ -88,7 +89,7 @@ let getIconForFile: (t, string, string) => option(IconDefinition.t) =
       | None =>
         switch (
           StringMap.find_opt(
-            normalizeExtension(Rench.Path.extname(fileName)),
+            normalizeExtension(CoreUtility.Path.getExtension(fileName)),
             iconTheme.fileExtensions,
           )
         ) {

--- a/src/Core/Utility/Path.re
+++ b/src/Core/Utility/Path.re
@@ -82,6 +82,7 @@ let%test_module "getExtension" =
   (module
    {
      let%test "Simple file" = getExtension("/home/oni/test.md") == ".md";
+     let%test "Simple file, no extension" = getExtension("/home/oni/test") == "";
      let%test "No file name, only extension" =
        getExtension("/home/oni/.bashrc") == ".bashrc";
      let%test "No path" = getExtension("") == "";

--- a/src/Core/Utility/Path.re
+++ b/src/Core/Utility/Path.re
@@ -82,7 +82,8 @@ let%test_module "getExtension" =
   (module
    {
      let%test "Simple file" = getExtension("/home/oni/test.md") == ".md";
-     let%test "Simple file, no extension" = getExtension("/home/oni/test") == "";
+     let%test "Simple file, no extension" =
+       getExtension("/home/oni/test") == "";
      let%test "No file name, only extension" =
        getExtension("/home/oni/.bashrc") == ".bashrc";
      let%test "No path" = getExtension("") == "";

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -198,14 +198,12 @@ module SearchSubscription =
     type action = msg;
   });
 
-let subscriptions = (ripgrep, dispatch) => {
+let subscriptions = (~workingDirectory, ripgrep, dispatch) => {
   let search = query => {
-    let directory = Rench.Environment.getWorkingDirectory();
-
     SearchSubscription.create(
       ~id="workspace-search",
       ~query,
-      ~directory,
+      ~directory=workingDirectory,
       ~ripgrep,
       ~onUpdate=items => dispatch(Update(items)),
       ~onCompleted=() => Complete,

--- a/src/Feature/Search/Feature_Search.rei
+++ b/src/Feature/Search/Feature_Search.rei
@@ -27,7 +27,8 @@ let update: (model, msg) => (model, option(outmsg));
 let resetFocus: model => model;
 
 let subscriptions:
-  (Ripgrep.t, msg => unit, model) => list(Subscription.t(msg));
+  (~workingDirectory: string, Ripgrep.t, msg => unit, model) =>
+  list(Subscription.t(msg));
 
 let make:
   (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1251,11 +1251,12 @@ let updateSubscriptions = (setup: Setup.t) => {
   let searchSubscriptions = Feature_Search.subscriptions(ripgrep);
 
   (state: State.t, dispatch) => {
+    let workingDirectory = state.workspace.workingDirectory;
     quickmenuSubscriptions(dispatch, state)
     |> QuickmenuSubscriptionRunner.run(~dispatch);
 
     let searchDispatch = msg => dispatch(Search(msg));
-    searchSubscriptions(searchDispatch, state.searchPane)
+    searchSubscriptions(~workingDirectory, searchDispatch, state.searchPane)
     |> SearchSubscriptionRunner.run(~dispatch=searchDispatch);
   };
 };

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -7,7 +7,6 @@
  */
 
 open Revery.UI;
-open Rench;
 open Oni_Core;
 open Oni_Model;
 module OptionEx = Oni_Core.Utility.OptionEx;
@@ -236,7 +235,7 @@ let make =
       switch (renderer) {
       | Welcome => "Welcome"
       | Terminal({title, _}) => title
-      | _ => Path.filename(title)
+      | _ => Utility.Path.filename(title)
       };
     };
 


### PR DESCRIPTION
__Issue:__ I've observed occassional crashes with the following exception:
```
(Invalid_argument "\"\": invalid path"):
```

__Defect:__ This appears to be coming from our `Rench.Path` utilities, which can throw - in particular, if there happens to be malformed or empty filenames coming from ripgrep.

__Fix:__ Remove usages of Rench, replace with the `Oni_Core.Utility.Path`, which are more robust and don't throw.

As a future step - I'd like to look at strongly typing our paths with [`Fp`](https://github.com/facebookexperimental/reason-native/tree/master/src/fp) and use those utilities.