### PR TITLE
fix(explorer/#2556): Implement h/l for tree view to expand & collapse

### DIFF
--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -37,6 +37,10 @@ let create = (~rowHeight) => {
 
 let isScrollAnimated = ({isScrollAnimated, _}) => isScrollAnimated;
 
+let isSearchOpen = ({searchContext, _}) => {
+  searchContext |> SearchContext.isOpen;
+};
+
 let findIndex = (f, {items, _}) => {
   let len = Array.length(items);
   let rec loop = idx =>

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -2,7 +2,12 @@ open Oni_Core;
 open Utility;
 
 [@deriving show]
+type command =
+  | ToggleExpanded;
+
+[@deriving show]
 type msg =
+  | Command(command)
   | List(Component_VimList.msg);
 
 type nodeOrLeaf('node, 'leaf) =
@@ -239,6 +244,18 @@ let updateTreeList = (~searchText=?, treesWithId, expansionContext, model) => {
   };
 };
 
+let toggleExpanded = (~expanded, ~data: withUniqueId('a), model) => {
+  let expansionContext =
+    expanded
+      ? model.expansionContext |> ExpansionContext.collapse(data.uniqueId)
+      : model.expansionContext |> ExpansionContext.expand(data.uniqueId);
+
+  (
+    updateTreeList(model.trees, expansionContext, model),
+    expanded ? Collapsed(data.inner) : Expanded(data.inner),
+  );
+};
+
 let update = (msg, model) => {
   switch (msg) {
   | List(listMsg) =>
@@ -254,19 +271,19 @@ let update = (msg, model) => {
       | Some(ViewLeaf({data, _})) => (model, Selected(data))
       // TODO: Expand / collapse
       | Some(ViewNode({data, expanded, _})) =>
-        let expansionContext =
-          expanded
-            ? model.expansionContext
-              |> ExpansionContext.collapse(data.uniqueId)
-            : model.expansionContext |> ExpansionContext.expand(data.uniqueId);
-
-        (
-          updateTreeList(model.trees, expansionContext, model),
-          expanded ? Collapsed(data.inner) : Expanded(data.inner),
-        );
+        toggleExpanded(~expanded, ~data, model)
 
       | None => (model, Nothing)
       }
+    };
+
+  | Command(ToggleExpanded) =>
+    let selectedIndex = Component_VimList.selectedIndex(model.treeAsList);
+    switch (Component_VimList.get(selectedIndex, model.treeAsList)) {
+    | None => (model, Nothing)
+    | Some(ViewLeaf(_)) => (model, Nothing)
+    | Some(ViewNode({data, expanded, _})) =>
+      toggleExpanded(~expanded, ~data, model)
     };
   };
 };
@@ -330,12 +347,60 @@ let set =
   };
 };
 
+module Commands = {
+  open Feature_Commands.Schema;
+
+  let toggleExpanded =
+    define("vim.tree.toggleExpanded", Command(ToggleExpanded));
+};
+
+module Keybindings = {
+  open Oni_Input;
+
+  let commandCondition =
+    "!textInputFocus && vimListNavigation" |> WhenExpr.parse;
+
+  let keybindings =
+    Keybindings.[
+      {
+        key: "h",
+        command: Commands.toggleExpanded.id,
+        condition: commandCondition,
+      },
+      {
+        key: "l",
+        command: Commands.toggleExpanded.id,
+        condition: commandCondition,
+      },
+    ];
+};
+
 module Contributions = {
+  let keybindings = Keybindings.keybindings;
+
   let commands =
-    Component_VimList.Contributions.commands
-    |> List.map(Oni_Core.Command.map(msg => List(msg)));
-  let contextKeys = model =>
-    Component_VimList.Contributions.contextKeys(model.treeAsList);
+    (
+      Component_VimList.Contributions.commands
+      |> List.map(Oni_Core.Command.map(msg => List(msg)))
+    )
+    @ Commands.[toggleExpanded];
+
+  let contextKeys = model => {
+    open WhenExpr.ContextKeys;
+
+    let vimListKeys =
+      Component_VimList.Contributions.contextKeys(model.treeAsList);
+    let vimTreeKeys =
+      [
+        Schema.bool("vimTreeNavigation", ({treeAsList, _}) => {
+          !(treeAsList |> Component_VimList.isSearchOpen)
+        }),
+      ]
+      |> Schema.fromList
+      |> fromSchema(model);
+
+    [vimListKeys, vimTreeKeys] |> unionMany;
+  };
 };
 
 module View = {

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -269,7 +269,6 @@ let update = (msg, model) => {
     | Component_VimList.Selected({index}) =>
       switch (Component_VimList.get(index, treeAsList)) {
       | Some(ViewLeaf({data, _})) => (model, Selected(data))
-      // TODO: Expand / collapse
       | Some(ViewNode({data, expanded, _})) =>
         toggleExpanded(~expanded, ~data, model)
 

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -66,6 +66,7 @@ let scrollTo:
 
 module Contributions: {
   let commands: list(Command.t(msg));
+  let keybindings: list(Oni_Input.Keybindings.keybinding);
   let contextKeys: model('node, 'leaf) => WhenExpr.ContextKeys.t;
 };
 

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -412,7 +412,8 @@ let start = maybeKeyBindingsFilePath => {
         },
       ]
     @ Component_VimWindows.Contributions.keybindings
-    @ Component_VimList.Contributions.keybindings;
+    @ Component_VimList.Contributions.keybindings
+    @ Component_VimTree.Contributions.keybindings;
 
   let getKeybindingsFile = () => {
     Filesystem.getOrCreateConfigFile(


### PR DESCRIPTION
Fixes #2556 - adds `h` and `l` bindings to expand/collapse tree view nodes:
![2020-10-07 16 35 05](https://user-images.githubusercontent.com/13532591/95398633-31a90880-08bb-11eb-8214-8305f9dff844.gif)
