### PR TITLE
feat(completion): Initial keyword completion

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -70,6 +70,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
     - _"selection"_ - Render whitespace characters in visual mode selected text
     - _"none"_ - Don't render whitespace at all
 
+- `editor.wordBasedSuggestions` __(_bool_ default: `true`)__ When `true`, keywords are provided as completion suggestions.
+
 - `editor.rulers` __(_list of int_ default: `[]`)__ - Render vertical rulers at given columns.
 
 - `explorer.autoReveal` __(_string|bool_ default: `true`)__  - When `true`, the file explorer will jump to highlight the file current focused. When `false` the file explorer will remain static. If a string is entered it must be `"focusNoScroll"` which will still highlight the currently focused file in the file explorer but the file explorer will not scroll to it. Any other string supplied will be treated as if `false` was entered and the file explorer will remain static and not highlight the currently focused file. 

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -21,6 +21,17 @@ let contains = (query, str) => {
 let explode = str =>
   str |> String.to_seq |> List.of_seq |> List.map(c => String.make(1, c));
 
+let padFront = (~totalLength, char, str) => {
+  let originalLength = String.length(str);
+  let padLength = totalLength - originalLength;
+
+  if (padLength <= 0) {
+    str;
+  } else {
+    String.make(padLength, char) ++ str;
+  };
+};
+
 exception NoMatchException;
 
 /**

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -421,7 +421,7 @@ module Session = {
           );
 
         maybeMeet
-        |> Option.map(({base, location, _}: CompletionMeet.t)
+        |> Option.map(({location, _}: CompletionMeet.t)
              // If different buffer or location... start over!
              =>
                switch (previous.state) {
@@ -436,7 +436,7 @@ module Session = {
                      ~languageConfiguration,
                      ~trigger,
                      ~buffer,
-                     ~location,
+                     ~location=activeCursor,
                      model,
                    );
                  } else {
@@ -456,7 +456,7 @@ module Session = {
                    ~languageConfiguration,
                    ~trigger,
                    ~buffer,
-                   ~location,
+                   ~location=activeCursor,
                    model,
                  );
                }

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -173,10 +173,6 @@ module Session = {
         ProviderImpl.handle;
       };
 
-  //  let base =
-  //    fun
-  //    | Session({base, _}) => base;
-
   let complete =
     fun
     | Session({state, _} as session) => {
@@ -382,6 +378,7 @@ module Session = {
         maybeMeet
         |> OptionEx.flatMap((meet: CompletionMeet.t) => {
              ProviderImpl.create(
+               ~languageConfiguration,
                ~base=meet.base,
                ~trigger,
                ~buffer,

--- a/src/Feature/LanguageSupport/CompletionConfig.re
+++ b/src/Feature/LanguageSupport/CompletionConfig.re
@@ -1,0 +1,76 @@
+open Oni_Core;
+open Utility;
+
+module QuickSuggestionsSetting = {
+  [@deriving show]
+  type t = {
+    comments: bool,
+    strings: bool,
+    other: bool,
+  };
+
+  let initial = {comments: false, strings: false, other: true};
+
+  let enabledFor = (~syntaxScope: SyntaxScope.t, {comments, strings, other}) => {
+    let isCommentAndAllowed = syntaxScope.isComment && comments;
+
+    let isStringAndAllowed = syntaxScope.isString && strings;
+
+    let isOtherAndAllowed =
+      !syntaxScope.isComment && !syntaxScope.isString && other;
+
+    isCommentAndAllowed || isStringAndAllowed || isOtherAndAllowed;
+  };
+
+  module Decode = {
+    open Json.Decode;
+    let decodeBool =
+      bool
+      |> map(
+           fun
+           | false => {comments: false, strings: false, other: false}
+           | true => {comments: true, strings: true, other: true},
+         );
+
+    let decodeObj =
+      obj(({field, _}) =>
+        {
+          comments: field.withDefault("comments", initial.comments, bool),
+          strings: field.withDefault("strings", initial.strings, bool),
+          other: field.withDefault("other", initial.other, bool),
+        }
+      );
+
+    let decode = one_of([("bool", decodeBool), ("obj", decodeObj)]);
+  };
+
+  let decode = Decode.decode;
+
+  let encode = setting =>
+    Json.Encode.(
+      {
+        obj([
+          ("comments", setting.comments |> bool),
+          ("strings", setting.strings |> bool),
+          ("other", setting.other |> bool),
+        ]);
+      }
+    );
+};
+
+// CONFIGURATION
+
+open Config.Schema;
+
+let quickSuggestions =
+  setting(
+    "editor.quickSuggestions",
+    custom(
+      ~decode=QuickSuggestionsSetting.decode,
+      ~encode=QuickSuggestionsSetting.encode,
+    ),
+    ~default=QuickSuggestionsSetting.initial,
+  );
+
+let wordBasedSuggestions =
+  setting("editor.wordBasedSuggestions", bool, ~default=true);

--- a/src/Feature/LanguageSupport/CompletionConfig.re
+++ b/src/Feature/LanguageSupport/CompletionConfig.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Utility;
 
 module QuickSuggestionsSetting = {
   [@deriving show]

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -65,17 +65,17 @@ let keyword = (~sortOrder: int, ~isFuzzyMatching, keyword) => {
 };
 
 let prefer = (itemA, itemB) => {
-  switch ((itemA.handle, itemB.handle)) {
+  switch (itemA.handle, itemB.handle) {
   // Prefer items with a handle - in other words, items that come from the extension host
-  | (Some(_), None) => -1
+  | (Some(_), None) => (-1)
   | (None, Some(_)) => 1
   // They both have a handle, or neither does... use sort text to break the tie
   | (Some(_), Some(_))
-  | (None, None) => 
+  | (None, None) =>
     if (String.compare(itemA.sortText, itemB.sortText) <= 0) {
-        -1
+      (-1);
     } else {
-        1
+      1;
     }
-  }  
+  };
 };

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -63,3 +63,19 @@ let keyword = (~sortOrder: int, ~isFuzzyMatching, keyword) => {
     isFuzzyMatching,
   };
 };
+
+let prefer = (itemA, itemB) => {
+  switch ((itemA.handle, itemB.handle)) {
+  // Prefer items with a handle - in other words, items that come from the extension host
+  | (Some(_), None) => -1
+  | (None, Some(_)) => 1
+  // They both have a handle, or neither does... use sort text to break the tie
+  | (Some(_), Some(_))
+  | (None, None) => 
+    if (String.compare(itemA.sortText, itemB.sortText) <= 0) {
+        -1
+    } else {
+        1
+    }
+  }  
+};

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -1,3 +1,5 @@
+open Oni_Core;
+open Utility;
 open Exthost;
 
 [@deriving show]
@@ -38,21 +40,26 @@ let create = (~isFuzzyMatching: bool, ~handle, item: SuggestItem.t) => {
 };
 
 let keyword = (~sortOrder: int, ~isFuzzyMatching, keyword) => {
-  chainedCacheId: None,
-  handle: None,
-  label: keyword,
-  kind: Exthost.CompletionKind.Keyword,
-  detail: None,
-  documentation: None,
-  insertText: keyword,
-  insertTextRules: Exthost.SuggestItem.InsertTextRules.none,
-  filterText: keyword,
-  // Keywords should always be last, vs other completions...
-  // But still sort them relative to each other
-  sortText: "ZZZZZZ" ++ string_of_int(sortOrder),
-  suggestRange: None,
-  commitCharacters: [],
-  additionalTextEdits: [],
-  command: None,
-  isFuzzyMatching,
+  let sortText =
+    "ZZZZ"
+    ++ (string_of_int(sortOrder) |> StringEx.padFront(~totalLength=8, '0'));
+  {
+    chainedCacheId: None,
+    handle: None,
+    label: keyword,
+    kind: Exthost.CompletionKind.Keyword,
+    detail: None,
+    documentation: None,
+    insertText: keyword,
+    insertTextRules: Exthost.SuggestItem.InsertTextRules.none,
+    filterText: keyword,
+    // Keywords should always be last, vs other completions...
+    // But still sort them relative to each other
+    sortText,
+    suggestRange: None,
+    commitCharacters: [],
+    additionalTextEdits: [],
+    command: None,
+    isFuzzyMatching,
+  };
 };

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -37,7 +37,7 @@ let create = (~isFuzzyMatching: bool, ~handle, item: SuggestItem.t) => {
   isFuzzyMatching,
 };
 
-let keyword = (~isFuzzyMatching, keyword) => {
+let keyword = (~sortOrder: int, ~isFuzzyMatching, keyword) => {
   chainedCacheId: None,
   handle: None,
   label: keyword,
@@ -47,7 +47,9 @@ let keyword = (~isFuzzyMatching, keyword) => {
   insertText: keyword,
   insertTextRules: Exthost.SuggestItem.InsertTextRules.none,
   filterText: keyword,
-  sortText: keyword,
+  // Keywords should always be last, vs other completions...
+  // But still sort them relative to each other
+  sortText: "ZZZZZZ" ++ string_of_int(sortOrder),
   suggestRange: None,
   commitCharacters: [],
   additionalTextEdits: [],

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -3,13 +3,14 @@ open Exthost;
 [@deriving show]
 type t = {
   chainedCacheId: option(ChainedCacheId.t),
-  handle: int,
+  handle: option(int),
   label: string,
   kind: CompletionKind.t,
   detail: option(string),
   documentation: option(MarkdownString.t),
   insertText: string,
   insertTextRules: SuggestItem.InsertTextRules.t,
+  filterText: string,
   sortText: string,
   suggestRange: option(SuggestItem.SuggestRange.t),
   commitCharacters: list(string),
@@ -20,17 +21,36 @@ type t = {
 
 let create = (~isFuzzyMatching: bool, ~handle, item: SuggestItem.t) => {
   chainedCacheId: item.chainedCacheId,
-  handle,
+  handle: Some(handle),
   label: item.label,
   kind: item.kind,
   detail: item.detail,
   documentation: item.documentation,
   insertText: item |> SuggestItem.insertText,
   insertTextRules: item.insertTextRules,
+  filterText: item |> SuggestItem.filterText,
   sortText: item |> SuggestItem.sortText,
   suggestRange: item.suggestRange,
   commitCharacters: item.commitCharacters,
   additionalTextEdits: item.additionalTextEdits,
   command: item.command,
+  isFuzzyMatching,
+};
+
+let keyword = (~isFuzzyMatching, keyword) => {
+  chainedCacheId: None,
+  handle: None,
+  label: keyword,
+  kind: Exthost.CompletionKind.Keyword,
+  detail: None,
+  documentation: None,
+  insertText: keyword,
+  insertTextRules: Exthost.SuggestItem.InsertTextRules.none,
+  filterText: keyword,
+  sortText: keyword,
+  suggestRange: None,
+  commitCharacters: [],
+  additionalTextEdits: [],
+  command: None,
   isFuzzyMatching,
 };

--- a/src/Feature/LanguageSupport/CompletionItemSorter.re
+++ b/src/Feature/LanguageSupport/CompletionItemSorter.re
@@ -30,7 +30,7 @@ let%test_module "compare" =
      let create = (~isFuzzyMatching, ~label, ~sortText) => {
        CompletionItem.{
          chainedCacheId: None,
-         handle: 0,
+         handle: None,
          label,
          kind: Exthost.CompletionKind.Method,
          detail: None,

--- a/src/Feature/LanguageSupport/CompletionItemSorter.re
+++ b/src/Feature/LanguageSupport/CompletionItemSorter.re
@@ -1,28 +1,37 @@
 open Oni_Core;
 
 let compare =
-    (a: Filter.result(CompletionItem.t), b: Filter.result(CompletionItem.t)) => {
-  // First, use the sortText, if available
-  let sortValue =
-    if (!a.item.isFuzzyMatching && !b.item.isFuzzyMatching) {
-      String.compare(a.item.sortText, b.item.sortText);
-    } else {
-      0;
-      // If we're fuzzy matching,
-    };
-
-  if (sortValue == 0) {
-    let aLen = String.length(a.item.label);
-    let bLen = String.length(b.item.label);
-    if (aLen == bLen) {
-      String.compare(a.item.label, b.item.label);
-    } else {
-      aLen - bLen;
-    };
+    (
+      ~pinnedLabel: option(string)=None,
+      a: Filter.result(CompletionItem.t),
+      b: Filter.result(CompletionItem.t),
+    ) =>
+  if (pinnedLabel == Some(a.item.label)) {
+    (-1);
+  } else if (pinnedLabel == Some(b.item.label)) {
+    1;
   } else {
-    sortValue;
+    // First, use the sortText, if available
+    let sortValue =
+      if (!a.item.isFuzzyMatching && !b.item.isFuzzyMatching) {
+        String.compare(a.item.sortText, b.item.sortText);
+      } else {
+        0;
+        // If we're fuzzy matching,
+      };
+
+    if (sortValue == 0) {
+      let aLen = String.length(a.item.label);
+      let bLen = String.length(b.item.label);
+      if (aLen == bLen) {
+        String.compare(a.item.label, b.item.label);
+      } else {
+        aLen - bLen;
+      };
+    } else {
+      sortValue;
+    };
   };
-};
 
 let%test_module "compare" =
   (module

--- a/src/Feature/LanguageSupport/CompletionItemSorter.re
+++ b/src/Feature/LanguageSupport/CompletionItemSorter.re
@@ -37,6 +37,7 @@ let%test_module "compare" =
          documentation: None,
          insertText: label,
          insertTextRules: Exthost.SuggestItem.InsertTextRules.none,
+         filterText: label,
          sortText,
          suggestRange: None,
          commitCharacters: [],

--- a/src/Feature/LanguageSupport/CompletionMeet.re
+++ b/src/Feature/LanguageSupport/CompletionMeet.re
@@ -10,12 +10,17 @@ open Oni_Core;
 
 module Zed_utf8 = ZedBundled;
 
+[@deriving show]
 type t = {
   bufferId: int,
   // Base is the prefix string
   base: string,
   // Meet is the location where we request completions
   location: CharacterPosition.t,
+};
+
+let matches = (a, b) => {
+  a.bufferId == b.bufferId && a.location == b.location;
 };
 
 let toString = (meet: t) =>
@@ -29,6 +34,7 @@ let defaultTriggerCharacters = [Uchar.of_char('.')];
 
 let fromLine =
     (
+      ~languageConfiguration,
       ~triggerCharacters=defaultTriggerCharacters,
       ~lineNumber=0,
       ~bufferId,
@@ -45,66 +51,67 @@ let fromLine =
       - 1,
       cursorIdx,
     );
-  let pos = ref(idx);
+
+  //  let idx = max(0, idx - 1);
 
   let matchesTriggerCharacters = c => {
     List.exists(tc => Uchar.equal(c, tc), triggerCharacters);
   };
 
-  let lastCharacter = ref(None);
-  let found = ref(false);
-
-  let candidateBase = ref([]);
-
-  while (pos^ >= 0 && ! found^) {
-    let c = BufferLine.getUcharExn(~index=CharacterIndex.ofInt(pos^), line);
-    lastCharacter := Some(c);
-
-    if (matchesTriggerCharacters(c)
-        || Uucp.White.is_white_space(c)
-        && List.length(candidateBase^) > 0) {
-      found := true;
-      incr(pos);
+  let rec loop = (acc, currentPos) =>
+    if (currentPos < 0) {
+      (false, [], 0);
     } else {
-      candidateBase := [Zed_utf8.singleton(c), ...candidateBase^];
-      decr(pos);
+      let uchar =
+        BufferLine.getUcharExn(
+          ~index=CharacterIndex.ofInt(currentPos),
+          line,
+        );
+      if (currentPos == 0) {
+        let all = [uchar, ...acc];
+        (List.length(all) >= 1, all, currentPos);
+      } else if (matchesTriggerCharacters(uchar)
+                 || !
+                      LanguageConfiguration.isWordCharacter(
+                        uchar,
+                        languageConfiguration,
+                      )) {
+        // If the cursor is after a trigger character, like console.|,
+        // an empty string is valid. However, if it's just a non-word character,
+        // we require at least a single character for a meet.
+        let validLength = matchesTriggerCharacters(uchar) ? 0 : 1;
+        (List.length(acc) >= validLength, acc, currentPos + 1);
+      } else {
+        loop([uchar, ...acc], currentPos - 1);
+      };
     };
-  };
 
-  let base = candidateBase^ |> String.concat("");
+  let (isValid, characters, pos) = loop([], idx);
+  let base = Zed_utf8.implode(characters);
 
-  let baseLength = Zed_utf8.length(base);
-
-  switch (pos^) {
-  | (-1) =>
-    if (baseLength == cursorIdx && baseLength > 0) {
-      Some({
-        bufferId,
-        location:
-          CharacterPosition.{
-            line: EditorCoreTypes.LineNumber.ofZeroBased(lineNumber),
-            character: CharacterIndex.zero,
-          },
-        base,
-      });
-    } else {
-      None;
-    }
-  | v =>
-    Some({
+  if (isValid) {
+    let meet = {
       bufferId,
       location:
         CharacterPosition.{
           line: EditorCoreTypes.LineNumber.ofZeroBased(lineNumber),
-          character: CharacterIndex.ofInt(v),
+          character: CharacterIndex.ofInt(pos),
         },
       base,
-    })
+    };
+    prerr_endline("VALID MEET: " ++ show(meet));
+    Some(meet);
+  } else {
+    prerr_endline(
+      Printf.sprintf("!!! NOT VALID: base: |%s| pos: |%d|", base, pos),
+    );
+    None;
   };
 };
 
 let fromBufferPosition =
     (
+      ~languageConfiguration,
       ~triggerCharacters=defaultTriggerCharacters,
       ~position: CharacterPosition.t,
       buffer: Buffer.t,
@@ -115,6 +122,7 @@ let fromBufferPosition =
   if (line0 < bufferLines) {
     let line = Buffer.getLine(line0, buffer);
     fromLine(
+      ~languageConfiguration,
       ~bufferId=Buffer.getId(buffer),
       ~lineNumber=line0,
       ~triggerCharacters,

--- a/src/Feature/LanguageSupport/CompletionMeet.re
+++ b/src/Feature/LanguageSupport/CompletionMeet.re
@@ -67,17 +67,7 @@ let fromLine =
       let matchesTrigger = matchesTriggerCharacters(uchar);
       let isWordCharacter =
         LanguageConfiguration.isWordCharacter(uchar, languageConfiguration);
-      prerr_endline(
-        Printf.sprintf(
-          "--Checking character: |%s| at pos: %d trigger: %b word: %b",
-          Zed_utf8.make(1, uchar),
-          currentPos,
-          matchesTrigger,
-          isWordCharacter,
-        ),
-      );
       if (matchesTrigger || !isWordCharacter) {
-        prerr_endline("hit !wordCharacter case");
         // If the cursor is after a trigger character, like console.|,
         // an empty string is valid. However, if it's just a non-word character,
         // we require at least a single character for a meet.
@@ -104,12 +94,8 @@ let fromLine =
         },
       base,
     };
-    prerr_endline("VALID MEET: " ++ show(meet));
     Some(meet);
   } else {
-    prerr_endline(
-      Printf.sprintf("!!! NOT VALID: base: |%s| pos: |%d|", base, pos),
-    );
     None;
   };
 };

--- a/src/Feature/LanguageSupport/CompletionMeet.rei
+++ b/src/Feature/LanguageSupport/CompletionMeet.rei
@@ -5,6 +5,7 @@ open Oni_Core;
 // (where the candidate completions _meet_ the text). It includes
 // the position where completions should be requested from, as well
 // as the 'base' - candidate text that should apply to the filtering of completion items.
+[@deriving show]
 type t = {
   bufferId: int,
   // Base is the prefix string
@@ -13,10 +14,13 @@ type t = {
   location: CharacterPosition.t,
 };
 
+let matches: (t, t) => bool;
+
 let toString: t => string;
 
 let fromLine:
   (
+    ~languageConfiguration: LanguageConfiguration.t,
     ~triggerCharacters: list(Uchar.t)=?,
     ~lineNumber: int=?,
     ~bufferId: int,
@@ -27,6 +31,7 @@ let fromLine:
 
 let fromBufferPosition:
   (
+    ~languageConfiguration: LanguageConfiguration.t,
     ~triggerCharacters: list(Uchar.t)=?,
     ~position: CharacterPosition.t,
     Buffer.t

--- a/src/Feature/LanguageSupport/CompletionMeet.rei
+++ b/src/Feature/LanguageSupport/CompletionMeet.rei
@@ -18,6 +18,12 @@ let matches: (t, t) => bool;
 
 let toString: t => string;
 
+// For both [fromLine] and [fromBufferPosition], the [index] is the cursor position, which is usually _after_ a character
+// that could compose the base. For example, for the line ["console.l|"] where "|" is the cursor position, the expectation
+// is that `index` would be called with [9] - the 0-based index _after_ the "l" character.
+
+// This would return a meet at index 7 (the [.]) character, and a base of ["l"].
+
 let fromLine:
   (
     ~languageConfiguration: LanguageConfiguration.t,

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -10,6 +10,7 @@ module type S = {
 
   let create:
     (
+      ~languageConfiguration: LanguageConfiguration.t,
       ~trigger: Exthost.CompletionContext.t,
       ~buffer: Oni_Core.Buffer.t,
       ~base: string,
@@ -70,7 +71,14 @@ module ExthostCompletionProvider =
   type msg = exthostMsg;
   type model = exthostModel;
 
-  let create = (~trigger as _, ~buffer, ~base as _, ~location as _) =>
+  let create =
+      (
+        ~languageConfiguration as _,
+        ~trigger as _,
+        ~buffer,
+        ~base as _,
+        ~location as _,
+      ) =>
     if (!Exthost.DocumentSelector.matchesBuffer(~buffer, Config.selector)) {
       None;
     } else {
@@ -204,6 +212,7 @@ module KeywordCompletionProvider =
 
   let create =
       (
+        ~languageConfiguration: LanguageConfiguration.t,
         ~trigger: Exthost.CompletionContext.t,
         ~buffer,
         ~base: string,
@@ -213,11 +222,7 @@ module KeywordCompletionProvider =
     ignore(base);
     ignore(location);
 
-    let keywords =
-      Feature_Keywords.keywords(
-        ~languageConfiguration=Oni_Core.LanguageConfiguration.default,
-        ~buffer,
-      );
+    let keywords = Feature_Keywords.keywords(~languageConfiguration, ~buffer);
 
     let keywords =
       keywords

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -10,6 +10,7 @@ module type S = {
 
   let create:
     (
+      ~config: Oni_Core.Config.resolver,
       ~languageConfiguration: LanguageConfiguration.t,
       ~trigger: Exthost.CompletionContext.t,
       ~buffer: Oni_Core.Buffer.t,
@@ -73,6 +74,7 @@ module ExthostCompletionProvider =
 
   let create =
       (
+        ~config as _,
         ~languageConfiguration as _,
         ~trigger as _,
         ~buffer,
@@ -212,6 +214,7 @@ module KeywordCompletionProvider =
 
   let create =
       (
+        ~config,
         ~languageConfiguration: LanguageConfiguration.t,
         ~trigger: Exthost.CompletionContext.t,
         ~buffer,
@@ -222,19 +225,24 @@ module KeywordCompletionProvider =
     ignore(base);
     ignore(location);
 
-    let keywords = Feature_Keywords.keywords(~languageConfiguration, ~buffer);
+    if (!CompletionConfig.wordBasedSuggestions.get(config)) {
+      None;
+    } else {
+      let keywords =
+        Feature_Keywords.keywords(~languageConfiguration, ~buffer);
 
-    let keywords =
-      keywords
-      |> List.mapi((idx, keyword) => {
-           CompletionItem.keyword(
-             ~sortOrder=idx,
-             ~isFuzzyMatching=base != "",
-             keyword,
-           )
-         });
+      let keywords =
+        keywords
+        |> List.mapi((idx, keyword) => {
+             CompletionItem.keyword(
+               ~sortOrder=idx,
+               ~isFuzzyMatching=base != "",
+               keyword,
+             )
+           });
 
-    Some(keywords);
+      Some(keywords);
+    };
   };
 
   let update = (~isFuzzyMatching as _, _msg: msg, model: model) => model;

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -221,8 +221,12 @@ module KeywordCompletionProvider =
 
     let keywords =
       keywords
-      |> List.map(keyword => {
-           CompletionItem.keyword(~isFuzzyMatching=base != "", keyword)
+      |> List.mapi((idx, keyword) => {
+           CompletionItem.keyword(
+             ~sortOrder=idx,
+             ~isFuzzyMatching=base != "",
+             keyword,
+           )
          });
 
     Some(keywords);

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -1,3 +1,5 @@
+open Oni_Core;
+open Utility;
 open EditorCoreTypes;
 
 module type S = {
@@ -54,10 +56,13 @@ type exthostMsg =
     });
 
 module ExthostCompletionProvider =
-       (Config: {
-       let handle: int;
-       let selector: Exthost.DocumentSelector.t;
-       })
+       (
+         Config: {
+           let handle: int;
+           let selector: Exthost.DocumentSelector.t;
+           let supportsResolve: bool;
+         },
+       )
        : (S with type model = exthostModel and type msg = exthostMsg) => {
   // Functor-supplied details
   let providerHandle = Config.handle;
@@ -65,14 +70,12 @@ module ExthostCompletionProvider =
   type msg = exthostMsg;
   type model = exthostModel;
 
-  let create = (~trigger as _, ~buffer, ~base as _, ~location as _) => {
-    // TODO: Check if meet is valid?
-    if (Exthost.DocumentSelector.matchesBuffer(~buffer, Config.selector)) {
-        None
+  let create = (~trigger as _, ~buffer, ~base as _, ~location as _) =>
+    if (!Exthost.DocumentSelector.matchesBuffer(~buffer, Config.selector)) {
+      None;
     } else {
-        Some(Ok([]));
-    }
-  };
+      Some(Ok([]));
+    };
 
   let handle = () => Some(providerHandle);
 
@@ -111,40 +114,78 @@ module ExthostCompletionProvider =
 
   let items = model => model;
 
-  let sub = (~client, ~position, ~buffer, ~selectedItem as _, model) => {
-    prerr_endline("SUB!");
-    Service_Exthost.Sub.completionItems(
-      // TODO: proper trigger kind
-      ~context=
-        Exthost.CompletionContext.{
-          triggerKind: Invoke,
-          triggerCharacter: None,
-        },
-      ~handle=providerHandle,
-      ~buffer,
-      ~position,
-      ~toMsg=
-        suggestResult => {
-          switch (suggestResult) {
-          | Ok(v) =>
-            prerr_endline("RESULT: " ++ Exthost.SuggestResult.show(v));
-            ResultAvailable({handle: providerHandle, result: v});
-          | Error(errorMsg) =>
-            ResultError({handle: providerHandle, errorMsg})
-          }
-        },
-      client,
-    );
+  let sub =
+      (
+        ~client,
+        ~position,
+        ~buffer,
+        ~selectedItem: option(CompletionItem.t),
+        _model,
+      ) => {
+    let itemsSub =
+      Service_Exthost.Sub.completionItems(
+        // TODO: proper trigger kind
+        ~context=
+          Exthost.CompletionContext.{
+            triggerKind: Invoke,
+            triggerCharacter: None,
+          },
+        ~handle=providerHandle,
+        ~buffer,
+        ~position,
+        ~toMsg=
+          suggestResult => {
+            switch (suggestResult) {
+            | Ok(v) => ResultAvailable({handle: providerHandle, result: v})
+            | Error(errorMsg) =>
+              ResultError({handle: providerHandle, errorMsg})
+            }
+          },
+        client,
+      );
+
+    selectedItem
+    |> OptionEx.flatMap((selected: CompletionItem.t) =>
+         if (selected.handle == Some(providerHandle) && Config.supportsResolve) {
+           selected.chainedCacheId
+           |> Option.map(chainedCacheId => {
+                let resolveSub =
+                  Service_Exthost.Sub.completionItem(
+                    ~handle=providerHandle,
+                    ~chainedCacheId,
+                    ~toMsg=
+                      fun
+                      | Ok(item) =>
+                        DetailsAvailable({handle: providerHandle, item})
+                      | Error(errorMsg) =>
+                        DetailsError({handle: providerHandle, errorMsg}),
+                    client,
+                  );
+
+                [itemsSub, resolveSub] |> Isolinear.Sub.batch;
+              });
+         } else {
+           None;
+         }
+       )
+    |> Option.value(~default=itemsSub);
   };
 };
-let exthost: (~selector: Exthost.DocumentSelector.t, ~handle: int) => provider(exthostModel, exthostMsg) =
-  (~selector, ~handle) => {
+let exthost:
+  (
+    ~selector: Exthost.DocumentSelector.t,
+    ~handle: int,
+    ~supportsResolve: bool
+  ) =>
+  provider(exthostModel, exthostMsg) =
+  (~selector, ~handle, ~supportsResolve) => {
     let provider:
       module S with type model = exthostModel and type msg = exthostMsg =
       (module
        ExthostCompletionProvider({
          let handle = handle;
          let selector = selector;
+         let supportsResolve = supportsResolve;
        }));
     provider;
   };
@@ -177,7 +218,6 @@ module KeywordCompletionProvider =
         ~languageConfiguration=Oni_Core.LanguageConfiguration.default,
         ~buffer,
       );
-    //    keywords |> List.iter(key => prerr_endline("KEYWORD: " ++ key));
 
     let keywords =
       keywords
@@ -188,7 +228,7 @@ module KeywordCompletionProvider =
     Some(keywords);
   };
 
-  let update = (~isFuzzyMatching: bool, _msg: msg, model: model) => model;
+  let update = (~isFuzzyMatching as _, _msg: msg, model: model) => model;
 
   let items = model => Ok(model);
 

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -1,0 +1,91 @@
+open EditorCoreTypes;
+
+module type S = {
+  type msg;
+  type model;
+
+  let update: (msg, model) => model;
+
+  let create:
+    (
+      ~trigger: Exthost.CompletionContext.t,
+      ~buffer: Oni_Core.Buffer.t,
+      ~base: string,
+      ~location: CharacterPosition.t
+    ) =>
+    option(model);
+
+  let items: model => result(list(Exthost.SuggestItem.t), string);
+
+  let sub:
+    (~selectedItem: option(Exthost.SuggestItem.t), model) =>
+    Isolinear.Sub.t(msg);
+};
+
+type provider('model, 'msg) = (module S with
+                                  type model = 'model and type msg = 'msg);
+
+type exthostModel = result(list(Exthost.SuggestItem.t), string);
+[@deriving show]
+type exthostMsg =
+  | ResultAvailable({
+      handle: int,
+      result: Exthost.SuggestResult.t,
+    })
+  | DetailsAvailable({
+      handle: int,
+      item: Exthost.SuggestItem.t,
+    })
+  | DetailsError({
+      handle: int,
+      errorMsg: string,
+    });
+
+module ExthostCompletionProvider =
+       (Config: {let handle: int;})
+       : (S with type model = exthostModel and type msg = exthostMsg) => {
+  // Functor-supplied details
+  let providerHandle = Config.handle;
+
+  type msg = exthostMsg;
+  type model = exthostModel;
+
+  let create = (~trigger as _, ~buffer as _, ~base as _, ~location as _) =>
+    None;
+
+  let update = (msg, model) =>
+    switch (msg) {
+    // TODO: Handle incomplete result
+    | ResultAvailable({handle, result}) when handle == providerHandle =>
+      Ok(Exthost.SuggestResult.(result.completions))
+    | DetailsAvailable({handle, item}) when handle == providerHandle =>
+      model
+      |> Result.map(items => {
+           items
+           |> List.map((previousItem: Exthost.SuggestItem.t) =>
+                if (previousItem.chainedCacheId == item.chainedCacheId) {
+                  item;
+                } else {
+                  previousItem;
+                }
+              )
+         })
+    | DetailsError({handle, errorMsg}) when handle == providerHandle =>
+      Error(errorMsg)
+    | _ => model
+    };
+
+  let items = model => model;
+
+  let sub = (~selectedItem as _, _model) => Isolinear.Sub.none;
+};
+let exthost: (~handle: int) => provider(exthostModel, exthostMsg) =
+  (~handle: int) => {
+    let provider:
+      module S with type model = exthostModel and type msg = exthostMsg =
+      (module
+       ExthostCompletionProvider({
+         let handle = handle;
+       }));
+    provider;
+  };

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -4,7 +4,7 @@ module type S = {
   type msg;
   type model;
 
-  let update: (msg, model) => model;
+  let update: (~isFuzzyMatching: bool, msg, model) => model;
 
   let create:
     (
@@ -15,17 +15,16 @@ module type S = {
     ) =>
     option(model);
 
-  let items: model => result(list(Exthost.SuggestItem.t), string);
+  let items: model => result(list(CompletionItem.t), string);
 
   let sub:
-    (~selectedItem: option(Exthost.SuggestItem.t), model) =>
-    Isolinear.Sub.t(msg);
+    (~selectedItem: option(CompletionItem.t), model) => Isolinear.Sub.t(msg);
 };
 
 type provider('model, 'msg) = (module S with
                                   type model = 'model and type msg = 'msg);
 
-type exthostModel = result(list(Exthost.SuggestItem.t), string);
+type exthostModel = result(list(CompletionItem.t), string);
 [@deriving show]
 type exthostMsg =
   | ResultAvailable({
@@ -53,18 +52,27 @@ module ExthostCompletionProvider =
   let create = (~trigger as _, ~buffer as _, ~base as _, ~location as _) =>
     None;
 
-  let update = (msg, model) =>
+  let update = (~isFuzzyMatching, msg, model) =>
     switch (msg) {
     // TODO: Handle incomplete result
     | ResultAvailable({handle, result}) when handle == providerHandle =>
-      Ok(Exthost.SuggestResult.(result.completions))
+      let completions =
+        Exthost.SuggestResult.(result.completions)
+        |> List.map(
+             CompletionItem.create(~isFuzzyMatching, ~handle=providerHandle),
+           );
+      Ok(completions);
     | DetailsAvailable({handle, item}) when handle == providerHandle =>
       model
       |> Result.map(items => {
            items
-           |> List.map((previousItem: Exthost.SuggestItem.t) =>
+           |> List.map((previousItem: CompletionItem.t) =>
                 if (previousItem.chainedCacheId == item.chainedCacheId) {
-                  item;
+                  CompletionItem.create(
+                    ~isFuzzyMatching,
+                    ~handle=providerHandle,
+                    item,
+                  );
                 } else {
                   previousItem;
                 }
@@ -89,3 +97,52 @@ let exthost: (~handle: int) => provider(exthostModel, exthostMsg) =
        }));
     provider;
   };
+
+type keywordModel = list(CompletionItem.t);
+[@deriving show]
+type keywordMsg = unit;
+
+module KeywordCompletionProvider =
+       (())
+       : (S with type msg = keywordMsg and type model = keywordModel) => {
+  type msg = keywordMsg;
+  type model = keywordModel;
+
+  let create =
+      (
+        ~trigger: Exthost.CompletionContext.t,
+        ~buffer,
+        ~base: string,
+        ~location: CharacterPosition.t,
+      ) => {
+    ignore(trigger);
+    ignore(base);
+    ignore(location);
+
+    let keywords =
+      Feature_Keywords.keywords(
+        ~languageConfiguration=Oni_Core.LanguageConfiguration.default,
+        ~buffer,
+      );
+    keywords |> List.iter(key => prerr_endline("KEYWORD: " ++ key));
+
+    let keywords =
+      keywords
+      |> List.map(keyword => {
+           CompletionItem.keyword(~isFuzzyMatching=base != "", keyword)
+         });
+
+    Some(keywords);
+  };
+
+  let update = (~isFuzzyMatching: bool, _msg: msg, model: model) => model;
+
+  let items = model => Ok(model);
+
+  let sub = (~selectedItem as _, _model) => Isolinear.Sub.none;
+};
+
+let keyword: provider(keywordModel, keywordMsg) = {
+  (module
+   KeywordCompletionProvider({}));
+};

--- a/src/Feature/LanguageSupport/CompletionProvider.rei
+++ b/src/Feature/LanguageSupport/CompletionProvider.rei
@@ -1,0 +1,58 @@
+open Oni_Core;
+open EditorCoreTypes;
+
+// [S] is the interface for completion providers
+module type S = {
+  type msg;
+  type model;
+
+  let update: (~isFuzzyMatching: bool, msg, model) => model;
+
+  let create:
+    (
+      ~config: Oni_Core.Config.resolver,
+      ~languageConfiguration: LanguageConfiguration.t,
+      ~trigger: Exthost.CompletionContext.t,
+      ~buffer: Oni_Core.Buffer.t,
+      ~base: string,
+      ~location: CharacterPosition.t
+    ) =>
+    option(model);
+
+  let items: model => result(list(CompletionItem.t), string);
+
+  let handle: unit => option(int);
+
+  let sub:
+    (
+      ~client: Exthost.Client.t,
+      ~position: CharacterPosition.t,
+      ~buffer: Oni_Core.Buffer.t,
+      ~selectedItem: option(CompletionItem.t),
+      model
+    ) =>
+    Isolinear.Sub.t(msg);
+};
+
+type provider('model, 'msg) = (module S with
+                                  type model = 'model and type msg = 'msg);
+
+type exthostModel;
+
+[@deriving show]
+type exthostMsg;
+
+let exthost:
+  (
+    ~selector: Exthost.DocumentSelector.t,
+    ~handle: int,
+    ~supportsResolve: bool
+  ) =>
+  provider(exthostModel, exthostMsg);
+
+type keywordModel;
+
+[@deriving show]
+type keywordMsg;
+
+let keyword: provider(keywordModel, keywordMsg);

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -97,6 +97,7 @@ module Msg = {
 
 let update =
     (
+      ~config,
       ~configuration,
       ~languageConfiguration,
       ~maybeSelection,
@@ -219,6 +220,7 @@ let update =
   | Completion(completionMsg) =>
     let (completion', outmsg) =
       Completion.update(
+        ~config,
         ~languageConfiguration,
         ~maybeBuffer,
         ~activeCursor=cursorLocation,

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -219,6 +219,7 @@ let update =
   | Completion(completionMsg) =>
     let (completion', outmsg) =
       Completion.update(
+        ~languageConfiguration,
         ~maybeBuffer,
         ~activeCursor=cursorLocation,
         completionMsg,
@@ -323,9 +324,18 @@ let update =
   };
 
 let bufferUpdated =
-    (~buffer, ~config, ~activeCursor, ~syntaxScope, ~triggerKey, model) => {
+    (
+      ~languageConfiguration,
+      ~buffer,
+      ~config,
+      ~activeCursor,
+      ~syntaxScope,
+      ~triggerKey,
+      model,
+    ) => {
   let completion =
     Completion.bufferUpdated(
+      ~languageConfiguration,
       ~buffer,
       ~config,
       ~activeCursor,
@@ -531,7 +541,7 @@ let sub =
   let completionSub =
     !isInsertMode
       ? Isolinear.Sub.none
-      : OldCompletion.sub(~client, completion)
+      : OldCompletion.sub(~activeBuffer, ~client, completion)
         |> Isolinear.Sub.map(msg => Completion(msg));
 
   let documentSymbolsSub =

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -352,7 +352,11 @@ let cursorMoved = (~previous, ~current, model) => {
   {...model, completion};
 };
 
-let startInsertMode = model => model;
+let startInsertMode = model => {
+  ...model,
+  completion: Completion.startInsertMode(model.completion),
+};
+
 let stopInsertMode = model => {
   ...model,
   completion: Completion.stopInsertMode(model.completion),

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -52,6 +52,7 @@ type outmsg =
 
 let update:
   (
+    ~config: Oni_Core.Config.resolver,
     ~configuration: Oni_Core.Configuration.t,
     ~languageConfiguration: Oni_Core.LanguageConfiguration.t,
     ~maybeSelection: option(CharacterRange.t),

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -66,6 +66,7 @@ let update:
 
 let bufferUpdated:
   (
+    ~languageConfiguration: Oni_Core.LanguageConfiguration.t,
     ~buffer: Oni_Core.Buffer.t,
     ~config: Oni_Core.Config.resolver,
     ~activeCursor: CharacterPosition.t,

--- a/src/Feature/LanguageSupport/dune
+++ b/src/Feature/LanguageSupport/dune
@@ -4,7 +4,7 @@
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.component.vimTree Oni2.core
    Oni2.syntax Oni2.feature.commands Oni2.feature.diagnostics
-   Oni2.component.inputText Oni2.service.exthost Oni2.service.font
-   Oni2.service.vim Oni2.input uucp)
+   Oni2.feature.keywords Oni2.component.inputText Oni2.service.exthost
+   Oni2.service.font Oni2.service.vim Oni2.input uucp)
  (preprocess
   (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1277,7 +1277,18 @@ let update =
                state.syntaxHighlights,
              );
            let config = Selectors.configResolver(state);
+
+           let languageConfiguration =
+             buffer
+             |> Oni_Core.Buffer.getFileType
+             |> Oni_Core.Buffer.FileType.toString
+             |> Exthost.LanguageInfo.getLanguageConfiguration(
+                  state.languageInfo,
+                )
+             |> Option.value(~default=LanguageConfiguration.default);
+
            Feature_LanguageSupport.bufferUpdated(
+             ~languageConfiguration,
              ~buffer,
              ~config,
              ~activeCursor,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -339,8 +339,11 @@ let update =
     let characterSelection =
       editor |> Feature_Editor.Editor.byteRangeToCharacterRange(selection);
 
+    let config = Selectors.configResolver(state);
+
     let (languageSupport, outmsg) =
       Feature_LanguageSupport.update(
+        ~config,
         ~languageConfiguration,
         ~configuration=state.configuration,
         ~maybeBuffer,

--- a/test/Feature/LanguageSupport/CompletionMeetTests.re
+++ b/test/Feature/LanguageSupport/CompletionMeetTests.re
@@ -32,7 +32,8 @@ describe("CompletionMeet", ({describe, _}) => {
     test("empty line - no meet", ({expect, _}) => {
       let result =
         CompletionMeet.fromLine(
-          ~index=CharacterIndex.zero,
+          ~languageConfiguration=LanguageConfiguration.default,
+          ~index=CharacterIndex.(zero + 1),
           ~bufferId=0,
           "" |> makeLine,
         );
@@ -42,6 +43,7 @@ describe("CompletionMeet", ({describe, _}) => {
     test("single character at beginning", ({expect, _}) => {
       let result =
         CompletionMeet.fromLine(
+          ~languageConfiguration=LanguageConfiguration.default,
           ~index=CharacterIndex.(zero + 1),
           ~bufferId=0,
           "a" |> makeLine,
@@ -56,7 +58,8 @@ describe("CompletionMeet", ({describe, _}) => {
     test("spaces prior to character", ({expect, _}) => {
       let result =
         CompletionMeet.fromLine(
-          ~index=CharacterIndex.(zero + 1),
+          ~languageConfiguration=LanguageConfiguration.default,
+          ~index=CharacterIndex.(zero + 2),
           ~bufferId=0,
           " a" |> makeLine,
         );
@@ -66,9 +69,24 @@ describe("CompletionMeet", ({describe, _}) => {
       expect.equal(result, Some(expected));
     });
 
+    test("between non-word characters", ({expect, _}) => {
+      let result =
+        CompletionMeet.fromLine(
+          ~languageConfiguration=LanguageConfiguration.default,
+          ~index=CharacterIndex.(zero + 3),
+          ~bufferId=0,
+          " (a)" |> makeLine,
+        );
+
+      let expected =
+        CompletionMeet.{location: line0column2, base: "a", bufferId: 0};
+      expect.equal(result, Some(expected));
+    });
+
     test("longer base", ({expect, _}) => {
       let result =
         CompletionMeet.fromLine(
+          ~languageConfiguration=LanguageConfiguration.default,
           ~index=CharacterIndex.(zero + 4),
           ~bufferId=0,
           " abc" |> makeLine,
@@ -81,7 +99,8 @@ describe("CompletionMeet", ({describe, _}) => {
     test("default trigger character", ({expect, _}) => {
       let result =
         CompletionMeet.fromLine(
-          ~index=CharacterIndex.(zero + 1),
+          ~languageConfiguration=LanguageConfiguration.default,
+          ~index=CharacterIndex.(zero + 2),
           ~bufferId=0,
           " ." |> makeLine,
         );
@@ -93,6 +112,7 @@ describe("CompletionMeet", ({describe, _}) => {
     test("default trigger character with base", ({expect, _}) => {
       let result =
         CompletionMeet.fromLine(
+          ~languageConfiguration=LanguageConfiguration.default,
           ~index=CharacterIndex.(zero + 10),
           ~bufferId=0,
           "console.lo" |> makeLine,


### PR DESCRIPTION
Building off the work in #2575 - this implements a keyword completion provider:

- Abstract out completion strategies via the `CompletionProvider` signature
- Add `editor.wordBasedSuggestions` configuration for turning on/off keyword completion
- Coalesce duplicate completion items - prefer extension host items vs keyword completion, when the labels are the same
- Implement sorting - keyword items should be sorted latest
- 'Pin' the selected item when new items are coming in - otherwise, the filter order could change, and if the user completes while new items are popping in - there could be an incorrect insertion.
- Fix some issues with completion meets (not working for first character, not working inside parentheses)

![2020-10-13 10 51 44](https://user-images.githubusercontent.com/13532591/95897458-6fd27c00-0d42-11eb-8141-700e84f0f18f.gif)

Keyword completion can be disable with the following configuration:

```
  "editor.wordBasedSuggestions": false,
```

or per-filetype, like:

```
  "[markdown]": {
      "editor.wordBasedSuggestions": false
  }
```

__Future work:__
- The current keyword extractor just works in the current buffer. Should pick up keywords across open files or using Vim's path logic.
- A locality based bonus should be implement for sorting for completion items - still improvements to be made on sort order. The #1566 work to integrate `fzy` will help significantly, too
