### PR TITLE
refactor(dependency): libvim -> 8.10869.61

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a2f40fa894f762355b3a9dac881f683c",
+  "checksum": "6c75cff7f6f58bccf8419b7648733903",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.60@d41d8cd9": {
-      "id": "libvim@8.10869.60@d41d8cd9",
+    "libvim@8.10869.61@d41d8cd9": {
+      "id": "libvim@8.10869.61@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.60",
+      "version": "8.10869.61",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.60.tgz#sha1:e70c642d41f0cb36bd25921d72276c373f633ee5"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.60@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a2f40fa894f762355b3a9dac881f683c",
+  "checksum": "6c75cff7f6f58bccf8419b7648733903",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.60@d41d8cd9": {
-      "id": "libvim@8.10869.60@d41d8cd9",
+    "libvim@8.10869.61@d41d8cd9": {
+      "id": "libvim@8.10869.61@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.60",
+      "version": "8.10869.61",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.60.tgz#sha1:e70c642d41f0cb36bd25921d72276c373f633ee5"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.60@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a2f40fa894f762355b3a9dac881f683c",
+  "checksum": "6c75cff7f6f58bccf8419b7648733903",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.60@d41d8cd9": {
-      "id": "libvim@8.10869.60@d41d8cd9",
+    "libvim@8.10869.61@d41d8cd9": {
+      "id": "libvim@8.10869.61@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.60",
+      "version": "8.10869.61",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.60.tgz#sha1:e70c642d41f0cb36bd25921d72276c373f633ee5"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.60@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.60",
+    "libvim": "8.10869.61",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reasonFuzz": "*",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a2f40fa894f762355b3a9dac881f683c",
+  "checksum": "6c75cff7f6f58bccf8419b7648733903",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.60@d41d8cd9": {
-      "id": "libvim@8.10869.60@d41d8cd9",
+    "libvim@8.10869.61@d41d8cd9": {
+      "id": "libvim@8.10869.61@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.60",
+      "version": "8.10869.61",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.60.tgz#sha1:e70c642d41f0cb36bd25921d72276c373f633ee5"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.60@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2b8752c59e7f5272cb6eded7c272cd95",
+  "checksum": "c0e8aeb211c0eee6e32328bdfe16efaf",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.60@d41d8cd9": {
-      "id": "libvim@8.10869.60@d41d8cd9",
+    "libvim@8.10869.61@d41d8cd9": {
+      "id": "libvim@8.10869.61@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.60",
+      "version": "8.10869.61",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.60.tgz#sha1:e70c642d41f0cb36bd25921d72276c373f633ee5"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.60@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",


### PR DESCRIPTION
This picks up a couple of `libvim` fixes:
- https://github.com/onivim/libvim/pull/228
- https://github.com/onivim/libvim/pull/229

https://github.com/onivim/libvim/pull/228 was the root cause for the flakiness in cursor positioning after exiting insert mode  due to inconsistent setting of the `nomove` state variable in insert mode - so this fixes several related issues:
- Fixes https://github.com/onivim/oni2/issues/2566
- Fixes #2268 
- Fixes #1194
- Fixes #831

Possibly addresses #916 as well, but need to confirm.
