### PR TITLE
fix(input/#2601): vim.esc command not working as expected

### DIFF
--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -709,7 +709,8 @@ let start =
 
   let escapeEffect =
     Isolinear.Effect.create(~name="vim.esc", () => {
-      let _: (Vim.Context.t, list(Vim.Effect.t)) = Vim.key("<esc>");
+      let ({mode, _}: Vim.Context.t, effects) = Vim.key("<esc>");
+      updateActiveEditorMode(mode, effects);
       ();
     });
 


### PR DESCRIPTION
__Issue:__ Keybindings that use `vim.esc`, like:
```
   { "key": "jk", "command": "vim.esc", when: "insertMode" },
```

were not working as expected - it'd look like the editor would be back in normal mode, but subsequent characters would be inserted again.

__Defect:__ This was a regression from https://github.com/onivim/oni2/pull/2593 - in the `vim.esc` case, we weren't telling the editor that the mode has switched to normal. The editor would still be in insert mode, which would be synchronized on a subsequent press.

__Fix:__ Keep the editor up-to-date when the mode changes. Update an integration test to cover this.

Thanks @CrossR for the initial investigation! Fixes #2601 
