### PR TITLE
docs(core/#2611): improve build docs and dependencies 

### DIFF
--- a/docs/docs/configuration/extensions.md
+++ b/docs/docs/configuration/extensions.md
@@ -49,7 +49,7 @@ If your favorite extension is missing - you can help us out by publishing it to 
 1) Register for an account using the [Open VSX GitHub OAuth](https://open-vsx.org/oauth2/authorization/github) provider
 2) Create a [personal access token](https://open-vsx.org/user-settings/tokens) 
 3) Install the `ovsx` tool - `npm install -g ovsx`
-4) Create a namespace corrresponding to your extension: `ovsx create-namespace <publisher> --pat <token>`
+4) Create a namespace corresponding to your extension: `ovsx create-namespace <publisher> --pat <token>`
 5) Run `ovsx publish --pat <token>` in the directory of the extension you want to publish.
 
 ## Vim Extensions

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -34,7 +34,7 @@ When a key is pressed:
 - If a rule is found and has a `command` set, the `command` is executed.
 - If no matching rules are found, we pass the input key through to `libvim` to be handled by Vim.
 
-There are a set of default rules provided by Onivim, but the customized rules are appended to the bottom - thus, user key bindings are esxecuted first.
+There are a set of default rules provided by Onivim, but the customized rules are appended to the bottom - thus, user key bindings are executed first.
 
 ### `key` format
 

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -10,7 +10,7 @@ sidebar_label: Building from Source
 
 - Install [Git](https://git-scm.com/)
 - Install [Node](https://nodejs.org/en)
-- Install [Esy](https://esy.sh) (__0.6.2__ or above is required, but the latest version is recommened: `npm install -g esy@latest`)
+- Install [Esy](https://esy.sh) (__0.6.2__ or above is required, but the latest version is recommended: `npm install -g esy@latest`)
 - __Windows-only__: Run `npm install -g windows-build-tools` (this installs some build tools that aren't included by default on Windows)
 - Install any other system packages required by Oni2 dependencies, as outlined below.
 
@@ -49,8 +49,8 @@ cd oni2
 # Install dependencies in package.json
 esy install
 
-# Builds most pacakges and run Oni2 specific bootstrapping.
-# Will take upwards of 30 mins on a normal machine.
+# Builds most dependencies and run Oni2 specific bootstrapping.
+# Takes upwards of 30 mins on a normal machine.
 # esy does intelligently cache to ~/.esy, subsequent builds are fast.
 esy bootstrap
 
@@ -141,7 +141,7 @@ There is a development extension in `src/development_extensions/oni-dev-extensio
 #### Resources
 - [VS Code API reference](https://code.visualstudio.com/api/references/vscode-api)
 
-### Intrumenting extensions
+### Instrumenting extensions
 
 To add logging, use `console.error` - messages on `stderr` will be shown in Onivim's log. (Make sure to turn debug logging on, via `ONI2_DEBUG=1` environment variable or the `--debug` command-line arg).
 

--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -32,7 +32,7 @@ Requires `libtool` and `gettext` from homebrew: `brew install libtool gettext`.
 Some Linux distributions may need other packages:
 
  - Ubuntu : `libacl1-dev`, `libncurses-dev` for `libvim`.
- - Fedora/CentOS : `libXt-devel`, `libSM-devel`, `libICE-devel` for `libvim`
+ - Fedora/CentOS : `libXt-devel`, `libSM-devel`, `libICE-devel`, `libacl-devel` and `ncurses-devel ` for `libvim`
 
 ## Build and Run
 
@@ -45,8 +45,16 @@ Some Linux distributions may need other packages:
 ```sh
 git clone https://github.com/onivim/oni2
 cd oni2
+
+# Install dependencies in package.json
 esy install
+
+# Builds most pacakges and run Oni2 specific bootstrapping.
+# Will take upwards of 30 mins on a normal machine.
+# esy does intelligently cache to ~/.esy, subsequent builds are fast.
 esy bootstrap
+
+# Finish up remaining parts of building. Should be quick.
 esy build
 ```
 

--- a/docs/docs/using-onivim/command-line.md
+++ b/docs/docs/using-onivim/command-line.md
@@ -16,7 +16,7 @@ during the Installation process, if the option is selected during installation.
 ## macOS
 
 On macOS, `oni2` can be added manually with the "Add to System PATH" command in the
-command pallette, by pressing `Cmd-Shift-P` and searching for `System`.
+command palette, by pressing `Cmd-Shift-P` and searching for `System`.
 
 After selecting the option and giving admin permissions, the `oni2` executable
 should be accessible.
@@ -53,7 +53,7 @@ Passing `oni2` a file will open that file in Oni2, and set the open folder in On
 that file is in. That is, `oni2 ~/my_project/docs/cli.md` will open `cli.md` in Oni2, and set the folder
 to `~/my_project/docs/`. There is also a Zen mode configuration option around this single file mode, which
 is outlined over [here](./../configuration/settings.md). By default, when opening with 1 file, `oni2` will
-enter Zen mode, which can be disabled from the command pallette.
+enter Zen mode, which can be disabled from the command palette.
 
 You can also pass over multiple files to open at once, and the first folder will be used as the current
 working directory (unless over-ridden with the `--working-directory` flag.)
@@ -107,7 +107,7 @@ and provide logging output.
 There are a also few options that can be specified using either environment variables or command line arguments:
 - `ONI2_DEBUG` or `--debug` (e.g., `ONI2_DEBUG=1 oni2 -f` or `oni2 -f --debug`) - enable debug logging. This is very verbose but is helpful when logging issues!
 - `--trace` - enable trace logging. This is extremely verbose!
-- `--quiet` - print only error log messages. This can be sueful to quickly see if an extension failed to load, for example.
+- `--quiet` - print only error log messages. This can be useful to quickly see if an extension failed to load, for example.
 - `ONI2_LOG_FILE` or `--log-file` (e.g., `ONI2_LOG_FILE='oni.log' oni2` or `oni2 --log-file oni.log`) - enable logging to a file.
 - `ONI2_LOG_FILTER` or `--log-filter` (e.g.. `ONI2_LOG_FILTER=Oni2.* oni2 -f` or `oni2 -f --log-filter "Oni2.*"`) - filter log messages using a comma-separated list of glob patterns matched against each message's namespace. Prefix a pattern with `-` to exclude rather than include matches. E.g. `ONI2_LOG_FILTER="Oni2.*, -*Ext*"` will include everything that matches `Oni2.*`, but exclude messages that also match `*Ext*`.
 

--- a/docs/docs/using-onivim/visual-mode.md
+++ b/docs/docs/using-onivim/visual-mode.md
@@ -15,8 +15,5 @@ There are three variations of visual mode, and they can be entered from normal m
 
 When in visual mode, pressing a [motion] key - like <kbd>h</kbd>, <kdb>w</kbd>, etc - will extend the visual range.
 
-Visual mode is a great to learn Vim motions, because you get immediate visual feedback!o
-
-
-
+Visual mode is a great to learn Vim motions, because you get immediate visual feedback!
 


### PR DESCRIPTION
Small change to include all the builds deps for Fedora 32. I've updated the Revery deps already, since that is just in the Wiki there and doesn't need a PR.

Also just updated to explain what the 3 build steps do, a common question I see is "The bootstrapping is taking ages! The build is going to take even longer..." when really the build step is a few seconds since 99% of the work happens in the bootstrap bit. (We can't swap the steps around as eventually you hit an error as the bootstrap files are needed and getting and error during the build would cause even more questions).

Fixes #2611.