### PR TITLE
fix(completion/#2235): Prioritize fuzzy match over sort text

### DIFF
--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -327,10 +327,13 @@ let getMeetLocation = (~handle, model) => {
 let recomputeAllItems = (sessions: IntMap.t(Session.t)) => {
   sessions
   |> IntMap.bindings
-  |> List.map(((handle, session)) => {
+  |> List.map(((handle, session: Session.t)) => {
+       let isFuzzyMatching = session.base != "";
        session
        |> Session.filteredItems
-       |> List.map(Filter.map(CompletionItem.create(~handle)))
+       |> List.map(
+            Filter.map(CompletionItem.create(~isFuzzyMatching, ~handle)),
+          );
      })
   |> List.flatten
   |> List.fast_sort(CompletionItemSorter.compare)

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -15,9 +15,10 @@ type t = {
   commitCharacters: list(string),
   additionalTextEdits: list(Edit.SingleEditOperation.t),
   command: option(Command.t),
+  isFuzzyMatching: bool,
 };
 
-let create = (~handle, item: SuggestItem.t) => {
+let create = (~isFuzzyMatching: bool, ~handle, item: SuggestItem.t) => {
   chainedCacheId: item.chainedCacheId,
   handle,
   label: item.label,
@@ -31,4 +32,5 @@ let create = (~handle, item: SuggestItem.t) => {
   commitCharacters: item.commitCharacters,
   additionalTextEdits: item.additionalTextEdits,
   command: item.command,
+  isFuzzyMatching,
 };

--- a/src/Feature/LanguageSupport/CompletionItemSorter.re
+++ b/src/Feature/LanguageSupport/CompletionItemSorter.re
@@ -3,7 +3,14 @@ open Oni_Core;
 let compare =
     (a: Filter.result(CompletionItem.t), b: Filter.result(CompletionItem.t)) => {
   // First, use the sortText, if available
-  let sortValue = String.compare(a.item.sortText, b.item.sortText);
+  let sortValue =
+    if (!a.item.isFuzzyMatching && !b.item.isFuzzyMatching) {
+      String.compare(a.item.sortText, b.item.sortText);
+    } else {
+      0;
+      // If we're fuzzy matching,
+    };
+
   if (sortValue == 0) {
     let aLen = String.length(a.item.label);
     let bLen = String.length(b.item.label);
@@ -20,7 +27,7 @@ let compare =
 let%test_module "compare" =
   (module
    {
-     let create = (~label, ~sortText) => {
+     let create = (~isFuzzyMatching, ~label, ~sortText) => {
        CompletionItem.{
          chainedCacheId: None,
          handle: 0,
@@ -35,30 +42,55 @@ let%test_module "compare" =
          commitCharacters: [],
          additionalTextEdits: [],
          command: None,
+         isFuzzyMatching,
        }
        |> Filter.result;
      };
 
      let%test "sortText takes precedence" = {
-       let sortTextZ = create(~label="abc", ~sortText="z");
-       let sortTextA = create(~label="def", ~sortText="a");
+       let sortTextZ =
+         create(~isFuzzyMatching=false, ~label="abc", ~sortText="z");
+       let sortTextA =
+         create(~isFuzzyMatching=false, ~label="def", ~sortText="a");
 
        [sortTextZ, sortTextA]
        |> List.sort(compare) == [sortTextA, sortTextZ];
      };
 
      let%test "falls back to label" = {
-       let abc = create(~label="abc", ~sortText="a");
-       let def = create(~label="def", ~sortText="a");
+       let abc = create(~isFuzzyMatching=false, ~label="abc", ~sortText="a");
+       let def = create(~isFuzzyMatching=false, ~label="def", ~sortText="a");
 
        [def, abc] |> List.sort(compare) == [abc, def];
      };
 
      let%test "when falling back to label, prefer shorter result" = {
-       let toString = create(~label="toString", ~sortText="a");
-       let toLocaleString = create(~label="toLocaleString", ~sortText="a");
+       let toString =
+         create(~isFuzzyMatching=false, ~label="toString", ~sortText="a");
+       let toLocaleString =
+         create(
+           ~isFuzzyMatching=false,
+           ~label="toLocaleString",
+           ~sortText="a",
+         );
 
        [toLocaleString, toString]
        |> List.sort(compare) == [toString, toLocaleString];
+     };
+
+     let%test "#2235: should prefer fuzzy-matches over sort text" = {
+       // ...but once we start searching
+       let forEachWithIndex =
+         create(
+           ~isFuzzyMatching=true,
+           ~label="forEachWithIndex",
+           ~sortText="a",
+         );
+       let range =
+         create(~isFuzzyMatching=true, ~label="range", ~sortText="z");
+
+       // ...prioritize fuzzy score (well, until fzy is hooked up - string length as a proxy)
+       [forEachWithIndex, range]
+       |> List.sort(compare) == [range, forEachWithIndex];
      };
    });


### PR DESCRIPTION
This adjusts the completion-item sorting to prefer fuzzy matches vs the extension-host-provided sort text.

Once fuzzy-matching is started, as more characters are typed, the `sortText` was still preferred over matches. This would lead to unintuitive results (like in #2235, the `forEachRange` was matched instead of `range` for the filter `ran`, because the `sortText` for `forEachRange` was `f`, whereas for `range` it was `r` - and that was used preferentially.

Fixes #2235 
![Screen Shot 2020-10-10 at 10 03 37 AM](https://user-images.githubusercontent.com/13532591/95660946-0d7a4100-0ae0-11eb-8529-eec1c3049ed6.png)

The `fzy` integration in #1566 has the potential to improve this further.