### PR TITLE
fix(editor/#760): Confusing scroll/viewport reconciliation

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5ee9b3d53ce78899097b5212100c288e",
+  "checksum": "bd4162601e36968e01eced18e4674b88",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.63@d41d8cd9": {
-      "id": "libvim@8.10869.63@d41d8cd9",
+    "libvim@8.10869.64@d41d8cd9": {
+      "id": "libvim@8.10869.64@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.63",
+      "version": "8.10869.64",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.64.tgz#sha1:c6edfd47c5a8924c95c7ba8c787f5fec89b87f42"
         ]
       },
       "overrides": [],
@@ -942,7 +942,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.64@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
@@ -2977,14 +2977,14 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -3501,8 +3501,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ctypes@opam:0.15.1@b0227b2f": {
-      "id": "@opam/ctypes@opam:0.15.1@b0227b2f",
+    "@opam/ctypes@opam:0.15.1@9c7ab4ec": {
+      "id": "@opam/ctypes@opam:0.15.1@9c7ab4ec",
       "name": "@opam/ctypes",
       "version": "opam:0.15.1",
       "source": {

--- a/bench.esy.lock/opam/ctypes.0.15.1/opam
+++ b/bench.esy.lock/opam/ctypes.0.15.1/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.1.tar.gz"
   checksum: "md5=e87b2646f7597e00b8b9a1f5f8e36ee6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5ee9b3d53ce78899097b5212100c288e",
+  "checksum": "bd4162601e36968e01eced18e4674b88",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.63@d41d8cd9": {
-      "id": "libvim@8.10869.63@d41d8cd9",
+    "libvim@8.10869.64@d41d8cd9": {
+      "id": "libvim@8.10869.64@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.63",
+      "version": "8.10869.64",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.64.tgz#sha1:c6edfd47c5a8924c95c7ba8c787f5fec89b87f42"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.64@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
@@ -2976,14 +2976,14 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -3500,8 +3500,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ctypes@opam:0.15.1@b0227b2f": {
-      "id": "@opam/ctypes@opam:0.15.1@b0227b2f",
+    "@opam/ctypes@opam:0.15.1@9c7ab4ec": {
+      "id": "@opam/ctypes@opam:0.15.1@9c7ab4ec",
       "name": "@opam/ctypes",
       "version": "opam:0.15.1",
       "source": {

--- a/esy.lock/opam/ctypes.0.15.1/opam
+++ b/esy.lock/opam/ctypes.0.15.1/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.1.tar.gz"
   checksum: "md5=e87b2646f7597e00b8b9a1f5f8e36ee6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/integration_test/QuickOpenEventuallyCompletesTest.re
+++ b/integration_test/QuickOpenEventuallyCompletesTest.re
@@ -7,7 +7,7 @@ runTest(~name="QuickOpen eventually completes", (dispatch, wait, runEffects) => 
   );
 
   /* Switch to root directory */
-  let _: Vim.Context.t =
+  let (_: Vim.Context.t, _: list(Vim.Effect.t)) =
     if (Revery.Environment.os == Revery.Environment.Mac) {
       // CI machines timeout with '/' - so we'll use home (which also reproduces the crash)
       Vim.command(

--- a/integration_test/RegressionNonExistentDirectory.re
+++ b/integration_test/RegressionNonExistentDirectory.re
@@ -9,10 +9,10 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
     splitCount == 1;
   });
 
-  ignore(Vim.command("e test.txt"): Vim.Context.t);
+  ignore(Vim.command("e test.txt"): (Vim.Context.t, list(Vim.Effect.t)));
 
   /* :vsp with no arguments should create a second split w/ same buffer */
-  ignore(Vim.command("vsp"): Vim.Context.t);
+  ignore(Vim.command("vsp"): (Vim.Context.t, list(Vim.Effect.t)));
 
   wait(~name="Wait for split to be created", (state: State.t) => {
     let splitCount =

--- a/integration_test/RegressionVspEmptyInitialBufferTest.re
+++ b/integration_test/RegressionVspEmptyInitialBufferTest.re
@@ -27,7 +27,7 @@ runTest(~name="RegressionVspEmpty", (_, wait, _) => {
   });
 
   /* :vsp with no arguments should create a second split w/ same buffer */
-  ignore(Vim.command("vsp"): Vim.Context.t);
+  ignore(Vim.command("vsp"): (Vim.Context.t, list(Vim.Effect.t)));
 
   wait(~name="Wait for split to be created", (state: State.t) => {
     let splitCount =

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5ee9b3d53ce78899097b5212100c288e",
+  "checksum": "bd4162601e36968e01eced18e4674b88",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.63@d41d8cd9": {
-      "id": "libvim@8.10869.63@d41d8cd9",
+    "libvim@8.10869.64@d41d8cd9": {
+      "id": "libvim@8.10869.64@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.63",
+      "version": "8.10869.64",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.64.tgz#sha1:c6edfd47c5a8924c95c7ba8c787f5fec89b87f42"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.64@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
@@ -2977,14 +2977,14 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -3501,8 +3501,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ctypes@opam:0.15.1@b0227b2f": {
-      "id": "@opam/ctypes@opam:0.15.1@b0227b2f",
+    "@opam/ctypes@opam:0.15.1@9c7ab4ec": {
+      "id": "@opam/ctypes@opam:0.15.1@9c7ab4ec",
       "name": "@opam/ctypes",
       "version": "opam:0.15.1",
       "source": {

--- a/integrationtest.esy.lock/opam/ctypes.0.15.1/opam
+++ b/integrationtest.esy.lock/opam/ctypes.0.15.1/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.1.tar.gz"
   checksum: "md5=e87b2646f7597e00b8b9a1f5f8e36ee6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.63",
+    "libvim": "8.10869.64",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reasonFuzz": "*",
@@ -256,7 +256,6 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#18eb60e",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
+    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#18eb60e",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5ee9b3d53ce78899097b5212100c288e",
+  "checksum": "bd4162601e36968e01eced18e4674b88",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.63@d41d8cd9": {
-      "id": "libvim@8.10869.63@d41d8cd9",
+    "libvim@8.10869.64@d41d8cd9": {
+      "id": "libvim@8.10869.64@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.63",
+      "version": "8.10869.64",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.64.tgz#sha1:c6edfd47c5a8924c95c7ba8c787f5fec89b87f42"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.64@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
@@ -2976,14 +2976,14 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -3500,8 +3500,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ctypes@opam:0.15.1@b0227b2f": {
-      "id": "@opam/ctypes@opam:0.15.1@b0227b2f",
+    "@opam/ctypes@opam:0.15.1@9c7ab4ec": {
+      "id": "@opam/ctypes@opam:0.15.1@9c7ab4ec",
       "name": "@opam/ctypes",
       "version": "opam:0.15.1",
       "source": {

--- a/release.esy.lock/opam/ctypes.0.15.1/opam
+++ b/release.esy.lock/opam/ctypes.0.15.1/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.1.tar.gz"
   checksum: "md5=e87b2646f7597e00b8b9a1f5f8e36ee6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/src/Core/VimEx.re
+++ b/src/Core/VimEx.re
@@ -3,7 +3,7 @@ module Zed_utf8 = ZedBundled;
 let repeatKey = (reps, input) => {
   let rec loop = (reps, context) =>
     if (reps > 0) {
-      let context = Vim.key(~context, input);
+      let (context, _effects) = Vim.key(~context, input);
       loop(reps - 1, context);
     } else {
       context;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -632,7 +632,7 @@ let exposePrimaryCursor = editor => {
         scrollY;
       };
 
-    {...editor, scrollX: adjustedScrollX, scrollY: adjustedScrollY};
+    {...editor, scrollX: adjustedScrollX, scrollY: adjustedScrollY, isScrollAnimated: true};
 
   | _ => editor
   };

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -755,11 +755,6 @@ let scrollDeltaPixelX = (~pixelX, editor) => {
   scrollToPixelX(~pixelX, editor);
 };
 
-let scrollToColumn = (~column, view) => {
-  let pixelX = float_of_int(column) *. getCharacterWidth(view);
-  {...scrollToPixelX(~pixelX, view), isScrollAnimated: true};
-};
-
 let scrollDeltaPixelY = (~pixelY, view) => {
   let pixelY = view.scrollY +. pixelY;
   scrollToPixelY(~pixelY, view);
@@ -795,7 +790,7 @@ let scrollAndMoveCursor = (~deltaViewLines, editor) => {
         ~hi=totalViewLines - 1,
         currentViewLine + deltaViewLines,
       );
-    let {line as outLine, byteOffset, _}: Wrapping.bufferPosition =
+    let {line: outLine, byteOffset, _}: Wrapping.bufferPosition =
       Wrapping.viewLineToBufferPosition(~line=newViewLine, wrapping);
     BytePosition.{line: outLine, byte: byteOffset};
   };
@@ -806,14 +801,12 @@ let scrollAndMoveCursor = (~deltaViewLines, editor) => {
     | Operator({cursor, _}) => Vim.Mode.Normal({cursor: cursor})
     // Don't do anything for command line mode
     | CommandLine => CommandLine
-    | Normal({cursor}) =>
-      Normal({cursor: adjustCursor(cursor)});
+    | Normal({cursor}) => Normal({cursor: adjustCursor(cursor)})
     | Visual(curr) =>
-      Visual(Vim.VisualRange.{...curr, cursor: adjustCursor(curr.cursor)});
+      Visual(Vim.VisualRange.{...curr, cursor: adjustCursor(curr.cursor)})
     | Select(curr) =>
-      Select(Vim.VisualRange.{...curr, cursor: adjustCursor(curr.cursor)});
-    | Replace({cursor}) =>
-      Replace({cursor: adjustCursor(cursor)});
+      Select(Vim.VisualRange.{...curr, cursor: adjustCursor(curr.cursor)})
+    | Replace({cursor}) => Replace({cursor: adjustCursor(cursor)})
     | Insert({cursors}) =>
       Insert({cursors: List.map(adjustCursor, cursors)})
     };
@@ -823,10 +816,10 @@ let scrollAndMoveCursor = (~deltaViewLines, editor) => {
 
   let newCursor = getPrimaryCursorByte(editor');
   // Figure out the delta in scrollY
-  let ({y as oldY, _}: PixelPosition.t, _) =
+  let ({y: oldY, _}: PixelPosition.t, _) =
     bufferBytePositionToPixel(~position=oldCursor, editor);
 
-  let ({y as newY, _}: PixelPosition.t, _) =
+  let ({y: newY, _}: PixelPosition.t, _) =
     bufferBytePositionToPixel(~position=newCursor, editor');
 
   // Adjust scroll to compensate cursor position - keeping the cursor in the same

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -149,8 +149,8 @@ type t = {
 let key = ({key, _}) => key;
 let selection = ({mode, _}) =>
   switch (mode) {
-  | Visual({range}) => Some(Oni_Core.VisualRange.ofVim(range))
-  | Select({range}) => Some(Oni_Core.VisualRange.ofVim(range))
+  | Visual(range) => Some(Oni_Core.VisualRange.ofVim(range))
+  | Select(range) => Some(Oni_Core.VisualRange.ofVim(range))
   | _ => None
   };
 let visiblePixelWidth = ({pixelWidth, _}) => pixelWidth;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -144,6 +144,9 @@ type t = {
   yankHighlight: option(yankHighlight),
   wrapMode: WrapMode.t,
   wrapState: WrapState.t,
+  // Number of lines to preserve before or after the cursor, when scrolling.
+  // Like the `scrolloff` vim setting or the `editor.cursorSurroundingLines` VSCode setting.
+  verticalScrollMargin: int,
 };
 
 let key = ({key, _}) => key;
@@ -316,6 +319,7 @@ let create = (~wrapMode=WrapMode.NoWrap, ~config, ~buffer, ()) => {
     yankHighlight: None,
     wrapState,
     wrapMode,
+    verticalScrollMargin: 1,
   };
 };
 
@@ -607,7 +611,8 @@ let exposePrimaryCursor = editor => {
       bufferBytePositionToPixel(~position=primaryCursor, editor);
 
     let scrollOffX = getCharacterWidth(editor) *. 2.;
-    let scrollOffY = lineHeightInPixels(editor);
+    let scrollOffY =
+      lineHeightInPixels(editor) *. float(editor.verticalScrollMargin);
 
     let availableX = pixelWidth -. scrollOffX;
     let availableY = pixelHeight -. scrollOffY;
@@ -622,8 +627,8 @@ let exposePrimaryCursor = editor => {
       };
 
     let adjustedScrollY =
-      if (pixelY < 0.) {
-        scrollY +. pixelY;
+      if (pixelY < scrollOffY) {
+        scrollY -. scrollOffY +. pixelY;
       } else if (pixelY >= availableY) {
         scrollY +. (pixelY -. availableY);
       } else {

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -812,6 +812,24 @@ let scrollCursorBottom = editor => {
   scrollToPixelY(~pixelY, editor) |> animateScroll;
 };
 
+let scrollLines = (~count, editor) => {
+ let delta = float(count) *. lineHeightInPixels(editor);   
+ let pixelY = editor.scrollY +. delta;
+ scrollToPixelY(~pixelY, editor);
+};
+
+let scrollHalfPage = (~count, editor) => {
+ let delta = float(count) *. float(editor.pixelHeight) /. 2.;
+ let pixelY = editor.scrollY +. delta;
+ scrollToPixelY(~pixelY, editor);
+};
+
+let scrollPage = (~count, editor) => {
+ let delta = float(count) *. float(editor.pixelHeight);
+ let pixelY = editor.scrollY +. delta;
+ scrollToPixelY(~pixelY, editor);
+};
+
 // PROJECTION
 
 let project = (~line, ~column: int, ~pixelWidth: int, ~pixelHeight, editor) => {

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -100,8 +100,6 @@ let setLineHeight: (~lineHeight: LineHeight.t, t) => t;
 let characterWidthInPixels: t => float;
 
 let selection: t => option(VisualRange.t);
-let setSelection: (~selection: VisualRange.t, t) => t;
-let clearSelection: t => t;
 
 let selectionOrCursorRange: t => ByteRange.t;
 
@@ -118,6 +116,10 @@ let scrollDeltaPixelY: (~pixelY: float, t) => t;
 
 let scrollToPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
 let scrollDeltaPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
+
+let scrollCenterCursorVertically: t => t;
+let scrollCursorTop: t => t;
+let scrollCursorBottom: t => t;
 
 let getCharacterWidth: t => float;
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -106,7 +106,6 @@ let selectionOrCursorRange: t => ByteRange.t;
 let totalViewLines: t => int;
 
 let isScrollAnimated: t => bool;
-//let scrollToColumn: (~column: int, t) => t;
 let scrollToPixelX: (~pixelX: float, t) => t;
 let scrollDeltaPixelX: (~pixelX: float, t) => t;
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -120,6 +120,9 @@ let scrollDeltaPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
 let scrollCenterCursorVertically: t => t;
 let scrollCursorTop: t => t;
 let scrollCursorBottom: t => t;
+let scrollLines: (~count: int, t) => t;
+let scrollHalfPage: (~count: int, t) => t;
+let scrollPage: (~count: int, t) => t;
 
 let getCharacterWidth: t => float;
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -108,7 +108,7 @@ let selectionOrCursorRange: t => ByteRange.t;
 let totalViewLines: t => int;
 
 let isScrollAnimated: t => bool;
-let scrollToColumn: (~column: int, t) => t;
+//let scrollToColumn: (~column: int, t) => t;
 let scrollToPixelX: (~pixelX: float, t) => t;
 let scrollDeltaPixelX: (~pixelX: float, t) => t;
 

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -127,11 +127,6 @@ let update = (editor, msg) => {
     )
   | SelectionCleared => (Editor.clearSelection(editor), Nothing)
   | ModeChanged(mode) => (Editor.setMode(mode, editor), Nothing)
-  | ScrollToLine(line) => (Editor.scrollToLine(~line, editor), Nothing)
-  | ScrollToColumn(column) => (
-      Editor.scrollToColumn(~column, editor),
-      Nothing,
-    )
   | MinimapEnabledConfigChanged(enabled) => (
       Editor.setMinimapEnabled(~enabled, editor),
       Nothing,

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -122,12 +122,6 @@ let update = (editor, msg) => {
       },
     )
   | ModeChanged({mode, effects}) =>
-    //    | Scroll({count, direction}) => switch(direction) {
-
-    //    }
-
-    //    );
-
     let handleScrollEffect = (~count, ~direction, editor) => {
       let count = max(count, 1);
       Vim.Scroll.(

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -155,9 +155,6 @@ let update = (editor, msg) => {
            editor',
          );
     (editor'', Nothing);
-  //    | _ => Fun.identity
-  //
-  //    let effectHandler = (editor) => Vim.Effect.(fun
   | MinimapEnabledConfigChanged(enabled) => (
       Editor.setMinimapEnabled(~enabled, editor),
       Nothing,

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -121,12 +121,42 @@ let update = (editor, msg) => {
         |> Option.value(~default=Nothing);
       },
     )
-  | SelectionChanged(selection) => (
-      Editor.setSelection(~selection, editor),
-      Nothing,
-    )
-  | SelectionCleared => (Editor.clearSelection(editor), Nothing)
-  | ModeChanged(mode) => (Editor.setMode(mode, editor), Nothing)
+  | ModeChanged({mode, effects}) =>
+    //    | Scroll({count, direction}) => switch(direction) {
+
+    //    }
+
+    //    );
+
+    let handleScrollEffect = (~count, ~direction, editor) => {
+      Vim.Scroll.(
+        switch (direction) {
+        | CursorCenterVertically =>
+          Editor.scrollCenterCursorVertically(editor)
+        | CursorTop => Editor.scrollCursorTop(editor)
+        | CursorBottom => Editor.scrollCursorBottom(editor)
+        | _ => editor
+        }
+      );
+    };
+
+    let editor' = Editor.setMode(mode, editor);
+    let editor'' =
+      effects
+      |> List.fold_left(
+           (acc, effect) => {
+             switch (effect) {
+             | Vim.Effect.Scroll({count, direction}) =>
+               handleScrollEffect(~count, ~direction, acc)
+             | _ => acc
+             }
+           },
+           editor',
+         );
+    (editor'', Nothing);
+    //    | _ => Fun.identity
+    //
+    //    let effectHandler = (editor) => Vim.Effect.(fun
   | MinimapEnabledConfigChanged(enabled) => (
       Editor.setMinimapEnabled(~enabled, editor),
       Nothing,
@@ -135,10 +165,6 @@ let update = (editor, msg) => {
       Editor.setLineHeight(~lineHeight, editor),
       Nothing,
     )
-//  | Scroll({ count: int, direction: Vim.Scroll.direction}) => (
-  | Scroll(_) => (
-    editor |> Editor.scrollToLine(~line=1), Nothing
-  )
   };
 };
 

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -136,12 +136,12 @@ let update = (editor, msg) => {
           Editor.scrollCenterCursorVertically(editor)
         | CursorTop => Editor.scrollCursorTop(editor)
         | CursorBottom => Editor.scrollCursorBottom(editor)
-        | LineUp => Editor.scrollLines(~count=count * -1, editor)
+        | LineUp => Editor.scrollLines(~count=count * (-1), editor)
         | LineDown => Editor.scrollLines(~count, editor)
-        | HalfPageUp => Editor.scrollHalfPage(~count=count * -1, editor)
-        | HalfPageDown => Editor.scrollHalfPage(~count=count, editor)
-        | PageUp => Editor.scrollPage(~count=count * -1, editor)
-        | PageDown => Editor.scrollPage(~count=count, editor)
+        | HalfPageUp => Editor.scrollHalfPage(~count=count * (-1), editor)
+        | HalfPageDown => Editor.scrollHalfPage(~count, editor)
+        | PageUp => Editor.scrollPage(~count=count * (-1), editor)
+        | PageDown => Editor.scrollPage(~count, editor)
         | _ => editor
         }
       );
@@ -161,9 +161,9 @@ let update = (editor, msg) => {
            editor',
          );
     (editor'', Nothing);
-    //    | _ => Fun.identity
-    //
-    //    let effectHandler = (editor) => Vim.Effect.(fun
+  //    | _ => Fun.identity
+  //
+  //    let effectHandler = (editor) => Vim.Effect.(fun
   | MinimapEnabledConfigChanged(enabled) => (
       Editor.setMinimapEnabled(~enabled, editor),
       Nothing,

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -129,7 +129,7 @@ let update = (editor, msg) => {
     //    );
 
     let handleScrollEffect = (~count, ~direction, editor) => {
-      let count = min(count, 1);
+      let count = max(count, 1);
       Vim.Scroll.(
         switch (direction) {
         | CursorCenterVertically =>

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -129,12 +129,19 @@ let update = (editor, msg) => {
     //    );
 
     let handleScrollEffect = (~count, ~direction, editor) => {
+      let count = min(count, 1);
       Vim.Scroll.(
         switch (direction) {
         | CursorCenterVertically =>
           Editor.scrollCenterCursorVertically(editor)
         | CursorTop => Editor.scrollCursorTop(editor)
         | CursorBottom => Editor.scrollCursorBottom(editor)
+        | LineUp => Editor.scrollLines(~count=count * -1, editor)
+        | LineDown => Editor.scrollLines(~count, editor)
+        | HalfPageUp => Editor.scrollHalfPage(~count=count * -1, editor)
+        | HalfPageDown => Editor.scrollHalfPage(~count=count, editor)
+        | PageUp => Editor.scrollPage(~count=count * -1, editor)
+        | PageDown => Editor.scrollPage(~count=count, editor)
         | _ => editor
         }
       );

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -135,6 +135,10 @@ let update = (editor, msg) => {
       Editor.setLineHeight(~lineHeight, editor),
       Nothing,
     )
+//  | Scroll({ count: int, direction: Vim.Scroll.direction}) => (
+  | Scroll(_) => (
+    editor |> Editor.scrollToLine(~line=1), Nothing
+  )
   };
 };
 

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -25,9 +25,9 @@ type t =
     })
   | MouseHovered({bytePosition: BytePosition.t})
   | MouseMoved({bytePosition: BytePosition.t})
-  | Scroll({count: int, direction: Vim.Scroll.direction})
-  | SelectionChanged([@opaque] VisualRange.t)
-  | SelectionCleared
-  | ModeChanged([@opaque] Vim.Mode.t)
+  | ModeChanged({
+      mode: [@opaque] Vim.Mode.t,
+      effects: [@opaque] list(Vim.Effect.t),
+    })
   | MinimapEnabledConfigChanged(bool)
   | LineHeightConfigChanged(LineHeight.t);

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -25,6 +25,7 @@ type t =
     })
   | MouseHovered({bytePosition: BytePosition.t})
   | MouseMoved({bytePosition: BytePosition.t})
+  | Scroll({count: int, direction: Vim.Scroll.direction})
   | SelectionChanged([@opaque] VisualRange.t)
   | SelectionCleared
   | ModeChanged([@opaque] Vim.Mode.t)

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -28,7 +28,5 @@ type t =
   | SelectionChanged([@opaque] VisualRange.t)
   | SelectionCleared
   | ModeChanged([@opaque] Vim.Mode.t)
-  | ScrollToLine(int)
-  | ScrollToColumn(int)
   | MinimapEnabledConfigChanged(bool)
   | LineHeightConfigChanged(LineHeight.t);

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -1,5 +1,4 @@
 open EditorCoreTypes;
-open Oni_Core;
 
 [@deriving show({with_path: false})]
 type t =

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -4,27 +4,27 @@ module Log = (val Log.withNamespace("Service_Vim"));
 
 let forceReload = () =>
   Isolinear.Effect.create(~name="vim.discardChanges", () =>
-    ignore(Vim.command("e!"): Vim.Context.t)
+    ignore(Vim.command("e!"): (Vim.Context.t, list(Vim.Effect.t)))
   );
 
 let forceOverwrite = () =>
   Isolinear.Effect.create(~name="vim.forceOverwrite", () =>
-    ignore(Vim.command("w!"): Vim.Context.t)
+    ignore(Vim.command("w!"): (Vim.Context.t, list(Vim.Effect.t)))
   );
 
 let reload = () =>
   Isolinear.Effect.create(~name="vim.reload", () => {
-    ignore(Vim.command("e"): Vim.Context.t)
+    ignore(Vim.command("e"): (Vim.Context.t, list(Vim.Effect.t)))
   });
 
 let saveAllAndQuit = () =>
   Isolinear.Effect.create(~name="lifecycle.saveAllAndQuit", () =>
-    ignore(Vim.command("xa"): Vim.Context.t)
+    ignore(Vim.command("xa"): (Vim.Context.t, list(Vim.Effect.t)))
   );
 
 let quitAll = () =>
   Isolinear.Effect.create(~name="lifecycle.saveAllAndQuit", () =>
-    ignore(Vim.command("qa!"): Vim.Context.t)
+    ignore(Vim.command("qa!"): (Vim.Context.t, list(Vim.Effect.t)))
   );
 
 module Effects = {
@@ -39,7 +39,8 @@ module Effects = {
         };
 
         Log.infof(m => m("Pasting: %s", text));
-        let latestContext: Vim.Context.t = Oni_Core.VimEx.inputString(text);
+        let (latestContext: Vim.Context.t, _effects) =
+          Oni_Core.VimEx.inputString(text);
 
         if (!isCmdLineMode) {
           Vim.command("set nopaste") |> ignore;
@@ -95,7 +96,8 @@ module Effects = {
         ByteIndex.toInt(cursor.byte) - CharacterIndex.toInt(meetColumn);
 
       let _: Vim.Context.t = VimEx.repeatKey(delta, "<BS>");
-      let {mode, _}: Vim.Context.t = VimEx.inputString(insertText);
+      let ({mode, _}: Vim.Context.t, _effects) =
+        VimEx.inputString(insertText);
 
       dispatch(toMsg(mode));
     });

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -366,7 +366,7 @@ let update =
             ~meetColumn, ~insertText, ~toMsg=mode =>
             Actions.Editor({
               scope: EditorScope.Editor(editorId),
-              msg: ModeChanged(mode),
+              msg: ModeChanged({mode, effects: []}),
             })
           ),
         )
@@ -391,7 +391,7 @@ let update =
             ~meetColumn, ~insertText, ~toMsg=mode =>
             Actions.Editor({
               scope: EditorScope.Editor(editorId),
-              msg: ModeChanged(mode),
+              msg: ModeChanged({mode, effects: []}),
             })
           ),
         );

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -485,7 +485,7 @@ let start = maybeKeyBindingsFilePath => {
 
   let executeExCommandEffect = command =>
     Isolinear.Effect.create(~name="keybindings.executeExCommand", () =>
-      ignore(Vim.command(command): Vim.Context.t)
+      ignore(Vim.command(command): (Vim.Context.t, list(Vim.Effect.t)))
     );
 
   let updater = (state: State.t, action: Actions.t) => {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -203,7 +203,19 @@ let start =
         )
 
       | MacroRecordingStopped(_) =>
-        dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped)),
+        dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped))
+
+      | Scroll({count, direction}) => {
+          let editorId =
+            Feature_Layout.activeEditor(getState().layout) |> Editor.getId;
+
+            dispatch(
+              Editor({
+                scope: Oni_Model.EditorScope.Editor(editorId),
+                msg: Scroll({ count: count, direction })
+              }),
+            )
+       },
     );
 
   let _: unit => unit =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -629,26 +629,6 @@ let start =
           dispatch(Actions.OpenBufferById({bufferId: bufferId}));
         };
 
-        // TODO: This has a sensitive timing dependency - the scroll actions need to happen first,
-        // and then the cursor changed. This is because the cursor changed may impact the scroll
-        // (ensuring the cursor is visible).
-        //
-        // Ultimately - we want to get rid of those topline/columnline sync, and have Onivim wholly
-        // own the 'scroll' experience.
-        // ie: https://github.com/onivim/oni2/pull/2067/commits/a1eb60dd3b9679d0aabda83616c4400ebe1eb3d3
-        dispatch(
-          Actions.Editor({
-            scope: EditorScope.Editor(editorId),
-            msg: ScrollToLine(newTopLine - 1),
-          }),
-        );
-        dispatch(
-          Actions.Editor({
-            scope: EditorScope.Editor(editorId),
-            msg: ScrollToColumn(newLeftColumn),
-          }),
-        );
-
         dispatch(
           Actions.Editor({
             scope: EditorScope.Editor(editorId),
@@ -796,9 +776,6 @@ let start =
       // Update the editor, which is the source of truth for cursor position
       let scope = EditorScope.Editor(editorId);
       dispatch(Actions.Editor({scope, msg: ModeChanged(mode)}));
-      // TODO: Remove this
-      dispatch(Actions.Editor({scope, msg: ScrollToLine(newTopLine - 1)}));
-      dispatch(Actions.Editor({scope, msg: ScrollToColumn(newLeftColumn)}));
     });
   };
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -144,6 +144,10 @@ let start =
   let _: unit => unit =
     Vim.onEffect(
       fun
+      // This is handled by the returned `effects` list -
+      // ideally, all the commands here could be factored to be handled in the same way
+      | Scroll(_) => ()
+
       | Goto(gotoType) => handleGoto(gotoType)
       | TabPage(msg) => dispatch(TabPage(msg))
       | Format(Buffer(_)) =>
@@ -182,19 +186,7 @@ let start =
         )
 
       | MacroRecordingStopped(_) =>
-        dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped))
-
-      | Scroll({count, direction}) => (),
-      //          let editorId =
-      //            Feature_Layout.activeEditor(getState().layout) |> Editor.getId;
-      //
-      //            dispatch(
-      //              Editor({
-      //                scope: Oni_Model.EditorScope.Editor(editorId),
-      //                msg: Scroll({ count: count, direction })
-      //              }),
-      //            )
-      //       },
+        dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped)),
     );
 
   let _: unit => unit =
@@ -605,10 +597,7 @@ let start =
         let previousBufferId = context.bufferId;
 
         currentTriggerKey := Some(key);
-        let (
-          {mode, topLine: newTopLine, leftColumn: newLeftColumn, bufferId, _}: Vim.Context.t,
-          effects,
-        ) =
+        let ({mode, bufferId, _}: Vim.Context.t, effects) =
           isText ? Vim.input(~context, key) : Vim.key(~context, key);
         currentTriggerKey := None;
 
@@ -759,11 +748,7 @@ let start =
       let _: (Vim.Context.t, list(Vim.Effect.t)) = Vim.input("g");
       let _: (Vim.Context.t, list(Vim.Effect.t)) = Vim.input("g");
       let _: (Vim.Context.t, list(Vim.Effect.t)) = Vim.input("G");
-      let (
-        {mode, topLine: newTopLine, leftColumn: newLeftColumn, _}: Vim.Context.t,
-        effects,
-      ) =
-        Vim.input("$");
+      let ({mode, _}: Vim.Context.t, effects) = Vim.input("$");
 
       // Update the editor, which is the source of truth for cursor position
       let scope = EditorScope.Editor(editorId);

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -44,7 +44,8 @@ module Parts = {
         );
       let onEditorSizeChanged = (editorId, pixelWidth, pixelHeight) =>
         dispatch(EditorSizeChanged({id: editorId, pixelWidth, pixelHeight}));
-      let changeMode = mode => editorDispatch(ModeChanged(mode));
+      let changeMode = mode =>
+        editorDispatch(ModeChanged({mode, effects: []}));
 
       <EditorSurface
         key={editor |> Feature_Editor.Editor.key}

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -9,4 +9,5 @@ type t =
   | MacroRecordingStopped({
       register: char,
       value: option(string),
-    });
+    })
+  | Scroll({ count: int, direction: Scroll.direction})

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -10,4 +10,7 @@ type t =
       register: char,
       value: option(string),
     })
-  | Scroll({ count: int, direction: Scroll.direction})
+  | Scroll({
+      count: int,
+      direction: Scroll.direction,
+    });

--- a/src/reason-libvim/GlobalState.re
+++ b/src/reason-libvim/GlobalState.re
@@ -1,5 +1,7 @@
 open EditorCoreTypes;
 
+let effects: ref(list(Effect.t)) = ref([]);
+
 let autoIndent:
   ref(
     option(

--- a/src/reason-libvim/Scroll.re
+++ b/src/reason-libvim/Scroll.re
@@ -1,0 +1,14 @@
+[@deriving show]
+type direction =
+| CursorCenterVertically // zz
+| CursorCenterHorizontally 
+| CursorTop // zt
+| CursorBottom // zb
+| CursorLeft
+| CursorRight
+| LineUp
+| LineDown
+| HalfPageUp
+| HalfPageDown
+| PageDown
+| PageUp;

--- a/src/reason-libvim/Scroll.re
+++ b/src/reason-libvim/Scroll.re
@@ -1,14 +1,14 @@
 [@deriving show]
 type direction =
-| CursorCenterVertically // zz
-| CursorCenterHorizontally 
-| CursorTop // zt
-| CursorBottom // zb
-| CursorLeft
-| CursorRight
-| LineUp
-| LineDown
-| HalfPageUp
-| HalfPageDown
-| PageDown
-| PageUp;
+  | CursorCenterVertically // zz
+  | CursorCenterHorizontally
+  | CursorTop // zt
+  | CursorBottom // zb
+  | CursorLeft
+  | CursorRight
+  | LineUp
+  | LineDown
+  | HalfPageUp
+  | HalfPageDown
+  | PageDown
+  | PageUp;

--- a/src/reason-libvim/Scroll.re
+++ b/src/reason-libvim/Scroll.re
@@ -11,4 +11,8 @@ type direction =
   | HalfPageDown
   | HalfPageUp
   | PageDown
-  | PageUp;
+  | PageUp
+  | HalfPageLeft
+  | HalfPageRight
+  | ColumnLeft
+  | ColumnRight;

--- a/src/reason-libvim/Scroll.re
+++ b/src/reason-libvim/Scroll.re
@@ -8,7 +8,7 @@ type direction =
   | CursorRight
   | LineUp
   | LineDown
-  | HalfPageUp
   | HalfPageDown
+  | HalfPageUp
   | PageDown
   | PageUp;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -19,6 +19,7 @@ module Event = Event;
 module Format = Format;
 module Goto = Goto;
 module Operator = Operator;
+module Scroll = Scroll;
 module TabPage = TabPage;
 module Mode = Mode;
 module Options = Options;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -452,13 +452,6 @@ let _onSettingChanged = (setting: Setting.t) => {
 };
 
 let _onScroll = (direction: Scroll.direction, count: int) => {
-  prerr_endline(
-    Printf.sprintf(
-      "SCROLL: %s count: %d",
-      direction |> Scroll.show_direction,
-      count,
-    ),
-  );
   queueEffect(Effect.Scroll({direction, count}));
 };
 

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -381,8 +381,8 @@ module Scroll: {
     | CursorRight
     | LineUp
     | LineDown
-    | HalfPageUp
     | HalfPageDown
+    | HalfPageUp
     | PageDown
     | PageUp;
 };

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -370,6 +370,23 @@ module Setting: {
   };
 };
 
+module Scroll: {
+    [@deriving show]
+    type direction =
+    | CursorCenterVertically // zz
+    | CursorCenterHorizontally 
+    | CursorTop // zt
+    | CursorBottom // zb
+    | CursorLeft
+    | CursorRight
+    | LineUp
+    | LineDown
+    | HalfPageUp
+    | HalfPageDown
+    | PageDown
+    | PageUp;
+};
+
 module Effect: {
   type t =
     | Goto(Goto.effect)
@@ -382,7 +399,8 @@ module Effect: {
     | MacroRecordingStopped({
         register: char,
         value: option(string),
-      });
+      })
+    | Scroll({ count: int, direction: Scroll.direction })
 };
 
 /**

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -385,10 +385,10 @@ module Scroll: {
     | HalfPageUp
     | PageDown
     | PageUp
-      | HalfPageLeft
-      | HalfPageRight
-      | ColumnLeft
-      | ColumnRight;
+    | HalfPageLeft
+    | HalfPageRight
+    | ColumnLeft
+    | ColumnRight;
 };
 
 module Effect: {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -384,7 +384,11 @@ module Scroll: {
     | HalfPageDown
     | HalfPageUp
     | PageDown
-    | PageUp;
+    | PageUp
+      | HalfPageLeft
+      | HalfPageRight
+      | ColumnLeft
+      | ColumnRight;
 };
 
 module Effect: {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -371,10 +371,10 @@ module Setting: {
 };
 
 module Scroll: {
-    [@deriving show]
-    type direction =
+  [@deriving show]
+  type direction =
     | CursorCenterVertically // zz
-    | CursorCenterHorizontally 
+    | CursorCenterHorizontally
     | CursorTop // zt
     | CursorBottom // zb
     | CursorLeft
@@ -400,7 +400,10 @@ module Effect: {
         register: char,
         value: option(string),
       })
-    | Scroll({ count: int, direction: Scroll.direction })
+    | Scroll({
+        count: int,
+        direction: Scroll.direction,
+      });
 };
 
 /**
@@ -420,7 +423,7 @@ The value [s] must be a string of UTF-8 characters.
 
 The keystroke is processed synchronously.
 */
-let input: (~context: Context.t=?, string) => Context.t;
+let input: (~context: Context.t=?, string) => (Context.t, list(Effect.t));
 
 /**
 [key(s)] sends a single keystroke.
@@ -431,7 +434,7 @@ The value [s] must be a valid Vim key, such as:
 */
 
 // TODO: Strongly type these keys...
-let key: (~context: Context.t=?, string) => Context.t;
+let key: (~context: Context.t=?, string) => (Context.t, list(Effect.t));
 
 let eval: string => result(string, string);
 
@@ -444,7 +447,7 @@ You may use any valid Ex command, although you must omit the leading semicolon.
 
 The command [cmd] is processed synchronously.
 */
-let command: (~context: Context.t=?, string) => Context.t;
+let command: (~context: Context.t=?, string) => (Context.t, list(Effect.t));
 
 /**
 [onDirectoryChanged(f)] registers a directory changed listener [f].

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -637,7 +637,6 @@ colnr_T srcColumn, colnr_T wantColumn, linenr_T *destLine, colnr_T *destColumn) 
 void onScrollCallback(scrollDirection_T dir, long count) {
    CAMLparam0();
 
-   printf("-- ONSCROLLCALLBACK: %d\n", dir);
    int outScroll = 0;
    switch (dir) {
     case SCROLL_CURSORCENTERH:

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -637,6 +637,7 @@ colnr_T srcColumn, colnr_T wantColumn, linenr_T *destLine, colnr_T *destColumn) 
 void onScrollCallback(scrollDirection_T dir, long count) {
    CAMLparam0();
 
+   printf("-- ONSCROLLCALLBACK: %d\n", dir);
    int outScroll = 0;
    switch (dir) {
     case SCROLL_CURSORCENTERH:

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -634,6 +634,59 @@ colnr_T srcColumn, colnr_T wantColumn, linenr_T *destLine, colnr_T *destColumn) 
    CAMLreturn0;
 }
 
+void onScrollCallback(scrollDirection_T dir, long count) {
+   CAMLparam0();
+
+   int outScroll = 0;
+   switch (dir) {
+    case SCROLL_CURSORCENTERH:
+        outScroll = 1;
+        break;
+    case SCROLL_CURSORTOP:
+        outScroll = 2;
+        break;
+    case SCROLL_CURSORBOTTOM:
+        outScroll = 3;
+        break;
+    case SCROLL_CURSORLEFT:
+        outScroll = 4;
+        break;
+    case SCROLL_CURSORRIGHT:
+        outScroll = 5;
+        break;
+    case SCROLL_LINE_UP:
+        outScroll = 6;
+        break;
+    case SCROLL_LINE_DOWN:
+        outScroll = 7;
+        break;
+    case SCROLL_HALFPAGE_DOWN:
+        outScroll = 8;
+        break;
+    case SCROLL_HALFPAGE_UP:
+        outScroll = 9;
+        break;
+    case SCROLL_PAGE_DOWN:
+        outScroll = 10;
+        break;
+    case SCROLL_PAGE_UP:
+        outScroll = 11;
+        break;
+    case SCROLL_CURSORCENTERV:
+    default:
+        outScroll = 0;
+        break;
+   }
+
+   static const value *lv_onScroll = NULL;
+   if (lv_onScroll == NULL) {
+     lv_onScroll = caml_named_value("lv_onScroll");
+   }
+
+   caml_callback2(*lv_onScroll, Val_int(outScroll), Val_int(count));
+   CAMLreturn0;
+}
+
 CAMLprim value libvim_vimInit(value unit) {
   vimMacroSetStartRecordCallback(&onMacroStartRecord);
   vimMacroSetStopRecordCallback(&onMacroStopRecord);
@@ -661,6 +714,7 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetFileWriteFailureCallback(&onWriteFailure);
   vimSetCursorMoveScreenLineCallback(&onCursorMoveScreenLine);
   vimSetCursorMoveScreenPositionCallback(&onCursorMoveScreenPosition);
+  vimSetScrollCallback(&onScrollCallback);
 
   char *args[0];
   vimInit(0, args);

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -639,19 +639,19 @@ void onScrollCallback(scrollDirection_T dir, long count) {
 
    int outScroll = 0;
    switch (dir) {
-    case SCROLL_CURSORCENTERH:
+    case SCROLL_CURSOR_CENTERH:
         outScroll = 1;
         break;
-    case SCROLL_CURSORTOP:
+    case SCROLL_CURSOR_TOP:
         outScroll = 2;
         break;
-    case SCROLL_CURSORBOTTOM:
+    case SCROLL_CURSOR_BOTTOM:
         outScroll = 3;
         break;
-    case SCROLL_CURSORLEFT:
+    case SCROLL_CURSOR_LEFT:
         outScroll = 4;
         break;
-    case SCROLL_CURSORRIGHT:
+    case SCROLL_CURSOR_RIGHT:
         outScroll = 5;
         break;
     case SCROLL_LINE_UP:
@@ -672,7 +672,19 @@ void onScrollCallback(scrollDirection_T dir, long count) {
     case SCROLL_PAGE_UP:
         outScroll = 11;
         break;
-    case SCROLL_CURSORCENTERV:
+    case SCROLL_HALFPAGE_LEFT:
+        outScroll = 12;
+        break;
+    case SCROLL_HALFPAGE_RIGHT:
+        outScroll = 13;
+        break;
+    case SCROLL_COLUMN_LEFT:
+        outScroll = 14;
+        break;
+    case SCROLL_COLUMN_RIGHT:
+        outScroll = 15;
+        break;
+    case SCROLL_CURSOR_CENTERV:
     default:
         outScroll = 0;
         break;

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6f407660966c45a2a28ae85dfe62d0ce",
+  "checksum": "bfb955ea3aa5af4ebfbd5c99ccf6e92b",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -154,7 +154,7 @@
         "@opam/lru@github:bryphe/lru:lru.opam#2708c70@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/charInfo_width@opam:1.1.0@4296bdfe",
         "@opam/bos@opam:0.2.0@df49e63f", "@glennsl/timber@1.2.0@d41d8cd9",
         "@esy-ocaml/reason@3.6.2@d41d8cd9",
@@ -425,14 +425,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.63@d41d8cd9": {
-      "id": "libvim@8.10869.63@d41d8cd9",
+    "libvim@8.10869.64@d41d8cd9": {
+      "id": "libvim@8.10869.64@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.63",
+      "version": "8.10869.64",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.63.tgz#sha1:f9d83dbb54a82ea2368f388480f99923286cc1ee"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.64.tgz#sha1:c6edfd47c5a8924c95c7ba8c787f5fec89b87f42"
         ]
       },
       "overrides": [],
@@ -941,7 +941,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reasonFuzz@github:CrossR/reasonFuzz#1ad6f5d@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.63@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.64@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
@@ -2977,14 +2977,14 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/dune@opam:2.5.0@e0bac278",
-        "@opam/ctypes@opam:0.15.1@b0227b2f",
+        "@opam/ctypes@opam:0.15.1@9c7ab4ec",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -3501,8 +3501,8 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.0@e0bac278"
       ]
     },
-    "@opam/ctypes@opam:0.15.1@b0227b2f": {
-      "id": "@opam/ctypes@opam:0.15.1@b0227b2f",
+    "@opam/ctypes@opam:0.15.1@9c7ab4ec": {
+      "id": "@opam/ctypes@opam:0.15.1@9c7ab4ec",
       "name": "@opam/ctypes",
       "version": "opam:0.15.1",
       "source": {

--- a/test.esy.lock/opam/ctypes.0.15.1/opam
+++ b/test.esy.lock/opam/ctypes.0.15.1/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.1.tar.gz"
   checksum: "md5=e87b2646f7597e00b8b9a1f5f8e36ee6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/test/reason-libvim/AutoClosingPairsTest.re
+++ b/test/reason-libvim/AutoClosingPairsTest.re
@@ -5,13 +5,23 @@ open TestFramework;
 let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
 let input = (~autoClosingPairs=AutoClosingPairs.empty, s) => {
   ignore(
-    Vim.input(~context={...Context.current(), autoClosingPairs}, s): Context.t,
+    Vim.input(~context={...Context.current(), autoClosingPairs}, s): (
+                                                                    Context.t,
+                                                                    list(
+                                                                    Effect.t,
+                                                                    ),
+                                                                    ),
   );
 };
 
 let key = (~autoClosingPairs=AutoClosingPairs.empty, s) => {
   ignore(
-    Vim.key(~context={...Context.current(), autoClosingPairs}, s): Context.t,
+    Vim.key(~context={...Context.current(), autoClosingPairs}, s): (
+                                                                    Context.t,
+                                                                    list(
+                                                                    Effect.t,
+                                                                    ),
+                                                                   ),
   );
 };
 

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -13,7 +13,7 @@ let input = (~insertSpaces=false, ~tabSize=3, ~autoIndent, s) => {
     Vim.input(
       ~context={...Context.current(), insertSpaces, tabSize, autoIndent},
       s,
-    ): Context.t,
+    ): (Context.t, list(Effect.t)),
   );
 };
 
@@ -22,7 +22,7 @@ let key = (~insertSpaces=false, ~tabSize=3, ~autoIndent, s) => {
     Vim.key(
       ~context={...Context.current(), insertSpaces, tabSize, autoIndent},
       s,
-    ): Context.t,
+    ): (Context.t, list(Effect.t)),
   );
 };
 

--- a/test/reason-libvim/BufferTest.re
+++ b/test/reason-libvim/BufferTest.re
@@ -371,7 +371,7 @@ describe("Buffer", ({describe, _}) => {
       let dispose =
         Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
 
-      let _: Context.t = command("e! some-new-file.txt");
+      ignore(command("e! some-new-file.txt"): (Context.t, list(Effect.t)));
 
       /* A filename changed event should not have been triggered */
       expect.int(List.length(updates^)).toBe(0);
@@ -395,7 +395,9 @@ describe("Buffer", ({describe, _}) => {
 
       let previousFilename =
         Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
-      let _: Context.t = command("sav! some-new-file-2.txt");
+      ignore(
+        command("sav! some-new-file-2.txt"): (Context.t, list(Effect.t)),
+      );
       let newFilename =
         Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
 
@@ -416,7 +418,7 @@ describe("Buffer", ({describe, _}) => {
           updates := [meta.fileType, ...updates^]
         );
 
-      let _: Context.t = command("set filetype=derp");
+      ignore(command("set filetype=derp"): (Context.t, list(Effect.t)));
 
       /* A filename changed event should not have been triggered */
       expect.int(List.length(updates^)).toBe(1);
@@ -433,7 +435,12 @@ describe("Buffer", ({describe, _}) => {
       let writes = ref([]);
       let dispose = Buffer.onWrite(id => writes := [id, ...writes^]);
 
-      let _context: Context.t = command("w! some-new-file-again-write.txt");
+      ignore(
+        command("w! some-new-file-again-write.txt"): (
+                                                      Context.t,
+                                                      list(Effect.t),
+                                                    ),
+      );
 
       expect.int(List.length(writes^)).toBe(1);
 

--- a/test/reason-libvim/ColorSchemeTest.re
+++ b/test/reason-libvim/ColorSchemeTest.re
@@ -22,7 +22,7 @@ describe("ColorScheme", ({describe, _}) => {
           }),
         );
 
-      let _: Context.t = command("colorscheme");
+      ignore(command("colorscheme"): (Context.t, list(Effect.t)));
 
       expect.equal(colorSchemeSets^, [None]);
 
@@ -40,7 +40,7 @@ describe("ColorScheme", ({describe, _}) => {
           }),
         );
 
-      let _: Context.t = command("colorscheme abyss");
+      ignore(command("colorscheme abyss"): (Context.t, list(Effect.t)));
 
       expect.equal(colorSchemeSets^, [Some("abyss")]);
 
@@ -57,7 +57,12 @@ describe("ColorScheme", ({describe, _}) => {
           }),
         );
 
-      let _: Context.t = command("colorscheme Dark (with parentheses)");
+      ignore(
+        command("colorscheme Dark (with parentheses)"): (
+                                                         Context.t,
+                                                         list(Effect.t),
+                                                       ),
+      );
 
       expect.equal(colorSchemeSets^, [Some("Dark (with parentheses)")]);
 

--- a/test/reason-libvim/CursorTest.re
+++ b/test/reason-libvim/CursorTest.re
@@ -34,46 +34,7 @@ describe("Cursor", ({describe, _}) => {
       expect.int(Cursor.get() |> BytePosition.byte |> ByteIndex.toInt).toBe(
         4,
       );
-    });
-
-    test(
-      "topline should be updated when moving outside the viewport",
-      ({expect, _}) => {
-      let _ = resetBuffer();
-
-      Window.setWidth(80);
-      Window.setHeight(40);
-      Window.setTopLeft(1, 1);
-
-      Cursor.set(
-        BytePosition.{line: LineNumber.zero, byte: ByteIndex.(zero + 1)},
-      );
-      Cursor.set(
-        BytePosition.{
-          line: LineNumber.ofOneBased(90),
-          byte: ByteIndex.(zero + 1),
-        },
-      );
-
-      expect.int(Window.getTopLine()).toBe(61);
-    });
-
-    test(
-      "topline should not be updated when moving inside the viewport",
-      ({expect, _}) => {
-      Window.setWidth(80);
-      Window.setHeight(40);
-
-      let _ = resetBuffer();
-
-      Window.setTopLeft(71, 4);
-      Cursor.set({
-        line: LineNumber.ofOneBased(90),
-        byte: ByteIndex.(zero + 1),
-      });
-
-      expect.int(Window.getTopLine()).toBe(71);
-    });
+    })
   });
   describe("normal mode", ({test, _}) => {
     test("j / k", ({expect, _}) => {

--- a/test/reason-libvim/DirectoryChangedTest.re
+++ b/test/reason-libvim/DirectoryChangedTest.re
@@ -12,10 +12,10 @@ describe("DirectoryChanged", ({test, _}) => {
     let updates: ref(list(string)) = ref([]);
     let dispose = onDirectoryChanged(upd => updates := [upd, ...updates^]);
 
-    let _context: Context.t = command("cd test");
+    ignore(command("cd test"): (Context.t, list(Effect.t)));
     expect.int(List.length(updates^)).toBe(1);
 
-    let _context: Context.t = command("cd ..");
+    ignore(command("cd .."): (Context.t, list(Effect.t)));
     expect.int(List.length(updates^)).toBe(2);
 
     dispose();

--- a/test/reason-libvim/FormatTest.re
+++ b/test/reason-libvim/FormatTest.re
@@ -4,7 +4,7 @@ open Vim;
 
 let resetBuffer = () =>
   Helpers.resetBuffer("test/reason-libvim/testfile.txt");
-let input = s => ignore(Vim.input(s): Context.t);
+let input = s => ignore(Vim.input(s): (Context.t, list(Effect.t)));
 
 describe("Format", ({test, _}) => {
   test("gg=G", ({expect, _}) => {

--- a/test/reason-libvim/GotoTest.re
+++ b/test/reason-libvim/GotoTest.re
@@ -2,7 +2,7 @@ open TestFramework;
 open Vim;
 
 let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
-let input = s => ignore(Vim.input(s): Context.t);
+let input = s => ignore(Vim.input(s): (Context.t, list(Effect.t)));
 
 describe("Goto", ({test, _}) => {
   test("gd", ({expect, _}) => {

--- a/test/reason-libvim/MessageTest.re
+++ b/test/reason-libvim/MessageTest.re
@@ -14,7 +14,7 @@ describe("Messages", ({test, _}) => {
         messages := [(priority, title, contents), ...messages^]
       );
 
-    let _: Context.t = command("echo 'hello'");
+    let (_: Context.t, _: list(Effect.t)) = command("echo 'hello'");
 
     expect.int(List.length(messages^)).toBe(1);
 
@@ -35,7 +35,7 @@ describe("Messages", ({test, _}) => {
         messages := [(priority, title, contents), ...messages^]
       );
 
-    let _: Context.t = command("echoerr 'aproblem'");
+    let (_: Context.t, _: list(Effect.t)) = command("echoerr 'aproblem'");
 
     /* TODO: Fix this! */
     /* expect.int(List.length(messages^)).toBe(1); */

--- a/test/reason-libvim/ModeTest.re
+++ b/test/reason-libvim/ModeTest.re
@@ -17,7 +17,7 @@ describe("Mode", ({describe, _}) => {
       expect.bool(Mode.isNormal(Mode.current())).toBe(true);
 
       // Force selection mode - and type 'a'
-      let outContext =
+      let (outContext, _: list(Effect.t)) =
         Vim.input(
           ~context={
             ...Vim.Context.current(),
@@ -62,7 +62,7 @@ describe("Mode", ({describe, _}) => {
       expect.bool(Mode.isNormal(Mode.current())).toBe(true);
 
       // Force visual mode - and delete with 'x'
-      let outContext =
+      let (outContext, _: list(Effect.t)) =
         Vim.input(
           ~context={
             ...Vim.Context.current(),
@@ -144,7 +144,7 @@ describe("Mode", ({describe, _}) => {
       let _ = resetBuffer();
 
       // delete pending op
-      let {mode, _}: Vim.Context.t = Vim.input("jjd");
+      let ({mode, _}: Vim.Context.t, _: list(Effect.t)) = Vim.input("jjd");
 
       expect.equal(
         mode,

--- a/test/reason-libvim/MotionTest.re
+++ b/test/reason-libvim/MotionTest.re
@@ -21,7 +21,7 @@ describe("MotionTest", ({describe, _}) => {
 
       let context = {...Vim.Context.current(), viewLineMotion};
 
-      let context = Vim.input(~context, "L");
+      let (context, _effects: list(Effect.t)) = Vim.input(~context, "L");
       expect.equal(
         context.mode,
         Normal({
@@ -33,7 +33,8 @@ describe("MotionTest", ({describe, _}) => {
         }),
       );
 
-      let context = Vim.input(~context={...context, viewLineMotion}, "M");
+      let (context, _effects: list(Effect.t)) =
+        Vim.input(~context={...context, viewLineMotion}, "M");
       expect.equal(
         context.mode,
         Normal({
@@ -45,7 +46,7 @@ describe("MotionTest", ({describe, _}) => {
         }),
       );
 
-      let context: Vim.Context.t =
+      let (context: Vim.Context.t, _effects: list(Effect.t)) =
         Vim.input(~context={...context, viewLineMotion}, "H");
       expect.equal(
         context.mode,
@@ -75,7 +76,7 @@ describe("MotionTest", ({describe, _}) => {
           Gc.compact();
           ret;
         };
-        let _context: Vim.Context.t =
+        let (_context: Vim.Context.t, _: list(Vim.Effect.t)) =
           Vim.input(
             ~context={...Vim.Context.current(), viewLineMotion},
             "M",
@@ -112,7 +113,7 @@ describe("MotionTest", ({describe, _}) => {
 
       let context = {...Vim.Context.current(), screenCursorMotion};
 
-      let context = Vim.input(~context, "5gj");
+      let (context, _: list(Vim.Effect.t)) = Vim.input(~context, "5gj");
       expect.equal(
         context.mode,
         Normal({
@@ -125,7 +126,7 @@ describe("MotionTest", ({describe, _}) => {
       );
 
       let context = {...Vim.Context.current(), screenCursorMotion};
-      let context = Vim.input(~context, "gk");
+      let (context, _: list(Effect.t)) = Vim.input(~context, "gk");
       expect.equal(
         context.mode,
         Normal({

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -11,7 +11,7 @@ let input =
       ~mode=Mode.Normal({cursor: BytePosition.zero}),
       key,
     ) => {
-  let out =
+  let (out, _effects: list(Effect.t)) =
     Vim.input(~context={...Context.current(), autoClosingPairs, mode}, key);
 
   Context.(out.mode);
@@ -23,7 +23,7 @@ let key =
       ~mode=Mode.Insert({cursors: []}),
       key,
     ) => {
-  let out =
+  let (out, _effects: list(Effect.t)) =
     Vim.key(
       ~context=Context.{...Context.current(), autoClosingPairs, mode},
       key,
@@ -99,7 +99,7 @@ describe("Multi-cursor", ({describe, _}) => {
       let updates: ref(list(BufferUpdate.t)) = ref([]);
       let dispose = Buffer.onUpdate(upd => updates := [upd, ...updates^]);
 
-      let _context: Context.t = Vim.input("i");
+      let (_context: Context.t, _effects: list(Effect.t)) = Vim.input("i");
       expect.int(List.length(updates^)).toBe(0);
 
       let mode =
@@ -160,7 +160,7 @@ describe("Multi-cursor", ({describe, _}) => {
       let updates: ref(list(BufferUpdate.t)) = ref([]);
       let dispose = Buffer.onUpdate(upd => updates := [upd, ...updates^]);
 
-      let _: Context.t = Vim.input("i");
+      let (_: Context.t, _: list(Effect.t)) = Vim.input("i");
       expect.int(List.length(updates^)).toBe(0);
 
       let mode =

--- a/test/reason-libvim/OptionsTest.re
+++ b/test/reason-libvim/OptionsTest.re
@@ -15,7 +15,7 @@ describe("Options", ({describe, _}) => {
       let effects = ref([]);
       let dispose = onEffect(eff => effects := [eff, ...effects^]);
 
-      let _: Context.t = Vim.command("set minimap");
+      let (_: Context.t, _: list(Effect.t)) = Vim.command("set minimap");
       expect.equal(
         effects^,
         [
@@ -33,7 +33,7 @@ describe("Options", ({describe, _}) => {
       let effects = ref([]);
       let dispose = onEffect(eff => effects := [eff, ...effects^]);
 
-      let _: Context.t = Vim.command("set rnu");
+      let (_: Context.t, _: list(Effect.t)) = Vim.command("set rnu");
       expect.equal(
         effects^,
         [
@@ -55,7 +55,7 @@ describe("Options", ({describe, _}) => {
       let effects = ref([]);
       let dispose = onEffect(eff => effects := [eff, ...effects^]);
 
-      let _: Context.t = Vim.command("set rtp=abc");
+      let (_: Context.t, _: list(Effect.t)) = Vim.command("set rtp=abc");
       expect.equal(
         effects^,
         [

--- a/test/reason-libvim/QuitTest.re
+++ b/test/reason-libvim/QuitTest.re
@@ -16,7 +16,7 @@ describe("Quit", ({test, _}) => {
         updates := [(quitType, forced), ...updates^]
       );
 
-    let _context: Context.t = command("q");
+    let (_context: Context.t, _effects: list(Vim.Effect.t)) = command("q");
     let (qt, forced) = List.hd(updates^);
 
     expect.int(List.length(updates^)).toBe(1);
@@ -66,7 +66,7 @@ describe("Quit", ({test, _}) => {
         updates := [(quitType, forced), ...updates^]
       );
 
-    let _context: Context.t = command("q!");
+    ignore(command("q!"): (Context.t, list(Effect.t)));
     let (qt, forced) = List.hd(updates^);
 
     expect.int(List.length(updates^)).toBe(1);
@@ -90,7 +90,7 @@ describe("Quit", ({test, _}) => {
         updates := [(quitType, forced), ...updates^]
       );
 
-    let _context: Context.t = command("qall");
+    ignore(command("qall"): (Context.t, list(Effect.t)));
     let (qt, forced) = List.hd(updates^);
 
     expect.int(List.length(updates^)).toBe(1);

--- a/test/reason-libvim/ScrollTest.re
+++ b/test/reason-libvim/ScrollTest.re
@@ -1,0 +1,34 @@
+open EditorCoreTypes;
+open TestFramework;
+
+open Vim;
+
+let resetBuffer = () =>
+  Helpers.resetBuffer("test/reason-libvim/testfile.txt");
+
+describe("Scroll", ({describe, _}) => {
+  describe("horizontal", ({test, _}) => {
+    test("zh", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let (_context: Context.t, effects: list(Effect.t)) =
+        input("zh");
+
+      expect.list(effects).toContainEqual(
+        Effect.Scroll({count: 1, direction: Scroll.ColumnRight})
+      );
+    });
+    });
+  describe("vertical", ({test, _}) => {
+    test("zz", ({expect, _}) => {
+      let _ = resetBuffer();
+
+      let (_context: Context.t, effects: list(Effect.t)) =
+        input("zz");
+
+      expect.list(effects).toContainEqual(
+        Effect.Scroll({count: 1, direction: Scroll.CursorCenterVertically})
+      );
+    });
+    });
+});

--- a/test/reason-libvim/ScrollTest.re
+++ b/test/reason-libvim/ScrollTest.re
@@ -1,4 +1,3 @@
-open EditorCoreTypes;
 open TestFramework;
 
 open Vim;
@@ -11,24 +10,22 @@ describe("Scroll", ({describe, _}) => {
     test("zh", ({expect, _}) => {
       let _ = resetBuffer();
 
-      let (_context: Context.t, effects: list(Effect.t)) =
-        input("zh");
+      let (_context: Context.t, effects: list(Effect.t)) = input("zh");
 
       expect.list(effects).toContainEqual(
-        Effect.Scroll({count: 1, direction: Scroll.ColumnRight})
+        Effect.Scroll({count: 1, direction: Scroll.ColumnRight}),
       );
-    });
-    });
+    })
+  });
   describe("vertical", ({test, _}) => {
     test("zz", ({expect, _}) => {
       let _ = resetBuffer();
 
-      let (_context: Context.t, effects: list(Effect.t)) =
-        input("zz");
+      let (_context: Context.t, effects: list(Effect.t)) = input("zz");
 
       expect.list(effects).toContainEqual(
-        Effect.Scroll({count: 1, direction: Scroll.CursorCenterVertically})
+        Effect.Scroll({count: 1, direction: Scroll.CursorCenterVertically}),
       );
-    });
-    });
+    })
+  });
 });

--- a/test/reason-libvim/SearchTest.re
+++ b/test/reason-libvim/SearchTest.re
@@ -57,7 +57,8 @@ describe("Search", ({describe, _}) => {
       let unsubscribe =
         Vim.Search.onStopSearchHighlight(() => incr(callCount));
 
-      let _context: Context.t = Vim.command("nohlsearch");
+      let (_context: Context.t, _effects: list(Vim.Effect.t)) =
+        Vim.command("nohlsearch");
 
       expect.int(callCount^).toBe(1);
 

--- a/test/reason-libvim/WindowTest.re
+++ b/test/reason-libvim/WindowTest.re
@@ -49,7 +49,8 @@ describe("Window", ({describe, _}) => {
           splits := [(splitType, name), ...splits^]
         );
 
-      let _context: Context.t = command("vsp test.txt");
+      let (_context: Context.t, _effects: list(Vim.Effect.t)) =
+        command("vsp test.txt");
 
       expect.int(List.length(splits^)).toBe(1);
 
@@ -70,7 +71,8 @@ describe("Window", ({describe, _}) => {
           splits := [(splitType, name), ...splits^]
         );
 
-      let _context: Context.t = command("sp test2.txt");
+      let (_context: Context.t, _effects: list(Vim.Effect.t)) =
+        command("sp test2.txt");
 
       expect.int(List.length(splits^)).toBe(1);
 


### PR DESCRIPTION
Prior to this change, we relied heavily on `libvim`'s concept of scrolling - letting `libvim` keeping track of a `topline` and `leftcol` (which is what terminal vim use for rendering - figuring out what characters to push to the screen).

However, there are several cases where our dependency on that causes some awkward behavior - an example of this is #760  - since we support 'free scroll' with the mouse (scrolling that doesn't move the mouse cursor), when we go back to reconcile that mouse position, `libvim` doesn't actually know about the free-scroll, and there is some awkwardness at that time - the screen doesn't necessarily move to where the user would expect, it moves to the last `topline` that `libvim` knew about.

Also, since word-wrap is managed by our rendering layer - `libvim` also doesn't know about that. So this change - to manage scrolling fully independently of `topline` and `leftcol` - is important for word wrap (#2578) - this lets us decide exactly how to handle all the scroll gestures (`zz`, `zb`, etc) in our view layer. Enabled by https://github.com/onivim/libvim/pull/213

Fixes #760
Required for #2578 