### PR TITLE
fix(editor/#2590): Go-to-definition / search causes the editor to slide

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -788,28 +788,6 @@ let getContentPixelWidth = editor => {
   layout.bufferWidthInPixels;
 };
 
-let setSize = (~pixelWidth, ~pixelHeight, editor) => {
-  let editor' = {...editor, pixelWidth, pixelHeight};
-
-  let contentPixelWidth = getContentPixelWidth(editor');
-
-  let wrapPadding =
-    switch (editor.wrapPadding) {
-    | None => EditorBuffer.measure(Uchar.of_char('W'), editor.buffer)
-    | Some(padding) => padding
-    };
-
-  let wrapWidth = contentPixelWidth -. wrapPadding;
-  let wrapState =
-    WrapState.resize(
-      ~pixelWidth=wrapWidth,
-      ~buffer=editor'.buffer,
-      editor'.wrapState,
-    );
-
-  {...editor', wrapState};
-};
-
 let scrollToPixelY = (~pixelY as newScrollY, editor) => {
   let {pixelHeight, _} = editor;
   let viewLines = editor |> totalViewLines;
@@ -1010,7 +988,7 @@ let setSize = (~pixelWidth, ~pixelHeight, originalEditor) => {
 
   // If we hadn't measured before, make sure the cursor is in view
   if (!hasSetSize(originalEditor)) {
-    scrollCenterCursorVertically(editor');
+    scrollCursorTop(editor');
   } else {
     editor';
   };

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -702,10 +702,10 @@ let exposePrimaryCursor = editor =>
       let ({x: pixelX, y: pixelY}: PixelPosition.t, _width) =
         bufferBytePositionToPixel(~position=primaryCursor, editor);
 
-        let scrollOffX = getCharacterWidth(editor) *. 2.;
-        let scrollOffY =
-          lineHeightInPixels(editor)
-          *. float(max(editor.verticalScrollMargin, 1));
+      let scrollOffX = getCharacterWidth(editor) *. 2.;
+      let scrollOffY =
+        lineHeightInPixels(editor)
+        *. float(max(editor.verticalScrollMargin, 1));
 
       let availableX = pixelWidth -. scrollOffX;
       let availableY = pixelHeight -. scrollOffY;
@@ -786,7 +786,7 @@ let getTokenAt =
 let getContentPixelWidth = editor => {
   let layout: EditorLayout.t = getLayout(editor);
   layout.bufferWidthInPixels;
-}
+};
 
 let setSize = (~pixelWidth, ~pixelHeight, editor) => {
   let editor' = {...editor, pixelWidth, pixelHeight};

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -711,22 +711,28 @@ let exposePrimaryCursor = editor =>
       let availableY = pixelHeight -. scrollOffY;
 
       let adjustedScrollX =
-        if (pixelX < 0.) {
-          scrollX +. pixelX;
-        } else if (pixelX >= availableX) {
-          scrollX +. (pixelX -. availableX);
-        } else {
-          scrollX;
-        };
+        max(
+          if (pixelX < 0.) {
+            scrollX +. pixelX;
+          } else if (pixelX >= availableX) {
+            scrollX +. (pixelX -. availableX);
+          } else {
+            scrollX;
+          },
+          0.,
+        );
 
       let adjustedScrollY =
-        if (pixelY < scrollOffY) {
-          scrollY -. scrollOffY +. pixelY;
-        } else if (pixelY >= availableY) {
-          scrollY +. (pixelY -. availableY);
-        } else {
-          scrollY;
-        };
+        max(
+          if (pixelY < scrollOffY) {
+            scrollY -. scrollOffY +. pixelY;
+          } else if (pixelY >= availableY) {
+            scrollY +. (pixelY -. availableY);
+          } else {
+            scrollY;
+          },
+          0.,
+        );
 
       {
         ...editor,
@@ -925,7 +931,8 @@ let scrollCursorTop = editor => {
     bufferBytePositionToPixel(~position=cursor, editor);
 
   let pixelY = pixelPosition.y +. editor.scrollY;
-  scrollToPixelY(~pixelY, editor)
+  editor
+  |> scrollToPixelY(~pixelY)
   |> exposePrimaryCursor  // account for scrolloff
   |> animateScroll;
 };

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -643,54 +643,64 @@ let getMinimapWidthScaleFactor = editor => {
   };
 };
 
-let exposePrimaryCursor = editor => {
-  switch (cursors(editor)) {
-  | [primaryCursor, ..._tail] =>
-    let {bufferWidthInPixels, _}: EditorLayout.t = getLayout(editor);
-
-    let pixelWidth = bufferWidthInPixels;
-
-    let {pixelHeight, scrollX, scrollY, _} = editor;
-    let pixelHeight = float(pixelHeight);
-
-    let ({x: pixelX, y: pixelY}: PixelPosition.t, _width) =
-      bufferBytePositionToPixel(~position=primaryCursor, editor);
-
-    let scrollOffX = getCharacterWidth(editor) *. 2.;
-    let scrollOffY =
-      lineHeightInPixels(editor) *. float(editor.verticalScrollMargin);
-
-    let availableX = pixelWidth -. scrollOffX;
-    let availableY = pixelHeight -. scrollOffY;
-
-    let adjustedScrollX =
-      if (pixelX < 0.) {
-        scrollX +. pixelX;
-      } else if (pixelX >= availableX) {
-        scrollX +. (pixelX -. availableX);
-      } else {
-        scrollX;
-      };
-
-    let adjustedScrollY =
-      if (pixelY < scrollOffY) {
-        scrollY -. scrollOffY +. pixelY;
-      } else if (pixelY >= availableY) {
-        scrollY +. (pixelY -. availableY);
-      } else {
-        scrollY;
-      };
-
-    {
-      ...editor,
-      scrollX: adjustedScrollX,
-      scrollY: adjustedScrollY,
-      isScrollAnimated: true,
-    };
-
-  | _ => editor
-  };
+let hasSetSize = editor => {
+  editor.pixelWidth > 1 && editor.pixelHeight > 1;
 };
+
+let exposePrimaryCursor = editor =>
+  if (!hasSetSize(editor)) {
+    // If the size hasn't been set yet - don't try to expose the cursor.
+    // We don't know about the viewport to do a good job.
+    // See:
+    editor;
+  } else {
+    switch (cursors(editor)) {
+    | [primaryCursor, ..._tail] =>
+      let {bufferWidthInPixels, _}: EditorLayout.t = getLayout(editor);
+
+      let pixelWidth = bufferWidthInPixels;
+
+      let {pixelHeight, scrollX, scrollY, _} = editor;
+      let pixelHeight = float(pixelHeight);
+
+      let ({x: pixelX, y: pixelY}: PixelPosition.t, _width) =
+        bufferBytePositionToPixel(~position=primaryCursor, editor);
+
+      let scrollOffX = getCharacterWidth(editor) *. 2.;
+      let scrollOffY =
+        lineHeightInPixels(editor) *. float(editor.verticalScrollMargin);
+
+      let availableX = pixelWidth -. scrollOffX;
+      let availableY = pixelHeight -. scrollOffY;
+
+      let adjustedScrollX =
+        if (pixelX < 0.) {
+          scrollX +. pixelX;
+        } else if (pixelX >= availableX) {
+          scrollX +. (pixelX -. availableX);
+        } else {
+          scrollX;
+        };
+
+      let adjustedScrollY =
+        if (pixelY < scrollOffY) {
+          scrollY -. scrollOffY +. pixelY;
+        } else if (pixelY >= availableY) {
+          scrollY +. (pixelY -. availableY);
+        } else {
+          scrollY;
+        };
+
+      {
+        ...editor,
+        scrollX: adjustedScrollX,
+        scrollY: adjustedScrollY,
+        isScrollAnimated: true,
+      };
+
+    | _ => editor
+    };
+  };
 
 let mode = ({mode, _}) => mode;
 
@@ -738,28 +748,6 @@ let getTokenAt =
 let getContentPixelWidth = editor => {
   let layout: EditorLayout.t = getLayout(editor);
   layout.bufferWidthInPixels;
-};
-
-let setSize = (~pixelWidth, ~pixelHeight, editor) => {
-  let editor' = {...editor, pixelWidth, pixelHeight};
-
-  let contentPixelWidth = getContentPixelWidth(editor');
-
-  let wrapPadding =
-    switch (editor.wrapPadding) {
-    | None => EditorBuffer.measure(Uchar.of_char('W'), editor.buffer)
-    | Some(padding) => padding
-    };
-
-  let wrapWidth = contentPixelWidth -. wrapPadding;
-  let wrapState =
-    WrapState.resize(
-      ~pixelWidth=wrapWidth,
-      ~buffer=editor'.buffer,
-      editor'.wrapState,
-    );
-
-  {...editor', wrapState};
 };
 
 let scrollToPixelY = (~pixelY as newScrollY, editor) => {
@@ -933,6 +921,35 @@ let scrollPage = (~count, editor) => {
     count
     * int_of_float(float(editor.pixelHeight) /. lineHeightInPixels(editor));
   scrollAndMoveCursor(~deltaViewLines=lineDelta, editor);
+};
+
+let setSize = (~pixelWidth, ~pixelHeight, originalEditor) => {
+  let editor = {...originalEditor, pixelWidth, pixelHeight};
+
+  let contentPixelWidth = getContentPixelWidth(editor);
+
+  let wrapPadding =
+    switch (editor.wrapPadding) {
+    | None => EditorBuffer.measure(Uchar.of_char('W'), editor.buffer)
+    | Some(padding) => padding
+    };
+
+  let wrapWidth = contentPixelWidth -. wrapPadding;
+  let wrapState =
+    WrapState.resize(
+      ~pixelWidth=wrapWidth,
+      ~buffer=editor.buffer,
+      editor.wrapState,
+    );
+
+  let editor' = {...editor, wrapState};
+
+  // If we hadn't measured before, make sure the cursor is in view
+  if (!hasSetSize(originalEditor)) {
+    scrollCenterCursorVertically(editor');
+  } else {
+    editor';
+  };
 };
 
 // PROJECTION


### PR DESCRIPTION
__Issue:__ As described in #2590 - when using go-to definition, or entering a find item in the search list, the editor will navigate to the definition but will slide, with the cursor outside the viewport, which is a pretty jarring experience.

__Defect:__ We were trying to scroll to the cursor before the editor has been sized - this leads to invalid results when trying to figure out the `scrollX` and `scrollY`.

__Fix:__ Don't scroll to the cursor until the editor has a size set. If it is the first time setting the size, we'll center the cursor in the viewport.

Fixes #2590 
Fixes #1168

(Technically, #1168 was actually fixed by #2597 - but noticed it here looking at related issues)