### PR TITLE
feat(editor): Add `:scrolloff` / `editor.cursorSurroundingLines` setting

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -25,6 +25,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.autoClosingBrackets` __(_"LanguageDefined"|"Never"_ default: `"LanguageDefined"`)__ - When set to `"LanguageDefined"`, Onivim will automatically close brackets and pairs, based on language configuration.
 
+- `editor.cursorSurroundingLines` __(_int_ default: `1`)__ - The number of view lines to keep visible above and below the cursor when scrolling. Equivalent to the Vim `scrolloff` setting.
+
 - `editor.detectIndentation` __(_bool_ default: `true`)__ - Allow Onivim to auto-detect indentation settings (tab vs space, indent size)
 
 - `editor.fontFamily` __(_string_)__ - The font family used by the editor surface. This must be a monospace font. The font may be specified by either the name of the font, or an absolute path to the font file.

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -94,7 +94,6 @@ type t = {
   mode: [@opaque] Vim.Mode.t,
   pixelWidth: int,
   pixelHeight: int,
-  scrolloff: int,
   yankHighlight: option(yankHighlight),
   wrapMode: WrapMode.t,
   wrapState: WrapState.t,
@@ -378,7 +377,6 @@ let create = (~config, ~buffer, ()) => {
     scrollY: 0.,
     minimapMaxColumnWidth: 99,
     minimapScrollY: 0.,
-    scrolloff: 1,
     /*
      * We need an initial editor size, otherwise we'll immediately scroll the view
      * if a buffer loads prior to our first render.

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -931,7 +931,9 @@ let scrollCursorTop = editor => {
     bufferBytePositionToPixel(~position=cursor, editor);
 
   let pixelY = pixelPosition.y +. editor.scrollY;
-  scrollToPixelY(~pixelY, editor) |> animateScroll;
+  scrollToPixelY(~pixelY, editor)
+  |> exposePrimaryCursor  // account for scrolloff
+  |> animateScroll;
 };
 
 let scrollCursorBottom = editor => {
@@ -944,7 +946,9 @@ let scrollCursorBottom = editor => {
     pixelPosition.y
     +. editor.scrollY
     -. (heightInPixels -. lineHeightInPixels(editor));
-  scrollToPixelY(~pixelY, editor) |> animateScroll;
+  scrollToPixelY(~pixelY, editor)
+  |> exposePrimaryCursor  // account for scrolloff
+  |> animateScroll;
 };
 
 let scrollLines = (~count, editor) => {

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -59,6 +59,7 @@ let yankHighlight: t => option(yankHighlight);
 let setYankHighlight: (~yankHighlight: yankHighlight, t) => t;
 
 let setWrapPadding: (~padding: float, t) => t;
+let setVerticalScrollMargin: (~lines: int, t) => t;
 
 let setMinimap: (~enabled: bool, ~maxColumn: int, t) => t;
 let isMinimapEnabled: t => bool;

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -186,6 +186,13 @@ module VimSettings = {
       |> Option.value(~default=`Off)
     });
 
+  let scrolloff =
+    vim("scrolloff", scrolloffSetting => {
+      scrolloffSetting
+      |> VimSetting.decode_value_opt(int)
+      |> Option.value(~default=1)
+    });
+
   let lineNumbers =
     vim2("relativenumber", "number", (maybeRelative, maybeNumber) => {
       let maybeRelativeBool =
@@ -261,6 +268,13 @@ let renderIndentGuides =
 let renderWhitespace =
   setting("editor.renderWhitespace", whitespace, ~default=`Selection);
 let rulers = setting("editor.rulers", list(int), ~default=[]);
+let scrolloff =
+  setting(
+    "editor.cursorSurroundingLines",
+    ~vim=VimSettings.scrolloff,
+    int,
+    ~default=1,
+  );
 let scrollShadow = setting("editor.scrollShadow", bool, ~default=true);
 let smoothScroll =
   setting(
@@ -341,6 +355,7 @@ let contributions = [
   renderWhitespace.spec,
   rulers.spec,
   scrollShadow.spec,
+  scrolloff.spec,
   smoothScroll.spec,
   tabSize.spec,
   yankHighlightColor.spec,


### PR DESCRIPTION
__Issue:__ Since scrolling is now handled entirely by Onivim in #2597 , the `scrolloff` setting needs to be handled here too.

__Fix:__ Implement configuration, and account for scrolloff when cursor is near boundaries. Small refactor to share the configuration-setting code across editor creation and configuration changed.

__TODO:__
- [x] Account for scrolloff with zz/zb/zt