### PR TITLE
fix(cli/#2507): Better feedback when extension can't be installed

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,21 +10,21 @@ echo "prrerr_endline count: $PRERR_COUNT"
 echo "print_endline count: $PRINT_COUNT"
 echo "Printf.printf count: $PRINTF_COUNT"
 
-if [ "$PRERR_COUNT" -ne "6" ]; then
+if [ "$PRERR_COUNT" -ne "7" ]; then
     echo "New prerr_endline introduced; please remove and re-check:"
     echo "---"
     echo "Output: $(git grep prerr_endline)"
     exit 3
 fi
 
-if [ "$PRINT_COUNT" -ne "15" ]; then
+if [ "$PRINT_COUNT" -ne "16" ]; then
     echo "New print_endline introduced; please remove and re-check."
     echo "---"
     echo "Output: $(git grep print_endline)"
     exit 3
 fi
 
-if [ "$PRINTF_COUNT" -ne "2" ]; then
+if [ "$PRINTF_COUNT" -ne "3" ]; then
     echo "New Printf.printf introduced; please remove and re-check."
     echo "---"
     echo "Output: $(git grep Printf.printf)"

--- a/src/bin_editor/Cli.re
+++ b/src/bin_editor/Cli.re
@@ -1,0 +1,134 @@
+/*
+ * Cli.re
+ *
+ * Helpers for the editor command-line interface
+ */
+
+open Oni_CLI;
+
+module Core = Oni_Core;
+module ExtC = Service_Extensions.Catalog;
+module ExtM = Service_Extensions.Management;
+module Log = (val Core.Log.withNamespace("Oni2_editor"));
+module ReveryLog = (val Core.Log.withNamespace("Revery"));
+
+module LwtEx = Core.Utility.LwtEx;
+module OptionEx = Core.Utility.OptionEx;
+
+let installExtension = (path, Oni_CLI.{overriddenExtensionsDir, _}) => {
+  let setup = Core.Setup.init();
+  let result =
+    ExtM.install(~setup, ~extensionsFolder=?overriddenExtensionsDir, path)
+    |> LwtEx.sync;
+
+  switch (result) {
+  | Ok(_) =>
+    Printf.printf("Successfully installed extension: %s\n", path);
+    0;
+
+  | Error(_) =>
+    Printf.printf("Failed to install extension: %s\n", path);
+
+    let candidates: result(Service_Extensions.Catalog.SearchResponse.t, exn) =
+      ExtC.search(~offset=0, ~setup, path) |> LwtEx.sync;
+
+    switch (candidates) {
+    | Ok({extensions, _}) when extensions == [] => ()
+    | Ok({extensions, _}) =>
+      Printf.printf("\nDid you mean one of these extensions?\n");
+      extensions
+      |> List.iter((summary: ExtC.Summary.t) => {
+           print_endline(
+             Printf.sprintf("- %s.%s", summary.namespace, summary.name),
+           )
+         });
+      ();
+    | Error(exn) =>
+      prerr_endline("Error querying catalog: " ++ Printexc.to_string(exn))
+    };
+    1;
+  };
+};
+
+let uninstallExtension = (extensionId, {overriddenExtensionsDir, _}) => {
+  let result =
+    ExtM.uninstall(~extensionsFolder=?overriddenExtensionsDir, extensionId)
+    |> LwtEx.sync;
+
+  switch (result) {
+  | Ok(_) =>
+    Printf.sprintf("Successfully uninstalled extension: %s\n", extensionId)
+    |> print_endline;
+    0;
+
+  | Error(msg) =>
+    Printf.sprintf(
+      "Failed to uninstall extension: %s\n%s",
+      extensionId,
+      Printexc.to_string(msg),
+    )
+    |> prerr_endline;
+    1;
+  };
+};
+
+let printVersion = () => {
+  print_endline("Onivim 2 (" ++ Core.BuildInfo.version ++ ")");
+  0;
+};
+
+let queryExtension = (extension, _cli) => {
+  let setup = Core.Setup.init();
+  Service_Extensions.
+    // Try to parse the extension id - either search, or
+    // get details
+    (
+      switch (Catalog.Identifier.fromString(extension)) {
+      | Some(identifier) =>
+        Catalog.details(~setup, identifier)
+        |> LwtEx.sync
+        |> (
+          fun
+          | Ok(ext) => {
+              ext |> Catalog.Details.toString |> print_endline;
+              0;
+            }
+          | Error(msg) => {
+              prerr_endline(Printexc.to_string(msg));
+              1;
+            }
+        )
+      | None =>
+        Catalog.search(~offset=0, ~setup, extension)
+        |> LwtEx.sync
+        |> (
+          fun
+          | Ok(response) => {
+              response |> Catalog.SearchResponse.toString |> print_endline;
+              0;
+            }
+          | Error(msg) => {
+              prerr_endline(Printexc.to_string(msg));
+              1;
+            }
+        )
+      }
+    );
+};
+
+let listExtensions = ({overriddenExtensionsDir, _}) => {
+  Exthost.Extension.(
+    {
+      let extensions =
+        ExtM.get(~extensionsFolder=?overriddenExtensionsDir, ())
+        |> LwtEx.sync
+        |> Result.value(~default=[]);
+
+      let printExtension = (ext: Scanner.ScanResult.t) => {
+        print_endline(ext.manifest |> Manifest.identifier);
+      };
+      List.iter(printExtension, extensions);
+      0;
+    }
+  );
+};

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -20,106 +20,6 @@ module ReveryLog = (val Core.Log.withNamespace("Revery"));
 module LwtEx = Core.Utility.LwtEx;
 module OptionEx = Core.Utility.OptionEx;
 
-let installExtension = (path, Oni_CLI.{overriddenExtensionsDir, _}) => {
-  let setup = Core.Setup.init();
-  let result =
-    ExtM.install(~setup, ~extensionsFolder=?overriddenExtensionsDir, path)
-    |> LwtEx.sync;
-
-  switch (result) {
-  | Ok(_) =>
-    Printf.printf("Successfully installed extension: %s\n", path);
-    0;
-
-  | Error(_) =>
-    Printf.printf("Failed to install extension: %s\n", path);
-    1;
-  };
-};
-
-let uninstallExtension = (extensionId, {overriddenExtensionsDir, _}) => {
-  let result =
-    ExtM.uninstall(~extensionsFolder=?overriddenExtensionsDir, extensionId)
-    |> LwtEx.sync;
-
-  switch (result) {
-  | Ok(_) =>
-    Printf.sprintf("Successfully uninstalled extension: %s\n", extensionId)
-    |> print_endline;
-    0;
-
-  | Error(msg) =>
-    Printf.sprintf(
-      "Failed to uninstall extension: %s\n%s",
-      extensionId,
-      Printexc.to_string(msg),
-    )
-    |> prerr_endline;
-    1;
-  };
-};
-
-let printVersion = () => {
-  print_endline("Onivim 2 (" ++ Core.BuildInfo.version ++ ")");
-  0;
-};
-
-let queryExtension = (extension, _cli) => {
-  let setup = Core.Setup.init();
-  Service_Extensions.
-    // Try to parse the extension id - either search, or
-    // get details
-    (
-      switch (Catalog.Identifier.fromString(extension)) {
-      | Some(identifier) =>
-        Catalog.details(~setup, identifier)
-        |> LwtEx.sync
-        |> (
-          fun
-          | Ok(ext) => {
-              ext |> Catalog.Details.toString |> print_endline;
-              0;
-            }
-          | Error(msg) => {
-              prerr_endline(Printexc.to_string(msg));
-              1;
-            }
-        )
-      | None =>
-        Catalog.search(~offset=0, ~setup, extension)
-        |> LwtEx.sync
-        |> (
-          fun
-          | Ok(response) => {
-              response |> Catalog.SearchResponse.toString |> print_endline;
-              0;
-            }
-          | Error(msg) => {
-              prerr_endline(Printexc.to_string(msg));
-              1;
-            }
-        )
-      }
-    );
-};
-
-let listExtensions = ({overriddenExtensionsDir, _}) => {
-  Exthost.Extension.(
-    {
-      let extensions =
-        ExtM.get(~extensionsFolder=?overriddenExtensionsDir, ())
-        |> LwtEx.sync
-        |> Result.value(~default=[]);
-
-      let printExtension = (ext: Scanner.ScanResult.t) => {
-        print_endline(ext.manifest |> Manifest.identifier);
-      };
-      List.iter(printExtension, extensions);
-      0;
-    }
-  );
-};
-
 Log.debug("Startup: Parsing CLI options");
 let (cliOptions, eff) = Oni_CLI.parse(~getenv=Sys.getenv_opt, Sys.argv);
 
@@ -128,12 +28,13 @@ if (cliOptions.needsConsole) {
 };
 
 switch (eff) {
-| PrintVersion => printVersion() |> exit
-| InstallExtension(name) => installExtension(name, cliOptions) |> exit
-| QueryExtension(name) => queryExtension(name, cliOptions) |> exit
-| UninstallExtension(name) => uninstallExtension(name, cliOptions) |> exit
+| PrintVersion => Cli.printVersion() |> exit
+| InstallExtension(name) => Cli.installExtension(name, cliOptions) |> exit
+| QueryExtension(name) => Cli.queryExtension(name, cliOptions) |> exit
+| UninstallExtension(name) =>
+  Cli.uninstallExtension(name, cliOptions) |> exit
 | CheckHealth => HealthCheck.run(~checks=All, cliOptions) |> exit
-| ListExtensions => listExtensions(cliOptions) |> exit
+| ListExtensions => Cli.listExtensions(cliOptions) |> exit
 | StartSyntaxServer({parentPid, namedPipe}) =>
   Oni_Syntax_Server.start(~parentPid, ~namedPipe, ~healthCheck=() =>
     HealthCheck.run(~checks=Common, cliOptions)


### PR DESCRIPTION
__Issue:__ As described in #2507 - the feedback when installing an extension isn't very useful.

__Fix:__ Check to see if there are similar extensions in the extension catalog, if so, suggest them as alternatives:

```
Bryans-Mac-mini:oni2 bryphe$ oni2 --install-extension csharp
Failed to install extension: csharp

Did you mean one of these extensions?
- muhammad-sammy.csharp
- vscode.csharp
- pflannery.vscode-versionlens
- robole.snippets-ranger
```

Fixes #2507 