### PR TITLE
docs(infrastructure/esy#1099) fix docs to describe reality

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -11,7 +11,7 @@ sidebar_label: Building from Source
 - Install [Git](https://git-scm.com/)
 - Install [Node](https://nodejs.org/en)
 - Install [Esy](https://esy.sh) (__0.6.2__ or above is required, but the latest version is recommened: `npm install -g esy@latest`)
-> __NOTE:__ **Linux-only**: if you need to install using `sudo npm -g esy@latest` then you might run into this issue [esy/esy#1099](https://github.com/esy/esy/issues/1099), the actual workaround is the following :`sudo npm install -g --unsafe-perm esy`.
+> __NOTE:__ **Linux-only**: if you need to install using `sudo npm -g esy@latest` then your NPM installation **might be broken** follow [the instruction here to fix it](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) this is related to this issue [esy/esy#1099.](https://github.com/esy/esy/issues/1099)
 
 - __Windows-only__: Run `npm install -g windows-build-tools` (this installs some build tools that aren't included by default on Windows)
 - Install any other system packages required by Oni2 dependencies, as outlined below.

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -10,7 +10,9 @@ sidebar_label: Building from Source
 
 - Install [Git](https://git-scm.com/)
 - Install [Node](https://nodejs.org/en)
-- Install [Esy](https://esy.sh) (__0.6.2__ or above is required, but the latest version is recommended: `npm install -g esy@latest`)
+- Install [Esy](https://esy.sh) (__0.6.2__ or above is required, but the latest version is recommened: `npm install -g esy@latest`)
+> __NOTE:__ **Linux-only**: if you need to install using `sudo npm -g esy@latest` then you might run into this issue [esy/esy#1099](https://github.com/esy/esy/issues/1099), the actual workaround is the following :`sudo npm install -g --unsafe-perm esy`.
+
 - __Windows-only__: Run `npm install -g windows-build-tools` (this installs some build tools that aren't included by default on Windows)
 - Install any other system packages required by Oni2 dependencies, as outlined below.
 
@@ -109,9 +111,12 @@ We use auto formatting tool, you might want to run it before you commit changes
 To create a release build, run:
 
 - `esy '@release' run -f --checkhealth`
+- `esy '@release' install`
 - `esy '@release' create`
 
-This will create a `_release` folder at the root with the application bundle inside.
+This will create a `_esy/release` folder at the root with the application bundle inside that folder there will be folders for built binaries, in `_esy/release/install/bin` the `Oni2` binary resides along `Oni2_editor`.
+
+Mind that these are actually symbolic links to `oni2/_esy/release/store/b/oni2-<hashvalue>/install/default/bin/Oni2`, the same is true for the `Oni2_editor` binary.
 
 ### Windows
 


### PR DESCRIPTION
- Mention issue [esy/esy#1099](https://github.com/esy/esy/issues/1099) for Linux users.
- Update root binary folder created by `esy '@release' create`.
- Explain where the binary of Oni2 is actually generated, current documentation is false since no `_release` folder is created in the root folder of the Oni2 repo.
- I ran into an issue when running `esy '@release' create`, it was saying it failed since `esy '@release' install` had not been run prior to running it, so I added this line in the documentation.

Hope theses changes will help people to build Oni2 more easily. 