### PR TITLE
fix(terminal/#1548): use login shell for macOS

### DIFF
--- a/docs/docs/using-onivim/integrated-terminal.md
+++ b/docs/docs/using-onivim/integrated-terminal.md
@@ -71,7 +71,7 @@ The terminal font can be configured independently from the editor font, via the 
 
 - `terminal.integrated.fontFamily` __(_string_)__ - The font family used by the editor surface. This must be a monospace font. The font may be specified by either the name of the font, or an absolute path to the font file.
 - `terminal.integrated.fontSize` __(_int_ default: `12`)__ - The font size used by the editor surface.
-- `terminal.integrated.fontSmoothing` __(_"none"|"antialiased"|"subpixel-antialised"_)__ - The smoothing strategy used when rendering fonts. The `"antialised"` setting smooths font edges, and `"subpixel-antialiased"` means characters may be positioned fractionally on the pixel grid. 
+- `terminal.integrated.fontSmoothing` __(_"none"|"antialiased"|"subpixel-antialised"_)__ - The smoothing strategy used when rendering fonts. The `"antialised"` setting smooths font edges, and `"subpixel-antialiased"` means characters may be positioned fractionally on the pixel grid.
 
 ### Shell command & arguments
 
@@ -81,7 +81,7 @@ The terminal font can be configured independently from the editor font, via the 
 
 - `terminal.integrated.shellArgs.windows` __(_string list default: `[]`)__ - Arguments to pass to the Windows shell command.
 - `terminal.integrated.shellArgs.linux` __(_string list_ default: `[]`)__ - Arguments to pass to the Linux shell command.
-- `terminal.integrated.shellArgs.osx` __(_string list_ default: `[]`)__ - Arguments to pass to the Mac shell command.
+- `terminal.integrated.shellArgs.osx` __(_string list_ default: `["-l"]`)__ - Arguments to pass to the Mac shell command. Note that on macOS by default, each shell should be a login shell, as `~/.bash_profile` (or equivalents) are not loaded at login and should instead be loaded by each shell. See more at http://unix.stackexchange.com/a/119675/115410.
 
 The default shell and command will be used when running a terminal via `:term`, but can be overrided by passing a command to `:term`.
 

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -110,7 +110,11 @@ module Configuration = {
       setting(
         "terminal.integrated.shellArgs.osx",
         list(string),
-        ~default=[],
+        // ~/.[bash|zsh}_profile etc is not sourced when logging in on macOS.
+        // Instead, terminals on macOS should run as a login shell (which in turn
+        // sources these files).
+        // See more at http://unix.stackexchange.com/a/119675/115410.
+        ~default=["-l"],
       );
   };
 };


### PR DESCRIPTION
Tiny change to bring in a modification that I've been running locally for a bit. (Seeing the other terminal PR made me actually spend 2 mins and look it up!).

Apparently, shells on macOS should be login shells by default, at least according to the stackoverflow answer I've linked. VSCode also defaults to `["-l"]` on macOS, and links the to the same answer in their code, so I would say it should be fine.

Fixes #1548
Fixes #1161