### PR TITLE
fix(input/#1691): Keybindings - extra key needed to be pressed with gt keybinding

### DIFF
--- a/src/Input/Keybindings.re
+++ b/src/Input/Keybindings.re
@@ -94,7 +94,10 @@ module Internal = {
 
 type effect =
   Input.effect =
-    | Execute(string) | Text(string) | Unhandled(EditorInput.KeyPress.t);
+    | Execute(string)
+    | Text(string)
+    | Unhandled(EditorInput.KeyPress.t)
+    | RemapRecursionLimitHit;
 
 type t = Input.t;
 

--- a/src/Input/Keybindings.rei
+++ b/src/Input/Keybindings.rei
@@ -5,7 +5,8 @@ let empty: t;
 type effect =
   | Execute(string)
   | Text(string)
-  | Unhandled(EditorInput.KeyPress.t);
+  | Unhandled(EditorInput.KeyPress.t)
+  | RemapRecursionLimitHit;
 
 let count: t => int;
 

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -43,10 +43,10 @@ type t =
   | KeyBindingsReload
   | KeyBindingsParseError(string)
   | KeybindingInvoked({command: string})
-  | KeyDown([@opaque] EditorInput.KeyPress.t, [@opaque] Revery.Time.t)
-  | KeyUp([@opaque] EditorInput.KeyPress.t, [@opaque] Revery.Time.t)
+  | KeyDown(EditorInput.KeyPress.t, [@opaque] Revery.Time.t)
+  | KeyUp(EditorInput.KeyPress.t, [@opaque] Revery.Time.t)
   | Logging(Feature_Logging.msg)
-  | TextInput([@opaque] string, [@opaque] Revery.Time.t)
+  | TextInput(string, [@opaque] Revery.Time.t)
   | DisableKeyDisplayer
   | EnableKeyDisplayer
   // TODO: This should be a function call - wired up from an input feature

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -132,6 +132,9 @@ let start = (window: option(Revery.Window.t), runEffects) => {
       | None => []
       | Some(k) => handleTextEffect(~isText=false, state, k)
       };
+
+    // TODO: Show a notification that recursion limit was hit
+    | Keybindings.RemapRecursionLimitHit => []
     };
 
   let reveryKeyToEditorKey =

--- a/src/editor-input/EditorInput.re
+++ b/src/editor-input/EditorInput.re
@@ -371,10 +371,14 @@ module Make = (Config: {
 
       let potentialBindingCount = candidateBindingCount - readyBindingCount;
 
+      // We've got more than one potential binding, so let's wait
+      // and see what the user presses next.
       if (potentialBindingCount > 0) {
         ({...bindings, revKeys}, []);
       } else {
+        // No 'potential' bindings - but is there one ready?
         switch (List.nth_opt(readyBindings, 0)) {
+        // There is a matching, ready binding - let's run it.
         | Some(binding) =>
           let bindings' =
             useUpKeysForBinding(~context, ~bindingId=binding.id, bindings);
@@ -384,10 +388,12 @@ module Make = (Config: {
               {...bindings', text, suppressText: true},
               [Execute(command)],
             )
+
           | Remap(_) =>
             // Let flush handle the remap action
             flush(~recursionDepth, ~context, {...bindings, revKeys})
           };
+
         | None => flush(~recursionDepth, ~context, {...bindings, revKeys})
         };
       };

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -31,6 +31,7 @@ module Key: {
 };
 
 module Modifiers: {
+  [@deriving show]
   type t = {
     control: bool,
     alt: bool,
@@ -67,6 +68,7 @@ module Matcher: {
 };
 
 module KeyPress: {
+  [@deriving show]
   type t = {
     scancode: int,
     keycode: int,
@@ -107,7 +109,6 @@ module type Input = {
   let keyDown: (~context: context, ~key: KeyPress.t, t) => (t, list(effect));
   let text: (~text: string, t) => (t, list(effect));
   let keyUp: (~context: context, ~key: KeyPress.t, t) => (t, list(effect));
-  let flush: (~context: context, t) => (t, list(effect));
 
   /**
   [isPending(bindings)] returns true if there is a potential

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -99,7 +99,10 @@ module type Input = {
     | Text(string)
     // The `Unhandled` effect occurs when an unhandled `keyDown` input event occurs.
     // This can happen if there is no binding associated with a key.
-    | Unhandled(KeyPress.t);
+    | Unhandled(KeyPress.t)
+    // RemapRecursionLimitHit is produced if there is a recursive loop
+    // in remappings such that we hit the max limit.
+    | RemapRecursionLimitHit;
 
   let keyDown: (~context: context, ~key: KeyPress.t, t) => (t, list(effect));
   let text: (~text: string, t) => (t, list(effect));

--- a/src/editor-input/KeyPress.re
+++ b/src/editor-input/KeyPress.re
@@ -1,3 +1,4 @@
+[@deriving show]
 type t = {
   scancode: int,
   keycode: int,

--- a/src/editor-input/Modifiers.re
+++ b/src/editor-input/Modifiers.re
@@ -1,3 +1,4 @@
+[@deriving show]
 type t = {
   control: bool,
   alt: bool,

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -432,7 +432,10 @@ describe("EditorInput", ({describe, _}) => {
       let (_bindings, effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
-      expect.equal(effects, [Unhandled(aKeyNoModifiers)]);
+      expect.equal(
+        effects,
+        [RemapRecursionLimitHit, Unhandled(aKeyNoModifiers)],
+      );
     });
 
     test("unhandled, sequence remap", ({expect, _}) => {
@@ -455,21 +458,23 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, [Unhandled(cKeyNoModifiers)]);
     });
-    /*test("unhandled, multiple keys", ({expect, _}) => {
-        let (bindings, _id) =
-          Input.empty
-          |> Input.addMapping(
-               [Keydown(Keycode(1, Modifiers.none)],
-               _ => true,
-               [bKeyNoModifiers, cKeyNoModifiers],
-             );
+    test("unhandled, multiple keys", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
+             _ => true,
+             [bKeyNoModifiers, cKeyNoModifiers],
+           );
 
-        let (_bindings, effects) = Input.keyDown(context=true, aKeyNoModifiers, bindings);
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
-        expect.equal(effects, [
-          Unhandled(cKeyNoModifiers),
-          Unhandled(bKeyNoModifiers)]);
-      });*/
+      expect.equal(
+        effects,
+        [Unhandled(bKeyNoModifiers), Unhandled(cKeyNoModifiers)],
+      );
+    });
     test("with command", ({expect, _}) => {
       let (bindings, _id) =
         Input.empty
@@ -490,6 +495,35 @@ describe("EditorInput", ({describe, _}) => {
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("command2")]);
+    });
+    test("with multiple commands", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
+             _ => true,
+             [bKeyNoModifiers, cKeyNoModifiers],
+           );
+      let (bindings, _id) =
+        bindings
+        |> Input.addBinding(
+             Sequence([Keydown(Keycode(2, Modifiers.none))]),
+             _ => true,
+             "command2",
+           );
+
+      let (bindings, _id) =
+        bindings
+        |> Input.addBinding(
+             Sequence([Keydown(Keycode(3, Modifiers.none))]),
+             _ => true,
+             "command3",
+           );
+
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Execute("command2"), Execute("command3")]);
     });
   });
 });

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -222,41 +222,6 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, [Execute("commandA!A")]);
     });
