### PR TITLE
feat(editor/#1444): Part 3 - Update Tokenizer / BufferLineColorizer API

### DIFF
--- a/src/Core/Tokenizer.re
+++ b/src/Core/Tokenizer.re
@@ -13,18 +13,23 @@ module TextRun = {
     startByte: ByteIndex.t,
     endByte: ByteIndex.t,
     /*
-     * Indices refer to the UTF-8 position in the parent string
+     * Character indices refer to the UTF-8 position in the parent string
      */
     startIndex: CharacterIndex.t,
     endIndex: CharacterIndex.t,
+    /*
+     * Pixel positions for the start / end of the token
+     */
+    startPixel: float,
   };
 
-  let create = (~text, ~startByte, ~endByte, ~startIndex, ~endIndex, ()) => {
+  let create = (~text, ~startByte, ~endByte, ~startIndex, ~endIndex, ~startPixel, ()) => {
     text,
     startByte,
     endByte,
     startIndex,
     endIndex,
+    startPixel,
   };
 };
 
@@ -39,31 +44,31 @@ type splitFunc =
   ) =>
   bool;
 
-//type splitFunc = (int, Uchar.t, int, Uchar.t) => bool;
+module Internal = {
+    let getNextBreak =
+        (bufferLine: BufferLine.t, start: int, max: int, f: splitFunc) => {
+      let pos = ref(start);
+      let found = ref(false);
 
-let _getNextBreak =
-    (bufferLine: BufferLine.t, start: int, max: int, f: splitFunc) => {
-  let pos = ref(start);
-  let found = ref(false);
+      while (pos^ < max - 1 && ! found^) {
+        let index0 = CharacterIndex.ofInt(pos^);
+        let index1 = CharacterIndex.ofInt(pos^ + 1);
+        let char0 = BufferLine.getUcharExn(~index=index0, bufferLine);
+        let char1 = BufferLine.getUcharExn(~index=index1, bufferLine);
+        let byte0 = BufferLine.getByteFromIndex(~index=index0, bufferLine);
+        let byte1 = BufferLine.getByteFromIndex(~index=index1, bufferLine);
 
-  while (pos^ < max - 1 && ! found^) {
-    let index0 = CharacterIndex.ofInt(pos^);
-    let index1 = CharacterIndex.ofInt(pos^ + 1);
-    let char0 = BufferLine.getUcharExn(~index=index0, bufferLine);
-    let char1 = BufferLine.getUcharExn(~index=index1, bufferLine);
-    let byte0 = BufferLine.getByteFromIndex(~index=index0, bufferLine);
-    let byte1 = BufferLine.getByteFromIndex(~index=index1, bufferLine);
+        if (f(~index0, ~index1, ~char0, ~char1, ~byte0, ~byte1)) {
+          found := true;
+        };
 
-    if (f(~index0, ~index1, ~char0, ~char1, ~byte0, ~byte1)) {
-      found := true;
+        if (! found^) {
+          incr(pos);
+        };
+      };
+
+      pos^;
     };
-
-    if (! found^) {
-      incr(pos);
-    };
-  };
-
-  pos^;
 };
 
 let tokenize =
@@ -87,7 +92,7 @@ let tokenize =
 
     while (idx^ < maxIndex) {
       let startToken = idx^;
-      let endToken = _getNextBreak(bufferLine, startToken, maxIndex, f) + 1;
+      let endToken = Internal.getNextBreak(bufferLine, startToken, maxIndex, f) + 1;
 
       let text =
         BufferLine.subExn(
@@ -107,13 +112,20 @@ let tokenize =
           bufferLine,
         );
 
+      let startIndex = CharacterIndex.ofInt(startToken);
+      let endIndex = CharacterIndex.ofInt(endToken);
+
+      let (startPixel, _) =
+        BufferLine.getPixelPositionAndWidth(~index=startIndex, bufferLine);
+
       let textRun =
         TextRun.create(
           ~text,
           ~startByte,
           ~endByte,
-          ~startIndex=CharacterIndex.ofInt(startToken),
-          ~endIndex=CharacterIndex.ofInt(endToken),
+          ~startIndex,
+          ~endIndex,
+          ~startPixel,
           (),
         );
 

--- a/src/Core/Tokenizer.re
+++ b/src/Core/Tokenizer.re
@@ -23,7 +23,8 @@ module TextRun = {
     startPixel: float,
   };
 
-  let create = (~text, ~startByte, ~endByte, ~startIndex, ~endIndex, ~startPixel, ()) => {
+  let create =
+      (~text, ~startByte, ~endByte, ~startIndex, ~endIndex, ~startPixel, ()) => {
     text,
     startByte,
     endByte,
@@ -45,30 +46,30 @@ type splitFunc =
   bool;
 
 module Internal = {
-    let getNextBreak =
-        (bufferLine: BufferLine.t, start: int, max: int, f: splitFunc) => {
-      let pos = ref(start);
-      let found = ref(false);
+  let getNextBreak =
+      (bufferLine: BufferLine.t, start: int, max: int, f: splitFunc) => {
+    let pos = ref(start);
+    let found = ref(false);
 
-      while (pos^ < max - 1 && ! found^) {
-        let index0 = CharacterIndex.ofInt(pos^);
-        let index1 = CharacterIndex.ofInt(pos^ + 1);
-        let char0 = BufferLine.getUcharExn(~index=index0, bufferLine);
-        let char1 = BufferLine.getUcharExn(~index=index1, bufferLine);
-        let byte0 = BufferLine.getByteFromIndex(~index=index0, bufferLine);
-        let byte1 = BufferLine.getByteFromIndex(~index=index1, bufferLine);
+    while (pos^ < max - 1 && ! found^) {
+      let index0 = CharacterIndex.ofInt(pos^);
+      let index1 = CharacterIndex.ofInt(pos^ + 1);
+      let char0 = BufferLine.getUcharExn(~index=index0, bufferLine);
+      let char1 = BufferLine.getUcharExn(~index=index1, bufferLine);
+      let byte0 = BufferLine.getByteFromIndex(~index=index0, bufferLine);
+      let byte1 = BufferLine.getByteFromIndex(~index=index1, bufferLine);
 
-        if (f(~index0, ~index1, ~char0, ~char1, ~byte0, ~byte1)) {
-          found := true;
-        };
-
-        if (! found^) {
-          incr(pos);
-        };
+      if (f(~index0, ~index1, ~char0, ~char1, ~byte0, ~byte1)) {
+        found := true;
       };
 
-      pos^;
+      if (! found^) {
+        incr(pos);
+      };
     };
+
+    pos^;
+  };
 };
 
 let tokenize =
@@ -92,7 +93,8 @@ let tokenize =
 
     while (idx^ < maxIndex) {
       let startToken = idx^;
-      let endToken = Internal.getNextBreak(bufferLine, startToken, maxIndex, f) + 1;
+      let endToken =
+        Internal.getNextBreak(bufferLine, startToken, maxIndex, f) + 1;
 
       let text =
         BufferLine.subExn(

--- a/src/Feature/Editor/BufferLineColorizer.rei
+++ b/src/Feature/Editor/BufferLineColorizer.rei
@@ -20,7 +20,7 @@ type themedToken = {
  * Type [t] is a function of [(int) => tokenTheme)].
  *
  */
-type t = ByteIndex.t => themedToken;
+type t = (~startByte: ByteIndex.t, ByteIndex.t) => themedToken;
 
 /*
  * [create] takes information about the line, like
@@ -30,7 +30,6 @@ type t = ByteIndex.t => themedToken;
  */
 let create:
   (
-    ~startByte: ByteIndex.t,
     ~defaultBackgroundColor: Color.t,
     ~defaultForegroundColor: Color.t, // theme.editorForeground
     ~selectionHighlights: option(ByteRange.t),

--- a/test/Core/TokenizerTests.re
+++ b/test/Core/TokenizerTests.re
@@ -231,7 +231,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(1),
         ~startIndex=CharacterIndex.zero,
         ~endIndex=CharacterIndex.ofInt(1),
-          ~startPixel=0.,
+        ~startPixel=0.,
         (),
       ),
       TextRun.create(
@@ -240,7 +240,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(2),
         ~startIndex=CharacterIndex.ofInt(1),
         ~endIndex=CharacterIndex.ofInt(2),
-          ~startPixel=1.,
+        ~startPixel=1.,
         (),
       ),
       TextRun.create(
@@ -249,7 +249,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(3),
         ~startIndex=CharacterIndex.ofInt(2),
         ~endIndex=CharacterIndex.ofInt(3),
-          ~startPixel=2.,
+        ~startPixel=2.,
         (),
       ),
       TextRun.create(
@@ -258,7 +258,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(4),
         ~startIndex=CharacterIndex.ofInt(3),
         ~endIndex=CharacterIndex.ofInt(4),
-          ~startPixel=3.,
+        ~startPixel=3.,
         (),
       ),
     ];
@@ -281,7 +281,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(11),
         ~startIndex=CharacterIndex.zero,
         ~endIndex=CharacterIndex.ofInt(5),
-          ~startPixel=0.,
+        ~startPixel=0.,
         (),
       ),
     ];
@@ -305,7 +305,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(2),
         ~startIndex=CharacterIndex.zero,
         ~endIndex=CharacterIndex.ofInt(2),
-          ~startPixel=0.,
+        ~startPixel=0.,
         (),
       ),
       TextRun.create(
@@ -314,7 +314,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(6),
         ~startIndex=CharacterIndex.ofInt(2),
         ~endIndex=CharacterIndex.ofInt(6),
-          ~startPixel=2.,
+        ~startPixel=2.,
         (),
       ),
       TextRun.create(
@@ -323,7 +323,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(8),
         ~startIndex=CharacterIndex.ofInt(6),
         ~endIndex=CharacterIndex.ofInt(8),
-          ~startPixel=6.,
+        ~startPixel=6.,
         (),
       ),
     ];

--- a/test/Core/TokenizerTests.re
+++ b/test/Core/TokenizerTests.re
@@ -55,6 +55,7 @@ let validateToken =
   expect.int(actualToken.endIndex |> CharacterIndex.toInt).toBe(
     CharacterIndex.toInt(expectedToken.endIndex),
   );
+  expect.float(actualToken.startPixel).toBeCloseTo(expectedToken.startPixel);
 };
 
 let validateTokens =
@@ -118,6 +119,7 @@ describe("Tokenizer", ({test, describe, _}) => {
           ~endByte=ByteIndex.ofInt(3),
           ~startIndex=CharacterIndex.ofInt(1),
           ~endIndex=CharacterIndex.ofInt(3),
+          ~startPixel=1.0,
           (),
         ),
       ];
@@ -141,6 +143,7 @@ describe("Tokenizer", ({test, describe, _}) => {
           ~endByte=ByteIndex.ofInt(5),
           ~startIndex=CharacterIndex.ofInt(3),
           ~endIndex=CharacterIndex.ofInt(5),
+          ~startPixel=3.0,
           (),
         ),
       ];
@@ -166,6 +169,7 @@ describe("Tokenizer", ({test, describe, _}) => {
           ~endByte=ByteIndex.ofInt(1),
           ~startIndex=CharacterIndex.zero,
           ~endIndex=CharacterIndex.ofInt(1),
+          ~startPixel=0.,
           (),
         ),
         TextRun.create(
@@ -174,6 +178,7 @@ describe("Tokenizer", ({test, describe, _}) => {
           ~endByte=ByteIndex.ofInt(2),
           ~startIndex=CharacterIndex.ofInt(1),
           ~endIndex=CharacterIndex.ofInt(2),
+          ~startPixel=1.,
           (),
         ),
         TextRun.create(
@@ -182,6 +187,7 @@ describe("Tokenizer", ({test, describe, _}) => {
           ~endByte=ByteIndex.ofInt(3),
           ~startIndex=CharacterIndex.ofInt(2),
           ~endIndex=CharacterIndex.ofInt(3),
+          ~startPixel=2.,
           (),
         ),
         TextRun.create(
@@ -190,6 +196,7 @@ describe("Tokenizer", ({test, describe, _}) => {
           ~endByte=ByteIndex.ofInt(4),
           ~startIndex=CharacterIndex.ofInt(3),
           ~endIndex=CharacterIndex.ofInt(4),
+          ~startPixel=3.,
           (),
         ),
       ];
@@ -224,6 +231,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(1),
         ~startIndex=CharacterIndex.zero,
         ~endIndex=CharacterIndex.ofInt(1),
+          ~startPixel=0.,
         (),
       ),
       TextRun.create(
@@ -232,6 +240,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(2),
         ~startIndex=CharacterIndex.ofInt(1),
         ~endIndex=CharacterIndex.ofInt(2),
+          ~startPixel=1.,
         (),
       ),
       TextRun.create(
@@ -240,6 +249,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(3),
         ~startIndex=CharacterIndex.ofInt(2),
         ~endIndex=CharacterIndex.ofInt(3),
+          ~startPixel=2.,
         (),
       ),
       TextRun.create(
@@ -248,6 +258,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(4),
         ~startIndex=CharacterIndex.ofInt(3),
         ~endIndex=CharacterIndex.ofInt(4),
+          ~startPixel=3.,
         (),
       ),
     ];
@@ -270,6 +281,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(11),
         ~startIndex=CharacterIndex.zero,
         ~endIndex=CharacterIndex.ofInt(5),
+          ~startPixel=0.,
         (),
       ),
     ];
@@ -293,6 +305,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(2),
         ~startIndex=CharacterIndex.zero,
         ~endIndex=CharacterIndex.ofInt(2),
+          ~startPixel=0.,
         (),
       ),
       TextRun.create(
@@ -301,6 +314,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(6),
         ~startIndex=CharacterIndex.ofInt(2),
         ~endIndex=CharacterIndex.ofInt(6),
+          ~startPixel=2.,
         (),
       ),
       TextRun.create(
@@ -309,6 +323,7 @@ describe("Tokenizer", ({test, describe, _}) => {
         ~endByte=ByteIndex.ofInt(8),
         ~startIndex=CharacterIndex.ofInt(6),
         ~endIndex=CharacterIndex.ofInt(8),
+          ~startPixel=6.,
         (),
       ),
     ];


### PR DESCRIPTION
This makes a couple of tweaks to the `Tokenizer` and `BufferLineColorizer` API:

1) For the `Tokenizer`, store the pixel position of the token.
2) For the `BufferLineColorizer`, pivot the API such that we can reuse the same colorizer for different `startByte` values. Previously, we'd create a single `BufferLineColorizer.t` per view line (buffer line), but now, we want to reuse the same  colorizer, but apply it to different view lines. This can save us some computation to fast-forward the highlighter to the relevant byte.

Port of part of #1969 , related to #1444 