### PR TITLE
fix(): fix tab completion in quick menu for multiple argument commands

### DIFF
--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -291,7 +291,7 @@ let splitLines: string => (bool, array(string)) =
     (isMultipleLines(text), out);
   };
 
-/** unescaped meaning not preceded directly by a backslash "\" */
+/** unescaped meaning not preceded directly by a backslash (\) */
 let findUnescapedFromEnd: string => char => option(int) =
   (str, chr) => {
     let last_unescaped_index = ref(None); // default result

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -290,3 +290,17 @@ let splitLines: string => (bool, array(string)) =
 
     (isMultipleLines(text), out);
   };
+
+/** unescaped meaning not preceded directly by a backslash "\" */
+let findUnescapedFromEnd: string => char => option(int) =
+  (str, chr) => {
+    let last_unescaped_index = ref(Some(0)); // default result
+    String.iteri(
+      (i, c) =>
+        if (i > 0 && str.[i - 1] != '\\' && c == chr) {
+          last_unescaped_index := Some(i + 1); // Advance past space
+        },
+      str,
+    );
+    last_unescaped_index^;
+  };

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -294,7 +294,7 @@ let splitLines: string => (bool, array(string)) =
 /** unescaped meaning not preceded directly by a backslash "\" */
 let findUnescapedFromEnd: string => char => option(int) =
   (str, chr) => {
-    let last_unescaped_index = ref(Some(0)); // default result
+    let last_unescaped_index = ref(None); // default result
     String.iteri(
       (i, c) =>
         if (i > 0 && str.[i - 1] != '\\' && c == chr) {

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -270,6 +270,7 @@ let removeWindowsNewLines = s =>
   |> List.filter(c => c != '\r')
   |> List.map(c => String.make(1, c))
   |> String.concat("");
+
 let splitNewLines = s => s |> String.split_on_char('\n') |> Array.of_list;
 
 let removeTrailingNewLine = s => {
@@ -292,7 +293,7 @@ let splitLines: string => (bool, array(string)) =
   };
 
 /** unescaped meaning not preceded directly by a backslash (\) */
-let findUnescapedFromEnd: string => char => option(int) =
+let findUnescapedFromEnd: (string, char) => option(int) =
   (str, chr) => {
     let last_unescaped_index = ref(None); // default result
     String.iteri(
@@ -304,3 +305,11 @@ let findUnescapedFromEnd: string => char => option(int) =
     );
     last_unescaped_index^;
   };
+
+// turns 'hello world' into 'hello\ world'
+// may be worth replacing/complementing with 'escapeFilePath' */
+let escapeSpaces: string => string =
+  s =>
+    List.init(String.length(s), String.get(s))
+    |> List.map(c => (c == ' ' ? "\\" : "") ++ String.make(1, c))
+    |> String.concat("");

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -63,14 +63,18 @@ let update = (msg, model: model) => {
 module CommandLine = {
   let getCompletionMeet = commandLine => {
     let len = String.length(commandLine);
-
     if (len == 0) {
       None;
     } else {
-      String.rindex_opt(commandLine, ' ')
-      |> Option.map(idx => idx + 1)  // Advance past space
-      |> OptionEx.or_(Some(0));
-    };
+      let last_unescaped_space_index = ref(Some(0)); // default result
+      String.iteri(
+        (i, c) => if (i > 0 && commandLine.[i-1] != '\\' && c == ' ') {
+          last_unescaped_space_index := Some(i+1); // Advance past space
+        },
+        commandLine
+      );
+      last_unescaped_space_index^;
+    }
   };
 
   let%test "empty command line returns None" = {

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -81,11 +81,15 @@ module CommandLine = {
   };
 
   let%test "meet with a path, spaces" = {
-    getCompletionMeet("vsp /path with spaces/") == Some(4);
+    getCompletionMeet("vsp /path\\ with\\ spaces/") == Some(4);
   };
 
   let%test "meet multiple paths" = {
     getCompletionMeet("!cp /path1 /path2") == Some(11);
+  };
+
+  let%test "meet multiple paths with spaces" = {
+    getCompletionMeet("!cp /path\\ 1 /path\\ 2") == Some(11);
   };
 };
 

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -61,14 +61,8 @@ let update = (msg, model: model) => {
 };
 
 module CommandLine = {
-  let getCompletionMeet = commandLine => {
-    let len = String.length(commandLine);
-    if (len == 0) {
-      None;
-    } else {
-      StringEx.findUnescapedFromEnd(commandLine, ' ');
-    };
-  };
+  let getCompletionMeet = commandLine =>
+    StringEx.findUnescapedFromEnd(commandLine, ' ');
 
   let%test "empty command line returns None" = {
     getCompletionMeet("") == None;

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -67,7 +67,7 @@ module CommandLine = {
     if (len == 0) {
       None;
     } else {
-      String.index_opt(commandLine, ' ')
+      String.rindex_opt(commandLine, ' ')
       |> Option.map(idx => idx + 1)  // Advance past space
       |> OptionEx.or_(Some(0));
     };
@@ -91,6 +91,10 @@ module CommandLine = {
 
   let%test "meet with a path, spaces" = {
     getCompletionMeet("vsp /path with spaces/") == Some(4);
+  };
+
+  let%test "meet multiple paths" = {
+    getCompletionMeet("!cp /path1 /path2") == Some(11);
   };
 };
 

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -61,8 +61,14 @@ let update = (msg, model: model) => {
 };
 
 module CommandLine = {
-  let getCompletionMeet = commandLine =>
-    StringEx.findUnescapedFromEnd(commandLine, ' ');
+  let getCompletionMeet = commandLine => {
+    if (StringEx.isEmpty(commandLine)) { None; }
+    else {
+      let meet = StringEx.findUnescapedFromEnd(commandLine, ' ');
+      if (meet == None) { Some(0); }
+      else meet;
+    }
+  };
 
   let%test "empty command line returns None" = {
     getCompletionMeet("") == None;
@@ -89,7 +95,7 @@ module CommandLine = {
   };
 
   let%test "meet multiple paths with spaces" = {
-    getCompletionMeet("!cp /path\\ 1 /path\\ 2") == Some(11);
+    getCompletionMeet("!cp /path\\ 1 /path\\ 2") == Some(13);
   };
 };
 

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -61,14 +61,17 @@ let update = (msg, model: model) => {
 };
 
 module CommandLine = {
-  let getCompletionMeet = commandLine => {
-    if (StringEx.isEmpty(commandLine)) { None; }
-    else {
+  let getCompletionMeet = commandLine =>
+    if (StringEx.isEmpty(commandLine)) {
+      None;
+    } else {
       let meet = StringEx.findUnescapedFromEnd(commandLine, ' ');
-      if (meet == None) { Some(0); }
-      else meet;
-    }
-  };
+      if (meet == None) {
+        Some(0);
+      } else {
+        meet;
+      };
+    };
 
   let%test "empty command line returns None" = {
     getCompletionMeet("") == None;

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -65,12 +65,8 @@ module CommandLine = {
     if (StringEx.isEmpty(commandLine)) {
       None;
     } else {
-      let meet = StringEx.findUnescapedFromEnd(commandLine, ' ');
-      if (meet == None) {
-        Some(0);
-      } else {
-        meet;
-      };
+      StringEx.findUnescapedFromEnd(commandLine, ' ')
+      |> OptionEx.or_(Some(0));
     };
 
   let%test "empty command line returns None" = {

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -66,15 +66,8 @@ module CommandLine = {
     if (len == 0) {
       None;
     } else {
-      let last_unescaped_space_index = ref(Some(0)); // default result
-      String.iteri(
-        (i, c) => if (i > 0 && commandLine.[i-1] != '\\' && c == ' ') {
-          last_unescaped_space_index := Some(i+1); // Advance past space
-        },
-        commandLine
-      );
-      last_unescaped_space_index^;
-    }
+      StringEx.findUnescapedFromEnd(commandLine, ' ');
+    };
   };
 
   let%test "empty command line returns None" = {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -644,7 +644,8 @@ let start =
           currentPos := Vim.CommandLine.getPosition();
         };
 
-        let completion = Path.trimTrailingSeparator(completion);
+        let completion =
+          completion |> Path.trimTrailingSeparator |> StringEx.escapeSpaces;
         let (latestContext: Vim.Context.t, effects) =
           Core.VimEx.inputString(completion);
         updateActiveEditorMode(latestContext.mode, effects);


### PR DESCRIPTION
- fixed issue #2624 
- fixed by searching from the back of the input instead of front
- added an accompanying `let%test`. I'm 100% new to ReasonML so please let me know if I missed something which I likely did. I don't precisely know what `let%test` does