### PR TITLE
refactor(vim): Screen-space motion

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "486019be99d740bdc109fbe369502a25",
+  "checksum": "e59edff4c92b62fc0716580a593f2abc",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.61@d41d8cd9": {
-      "id": "libvim@8.10869.61@d41d8cd9",
+    "libvim@8.10869.62@d41d8cd9": {
+      "id": "libvim@8.10869.62@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.61",
+      "version": "8.10869.62",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "486019be99d740bdc109fbe369502a25",
+  "checksum": "e59edff4c92b62fc0716580a593f2abc",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.61@d41d8cd9": {
-      "id": "libvim@8.10869.61@d41d8cd9",
+    "libvim@8.10869.62@d41d8cd9": {
+      "id": "libvim@8.10869.62@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.61",
+      "version": "8.10869.62",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "486019be99d740bdc109fbe369502a25",
+  "checksum": "e59edff4c92b62fc0716580a593f2abc",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.61@d41d8cd9": {
-      "id": "libvim@8.10869.61@d41d8cd9",
+    "libvim@8.10869.62@d41d8cd9": {
+      "id": "libvim@8.10869.62@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.61",
+      "version": "8.10869.62",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.61",
+    "libvim": "8.10869.62",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reasonFuzz": "*",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "486019be99d740bdc109fbe369502a25",
+  "checksum": "e59edff4c92b62fc0716580a593f2abc",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.61@d41d8cd9": {
-      "id": "libvim@8.10869.61@d41d8cd9",
+    "libvim@8.10869.62@d41d8cd9": {
+      "id": "libvim@8.10869.62@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.61",
+      "version": "8.10869.62",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -177,6 +177,9 @@ let setMinimapEnabled = (~enabled, editor) => {
   isMinimapEnabled: enabled,
 };
 
+let getBufferLineCount = ({buffer, _}) =>
+  EditorBuffer.numberOfLines(buffer);
+
 let isMinimapEnabled = ({isMinimapEnabled, _}) => isMinimapEnabled;
 let isScrollAnimated = ({isScrollAnimated, _}) => isScrollAnimated;
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -56,6 +56,8 @@ let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getCursors: t => list(BytePosition.t);
 let setCursors: (~cursors: list(BytePosition.t), t) => t;
 
+let getBufferLineCount: t => int;
+
 let getTokenAt:
   (~languageConfiguration: LanguageConfiguration.t, CharacterPosition.t, t) =>
   option(CharacterRange.t);

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -112,9 +112,24 @@ let current = (state: State.t) => {
     |> Array.of_list;
   };
 
-  let viewLineMotion = (
-    ~motion as _, ~count as _, ~startLine
-  ) => startLine;
+  let viewLineMotion = (~motion, ~count, ~startLine) => {
+    switch (motion) {
+    | Vim.ViewLineMotion.MotionH =>
+      Editor.getTopVisibleLine(editor)
+      |> EditorCoreTypes.LineNumber.ofZeroBased
+    | Vim.ViewLineMotion.MotionM =>
+      Editor.getTopVisibleLine(editor)
+      + (
+        Editor.getBottomVisibleLine(editor)
+        - Editor.getTopVisibleLine(editor)
+      )
+      / 2
+      |> EditorCoreTypes.LineNumber.ofZeroBased
+    | Vim.ViewLineMotion.MotionL =>
+      Editor.getBottomVisibleLine(editor)
+      |> EditorCoreTypes.LineNumber.ofZeroBased
+    };
+  };
 
   Vim.Context.{
     autoIndent,

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -112,10 +112,15 @@ let current = (state: State.t) => {
     |> Array.of_list;
   };
 
+  let viewLineMotion = (
+    ~motion as _, ~count as _, ~startLine
+  ) => startLine;
+
   Vim.Context.{
     autoIndent,
     bufferId,
     colorSchemeProvider,
+    viewLineMotion,
     leftColumn,
     topLine,
     width,

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -131,11 +131,28 @@ let current = (state: State.t) => {
     };
   };
 
+  let screenCursorMotion =
+      (~direction, ~count, ~line as lnum, ~byte as byteOffset) => {
+    switch (direction) {
+    | `Up =>
+      BytePosition.{
+        line: EditorCoreTypes.LineNumber.(lnum - count),
+        byte: byteOffset,
+      }
+    | `Down =>
+      BytePosition.{
+        line: EditorCoreTypes.LineNumber.(lnum + count),
+        byte: byteOffset,
+      }
+    };
+  };
+
   Vim.Context.{
     autoIndent,
     bufferId,
     colorSchemeProvider,
     viewLineMotion,
+    screenCursorMotion,
     leftColumn,
     topLine,
     width,

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -8,6 +8,14 @@ type t = {
   viewLineMotion:
     (~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t) =>
     LineNumber.t,
+  screenCursorMotion:
+    (
+      ~direction: [ | `Up | `Down],
+      ~count: int,
+      ~line: LineNumber.t,
+      ~byte: ByteIndex.t
+    ) =>
+    BytePosition.t,
   bufferId: int,
   colorSchemeProvider: ColorScheme.Provider.t,
   width: int,
@@ -24,6 +32,10 @@ let current = () => {
   autoClosingPairs: AutoClosingPairs.empty,
   autoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
   viewLineMotion: (~motion as _, ~count as _, ~startLine) => startLine,
+  screenCursorMotion: (~direction as _, ~count as _, ~line, ~byte) => {
+    line,
+    byte,
+  },
   bufferId: Buffer.getCurrent() |> Buffer.getId,
   colorSchemeProvider: ColorScheme.Provider.default,
   width: Window.getWidth(),

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -5,9 +5,9 @@ type t = {
   autoIndent:
     (~previousLine: string, ~beforePreviousLine: option(string)) =>
     AutoIndent.action,
-    viewLineMotion: (
-     ~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t)
-     => LineNumber.t,
+  viewLineMotion:
+    (~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t) =>
+    LineNumber.t,
   bufferId: int,
   colorSchemeProvider: ColorScheme.Provider.t,
   width: int,

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -13,7 +13,8 @@ type t = {
       ~direction: [ | `Up | `Down],
       ~count: int,
       ~line: LineNumber.t,
-      ~byte: ByteIndex.t
+      ~currentByte: ByteIndex.t,
+      ~wantByte: ByteIndex.t
     ) =>
     BytePosition.t,
   bufferId: int,
@@ -32,9 +33,10 @@ let current = () => {
   autoClosingPairs: AutoClosingPairs.empty,
   autoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
   viewLineMotion: (~motion as _, ~count as _, ~startLine) => startLine,
-  screenCursorMotion: (~direction as _, ~count as _, ~line, ~byte) => {
+  screenCursorMotion:
+    (~direction as _, ~count as _, ~line, ~currentByte as _, ~wantByte) => {
     line,
-    byte,
+    byte: wantByte,
   },
   bufferId: Buffer.getCurrent() |> Buffer.getId,
   colorSchemeProvider: ColorScheme.Provider.default,

--- a/src/reason-libvim/Context.re
+++ b/src/reason-libvim/Context.re
@@ -5,6 +5,9 @@ type t = {
   autoIndent:
     (~previousLine: string, ~beforePreviousLine: option(string)) =>
     AutoIndent.action,
+    viewLineMotion: (
+     ~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t)
+     => LineNumber.t,
   bufferId: int,
   colorSchemeProvider: ColorScheme.Provider.t,
   width: int,
@@ -20,6 +23,7 @@ type t = {
 let current = () => {
   autoClosingPairs: AutoClosingPairs.empty,
   autoIndent: (~previousLine as _, ~beforePreviousLine as _) => AutoIndent.KeepIndent,
+  viewLineMotion: (~motion as _, ~count as _, ~startLine) => startLine,
   bufferId: Buffer.getCurrent() |> Buffer.getId,
   colorSchemeProvider: ColorScheme.Provider.default,
   width: Window.getWidth(),

--- a/src/reason-libvim/GlobalState.re
+++ b/src/reason-libvim/GlobalState.re
@@ -25,3 +25,18 @@ let viewLineMotion:
     ),
   ) =
   ref(None);
+
+let screenPositionMotion:
+  ref(
+    option(
+      (
+        ~direction: [ | `Up | `Down],
+        ~count: int,
+        ~line: LineNumber.t,
+        ~currentByte: ByteIndex.t,
+        ~wantByte: ByteIndex.t
+      ) =>
+      BytePosition.t,
+    ),
+  ) =
+  ref(None);

--- a/src/reason-libvim/GlobalState.re
+++ b/src/reason-libvim/GlobalState.re
@@ -1,3 +1,5 @@
+open EditorCoreTypes;
+
 let autoIndent:
   ref(
     option(
@@ -13,4 +15,13 @@ let colorSchemeProvider: ref(ColorScheme.Provider.t) =
 
 let overriddenMessageHandler:
   ref(option((Types.msgPriority, string, string) => unit)) =
+  ref(None);
+
+let viewLineMotion:
+  ref(
+    option(
+      (~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t) =>
+      LineNumber.t,
+    ),
+  ) =
   ref(None);

--- a/src/reason-libvim/ViewLineMotion.re
+++ b/src/reason-libvim/ViewLineMotion.re
@@ -1,0 +1,4 @@
+type t =
+| MotionH
+| MotionM
+| MotionL;

--- a/src/reason-libvim/ViewLineMotion.re
+++ b/src/reason-libvim/ViewLineMotion.re
@@ -1,4 +1,4 @@
 type t =
-| MotionH
-| MotionM
-| MotionL;
+  | MotionH
+  | MotionM
+  | MotionL;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -167,11 +167,13 @@ let runWith = (~context: Context.t, f) => {
 
   GlobalState.autoIndent := Some(context.autoIndent);
   GlobalState.colorSchemeProvider := context.colorSchemeProvider;
+  GlobalState.viewLineMotion := Some(context.viewLineMotion);
 
   let cursors = f();
 
   GlobalState.autoIndent := None;
   GlobalState.colorSchemeProvider := ColorScheme.Provider.default;
+  GlobalState.viewLineMotion := None;
 
   let newBuf = Buffer.getCurrent();
   let newMode = Mode.current();
@@ -380,6 +382,15 @@ let _onAutoIndent = (lnum: int, sourceLine: string) => {
   };
 };
 
+let _onCursorMoveScreenLine =
+    (motion: ViewLineMotion.t, count: int, line: int) => {
+  let startLine = LineNumber.ofOneBased(line);
+  GlobalState.viewLineMotion^
+  |> Option.map(f => f(~motion, ~count, ~startLine))
+  |> Option.map(LineNumber.toOneBased)
+  |> Option.value(~default=line);
+};
+
 let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
 };
@@ -455,6 +466,7 @@ let init = () => {
   Callback.register("lv_onVersion", _onVersion);
   Callback.register("lv_onYank", _onYank);
   Callback.register("lv_onWriteFailure", _onWriteFailure);
+  Callback.register("lv_onCursorMoveScreenLine", _onCursorMoveScreenLine);
 
   Native.vimInit();
 

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -31,6 +31,7 @@ module Testing = {
 module Visual = Visual;
 module VisualRange = VisualRange;
 module Window = Window;
+module ViewLineMotion = ViewLineMotion;
 module Yank = Yank;
 
 module Internal = {

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -168,12 +168,14 @@ let runWith = (~context: Context.t, f) => {
   GlobalState.autoIndent := Some(context.autoIndent);
   GlobalState.colorSchemeProvider := context.colorSchemeProvider;
   GlobalState.viewLineMotion := Some(context.viewLineMotion);
+  GlobalState.screenPositionMotion := Some(context.screenCursorMotion);
 
   let cursors = f();
 
   GlobalState.autoIndent := None;
   GlobalState.colorSchemeProvider := ColorScheme.Provider.default;
   GlobalState.viewLineMotion := None;
+  GlobalState.screenPositionMotion := None;
 
   let newBuf = Buffer.getCurrent();
   let newMode = Mode.current();
@@ -392,12 +394,27 @@ let _onCursorMoveScreenLine =
 };
 
 let _onCursorMoveScreenPosition =
-    (direction, count: int, line: int, byte: int) =>
-  if (direction == `Up) {
-    (line - count, (-1));
-  } else {
-    (line + count, 10000);
-  };
+    (direction, count: int, line: int, byte: int, wantByte: int) => {
+  let startLine = LineNumber.ofOneBased(line);
+  let startByte = ByteIndex.ofInt(byte);
+  GlobalState.screenPositionMotion^
+  |> Option.map(f =>
+       f(
+         ~direction,
+         ~count,
+         ~line=startLine,
+         ~currentByte=startByte,
+         ~wantByte=ByteIndex.ofInt(wantByte),
+       )
+     )
+  |> Option.map((bytePosition: BytePosition.t) => {
+       (
+         bytePosition.line |> LineNumber.toOneBased,
+         bytePosition.byte |> ByteIndex.toInt,
+       )
+     })
+  |> Option.value(~default=(line, wantByte));
+};
 
 let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -391,6 +391,14 @@ let _onCursorMoveScreenLine =
   |> Option.value(~default=line);
 };
 
+let _onCursorMoveScreenPosition =
+    (direction, count: int, line: int, byte: int) =>
+  if (direction == `Up) {
+    (line - count, (-1));
+  } else {
+    (line + count, 10000);
+  };
+
 let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
 };
@@ -467,6 +475,10 @@ let init = () => {
   Callback.register("lv_onYank", _onYank);
   Callback.register("lv_onWriteFailure", _onWriteFailure);
   Callback.register("lv_onCursorMoveScreenLine", _onCursorMoveScreenLine);
+  Callback.register(
+    "lv_onCursorMoveScreenPosition",
+    _onCursorMoveScreenPosition,
+  );
 
   Native.vimInit();
 

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -58,6 +58,14 @@ module Context: {
     viewLineMotion:
       (~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t) =>
       LineNumber.t,
+    screenCursorMotion:
+      (
+        ~direction: [ | `Up | `Down],
+        ~count: int,
+        ~line: LineNumber.t,
+        ~byte: ByteIndex.t
+      ) =>
+      BytePosition.t,
     bufferId: int,
     colorSchemeProvider: ColorScheme.Provider.t,
     width: int,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -42,12 +42,22 @@ module ColorScheme: {
   };
 };
 
+module ViewLineMotion: {
+   type t =
+   | MotionH
+   | MotionM
+   | MotionL;
+};
+
 module Context: {
   type t = {
     autoClosingPairs: AutoClosingPairs.t,
     autoIndent:
       (~previousLine: string, ~beforePreviousLine: option(string)) =>
       AutoIndent.action,
+    viewLineMotion: (
+     ~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t)
+     => LineNumber.t,
     bufferId: int,
     colorSchemeProvider: ColorScheme.Provider.t,
     width: int,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -63,7 +63,8 @@ module Context: {
         ~direction: [ | `Up | `Down],
         ~count: int,
         ~line: LineNumber.t,
-        ~byte: ByteIndex.t
+        ~currentByte: ByteIndex.t,
+        ~wantByte: ByteIndex.t
       ) =>
       BytePosition.t,
     bufferId: int,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -43,10 +43,10 @@ module ColorScheme: {
 };
 
 module ViewLineMotion: {
-   type t =
-   | MotionH
-   | MotionM
-   | MotionL;
+  type t =
+    | MotionH
+    | MotionM
+    | MotionL;
 };
 
 module Context: {
@@ -55,9 +55,9 @@ module Context: {
     autoIndent:
       (~previousLine: string, ~beforePreviousLine: option(string)) =>
       AutoIndent.action,
-    viewLineMotion: (
-     ~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t)
-     => LineNumber.t,
+    viewLineMotion:
+      (~motion: ViewLineMotion.t, ~count: int, ~startLine: LineNumber.t) =>
+      LineNumber.t,
     bufferId: int,
     colorSchemeProvider: ColorScheme.Provider.t,
     width: int,

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -597,13 +597,40 @@ void onCursorMoveScreenLine(screenLineMotion_T motion, int count, linenr_T start
 
 void onCursorMoveScreenPosition(int dir, int count, linenr_T srcLine,
 colnr_T srcColumn, linenr_T *destLine, colnr_T *destColumn) {
+    CAMLparam0();
+    CAMLlocal2(vDirection, vResult);
+
     if (dir == BACKWARD) {
-        *destLine = srcLine;
-        *destColumn = srcColumn - 10;
+        vDirection = hash_variant("Up");
     } else {
-        *destLine = srcLine;
-        *destColumn = srcColumn + 10;
+        vDirection = hash_variant("Down");
     }
+
+   static const value *lv_onCursorMoveScreenPosition = NULL;
+   if (lv_onCursorMoveScreenPosition == NULL) {
+     lv_onCursorMoveScreenPosition = caml_named_value("lv_onCursorMoveScreenPosition");
+   }
+  value *pArgs = (value *)malloc(sizeof(value) * 4);
+  pArgs[0] = vDirection,
+  pArgs[1] = Val_int(count);
+  pArgs[2] = Val_int(srcLine);
+  pArgs[3] = Val_long(destLine);
+
+    vResult = caml_callbackN(*lv_onCursorMoveScreenPosition,
+    4,
+    pArgs
+    );
+    free(pArgs);
+
+  if (Is_block(vResult)) {
+    *destLine = Int_val(Field(vResult, 0));
+    *destColumn = Int_val(Field(vResult, 1));
+  } else {
+    *destLine = srcLine;
+    *destColumn = srcColumn;
+  }
+
+   CAMLreturn0;
 }
 
 CAMLprim value libvim_vimInit(value unit) {

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -567,17 +567,32 @@ void onWriteFailure(writeFailureReason_T reason, buf_T *buf) {
 }
 
 void onCursorMoveScreenLine(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine) {
+    CAMLparam0();
+    CAMLlocal1(valDestLine);
+
+    int iMotion = 0;
     switch (motion) {
-    case MOTION_H:
-        *outLine = 1;
-        break;
     case MOTION_M:
-        *outLine = 2;
+        iMotion = 1;
         break;
     case MOTION_L:
-        *outLine = 3;
+        iMotion = 2;
+        break;
+    case MOTION_H:
+    default:
+        iMotion = 0;
         break;
     }
+
+   static const value *lv_onCursorMoveScreenLine = NULL;
+   if (lv_onCursorMoveScreenLine == NULL) {
+     lv_onCursorMoveScreenLine = caml_named_value("lv_onCursorMoveScreenLine");
+   }
+
+   valDestLine = caml_callback3(*lv_onCursorMoveScreenLine, Val_int(iMotion),
+   Val_int(count), Val_int(startLine));
+   *outLine = Int_val(valDestLine);
+   CAMLreturn0;
 }
 
 void onCursorMoveScreenPosition(int dir, int count, linenr_T srcLine,

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -596,7 +596,7 @@ void onCursorMoveScreenLine(screenLineMotion_T motion, int count, linenr_T start
 }
 
 void onCursorMoveScreenPosition(int dir, int count, linenr_T srcLine,
-colnr_T srcColumn, linenr_T *destLine, colnr_T *destColumn) {
+colnr_T srcColumn, colnr_T wantColumn, linenr_T *destLine, colnr_T *destColumn) {
     CAMLparam0();
     CAMLlocal2(vDirection, vResult);
 
@@ -610,14 +610,15 @@ colnr_T srcColumn, linenr_T *destLine, colnr_T *destColumn) {
    if (lv_onCursorMoveScreenPosition == NULL) {
      lv_onCursorMoveScreenPosition = caml_named_value("lv_onCursorMoveScreenPosition");
    }
-  value *pArgs = (value *)malloc(sizeof(value) * 4);
+  value *pArgs = (value *)malloc(sizeof(value) * 5);
   pArgs[0] = vDirection,
   pArgs[1] = Val_int(count);
   pArgs[2] = Val_int(srcLine);
-  pArgs[3] = Val_long(destLine);
+  pArgs[3] = Val_long(srcColumn);
+  pArgs[4] = Val_long(wantColumn);
 
     vResult = caml_callbackN(*lv_onCursorMoveScreenPosition,
-    4,
+    5,
     pArgs
     );
     free(pArgs);

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -566,6 +566,31 @@ void onWriteFailure(writeFailureReason_T reason, buf_T *buf) {
   CAMLreturn0;
 }
 
+void onCursorMoveScreenLine(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine) {
+    switch (motion) {
+    case MOTION_H:
+        *outLine = 1;
+        break;
+    case MOTION_M:
+        *outLine = 2;
+        break;
+    case MOTION_L:
+        *outLine = 3;
+        break;
+    }
+}
+
+void onCursorMoveScreenPosition(int dir, int count, linenr_T srcLine,
+colnr_T srcColumn, linenr_T *destLine, colnr_T *destColumn) {
+    if (dir == BACKWARD) {
+        *destLine = srcLine;
+        *destColumn = srcColumn - 10;
+    } else {
+        *destLine = srcLine;
+        *destColumn = srcColumn + 10;
+    }
+}
+
 CAMLprim value libvim_vimInit(value unit) {
   vimMacroSetStartRecordCallback(&onMacroStartRecord);
   vimMacroSetStopRecordCallback(&onMacroStopRecord);
@@ -591,6 +616,8 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetWindowSplitCallback(&onWindowSplit);
   vimSetYankCallback(&onYank);
   vimSetFileWriteFailureCallback(&onWriteFailure);
+  vimSetCursorMoveScreenLineCallback(&onCursorMoveScreenLine);
+  vimSetCursorMoveScreenPositionCallback(&onCursorMoveScreenPosition);
 
   char *args[0];
   vimInit(0, args);

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "012c480fe36ede7be6919203c2da8857",
+  "checksum": "072f326d89c45d456c022978969d5ef5",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.61@d41d8cd9": {
-      "id": "libvim@8.10869.61@d41d8cd9",
+    "libvim@8.10869.62@d41d8cd9": {
+      "id": "libvim@8.10869.62@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.61",
+      "version": "8.10869.62",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.61.tgz#sha1:11384ffe539a84eb715be32433c38e11899385cc"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.61@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test/reason-libvim/MotionTest.re
+++ b/test/reason-libvim/MotionTest.re
@@ -1,0 +1,169 @@
+open EditorCoreTypes;
+open TestFramework;
+
+open Vim;
+
+let resetBuffer = () =>
+  Helpers.resetBuffer("test/reason-libvim/lines_100.txt");
+
+describe("MotionTest", ({describe, _}) => {
+  describe("H / L / M", ({test, _}) => {
+    test("uses context value", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let viewLineMotion = (~motion, ~count as _, ~startLine as _) => {
+        switch (motion) {
+        | ViewLineMotion.MotionH => 1 |> LineNumber.ofOneBased
+        | ViewLineMotion.MotionM => 50 |> LineNumber.ofOneBased
+        | ViewLineMotion.MotionL => 100 |> LineNumber.ofOneBased
+        };
+      };
+
+      let context = {...Vim.Context.current(), viewLineMotion};
+
+      let context = Vim.input(~context, "L");
+      expect.equal(
+        context.cursors,
+        [
+          BytePosition.{
+            line: LineNumber.ofOneBased(100),
+            byte: ByteIndex.zero,
+          },
+        ],
+      );
+
+      let context = Vim.input(~context={...context, viewLineMotion}, "M");
+      expect.equal(
+        context.cursors,
+        [
+          BytePosition.{
+            line: LineNumber.ofOneBased(50),
+            byte: ByteIndex.zero,
+          },
+        ],
+      );
+
+      let context: Vim.Context.t =
+        Vim.input(~context={...context, viewLineMotion}, "H");
+      expect.equal(
+        context.cursors,
+        [
+          BytePosition.{line: LineNumber.ofOneBased(1), byte: ByteIndex.zero},
+        ],
+      );
+    });
+    test("GC stress test", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      for (_idx in 0 to 1000) {
+        let viewLineMotion = (~motion, ~count as _, ~startLine as _) => {
+          // Simulate large allocation
+          let _str = String.make(1024 * 1024, 'a');
+          let ret =
+            switch (motion) {
+            | ViewLineMotion.MotionH => 1 |> LineNumber.ofOneBased
+            | ViewLineMotion.MotionM => 50 |> LineNumber.ofOneBased
+            | ViewLineMotion.MotionL => 100 |> LineNumber.ofOneBased
+            };
+          // ...and compact.
+          Gc.compact();
+          ret;
+        };
+        let _context: Vim.Context.t =
+          Vim.input(
+            ~context={...Vim.Context.current(), viewLineMotion},
+            "M",
+          );
+        ();
+      };
+
+      let latestContext = Vim.Context.current();
+      expect.equal(
+        latestContext.cursors,
+        [
+          BytePosition.{
+            line: LineNumber.ofOneBased(50),
+            byte: ByteIndex.zero,
+          },
+        ],
+      );
+    });
+  });
+  describe("gj / gk", ({test, _}) => {
+    test("uses context value", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let screenCursorMotion =
+          (~direction, ~count, ~line as lnum, ~currentByte, ~wantByte as _) => {
+        let byteIdx = ByteIndex.toInt(currentByte);
+        switch (direction) {
+        | `Up =>
+          BytePosition.{byte: ByteIndex.ofInt(byteIdx - count), line: lnum}
+        | `Down => {byte: ByteIndex.ofInt(byteIdx + count), line: lnum}
+        };
+      };
+
+      let context = {...Vim.Context.current(), screenCursorMotion};
+
+      let context = Vim.input(~context, "5gj");
+      expect.equal(
+        context.cursors,
+        [
+          BytePosition.{
+            line: LineNumber.ofOneBased(1),
+            byte: ByteIndex.ofInt(5),
+          },
+        ],
+      );
+
+      let context = {...Vim.Context.current(), screenCursorMotion};
+      let context = Vim.input(~context, "gk");
+      expect.equal(
+        context.cursors,
+        [
+          BytePosition.{
+            line: LineNumber.ofOneBased(1),
+            byte: ByteIndex.ofInt(4),
+          },
+        ],
+      );
+    });
+    test("gc stress test", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let screenCursorMotion =
+          (~direction, ~count, ~line as lnum, ~currentByte, ~wantByte as _) => {
+        let _str = String.make(1024 * 1024, 'a');
+
+        let count = count < 1 ? 1 : count;
+        let byteIdx = ByteIndex.toInt(currentByte);
+        let ret =
+          switch (direction) {
+          | `Up =>
+            BytePosition.{byte: ByteIndex.ofInt(byteIdx - count), line: lnum}
+          | `Down => {byte: ByteIndex.ofInt(byteIdx + count), line: lnum}
+          };
+        Gc.compact();
+        ret;
+      };
+
+      for (_i in 0 to 1000) {
+        let context = {...Vim.Context.current(), screenCursorMotion};
+        let _context = Vim.input(~context, "gj");
+        let context = {...Vim.Context.current(), screenCursorMotion};
+        let _context = Vim.input(~context, "gk");
+        ();
+      };
+      let context = {...Vim.Context.current(), screenCursorMotion};
+      expect.equal(
+        context.cursors,
+        [
+          BytePosition.{
+            line: LineNumber.ofOneBased(1),
+            byte: ByteIndex.ofInt(0),
+          },
+        ],
+      );
+    });
+  });
+});


### PR DESCRIPTION
This implements handlers for `gj`, `gk`, `H`, `M`, L` - commands that are dependent on knowing about the current screen-space.

`libvim` doesn't know about the rendering metrics (ie, wrapping in #2578 ) - so this wires up handlers for those commands so that we can communicate where the destination cursor position should be for those commands, given our current editor state.

Needed for #2578 