-    //    test("partial match with another match", ({expect, _}) => {
-    //      let (bindings, _id) =
-    //        Input.empty
-    //        |> Input.addBinding(
-    //             Sequence([
-    //               Keydown(Keycode(1, Modifiers.none)),
-    //               Keydown(Keycode(3, Modifiers.none)),
-    //             ]),
-    //             _ => true,
-    //             "commandAC",
-    //           );
-    //
-    //      let (bindings, _id) =
-    //        bindings
-    //        |> Input.addBinding(
-    //             Sequence([Keydown(Keycode(1, Modifiers.none))]),
-    //             _ => true,
-    //             "commandA",
-    //           );
-    //
-    //      let (bindings, effects) =
-    //        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
-    //
-    //      expect.equal(effects, []);
-    //
-    //      let (bindings, effects) =
-    //        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
-    //
-    //      expect.equal(effects, [Execute("commandA")]);
-    //
-    //      let (_bindings, effects) =
-    //        Input.keyDown(~context=true, ~key=cKeyNoModifiers, bindings);
-    //
-    //      expect.equal(effects, [Execute("commandAC")]);
-    //    });
     test("partial match with unhandled", ({expect, _}) => {
       let (bindings, _id) =
         Input.empty

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -17,37 +17,6 @@ module Input =
   });
 
 describe("EditorInput", ({describe, _}) => {
-  describe("flush", ({test, _}) => {
-    test("simple sequence", ({expect, _}) => {
-      let (bindings, _id) =
-        Input.empty
-        |> Input.addBinding(
-             Sequence([
-               Keydown(Keycode(1, Modifiers.none)),
-               Keydown(Keycode(2, Modifiers.none)),
-             ]),
-             _ => true,
-             "commandAB",
-           );
-
-      let (bindings, _id) =
-        bindings
-        |> Input.addBinding(
-             Sequence([Keydown(Keycode(1, Modifiers.none))]),
-             _ => true,
-             "commandA",
-           );
-
-      let (bindings, effects) =
-        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
-
-      expect.equal(effects, []);
-
-      let (_bindings, effects) = Input.flush(~context=true, bindings);
-
-      expect.equal(effects, [Execute("commandA")]);
-    })
-  });
   describe("allKeysReleased", ({test, _}) => {
     test("basic release case", ({expect, _}) => {
       let (bindings, _id) =
@@ -253,41 +222,41 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, [Execute("commandA!A")]);
     });
-    test("partial match with another match", ({expect, _}) => {
-      let (bindings, _id) =
-        Input.empty
-        |> Input.addBinding(
-             Sequence([
-               Keydown(Keycode(1, Modifiers.none)),
-               Keydown(Keycode(3, Modifiers.none)),
-             ]),
-             _ => true,
-             "commandAC",
-           );
-
-      let (bindings, _id) =
-        bindings
-        |> Input.addBinding(
-             Sequence([Keydown(Keycode(1, Modifiers.none))]),
-             _ => true,
-             "commandA",
-           );
-
-      let (bindings, effects) =
-        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
-
-      expect.equal(effects, []);
-
-      let (bindings, effects) =
-        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
-
-      expect.equal(effects, [Execute("commandA")]);
-
-      let (_bindings, effects) =
-        Input.keyDown(~context=true, ~key=cKeyNoModifiers, bindings);
-
-      expect.equal(effects, [Execute("commandAC")]);
-    });
+    //    test("partial match with another match", ({expect, _}) => {
+    //      let (bindings, _id) =
+    //        Input.empty
+    //        |> Input.addBinding(
+    //             Sequence([
+    //               Keydown(Keycode(1, Modifiers.none)),
+    //               Keydown(Keycode(3, Modifiers.none)),
+    //             ]),
+    //             _ => true,
+    //             "commandAC",
+    //           );
+    //
+    //      let (bindings, _id) =
+    //        bindings
+    //        |> Input.addBinding(
+    //             Sequence([Keydown(Keycode(1, Modifiers.none))]),
+    //             _ => true,
+    //             "commandA",
+    //           );
+    //
+    //      let (bindings, effects) =
+    //        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+    //
+    //      expect.equal(effects, []);
+    //
+    //      let (bindings, effects) =
+    //        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+    //
+    //      expect.equal(effects, [Execute("commandA")]);
+    //
+    //      let (_bindings, effects) =
+    //        Input.keyDown(~context=true, ~key=cKeyNoModifiers, bindings);
+    //
+    //      expect.equal(effects, [Execute("commandAC")]);
+    //    });
     test("partial match with unhandled", ({expect, _}) => {
       let (bindings, _id) =
         Input.empty
@@ -318,7 +287,7 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(
         effects,
-        [Unhandled(bKeyNoModifiers), Execute("commandA")],
+        [Execute("commandA"), Unhandled(bKeyNoModifiers)],
       );
     });
     test("#1691: almost match gets unhandled", ({expect, _}) => {
@@ -334,8 +303,7 @@ describe("EditorInput", ({describe, _}) => {
              "commandAC",
            );
 
-
-      // Press a... 
+      // Press a...
       let (bindings, effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -321,6 +321,35 @@ describe("EditorInput", ({describe, _}) => {
         [Unhandled(bKeyNoModifiers), Execute("commandA")],
       );
     });
+    test("#1691: almost match gets unhandled", ({expect, _}) => {
+      // Add binding for 'aa'
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             Sequence([
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(1, Modifiers.none)),
+             ]),
+             _ => true,
+             "commandAC",
+           );
+
+
+      // Press a... 
+      let (bindings, effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+
+      expect.equal(effects, []);
+
+      // Press b...
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
+
+      expect.equal(
+        effects,
+        [Unhandled(aKeyNoModifiers), Unhandled(bKeyNoModifiers)],
+      );
+    });
   });
   describe("enabled / disabled", ({test, _}) => {
     let identity = context => context;


### PR DESCRIPTION
__Issue:__ As described in #1691 - mapping to `gt` would cause Vim commands - like `gg` to not work as expected. These sorts of input issues are important to fix as the [externalized mapping](https://github.com/onivim/libvim/pull/236) commands are hooked up - to be able to support `map`, `inoremap`, etc in Onivim properly.

__Defect:__ When the `gt` binding was added, and `gg` was run - the expected behavior would be that, in our EditorInput / keybindings, the following sequence would take place:
- First `g` pressed, put on pending keys - it could be the start of a `gt` binding
- Second `g` pressed - `gt` binding isn't a candidate anymore, flush both `g`s (should return effects like `[Unhandled(g), Unhandled(g)]`.

However, when the second `g` was pressed, only a single `g` would be flushed, and the second one would be left waiting.

__Fix:__ Once we've gotten to the point where there are no binding candidates, only accept entire matches. Before, we'd flush a single `g`, and then leave the other `g` as pending input, thinking that there might be a `t` to come along to complete it.

Fixes #1691 and lays some of the ground work needed to support vim remaps