### PR TITLE
feat(completion): Part 1 - Add feature for keyword extraction

### DIFF
--- a/src/Feature/Keywords/Feature_Keywords.re
+++ b/src/Feature/Keywords/Feature_Keywords.re
@@ -1,0 +1,180 @@
+open Oni_Core;
+
+module Constants = {
+  let maxLinesToConsider = 10000;
+  let maxLineLengthToConsider = 10000;
+};
+
+module Internal = {
+  let characterListToString =
+    fun
+    | []
+    | [_]
+    | [_, _] => None
+    | wordCharacters => Some(wordCharacters |> Zed_utf8.rev_implode);
+
+  let extractKeywordsFromLine =
+      (~wordMap=StringMap.empty, ~isWordCharacter, str) => {
+    let (remainingWord, outputWordMap) =
+      Zed_utf8.fold(
+        (uchar, (prevCharacters, wordMap)) => {
+          let isOnWord = isWordCharacter(uchar);
+
+          if (isOnWord) {
+            (
+              // Add the letter to a candidate word
+              [uchar, ...prevCharacters],
+              wordMap,
+            );
+          } else {
+            switch (characterListToString(prevCharacters)) {
+            // If we're empty, 1-letter, or 2-letter, just skip and continue
+            | None => ([], wordMap)
+            // Found a word that's at least 3 letters!
+            | Some(word) =>
+              let wordMap' =
+                StringMap.update(
+                  word,
+                  fun
+                  | None => Some(1)
+                  | Some(count) => Some(count + 1),
+                  wordMap,
+                );
+              ([], wordMap');
+            };
+          };
+        },
+        str,
+        ([], wordMap),
+      );
+
+    // If there was a word at the end, add it too
+    remainingWord
+    |> characterListToString
+    |> Option.map(word =>
+         StringMap.update(
+           word,
+           fun
+           | None => Some(1)
+           | Some(count) => Some(count + 1),
+           outputWordMap,
+         )
+       )
+    |> Option.value(~default=outputWordMap);
+  };
+
+  let%test_module "extractKeywordsFromLine" =
+    (module
+     {
+       let isWordCharacter = uchar =>
+         LanguageConfiguration.isWordCharacter(
+           uchar,
+           LanguageConfiguration.default,
+         );
+       let%test "simple extraction" = {
+         let keywords =
+           extractKeywordsFromLine(
+             ~wordMap=StringMap.empty,
+             ~isWordCharacter,
+             "abc def",
+           )
+           |> StringMap.bindings
+           |> List.map(fst);
+
+         keywords == ["abc", "def"];
+       };
+
+       let%test "short words ignored" = {
+         let keywords =
+           extractKeywordsFromLine(
+             ~wordMap=StringMap.empty,
+             ~isWordCharacter,
+             "abc a ab def",
+           )
+           |> StringMap.bindings
+           |> List.map(fst);
+
+         keywords == ["abc", "def"];
+       };
+
+       let%test "utf-8" = {
+         let keywords =
+           extractKeywordsFromLine(
+             ~wordMap=StringMap.empty,
+             ~isWordCharacter,
+             "abc κόσμε def",
+           )
+           |> StringMap.bindings
+           |> List.map(fst);
+
+         keywords == ["abc", "def", "κόσμε"];
+       };
+     });
+
+  let extractKeywordsFromLines =
+      (~wordMap=StringMap.empty, ~isWordCharacter, ~getLine) => {
+    let rec loop = (wordMap, lineNumber) => {
+      switch (getLine(lineNumber)) {
+      | None => wordMap
+      | Some(lineString) =>
+        if (String.length(lineString) < Constants.maxLineLengthToConsider) {
+          let wordMap' =
+            extractKeywordsFromLine(~isWordCharacter, ~wordMap, lineString);
+          loop(wordMap', lineNumber + 1);
+        } else {
+          loop(wordMap, lineNumber + 1);
+        }
+      };
+    };
+    loop(wordMap, 0)
+    |> StringMap.bindings
+    // Sort by occurrences
+    |> List.fast_sort((a, b) => snd(b) - snd(a))
+    // And return all items
+    |> List.map(fst);
+  };
+  let%test_module "extractKeywordsFromLines" =
+    (module
+     {
+       let isWordCharacter = uchar =>
+         LanguageConfiguration.isWordCharacter(
+           uchar,
+           LanguageConfiguration.default,
+         );
+       let getLine =
+         fun
+         | 0 => Some("abc def def ghi")
+         | 1 => Some("ghi ghi ghi ghi")
+         | _ => None;
+
+       let%test "sorted by frequency" = {
+         let keywords =
+           extractKeywordsFromLines(
+             ~wordMap=StringMap.empty,
+             ~isWordCharacter,
+             ~getLine,
+           );
+
+         keywords == ["ghi", "def", "abc"];
+       };
+     });
+};
+
+let keywords = (~languageConfiguration, ~buffer) => {
+  let wordMap = StringMap.empty;
+  let isWordCharacter = uchar =>
+    LanguageConfiguration.isWordCharacter(uchar, languageConfiguration);
+  let bufferLineCount = Buffer.getNumberOfLines(buffer);
+
+  let getLine = lineNumber =>
+    if (lineNumber >= bufferLineCount
+        || lineNumber >= Constants.maxLinesToConsider) {
+      None;
+    } else {
+      let bufferLine = Buffer.getLine(lineNumber, buffer);
+      let lineString = BufferLine.raw(bufferLine);
+      Some(lineString);
+    };
+
+  Internal.extractKeywordsFromLines(~wordMap, ~isWordCharacter, ~getLine);
+};

--- a/src/Feature/Keywords/Feature_Keywords.rei
+++ b/src/Feature/Keywords/Feature_Keywords.rei
@@ -1,0 +1,6 @@
+let keywords:
+  (
+    ~languageConfiguration: Oni_Core.LanguageConfiguration.t,
+    ~buffer: Oni_Core.Buffer.t
+  ) =>
+  list(string);

--- a/src/Feature/Keywords/dune
+++ b/src/Feature/Keywords/dune
@@ -1,0 +1,8 @@
+(library
+ (name Feature_Keywords)
+ (public_name Oni2.feature.keywords)
+ (inline_tests)
+ (libraries Oni2.editor-core-types Oni2.core Oni2.exthost isolinear base)
+ (preprocess
+  (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx
+    ppx_inline_test)))


### PR DESCRIPTION
This is a revamp of #1227 - #1227 used the syntax service / syntax tokens to generate keywords, but this isn't 100% accurate (notably, tokens often will have the same highlight color as surrounding text).

Instead, this uses the `LanguageConfiguration.wordPattern` to determine word boundaries, and extract from a line or a buffer.

This implements the keyword extraction step - next item is to have the completion feature leverage this, and to ensure merging of completion items from different providers works (ie, if two providers provide the same token, we need a mechanism for merging and determining precedence).