### PR TITLE
fix(extensions/#2484): Searching for extensions w/o network crashes Onivim

### DIFF
--- a/node/success.js
+++ b/node/success.js
@@ -1,0 +1,1 @@
+process.stdout.write("Successful node task!");

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -25,10 +25,7 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
 
     let success = () => {
       let allOutput =
-        buffers^
-        |> List.rev
-        |> List.map(Luv.Buffer.to_string)
-        |> String.concat("");
+        buffers^ |> List.rev_map(Luv.Buffer.to_string) |> String.concat("");
       Log.debugf(m => m("Got output: %s", allOutput));
       Lwt.wakeup(resolver, allOutput);
     };

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -11,7 +11,7 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
   let (promise, resolver) = Lwt.task();
 
   let scriptPath = Setup.getNodeScriptPath(~script, setup);
-  Log.info("Using node path: " ++ scriptPath);
+  prerr_endline("Using node path: " ++ scriptPath);
 
   let result = {
     open Base.Result.Let_syntax;
@@ -53,6 +53,7 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
         stdoutPipe,
         fun
         | Error(`EOF) => {
+            prerr_endline ("Got EOF");
             Log.info("Got EOF on stdout");
             Luv.Handle.close(stdoutPipe, ignore);
             let allOutput =

--- a/src/Feature/Extensions/ListView.re
+++ b/src/Feature/Extensions/ListView.re
@@ -192,11 +192,7 @@ let%component make =
       ]
       |> React.listToElement;
     } else {
-      <View
-        style={Styles.resultsContainer(
-          ~isFocused={isFocused && model.focusedWindow != SearchText},
-          theme,
-        )}>
+      let resultsList =
         <Component_VimList.View
           isActive={isInstalledFocused || isBundledFocused}
           font
@@ -244,7 +240,23 @@ let%component make =
               }
             />;
           }}
-        />
+        />;
+
+      let error =
+        <View style=Style.[padding(8)]>
+          <Text
+            fontFamily={font.family}
+            fontSize={font.size}
+            text="There was an error searching for extensions. Please check your network connection and try again."
+            style=Style.[color(Colors.EditorError.foreground.from(theme))]
+          />
+        </View>;
+      <View
+        style={Styles.resultsContainer(
+          ~isFocused={isFocused && model.focusedWindow != SearchText},
+          theme,
+        )}>
+        {model.lastSearchHadError ? error : resultsList}
       </View>;
     };
 

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -446,15 +446,15 @@ let getPersistedValue = (~shared, ~key, model) => {
   |> (l => List.nth_opt(l, 0));
 };
 
-let checkAndUpdateSearchText = (~previousText, ~newText, ~query) =>
+let checkAndUpdateSearchText = (~hasError, ~previousText, ~newText, ~query) =>
   if (previousText != newText) {
     if (String.length(newText) == 0) {
-      None;
+      (false, None);
     } else {
-      Some(Service_Extensions.Query.create(~searchText=newText));
+      (false, Some(Service_Extensions.Query.create(~searchText=newText)));
     };
   } else {
-    query;
+    (hasError, query);
   };
 
 let getExtensions = Internal.getExtensions;
@@ -529,14 +529,20 @@ let update = (~extHostClient, msg, model) => {
     let previousText = model.searchText |> Component_InputText.value;
     let searchText' = Component_InputText.handleInput(~key, model.searchText);
     let newText = searchText' |> Component_InputText.value;
-    let latestQuery =
+    let (hasError, latestQuery) =
       checkAndUpdateSearchText(
+        ~hasError=model.lastSearchHadError,
         ~previousText,
         ~newText,
         ~query=model.latestQuery,
       );
     (
-      {...model, searchText: searchText', latestQuery}
+      {
+        ...model,
+        lastSearchHadError: hasError,
+        searchText: searchText',
+        latestQuery,
+      }
       |> updateViewModelSearchResults,
       Nothing,
     );
@@ -544,14 +550,20 @@ let update = (~extHostClient, msg, model) => {
     let previousText = model.searchText |> Component_InputText.value;
     let searchText' = Component_InputText.paste(~text, model.searchText);
     let newText = searchText' |> Component_InputText.value;
-    let latestQuery =
+    let (hasError, latestQuery) =
       checkAndUpdateSearchText(
+        ~hasError=model.lastSearchHadError,
         ~previousText,
         ~newText,
         ~query=model.latestQuery,
       );
     (
-      {...model, searchText: searchText', latestQuery}
+      {
+        ...model,
+        lastSearchHadError: hasError,
+        searchText: searchText',
+        latestQuery,
+      }
       |> updateViewModelSearchResults,
       Nothing,
     );
@@ -565,23 +577,21 @@ let update = (~extHostClient, msg, model) => {
       | Component_InputText.Focus => Focus
       };
     let newText = searchText' |> Component_InputText.value;
-    let latestQuery =
+    let (hasError, latestQuery) =
       checkAndUpdateSearchText(
+        ~hasError=model.lastSearchHadError,
         ~previousText,
         ~newText,
         ~query=model.latestQuery,
       );
 
-    let lastSearchHadError =
-      if (newText != previousText) {
-        prerr_endline("-- UPDATING lastSearchHadError");
-        false;
-      } else {
-        model.lastSearchHadError;
-      };
-
     (
-      {...model, lastSearchHadError, searchText: searchText', latestQuery}
+      {
+        ...model,
+        lastSearchHadError: hasError,
+        searchText: searchText',
+        latestQuery,
+      }
       |> updateViewModelSearchResults,
       outmsg,
     );

--- a/src/Service/Extensions/Catalog.re
+++ b/src/Service/Extensions/Catalog.re
@@ -109,9 +109,11 @@ module Details = {
     open Json.Decode;
 
     let files = (name, decoder) => field("files", field(name, decoder));
+    let filesOpt = (name, decoder) =>
+      field("files", field_opt(name, decoder));
     let downloadUrl = files("download", string);
     let manifestUrl = files("manifest", string);
-    let iconUrl = files("icon", nullable(string));
+    let iconUrl = filesOpt("icon", string);
     let readmeUrl = files("readme", nullable(string));
     let homepageUrl = field("publishedBy", field("homepage", string));
 
@@ -167,7 +169,7 @@ module Summary = {
     open Json.Decode;
 
     let downloadUrl = field("files", field("download", string));
-    let iconUrl = field("files", field("icon", nullable(string)));
+    let iconUrl = field("files", field_opt("icon", string));
 
     obj(({field, whatever, _}) =>
       {

--- a/test/Core/NodeTaskTests.re
+++ b/test/Core/NodeTaskTests.re
@@ -1,0 +1,19 @@
+open Oni_Core;
+open Utility;
+open TestFramework;
+
+let setup = Setup.init();
+
+describe("NodeTask", ({test, _}) => {
+    test("successful task", ({expect, _}) => {
+      let result = NodeTask.run(~setup, "success.js")
+      |> LwtEx.sync;
+      expect.equal(result, Ok("Successful node task!"));
+    });
+
+    test("task with error", ({expect, _}) => {
+      let result = NodeTask.run(~setup, "error.js")
+      |> LwtEx.sync;
+      expect.equal(result |> Result.is_error, true);
+    });
+});

--- a/test/Core/NodeTaskTests.re
+++ b/test/Core/NodeTaskTests.re
@@ -5,15 +5,13 @@ open TestFramework;
 let setup = Setup.init();
 
 describe("NodeTask", ({test, _}) => {
-    test("successful task", ({expect, _}) => {
-      let result = NodeTask.run(~setup, "success.js")
-      |> LwtEx.sync;
-      expect.equal(result, Ok("Successful node task!"));
-    });
+  test("successful task", ({expect, _}) => {
+    let result = NodeTask.run(~setup, "success.js") |> LwtEx.sync;
+    expect.equal(result, Ok("Successful node task!"));
+  });
 
-    test("task with error", ({expect, _}) => {
-      let result = NodeTask.run(~setup, "error.js")
-      |> LwtEx.sync;
-      expect.equal(result |> Result.is_error, true);
-    });
+  test("task with error", ({expect, _}) => {
+    let result = NodeTask.run(~setup, "error.js") |> LwtEx.sync;
+    expect.equal(result |> Result.is_error, true);
+  });
 });


### PR DESCRIPTION
__Issue:__ When searching for extensions without a network connection, the editor would crash with:

```
(Invalid_argument Lwt.wakeup_exn)
Raised at file "stdlib.ml", line 30, characters 20-45
Called from file "src/process.ml", line 107, characters 12-54
```

__Defect:__ There is a race condition here - we are waiting for `EOF` on `stdout` to return the promise - and claim success. However, in the error case, we'd get EOF on stdout, run `Lwt.wakeup` to complete the promise, and _then_ get a call that the process has exited - and we'd call `Lwt.wakeup_exn` on the same promise. This triggers an invalid argument exception - we're trying to complete and then fail the same promise.

__Fix:__ Wait until both the process has exited, and stdout has given the `EOF` - then we'll complete the promise. At that point, we know if the process was successful or failed, and we could do the appropriate action on the promise.

In addition, while debugging this, I saw that parsing was failing frequently when querying `open-vsx` - our parsing code was making the assumption that an `icon` field was always available, when that's not the case. 

Finally, I also added an error message when the search query fails.

Fixes #2484 , and should fix #2545 as well