### PR TITLE
fix(osx/#1161): PATH not available when launching from Finder

### DIFF
--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -1,0 +1,9 @@
+
+# 1. Environment
+
+## 1.1 Validate PATH set correctly on OSX (#1161)
+
+- Run release Onivim from Finder (NOT terminal)
+- Run `:echo $PATH`
+- Validate full shell path is available
+

--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -12,6 +12,5 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 export ONI2_BUNDLED=1
-export ONI2_OSX_RUN_FROM_TERMINAL=1
 
 "$DIR"/../MacOS/Oni2 --working-directory "$CWD" "$@"

--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -12,5 +12,6 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 export ONI2_BUNDLED=1
+export ONI2_OSX_RUN_FROM_TERMINAL=1
 
 "$DIR"/../MacOS/Oni2 --working-directory "$CWD" "$@"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -147,6 +147,7 @@ if (process.platform == "linux") {
         }),
         LSEnvironment: {
             ONI2_BUNDLED: "1",
+            ONI2_LAUNCHED_FROM_FINDER: "1",
         },
         SUFeedURL: process.env.ONI2_APPCAST_BASEURL,
         NSAppTransportSecurity: {

--- a/src/Core/ShellUtility.re
+++ b/src/Core/ShellUtility.re
@@ -70,6 +70,85 @@ module Internal = {
       );
       None;
     };
