### PR TITLE
refactor(vim): Synchronize vim modes

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "5ee9b3d53ce78899097b5212100c288e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.62@d41d8cd9": {
-      "id": "libvim@8.10869.62@d41d8cd9",
+    "libvim@8.10869.63@d41d8cd9": {
+      "id": "libvim@8.10869.63@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.62",
+      "version": "8.10869.63",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "5ee9b3d53ce78899097b5212100c288e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.62@d41d8cd9": {
-      "id": "libvim@8.10869.62@d41d8cd9",
+    "libvim@8.10869.63@d41d8cd9": {
+      "id": "libvim@8.10869.63@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.62",
+      "version": "8.10869.63",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "5ee9b3d53ce78899097b5212100c288e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.62@d41d8cd9": {
-      "id": "libvim@8.10869.62@d41d8cd9",
+    "libvim@8.10869.63@d41d8cd9": {
+      "id": "libvim@8.10869.63@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.62",
+      "version": "8.10869.63",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.62",
+    "libvim": "8.10869.63",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reasonFuzz": "*",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e59edff4c92b62fc0716580a593f2abc",
+  "checksum": "5ee9b3d53ce78899097b5212100c288e",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.62@d41d8cd9": {
-      "id": "libvim@8.10869.62@d41d8cd9",
+    "libvim@8.10869.63@d41d8cd9": {
+      "id": "libvim@8.10869.63@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.62",
+      "version": "8.10869.63",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -3,7 +3,7 @@ open Oni_Core;
 module Internal = {
   let getTerminalNormalMode =
     fun
-    | Vim.Mode.Visual({range, _}) =>
+    | Vim.Mode.Visual(range) =>
       Mode.TerminalVisual({range: Oni_Core.VisualRange.ofVim(range)})
     | Vim.Mode.Operator({pending, _}) => Mode.Operator({pending: pending})
     | Vim.Mode.CommandLine => Mode.CommandLine
@@ -29,12 +29,12 @@ let current: State.t => Oni_Core.Mode.t =
                },
              )
            | Vim.Mode.Normal({cursor}) => Mode.Normal({cursor: cursor})
-           | Vim.Mode.Visual({range}) =>
+           | Vim.Mode.Visual(range) =>
              Mode.Visual({
                cursor: Vim.VisualRange.cursor(range),
                range: Oni_Core.VisualRange.ofVim(range),
              })
-           | Vim.Mode.Select({range}) =>
+           | Vim.Mode.Select(range) =>
              Mode.Select({
                cursor: Vim.VisualRange.cursor(range),
                range: Oni_Core.VisualRange.ofVim(range),

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -168,8 +168,8 @@ let start =
             Feature_Layout.activeEditor(getState().layout) |> Editor.getId;
 
           switch (newMode) {
-          | Visual({range, _})
-          | Select({range, _}) =>
+          | Visual(range)
+          | Select(range) =>
             dispatch(
               Editor({
                 scope: Oni_Model.EditorScope.Editor(editorId),

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -5,12 +5,12 @@ type t =
   | Insert({cursors: list(BytePosition.t)})
   | CommandLine
   | Replace({cursor: BytePosition.t})
-  | Visual({range: VisualRange.t})
+  | Visual(VisualRange.t)
   | Operator({
       cursor: BytePosition.t,
       pending: Operator.pending,
     })
-  | Select({range: VisualRange.t});
+  | Select(VisualRange.t);
 
 let show = (mode: t) => {
   switch (mode) {
@@ -29,9 +29,9 @@ let cursors =
   | Normal({cursor}) => [cursor]
   | Insert({cursors}) => cursors
   | Replace({cursor}) => [cursor]
-  | Visual({range}) => [range |> VisualRange.cursor]
+  | Visual(range) => [range |> VisualRange.cursor]
   | Operator({cursor, _}) => [cursor]
-  | Select({range}) => [range |> VisualRange.cursor]
+  | Select(range) => [range |> VisualRange.cursor]
   | CommandLine => [];
 
 let current = () => {
@@ -40,7 +40,7 @@ let current = () => {
   let cursor = Cursor.get();
   switch (nativeMode) {
   | Native.Normal => Normal({cursor: cursor})
-  | Native.Visual => Visual({range: VisualRange.current()})
+  | Native.Visual => Visual(VisualRange.current())
   | Native.CommandLine => CommandLine
   | Native.Replace => Replace({cursor: cursor})
   | Native.Operator =>
@@ -49,7 +49,7 @@ let current = () => {
       pending: Operator.get() |> Option.value(~default=Operator.default),
     })
   | Native.Insert => Insert({cursors: [cursor]})
-  | Native.Select => Select({range: VisualRange.current()})
+  | Native.Select => Select(VisualRange.current())
   };
 };
 
@@ -96,16 +96,22 @@ module Internal = {
       Native.vimKey("i");
     };
 
-  let ensureVisual = () =>
+  let ensureVisual = visualType =>
     if (!isVisual(current())) {
       ensureNormal();
-      // Just switch to _a_ visual mode - the actual type and selection will be set elsewhere
-      Native.vimKey("V");
+      Types.(
+        switch (visualType) {
+        | Block => Native.vimKey("<C-v>")
+        | Line => Native.vimKey("V")
+        | Character
+        | None => Native.vimKey("v")
+        }
+      );
     };
 
-  let ensureSelect = () =>
+  let ensureSelect = visualType =>
     if (!isSelect(current())) {
-      ensureVisual();
+      ensureVisual(visualType);
       Native.vimKey("<c-g>");
     };
 };
@@ -115,15 +121,15 @@ let trySet = newMode => {
   | Normal({cursor}) =>
     Internal.ensureNormal();
     Cursor.set(cursor);
-  | Visual({range}) =>
-    Internal.ensureVisual();
+  | Visual(range) =>
+    Internal.ensureVisual(range.visualType);
     Visual.set(
       ~visualType=range.visualType,
       ~start=range.anchor,
       ~cursor=range.cursor,
     );
-  | Select({range}) =>
-    Internal.ensureSelect();
+  | Select(range) =>
+    Internal.ensureSelect(range.visualType);
     Visual.set(
       ~visualType=range.visualType,
       ~start=range.anchor,

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -84,13 +84,13 @@ let isOperatorPending =
   | _ => false;
 
 module Internal = {
-  let ensureNormal = prevMode =>
+  let ensureNormal = () =>
     if (!isNormal(current())) {
       Native.vimKey("<ESC>");
       Native.vimKey("<ESC>");
     };
 
-  let ensureInsert = prevMode =>
+  let ensureInsert = () =>
     if (!isInsert(current())) {
       ensureNormal();
       Native.vimKey("i");

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -84,60 +84,57 @@ let isOperatorPending =
   | _ => false;
 
 module Internal = {
-    let ensureNormal = (prevMode) => {
-        if (!isNormal(current())) {
-            Native.vimKey("<ESC>");
-            Native.vimKey("<ESC>");
-        }
+  let ensureNormal = prevMode =>
+    if (!isNormal(current())) {
+      Native.vimKey("<ESC>");
+      Native.vimKey("<ESC>");
     };
 
-    let ensureInsert = (prevMode) => {
-        if (!isInsert(current())) {
-            ensureNormal();
-            Native.vimKey("i");
-        }
+  let ensureInsert = prevMode =>
+    if (!isInsert(current())) {
+      ensureNormal();
+      Native.vimKey("i");
     };
 
-    let ensureVisual = () => {
-       if (!isVisual(current())) {
-         ensureNormal();
-         // Just switch to _a_ visual mode - the actual type and selection will be set elsewhere
-         Native.vimKey("V");
-       } 
-    }
-
-    let ensureSelect = () => {
-        if (!isSelect(current())) {
-            ensureVisual();
-            Native.vimKey("<c-g>");
-        }
+  let ensureVisual = () =>
+    if (!isVisual(current())) {
+      ensureNormal();
+      // Just switch to _a_ visual mode - the actual type and selection will be set elsewhere
+      Native.vimKey("V");
     };
-}
 
-let trySet = (newMode) => {
-    switch (newMode) {
-    | Normal({cursor}) =>
-        Internal.ensureNormal();
-        Cursor.set(cursor);
-    | Visual({ range }) =>
-        Internal.ensureVisual();
-        Visual.set(
-            ~visualType=range.visualType,
-            ~start=range.anchor,
-            ~cursor=range.cursor);
-    | Select({ range }) =>
-        Internal.ensureSelect();
-        Visual.set(
-            ~visualType=range.visualType,
-            ~start=range.anchor,
-            ~cursor=range.cursor);
-    | Insert(_) =>
-        Internal.ensureInsert();
-    // These modes cannot be explicitly transitioned to currently
-    | Operator(_) 
-    | Replace(_)
-    | CommandLine => ();
-    }
+  let ensureSelect = () =>
+    if (!isSelect(current())) {
+      ensureVisual();
+      Native.vimKey("<c-g>");
+    };
+};
 
-    current();
-}
+let trySet = newMode => {
+  switch (newMode) {
+  | Normal({cursor}) =>
+    Internal.ensureNormal();
+    Cursor.set(cursor);
+  | Visual({range}) =>
+    Internal.ensureVisual();
+    Visual.set(
+      ~visualType=range.visualType,
+      ~start=range.anchor,
+      ~cursor=range.cursor,
+    );
+  | Select({range}) =>
+    Internal.ensureSelect();
+    Visual.set(
+      ~visualType=range.visualType,
+      ~start=range.anchor,
+      ~cursor=range.cursor,
+    );
+  | Insert(_) => Internal.ensureInsert()
+  // These modes cannot be explicitly transitioned to currently
+  | Operator(_)
+  | Replace(_)
+  | CommandLine => ()
+  };
+
+  current();
+};

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -144,8 +144,11 @@ external vimUndoSync: int => unit = "libvim_vimUndoSync";
 
 external vimVisualGetRange: unit => (int, int, int, int) =
   "libvim_vimVisualGetRange";
+external vimVisualSetStart: (int, int) => unit = "libvim_vimVisualSetStart";
 
 external vimVisualGetType: unit => Types.visualType =
+  "libvim_vimVisualGetType";
+external vimVisualSetType: Types.visualType => unit =
   "libvim_vimVisualGetType";
 
 external vimWindowGetWidth: unit => int = "libvim_vimWindowGetWidth";

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -161,7 +161,7 @@ let runWith = (~context: Context.t, f) => {
   context.lineComment |> Option.iter(Options.setLineComment);
 
   let oldBuf = Buffer.getCurrent();
-  let prevMode = Mode.current();
+  let prevMode = Mode.trySet(context.mode);
   let prevModified = Buffer.isModified(oldBuf);
   let prevLineEndings = Buffer.getLineEndings(oldBuf);
 

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -102,12 +102,12 @@ module Mode: {
     | Insert({cursors: list(BytePosition.t)})
     | CommandLine
     | Replace({cursor: BytePosition.t})
-    | Visual({range: VisualRange.t})
+    | Visual(VisualRange.t)
     | Operator({
         cursor: BytePosition.t,
         pending: Operator.pending,
       })
-    | Select({range: VisualRange.t});
+    | Select(VisualRange.t);
 
   let current: unit => t;
 

--- a/src/reason-libvim/Visual.re
+++ b/src/reason-libvim/Visual.re
@@ -27,8 +27,12 @@ let getRange = () => {
 
 let getType = Native.vimVisualGetType;
 
-let set = (~visualType: Types.visualType, ~start: BytePosition.t, 
-~cursor: BytePosition.t) => {
-   // TODO
-   (); 
-}
+let set =
+    (
+      ~visualType: Types.visualType,
+      ~start: BytePosition.t,
+      ~cursor: BytePosition.t,
+    ) => {
+  ();
+    // TODO
+};

--- a/src/reason-libvim/Visual.re
+++ b/src/reason-libvim/Visual.re
@@ -26,3 +26,9 @@ let getRange = () => {
 };
 
 let getType = Native.vimVisualGetType;
+
+let set = (~visualType: Types.visualType, ~start: BytePosition.t, 
+~cursor: BytePosition.t) => {
+   // TODO
+   (); 
+}

--- a/src/reason-libvim/Visual.re
+++ b/src/reason-libvim/Visual.re
@@ -40,5 +40,4 @@ let set =
     start.byte |> ByteIndex.toInt,
   );
   Cursor.set(cursor);
-  // TODO
 };

--- a/src/reason-libvim/Visual.re
+++ b/src/reason-libvim/Visual.re
@@ -34,5 +34,11 @@ let set =
       ~cursor: BytePosition.t,
     ) => {
   ();
-    // TODO
+  Native.vimVisualSetType(visualType);
+  Native.vimVisualSetStart(
+    start.line |> LineNumber.toOneBased,
+    start.byte |> ByteIndex.toInt,
+  );
+  Cursor.set(cursor);
+  // TODO
 };

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -1129,6 +1129,17 @@ CAMLprim value libvim_vimOptionGetTabSize(value unit) {
   return Val_int(tabSize);
 }
 
+CAMLprim value libvim_vimVisualSetStart(value vLine, value vByte) {
+    CAMLparam2(vLine, vByte);
+
+    pos_T start;
+    start.lnum = Int_val(vLine);
+    start.col = Int_val(vByte);
+    vimVisualSetStart(start);
+
+    CAMLreturn(Val_unit);
+}
+
 CAMLprim value libvim_vimVisualGetRange(value unit) {
   CAMLparam0();
   CAMLlocal1(ret);
@@ -1229,6 +1240,31 @@ CAMLprim value libvim_vimUndoSaveRegion(value startLine, value endLine) {
   int success = vimUndoSaveRegion(start, end);
 
   CAMLreturn(Val_bool(success != FAIL));
+}
+
+CAMLprim value libvim_vimVisualSetType(value vType) {
+    CAMLparam1(vType);    
+
+    char visualType = 0;
+    switch(Int_val(vType)) {
+    // character
+    case 0:
+      visualType ='v';
+      break;
+        // line
+    case 1:
+      visualType = 'V';
+      break;
+    case 2:
+       visualType = Ctrl_V;
+       break;
+    }
+
+    if (visualType != 0) {
+        vimVisualSetType(visualType);
+    }
+
+    CAMLreturn(Val_unit);
 }
 
 CAMLprim value libvim_vimVisualGetType(value unit) {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "072f326d89c45d456c022978969d5ef5",
+  "checksum": "6f407660966c45a2a28ae85dfe62d0ce",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.62@d41d8cd9": {
-      "id": "libvim@8.10869.62@d41d8cd9",
+    "libvim@8.10869.63@d41d8cd9": {
+      "id": "libvim@8.10869.63@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.62",
+      "version": "8.10869.63",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.62.tgz#sha1:d34a780ebb7efd7adc5f846e6a60582ce2acdd6c"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.62@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test/reason-libvim/ModeTest.re
+++ b/test/reason-libvim/ModeTest.re
@@ -1,10 +1,105 @@
 open EditorCoreTypes;
 open TestFramework;
 
+open Vim;
+
 let resetBuffer = () =>
   Helpers.resetBuffer("test/reason-libvim/testfile.txt");
 
 describe("Mode", ({describe, _}) => {
+  describe("explicit transitions", ({test, _}) => {
+    test("normal -> visual select (line)", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let buffer = Vim.Buffer.getCurrent();
+      expect.int(Buffer.getLineCount(buffer)).toBe(3);
+
+      expect.bool(Mode.isNormal(Mode.current())).toBe(true);
+
+      // Force selection mode - and type 'a'
+      let outContext =
+        Vim.input(
+          ~context={
+            ...Vim.Context.current(),
+            mode:
+              Mode.Select(
+                VisualRange.{
+                  cursor:
+                    BytePosition.{
+                      line: LineNumber.zero,
+                      byte: ByteIndex.zero,
+                    },
+                  anchor:
+                    BytePosition.{
+                      line: LineNumber.ofZeroBased(1),
+                      byte: ByteIndex.zero,
+                    },
+                  visualType: Vim.Types.Line,
+                },
+              ),
+          },
+          "a",
+        );
+
+      expect.bool(Mode.isInsert(outContext.mode)).toBe(true);
+
+      let buffer = Vim.Buffer.getCurrent();
+      expect.int(Buffer.getLineCount(buffer)).toBe(1);
+      expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
+        "aThis is the third line of a test file",
+      );
+
+      let cursor: BytePosition.t = Cursor.get();
+      expect.equal(cursor.byte, ByteIndex.ofInt(1));
+      expect.equal(cursor.line, LineNumber.zero);
+    });
+    test("normal -> visual (character)", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let buffer = Vim.Buffer.getCurrent();
+      expect.int(Buffer.getLineCount(buffer)).toBe(3);
+
+      expect.bool(Mode.isNormal(Mode.current())).toBe(true);
+
+      // Force visual mode - and delete with 'x'
+      let outContext =
+        Vim.input(
+          ~context={
+            ...Vim.Context.current(),
+            mode:
+              Mode.Visual(
+                VisualRange.{
+                  cursor:
+                    BytePosition.{
+                      line: LineNumber.zero,
+                      byte: ByteIndex.ofInt(4),
+                    },
+                  anchor:
+                    BytePosition.{
+                      line: LineNumber.zero,
+                      byte: ByteIndex.ofInt(6),
+                    },
+                  visualType: Vim.Types.Character,
+                },
+              ),
+          },
+          "x",
+        );
+
+      expect.bool(Mode.isNormal(outContext.mode)).toBe(true);
+
+      let buffer = Vim.Buffer.getCurrent();
+      expect.int(Buffer.getLineCount(buffer)).toBe(3);
+      expect.string(Buffer.getLine(buffer, LineNumber.ofZeroBased(0))).
+        toEqual(
+        "This the first line of a test file",
+      );
+
+      let cursor: BytePosition.t = Cursor.get();
+      expect.equal(cursor.byte, ByteIndex.ofInt(4));
+      expect.equal(cursor.line, LineNumber.zero);
+    });
+  });
   describe("replace mode", ({test, _}) => {
     test("replace mode is reported correctly", ({expect, _}) => {
       let _ = resetBuffer();

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -56,12 +56,14 @@ describe("Multi-cursor", ({describe, _}) => {
         // set cursor, and move up
         let mode2 =
           input(
-            ~mode=Normal({
-                cursor: BytePosition.{
+            ~mode=
+              Normal({
+                cursor:
+                  BytePosition.{
                     line: LineNumber.ofZeroBased(2),
                     byte: ByteIndex.zero,
-                }
-            }),
+                  },
+              }),
             "k",
           );
 

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -8,7 +8,7 @@ let resetBuffer = () =>
 let input =
     (
       ~autoClosingPairs=AutoClosingPairs.empty,
-      ~mode=Mode.Insert({cursors: []}),
+      ~mode=Mode.Normal({cursor: BytePosition.zero}),
       key,
     ) => {
   let out =
@@ -56,15 +56,12 @@ describe("Multi-cursor", ({describe, _}) => {
         // set cursor, and move up
         let mode2 =
           input(
-            ~mode=
-              Insert({
-                cursors: [
-                  BytePosition.{
-                    line: LineNumber.ofOneBased(3),
+            ~mode=Normal({
+                cursor: BytePosition.{
+                    line: LineNumber.ofZeroBased(2),
                     byte: ByteIndex.zero,
-                  },
-                ],
-              }),
+                }
+            }),
             "k",
           );
 
@@ -89,7 +86,7 @@ describe("Multi-cursor", ({describe, _}) => {
     })
   });
   describe("insert mode", ({test, _}) => {
-    test("multi-cursor auto-closing paris", ({expect, _}) => {
+    test("multi-cursor auto-closing pairs", ({expect, _}) => {
       let buf = resetBuffer();
 
       let autoClosingPairs =


### PR DESCRIPTION
This change is the next step from #2584 - when the mode provided by the `Editor.t` is different from the 'real' Vim state - synchronize it. 

Brings in https://github.com/onivim/libvim/pull/231 so that we can change the visual / select easily as part of that synchronization.