### PR TITLE
fix(terminal/#2374): Weird cursor jump when typing second character in terminal

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "90b5f12e9d950cce6c528929164774fa",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -107,14 +107,14 @@
       ],
       "devDependencies": []
     },
-    "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9": {
+    "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9": {
       "id":
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
       "name": "revery-terminal",
-      "version": "github:revery-ui/revery-terminal#37e19a3",
+      "version": "github:revery-ui/revery-terminal#bc0a670",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery-terminal#37e19a3" ]
+        "source": [ "github:revery-ui/revery-terminal#bc0a670" ]
       },
       "overrides": [],
       "dependencies": [
@@ -935,7 +935,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
         "revery@github:revery-ui/revery#18eb60e@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "90b5f12e9d950cce6c528929164774fa",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -107,14 +107,14 @@
       ],
       "devDependencies": []
     },
-    "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9": {
+    "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9": {
       "id":
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
       "name": "revery-terminal",
-      "version": "github:revery-ui/revery-terminal#37e19a3",
+      "version": "github:revery-ui/revery-terminal#bc0a670",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery-terminal#37e19a3" ]
+        "source": [ "github:revery-ui/revery-terminal#bc0a670" ]
       },
       "overrides": [],
       "dependencies": [
@@ -935,7 +935,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
         "revery@github:revery-ui/revery#18eb60e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "90b5f12e9d950cce6c528929164774fa",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -107,14 +107,14 @@
       ],
       "devDependencies": []
     },
-    "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9": {
+    "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9": {
       "id":
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
       "name": "revery-terminal",
-      "version": "github:revery-ui/revery-terminal#37e19a3",
+      "version": "github:revery-ui/revery-terminal#bc0a670",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery-terminal#37e19a3" ]
+        "source": [ "github:revery-ui/revery-terminal#bc0a670" ]
       },
       "overrides": [],
       "dependencies": [
@@ -935,7 +935,7 @@
       },
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
         "revery@github:revery-ui/revery#18eb60e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "rench": "bryphe/rench#a976fe5",
     "reasonFuzz": "CrossR/reasonFuzz#1ad6f5d",
     "isolinear": "revery-ui/isolinear#53fc4eb",
-    "revery-terminal": "link:../revery-terminal",
+    "revery-terminal": "revery-ui/revery-terminal#bc0a670",
     "@opam/fs": "bryphe/reason-native:fs.opam#fd0225c",
     "@opam/fp": "bryphe/reason-native:fp.opam#fd0225c",
     "@opam/dir": "bryphe/reason-native:dir.opam#fd0225",

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "rench": "bryphe/rench#a976fe5",
     "reasonFuzz": "CrossR/reasonFuzz#1ad6f5d",
     "isolinear": "revery-ui/isolinear#53fc4eb",
-    "revery-terminal": "revery-ui/revery-terminal#37e19a3",
+    "revery-terminal": "link:../revery-terminal",
     "@opam/fs": "bryphe/reason-native:fs.opam#fd0225c",
     "@opam/fp": "bryphe/reason-native:fp.opam#fd0225c",
     "@opam/dir": "bryphe/reason-native:dir.opam#fd0225",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "90b5f12e9d950cce6c528929164774fa",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -107,14 +107,14 @@
       ],
       "devDependencies": []
     },
-    "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9": {
+    "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9": {
       "id":
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
       "name": "revery-terminal",
-      "version": "github:revery-ui/revery-terminal#37e19a3",
+      "version": "github:revery-ui/revery-terminal#bc0a670",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery-terminal#37e19a3" ]
+        "source": [ "github:revery-ui/revery-terminal#bc0a670" ]
       },
       "overrides": [],
       "dependencies": [
@@ -935,7 +935,7 @@
       },
       "overrides": [ "release.json" ],
       "dependencies": [
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
         "revery@github:revery-ui/revery#18eb60e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -249,7 +249,7 @@ let token = (~context, ~line, ~colors: Colors.t, token: BufferViewTokenizer.t) =
       ~bold=token.bold,
       ~italic=token.italic,
       token.text,
-    );
+    )
 
   | Tab =>
     Skia.Paint.setColor(

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -108,6 +108,7 @@ let drawShapedText = {
        });
   };
 };
