### PR TITLE
feat(editor/#1444): WordWrap - Part 4 - Editor viewTokens API

### DIFF
--- a/src/Core/BufferLine.re
+++ b/src/Core/BufferLine.re
@@ -311,4 +311,32 @@ module Slow = {
 
     loop(0, characterLength - 1) |> CharacterIndex.ofInt;
   };
+
+  let getByteFromPixel = (~relativeToByte=ByteIndex.zero, ~pixelX, bufferLine) => {
+    let startIndex = getIndex(~byte=relativeToByte, bufferLine);
+    let (startPixel, _) =
+      getPixelPositionAndWidth(~index=startIndex, bufferLine);
+
+    let destPixelX = startPixel +. pixelX;
+    let length = lengthInBytes(bufferLine);
+
+    let rec loop = byteIndex =>
+      if (byteIndex >= length) {
+        length - 1;
+      } else {
+        let index = getIndex(~byte=ByteIndex.ofInt(byteIndex), bufferLine);
+        let (characterPixel, width) =
+          getPixelPositionAndWidth(~index, bufferLine);
+
+        if (destPixelX >= characterPixel
+            && destPixelX < characterPixel
+            +. width) {
+          byteIndex;
+        } else {
+          loop(byteIndex + 1);
+        };
+      };
+
+    loop(ByteIndex.toInt(relativeToByte)) |> ByteIndex.ofInt;
+  };
 };

--- a/src/Core/BufferLine.rei
+++ b/src/Core/BufferLine.rei
@@ -73,4 +73,7 @@ module Slow: {
    * _slow_ because requires traversal of the string, currently.
    */
   let getIndexFromPixel: (~pixel: float, t) => CharacterIndex.t;
+
+  let getByteFromPixel:
+    (~relativeToByte: ByteIndex.t=?, ~pixelX: float, t) => ByteIndex.t;
 };

--- a/src/Feature/Editor/ContentView.re
+++ b/src/Feature/Editor/ContentView.re
@@ -192,7 +192,6 @@ let renderText =
       ~matchingPairs,
       ~bufferSyntaxHighlights,
       ~shouldRenderWhitespace,
-      ~bufferWidthInPixels,
     ) =>
   Draw.renderImmediate(
     ~context,
@@ -208,17 +207,6 @@ let renderText =
           | _ => Some(List.hd(v))
           }
         };
-      let bufferLine = Editor.viewLine(editor, item).contents;
-      let startPixel = Editor.scrollX(editor);
-      let startCharacter =
-        BufferLine.Slow.getIndexFromPixel(~pixel=startPixel, bufferLine)
-        |> CharacterIndex.toInt;
-      let endCharacter =
-        BufferLine.Slow.getIndexFromPixel(
-          ~pixel=startPixel +. float(bufferWidthInPixels),
-          bufferLine,
-        )
-        |> CharacterIndex.toInt;
 
       let tokens =
         getTokensForLine(
@@ -229,8 +217,7 @@ let renderText =
           ~matchingPairs,
           ~bufferSyntaxHighlights,
           ~selection=selectionRange,
-          startCharacter,
-          endCharacter + 1,
+          ~scrollX=Editor.scrollX(editor),
           item,
         );
 
@@ -261,7 +248,6 @@ let render =
       ~languageConfiguration,
       ~bufferSyntaxHighlights,
       ~shouldRenderWhitespace,
-      ~bufferWidthInPixels,
     ) => {
   renderEmbellishments(
     ~context,
@@ -303,6 +289,5 @@ let render =
     ~matchingPairs,
     ~bufferSyntaxHighlights,
     ~shouldRenderWhitespace,
-    ~bufferWidthInPixels,
   );
 };

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -250,12 +250,12 @@ let viewTokens = (~line, ~scrollX, ~colorizer, editor) => {
   let viewStartIndex = BufferLine.getIndex(~byte=viewStartByte, bufferLine);
   let viewEndIndex = BufferLine.getIndex(~byte=viewEndByte, bufferLine);
 
-    BufferViewTokenizer.tokenize(
-      ~start=viewStartIndex,
-      ~stop=CharacterIndex.(viewEndIndex + 1),
-      bufferLine,
-      colorizer(~startByte=viewStartByte),
-    );
+  BufferViewTokenizer.tokenize(
+    ~start=viewStartIndex,
+    ~stop=CharacterIndex.(viewEndIndex + 1),
+    bufferLine,
+    colorizer(~startByte=viewStartByte),
+  );
 };
 
 let bufferCharacterPositionToPixel =

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -11,12 +11,6 @@ module GlobalState = {
   };
 };
 