+
+  let environmentLinesToMap = (hasDelimiter, lines) => {
+    let rec loop = (hasEncounteredDelimiter, acc, lines) => {
+      switch (lines) {
+      | [] => acc
+      | [line, ...lines] =>
+        if (!hasEncounteredDelimiter) {
+          if (StringEx.contains("_SHELL_ENV_DELIMITER_", line)) {
+            loop(true, acc, lines);
+          } else {
+            loop(false, acc, lines);
+          };
+        } else if (StringEx.contains("_SHELL_ENV_DELIMITER_", line)) {
+          acc;
+        } else if (!StringEx.isEmpty(line)) {
+          loop(true, [line, ...acc], lines);
+        } else {
+          loop(true, acc, lines);
+        }
+      };
+    };
+
+    let prunedLines = loop(!hasDelimiter, [], lines);
+    prunedLines
+    |> List.fold_left(
+         (acc, curr) => {
+           switch (String.split_on_char('=', curr)) {
+           | [] => acc
+           | [_] => acc
+           | [key, ...values] =>
+             let v = String.concat("=", values);
+             StringMap.add(key, v, acc);
+           }
+         },
+         StringMap.empty,
+       );
+  };
+
+  let getDefaultShellEnvironment = shellCmd => {
+    switch (Revery.Environment.os) {
+    // Linux and Mac - use `env` command, and parse using a strategy from shell-env:
+    // https://github.com/sindresorhus/shell-env/blob/a95fd441d3b7cc2c122899de72da30dae70936ec/index.js#L6
+    | Linux
+    | Mac =>
+      let args = [
+        "-ilc",
+        "printf \"\n_SHELL_ENV_DELIMITER_\"; env; printf \"\n_SHELL_ENV_DELIMITER_\n\"; exit",
+      ];
+      let (inp, out, err) =
+        Unix.open_process_args_full(
+          shellCmd,
+          [shellCmd, ...args] |> Array.of_list,
+          [||],
+        );
+      let lines = ref([]);
+
+      let outLines =
+        try(
+          {
+            while (true) {
+              lines := [input_line(inp), ...lines^];
+            };
+            lines^;
+          }
+        ) {
+        | End_of_file =>
+          close_in(inp);
+          lines^;
+        };
+
+      close_out(out);
+      close_in(err);
+      environmentLinesToMap(true, outLines);
+
+    // Windows - just use default environment.
+    | Windows
+    | _ => Unix.environment() |> Array.to_list |> environmentLinesToMap(false)
+    };
+  };
 };
 
 let getDefaultShell = () => {
@@ -97,18 +176,28 @@ let getDefaultShell = () => {
   |> Lazy.force;
 };
 
+let getDefaultShellEnvironment = () => {
+  (
+    lazy({
+      let shellCmd = getDefaultShell();
+      Internal.getDefaultShellEnvironment(shellCmd);
+    })
+  )
+  |> Lazy.force;
+};
+
 let getPathFromEnvironment = Internal.getPathFromEnvironment;
 
 let getPathFromShell = () => {
   let path =
     switch (Revery.Environment.os) {
     | Mac =>
-      let shell = getDefaultShell();
-      let shellCmd = Printf.sprintf("%s -lc 'echo $PATH'", shell);
-      try(Internal.runCommand(shellCmd)) {
-      | ex =>
-        Log.warn("Unable to retreive path: " ++ Printexc.to_string(ex));
+      let envMap = getDefaultShellEnvironment();
+      switch (StringMap.find_opt("PATH", envMap)) {
+      | None =>
+        Log.warn("Unable to retreive path from env command.");
         Internal.getPathFromEnvironment();
+      | Some(path) => path
       };
     | _ => Internal.getPathFromEnvironment()
     };
@@ -116,3 +205,24 @@ let getPathFromShell = () => {
   Log.debug("Path detected as: " ++ path);
   path;
 };
+
+let fixOSXPath = () =>
+  // #1161 - OSX - Make sure we're using the terminal / shell PATH.
+  // By default, if the application is opened via Finder, it won't get the shell $PATH.
+  // Use a strategy like the fix-path NPM module:
+  // https://github.com/sindresorhus/fix-path/blob/8f12bec72ee4319638a43758b40d61c25427404b/index.js#L5
+  if (Revery.Environment.os == Mac) {
+    let shellEnv = getDefaultShellEnvironment();
+    switch (StringMap.find_opt("PATH", shellEnv)) {
+    | Some(path) =>
+      Log.infof(m => m("OSX - setting path from shell: %s", path));
+      Luv.Env.setenv(~value=path, "PATH")
+      |> Utility.ResultEx.tapError(err => {
+           Log.errorf(m =>
+             m("Unable to set PATH: %s", Luv.Error.strerror(err))
+           )
+         })
+      |> Result.iter(() => Log.info("Set PATH successfully"));
+    | None => Log.warn("OSX - Unable to get shell path.")
+    };
+  };

--- a/src/Core/ShellUtility.rei
+++ b/src/Core/ShellUtility.rei
@@ -6,3 +6,8 @@ let getPathFromShell: unit => string;
 
 // Get the path from the current process environment
 let getPathFromEnvironment: unit => string;
+
+// Get a key-value pair representing the default shell environment
+let getDefaultShellEnvironment: unit => Kernel.StringMap.t(string);
+
+let fixOSXPath: unit => unit;

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -66,6 +66,9 @@ switch (eff) {
   };
   Oni_Core.Log.init();
 
+  // #1161 - OSX - Make sure we're using the terminal / shell PATH.
+  Core.ShellUtility.fixOSXPath();
+
   let initWorkingDirectory = () => {
     let path =
       switch (Oni_CLI.(cliOptions.folder)) {

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -67,7 +67,9 @@ switch (eff) {
   Oni_Core.Log.init();
 
   // #1161 - OSX - Make sure we're using the terminal / shell PATH.
-  if (Sys.getenv_opt("ONI2_OSX_RUN_FROM_TERMINAL") == None) {
+  // Only fix path when launched from finder -
+  // it seems running `zsh -ilc` hangs when running from terminal.
+  if (Sys.getenv_opt("ONI2_LAUNCHED_FROM_FINDER") |> Option.is_some) {
     Core.ShellUtility.fixOSXPath();
   };
 

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -67,7 +67,9 @@ switch (eff) {
   Oni_Core.Log.init();
 
   // #1161 - OSX - Make sure we're using the terminal / shell PATH.
-  Core.ShellUtility.fixOSXPath();
+  if (Sys.getenv_opt("ONI2_OSX_RUN_FROM_TERMINAL") == None) {
+    Core.ShellUtility.fixOSXPath();
+  };
 
   let initWorkingDirectory = () => {
     let path =


### PR DESCRIPTION
Continuation of the fix started in #2614 

Related to #1161 and #1548 - there is another bug with `PATH` on OSX. When running Onivim from finder, the Onivim process won't get shell environment variables like `PATH`. 

So you get a very small list of `PATH` variables:
![image](https://user-images.githubusercontent.com/13532591/96906340-810c3e80-144e-11eb-9546-ad26fc0fd6eb.png)

This is problematic for the extension host, as well - some extensions look for binaries in the user's current PATH, and if we're not sending the full terminal PATH, some of these utilities could be missed. Likewise for Vim shell commands (ie, `:!`).

It turns out, this isn't a problem unique to Onivim.... happens to Electron apps too, ie: https://stackoverflow.com/questions/62067127/path-variables-empty-in-electron  So we use a similar strategy to the [`fix-path`](https://github.com/sindresorhus/fix-path/blob/8f12bec72ee4319638a43758b40d61c25427404b/index.js#L9) NPM module to address it.

The original fix for #2614 worked from Finder, but broke opening from terminal - the spawned `zsh` process would hang when run from terminal. This refines the fix, such that the `PATH` update only happens when we run from finder - an environment variable is added to `LSEnvironment` to let us know when that is the case.