+
 let shapedText = drawShapedText;
 
 let drawUtf8Text = {
@@ -248,7 +249,7 @@ let token = (~context, ~line, ~colors: Colors.t, token: BufferViewTokenizer.t) =
       ~bold=token.bold,
       ~italic=token.italic,
       token.text,
-    )
+    );
 
   | Tab =>
     Skia.Paint.setColor(

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -162,7 +162,7 @@ let update = (~config: Config.resolver, model: t, msg) => {
           pid: None,
           title: None,
           screen: ReveryTerminal.Screen.initial,
-          cursor: ReveryTerminal.Cursor.{row: 0, column: 0, visible: false},
+          cursor: ReveryTerminal.Cursor.initial,
           closeOnExit,
         },
         model.idToTerminal,

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -195,12 +195,8 @@ let update = (~config: Config.resolver, model: t, msg) => {
       updateById(id, term => {...term, title: Some(title)}, model);
     (newModel, Nothing);
 
-  | Service(ScreenUpdated({id, screen})) =>
-    let newModel = updateById(id, term => {...term, screen}, model);
-    (newModel, Nothing);
-
-  | Service(CursorMoved({id, cursor})) =>
-    let newModel = updateById(id, term => {...term, cursor}, model);
+  | Service(ScreenUpdated({id, screen, cursor})) =>
+    let newModel = updateById(id, term => {...term, screen, cursor}, model);
     (newModel, Nothing);
 
   | Service(ProcessExit({id, exitCode})) => (

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -27,9 +27,6 @@ type msg =
   | ScreenUpdated({
       id: int,
       screen: [@opaque] ReveryTerminal.Screen.t,
-    })
-  | CursorMoved({
-      id: int,
       cursor: [@opaque] ReveryTerminal.Cursor.t,
     });
 
@@ -71,22 +68,20 @@ module Sub = {
 
         let isResizing = ref(false);
 
-        let throttledScreenDispatch =
-          FunEx.throttle(~time=Time.zero, dispatch);
-        let throttledCursorDispatch =
-          FunEx.throttle(~time=Time.zero, dispatch);
 
         let onEffect = eff =>
           switch (eff) {
           | ReveryTerminal.ScreenResized(_) => ()
           | ReveryTerminal.ScreenUpdated(screen) =>
-            if (! isResizing^) {
-              throttledScreenDispatch(
-                ScreenUpdated({id: params.id, screen}),
-              );
-            }
+//            if (! isResizing^) {
+//              throttledScreenDispatch(
+//                ScreenUpdated({id: params.id, screen}),
+//              );
+//            }
+();
           | ReveryTerminal.CursorMoved(cursor) =>
-            throttledCursorDispatch(CursorMoved({id: params.id, cursor}))
+//            throttledCursorDispatch(CursorMoved({id: params.id, cursor}))
+();
           | ReveryTerminal.Output(output) =>
             Exthost.Request.TerminalService.acceptProcessInput(
               ~id=params.id,
@@ -141,6 +136,10 @@ module Sub = {
             | SendProcessData({terminalId, data}) =>
               if (terminalId == params.id) {
                 ReveryTerminal.write(~input=data, terminal);
+
+                let cursor = ReveryTerminal.cursor(terminal);
+                let screen = ReveryTerminal.screen(terminal);
+                dispatch(ScreenUpdated({id: params.id, screen, cursor}));
               }
             | SendProcessExit({terminalId, exitCode}) =>
               dispatchIfMatches(

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -68,20 +68,20 @@ module Sub = {
 
         let isResizing = ref(false);
 
-
         let onEffect = eff =>
           switch (eff) {
           | ReveryTerminal.ScreenResized(_) => ()
           | ReveryTerminal.ScreenUpdated(screen) =>
-//            if (! isResizing^) {
-//              throttledScreenDispatch(
-//                ScreenUpdated({id: params.id, screen}),
-//              );
-//            }
-();
-          | ReveryTerminal.CursorMoved(cursor) =>
-//            throttledCursorDispatch(CursorMoved({id: params.id, cursor}))
-();
+            //              throttledScreenDispatch(
+
+            //              );
+
+            ()
+          //            }
+          //                ScreenUpdated({id: params.id, screen}),
+          //            if (! isResizing^) {
+          | ReveryTerminal.CursorMoved(cursor) => ()
+          //            throttledCursorDispatch(CursorMoved({id: params.id, cursor}))
           | ReveryTerminal.Output(output) =>
             Exthost.Request.TerminalService.acceptProcessInput(
               ~id=params.id,
@@ -136,7 +136,6 @@ module Sub = {
             | SendProcessData({terminalId, data}) =>
               if (terminalId == params.id) {
                 ReveryTerminal.write(~input=data, terminal);
-
                 let cursor = ReveryTerminal.cursor(terminal);
                 let screen = ReveryTerminal.screen(terminal);
                 dispatch(ScreenUpdated({id: params.id, screen, cursor}));

--- a/src/Service/Terminal/Service_Terminal.re
+++ b/src/Service/Terminal/Service_Terminal.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Oni_Core.Utility;
 
 module Time = Revery.Time;
 
@@ -71,17 +70,8 @@ module Sub = {
         let onEffect = eff =>
           switch (eff) {
           | ReveryTerminal.ScreenResized(_) => ()
-          | ReveryTerminal.ScreenUpdated(screen) =>
-            //              throttledScreenDispatch(
-
-            //              );
-
-            ()
-          //            }
-          //                ScreenUpdated({id: params.id, screen}),
-          //            if (! isResizing^) {
-          | ReveryTerminal.CursorMoved(cursor) => ()
-          //            throttledCursorDispatch(CursorMoved({id: params.id, cursor}))
+          | ReveryTerminal.ScreenUpdated(_) => ()
+          | ReveryTerminal.CursorMoved(_) => ()
           | ReveryTerminal.Output(output) =>
             Exthost.Request.TerminalService.acceptProcessInput(
               ~id=params.id,

--- a/src/Service/Terminal/Service_Terminal.rei
+++ b/src/Service/Terminal/Service_Terminal.rei
@@ -17,9 +17,6 @@ type msg =
   | ScreenUpdated({
       id: int,
       screen: ReveryTerminal.Screen.t,
-    })
-  | CursorMoved({
-      id: int,
       cursor: ReveryTerminal.Cursor.t,
     });
 

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "072f326d89c45d456c022978969d5ef5",
+  "checksum": "ecfb93d628edbd8afbcbb75a1d07877d",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -107,14 +107,14 @@
       ],
       "devDependencies": []
     },
-    "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9": {
+    "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9": {
       "id":
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
       "name": "revery-terminal",
-      "version": "github:revery-ui/revery-terminal#37e19a3",
+      "version": "github:revery-ui/revery-terminal#bc0a670",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery-terminal#37e19a3" ]
+        "source": [ "github:revery-ui/revery-terminal#bc0a670" ]
       },
       "overrides": [],
       "dependencies": [
@@ -935,7 +935,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "revery-terminal@github:revery-ui/revery-terminal#37e19a3@d41d8cd9",
+        "revery-terminal@github:revery-ui/revery-terminal#bc0a670@d41d8cd9",
         "revery@github:revery-ui/revery#18eb60e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",


### PR DESCRIPTION
Part of the fix for this will be over in [`revery-terminal`](https://github.com/revery-ui/revery-terminal)

__TODO:__
- [x] Pack `Vterm.Color.t` into a single `int` to reduce allocations
- [x] Pick up cursor style (underline)

Fixes #2374 