-type viewLine = {
-  contents: BufferLine.t,
-  byteOffset: int,
-  characterOffset: int,
-};
-
 module WrapMode = {
   [@deriving show]
   type t =
@@ -226,10 +220,42 @@ let setYankHighlight = (~yankHighlight, editor) => {
   yankHighlight: Some(yankHighlight),
 };
 
-let viewLine = (editor, lineNumber) => {
-  let contents = editor.buffer |> EditorBuffer.line(lineNumber);
+let viewTokens = (~line, ~scrollX, ~colorizer, editor) => {
+  let wrapping = editor.wrapState |> WrapState.wrapping;
+  let bufferPosition: Wrapping.bufferPosition =
+    Wrapping.viewLineToBufferPosition(~line, wrapping);
 
-  {contents, byteOffset: 0, characterOffset: 0};
+  let startByte = bufferPosition.byteOffset;
+
+  let bufferLine =
+    EditorBuffer.line(
+      bufferPosition.line |> EditorCoreTypes.LineNumber.toZeroBased,
+      editor.buffer,
+    );
+
+  let viewStartByte =
+    BufferLine.Slow.getByteFromPixel(
+      ~relativeToByte=startByte,
+      ~pixelX=scrollX,
+      bufferLine,
+    );
+
+  let viewEndByte =
+    BufferLine.Slow.getByteFromPixel(
+      ~relativeToByte=viewStartByte,
+      ~pixelX=float(editor.pixelWidth),
+      bufferLine,
+    );
+
+  let viewStartIndex = BufferLine.getIndex(~byte=viewStartByte, bufferLine);
+  let viewEndIndex = BufferLine.getIndex(~byte=viewEndByte, bufferLine);
+
+    BufferViewTokenizer.tokenize(
+      ~start=viewStartIndex,
+      ~stop=CharacterIndex.(viewEndIndex + 1),
+      bufferLine,
+      colorizer(~startByte=viewStartByte),
+    );
 };
 
 let bufferCharacterPositionToPixel =

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -10,12 +10,6 @@ type scrollbarMetrics = {
   thumbOffset: int,
 };
 
-type viewLine = {
-  contents: BufferLine.t,
-  byteOffset: int,
-  characterOffset: int,
-};
-
 type yankHighlight = {
   key: Brisk_reconciler.Key.t,
   pixelRanges: list(PixelRange.t),
@@ -88,7 +82,9 @@ let visiblePixelHeight: t => int;
 
 let font: t => Service_Font.font;
 
-let viewLine: (t, int) => viewLine;
+let viewTokens:
+  (~line: int, ~scrollX: float, ~colorizer: BufferLineColorizer.t, t) =>
+  list(BufferViewTokenizer.t);
 
 let scrollX: t => float;
 let scrollY: t => float;

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -79,7 +79,6 @@ let minimap =
       ~editor,
       ~diffMarkers,
       ~diagnosticsMap,
-      ~bufferWidthInCharacters,
       ~minimapWidthInPixels,
       ~languageSupport,
       (),
@@ -120,8 +119,7 @@ let minimap =
         ~colors,
         ~matchingPairs,
         ~bufferSyntaxHighlights,
-        0,
-        bufferWidthInCharacters,
+        ~scrollX=0.,
       )}
       selection=selectionRanges
       showSlider=showMinimapSlider
@@ -389,7 +387,6 @@ let%component make =
            selectionRanges
            showMinimapSlider={Config.Minimap.showSlider.get(config)}
            diffMarkers
-           bufferWidthInCharacters={layout.bufferWidthInCharacters}
            minimapWidthInPixels={layout.minimapWidthInPixels}
            languageSupport
          />

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -222,7 +222,6 @@ let%component make =
           ~languageConfiguration,
           ~bufferSyntaxHighlights,
           ~shouldRenderWhitespace=Config.renderWhitespace.get(config),
-          ~bufferWidthInPixels=bufferPixelWidth,
         );
 
         if (Config.scrollShadow.get(config)) {


### PR DESCRIPTION
Following from #2555 , #2559 , #2572  - this ports over an additional piece of functionality from #1969 for word wrapping.

This pivots the `Editor` API to provide a list of tokens via an `Editor.viewTokens` for a particular line. Before, we were picking up the entire buffer line, but in the case of word wrap, the entire buffer line isn't as useful - each view line only is concerned with the subset of the buffer line contained in the wrapped view.