### PR TITLE
fix(extension/#2641): ocamllsp not picked up from OPAM project

### DIFF
--- a/extensions/reason-vscode/src/index.js
+++ b/extensions/reason-vscode/src/index.js
@@ -2,57 +2,58 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-'use strict';
-const vscode = require("vscode");
-const {Uri, window} = vscode;
-const {LanguageClient, RevealOutputChannelOn} = require("vscode-languageclient");
-const {TextDocument} = require('vscode-languageserver-types');
-const path = require('path')
-const fs = require('fs')
-const cp = require('child_process');
+"use strict"
+const vscode = require("vscode")
+const { Uri, window } = vscode
+const { LanguageClient, RevealOutputChannelOn } = require("vscode-languageclient")
+const { TextDocument } = require("vscode-languageserver-types")
+const path = require("path")
+const fs = require("fs")
+const cp = require("child_process")
 
-const isWindows = process.platform == "win32";
+const isWindows = process.platform == "win32"
 
-const shouldReload = () => vscode.workspace.getConfiguration('reason_language_server').get('reloadOnChange')
+const shouldReload = () =>
+    vscode.workspace.getConfiguration("reason_language_server").get("reloadOnChange")
 
 /**
  * Taken from https://github.com/rust-lang/rls-vscode/blob/master/src/extension.ts
- * 
+ *
  * Sets up additional language configuration that's impossible to do via a
  * separate language-configuration.json file. See [1] for more information.
  *
  * [1]: https://github.com/Microsoft/vscode/issues/11514#issuecomment-244707076
  */
 function configureLanguage() {
-  return vscode.languages.setLanguageConfiguration('reason', {
-    onEnterRules: [
-      {
-        // Begins an auto-closed multi-line comment (standard or parent doc)
-        // e.g. /** | */ or /*! | */
-        beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
-        afterText: /^\s*\*\/$/,
-        action: { indentAction: vscode.IndentAction.IndentOutdent, appendText: ' * ' },
-      },
-      {
-        // Begins a multi-line comment (standard or parent doc)
-        // e.g. /** ...| or /*! ...|
-        beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
-        action: { indentAction: vscode.IndentAction.None, appendText: ' * ' },
-      },
-      {
-        // Continues a multi-line comment
-        // e.g.  * ...|
-        beforeText: /^(\ \ )*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
-        action: { indentAction: vscode.IndentAction.None, appendText: '* ' },
-      },
-      {
-        // Dedents after closing a multi-line comment
-        // e.g.  */|
-        beforeText: /^(\ \ )*\ \*\/\s*$/,
-        action: { indentAction: vscode.IndentAction.None, removeText: 1 },
-      },
-    ],
-  });
+    return vscode.languages.setLanguageConfiguration("reason", {
+        onEnterRules: [
+            {
+                // Begins an auto-closed multi-line comment (standard or parent doc)
+                // e.g. /** | */ or /*! | */
+                beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
+                afterText: /^\s*\*\/$/,
+                action: { indentAction: vscode.IndentAction.IndentOutdent, appendText: " * " },
+            },
+            {
+                // Begins a multi-line comment (standard or parent doc)
+                // e.g. /** ...| or /*! ...|
+                beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
+                action: { indentAction: vscode.IndentAction.None, appendText: " * " },
+            },
+            {
+                // Continues a multi-line comment
+                // e.g.  * ...|
+                beforeText: /^(\ \ )*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
+                action: { indentAction: vscode.IndentAction.None, appendText: "* " },
+            },
+            {
+                // Dedents after closing a multi-line comment
+                // e.g.  */|
+                beforeText: /^(\ \ )*\ \*\/\s*$/,
+                action: { indentAction: vscode.IndentAction.None, removeText: 1 },
+            },
+        ],
+    })
 }
 
 function activate(context) {
@@ -60,108 +61,143 @@ function activate(context) {
 
     let clientOptions = {
         documentSelector: [
-            {scheme: 'file', language: 'reason'},
-            {scheme: 'file', language: 'ocaml'},
-            {scheme: 'file', language: 'reason_lisp'}
+            { scheme: "file", language: "reason" },
+            { scheme: "file", language: "ocaml" },
+            { scheme: "file", language: "reason_lisp" },
         ],
         synchronize: {
             // Synchronize the setting section 'reason_language_server' to the server
-            configurationSection: 'reason_language_server',
+            configurationSection: "reason_language_server",
             fileEvents: [
-                vscode.workspace.createFileSystemWatcher('**/bsconfig.json'),
-                vscode.workspace.createFileSystemWatcher('**/.merlin')
-            ]
+                vscode.workspace.createFileSystemWatcher("**/bsconfig.json"),
+                vscode.workspace.createFileSystemWatcher("**/.merlin"),
+            ],
         },
         revealOutputChannelOn: RevealOutputChannelOn.Never,
-    };
+    }
 
     let client = null
     let lastStartTime = null
     let interval = null
-    let channel = window.createOutputChannel("reason-vscode");
-    context.subscriptions.push(channel);
+    let channel = window.createOutputChannel("reason-vscode")
+    context.subscriptions.push(channel)
 
-    let log = (msg) => channel.appendLine(msg);
+    let log = (msg) => channel.appendLine(msg)
 
     const validatePath = (pathToValidate) => {
         if (!pathToValidate) {
-            return null;
+            return null
         }
 
         if (!path.isAbsolute(pathToValidate)) {
-            pathToValidate = path.join(vscode.workspace.rootPath, pathToValidate);
+            pathToValidate = path.join(vscode.workspace.rootPath, pathToValidate)
         }
 
         if (!fs.existsSync(pathToValidate)) {
-            return null;
+            return null
         }
 
-        return pathToValidate;
-    };
+        return pathToValidate
+    }
 
     const isEsyProject = (projectPath) => {
-        const files = fs.readdirSync(projectPath);
+        const files = fs.readdirSync(projectPath)
 
         let filtered = files.filter((file) => {
-            return file == "dune" || file == "dune-project" || path.extname(file) == ".opam" || file == "esy.lock"
-        });
+            return (
+                file == "dune" ||
+                file == "dune-project" ||
+                path.extname(file) == ".opam" ||
+                file == "esy.lock"
+            )
+        })
         // We assume if there is an OPAM file or a dune file, this must be a native project.
-        const result = filtered.length > 0;
-        log(`isEsyProject(${projectPath}): ${result}`);
-        return result;
-    };
+        const result = filtered.length > 0
+        log(`isEsyProject(${projectPath}): ${result}`)
+        return result
+    }
 
     const isEsyAvailable = (projectPath) => {
         try {
-            cp.execSync("esy --version", { cwd: projectPath });
-            return true;
+            cp.execSync("esy --version", { cwd: projectPath })
+            return true
         } catch (ex) {
-            log("Unable to get esy version: " + ex.toString());
-            return false;
+            log("Unable to get esy version: " + ex.toString())
+            return false
         }
-    };
+    }
 
-    const addExe = (filePath) => 
-        isWindows ? filePath + ".exe" : filePath;
+    const addExe = (filePath) => (isWindows ? filePath + ".exe" : filePath)
 
-    const addCmd = (filePath) => 
-        isWindows ? filePath + ".cmd" : filePath;
+    const addCmd = (filePath) => (isWindows ? filePath + ".cmd" : filePath)
 
-    const getOcamlLspPath = (projectPath) => {
+    const findOcamlLspFromEsy = (projectPath) => {
         try {
-           let ocamlLspDirectory = cp.execSync("esy -q sh -c \"echo #{@opam/ocaml-lsp-server.bin}\"", { cwd: projectPath })
-           .toString()
-           .trim();
-            return path.join(ocamlLspDirectory, addExe("ocamllsp"));
+            let ocamlLspDirectory = cp
+                .execSync('esy -q sh -c "echo #{@opam/ocaml-lsp-server.bin}"', { cwd: projectPath })
+                .toString()
+                .trim()
+            return path.join(ocamlLspDirectory, addExe("ocamllsp"))
         } catch (ex) {
-            log("Unable to get ocaml-lsp-server binary: " + ex.toString());
-            return null;
+            log("Unable to get ocaml-lsp-server binary: " + ex.toString())
+            return null
         }
-    };
+    }
+
+    const findOcamlLspFromEnvironment = () => {
+        try {
+            let ocamlLspPath = cp.execSync("which ocamllsp").toString().trim()
+            if (fs.existsSync(ocamlLspPath)) {
+                return ocamlLspPath
+            } else {
+                return null
+            }
+        } catch (ex) {
+            log("Unable to get ocaml-lsp-server binary: " + ex.toString())
+            return null
+        }
+    }
 
     const getLocation = (_context) => {
-        let rlsBinaryLocation = validatePath(vscode.workspace.getConfiguration('reason_language_server').get('location'));
+        let rlsBinaryLocation = validatePath(
+            vscode.workspace.getConfiguration("reason_language_server").get("location"),
+        )
 
-        const projectPath = vscode.workspace.rootPath;
+        const projectPath = vscode.workspace.rootPath
         if (isEsyAvailable(projectPath) && isEsyProject(projectPath)) {
             // Let's see if ocaml-lsp-server is available
             log("Found esy. Looking to see if ocaml-lsp-server is available...")
-            const ocamlLspPath = getOcamlLspPath(projectPath);
+            const ocamlLspPath = findOcamlLspFromEsy(projectPath)
             if (ocamlLspPath) {
-                log('Got ocaml LSP binary: ' + ocamlLspPath);
-                return [addCmd("esy"), [ocamlLspPath]];
+                log("Got ocaml LSP binary: " + ocamlLspPath)
+                return [addCmd("esy"), [ocamlLspPath]]
             } else {
-                log("ocaml-lsp not found, falling back to RLS: " + rlsBinaryLocation);
-                return [rlsBinaryLocation, null]
+                const ocamlLspCandidate = findOcamlLspFromEnvironment()
+                if (ocamlLspCandidate) {
+                    log("Found ocamllsp in environment:" + ocamlLspCandidate)
+                    return [ocamlLspCandidate, null]
+                } else {
+                    log("ocaml-lsp not found, falling back to RLS: " + rlsBinaryLocation)
+                    return [rlsBinaryLocation, null]
+                }
             }
         } else {
-            log("Esy not found, falling back to RLS: " + rlsBinaryLocation);
-            return [rlsBinaryLocation, null];
+            // Try to find ocamllsp from the environment, like OPAM:
+            const ocamlLspCandidate = findOcamlLspFromEnvironment()
+            if (ocamlLspCandidate) {
+                log("Found ocamllsp in environment w/o esy: " + ocamlLspCandidate)
+                return [ocamlLspCandidate, null]
+            } else {
+                log("Esy not found, falling back to RLS: " + rlsBinaryLocation)
+                return [rlsBinaryLocation, null]
+            }
         }
     }
 
     const startChecking = (location) => {
-        vscode.window.showInformationMessage('DEBUG MODE: Will auto-restart the reason language server if it recompiles');
+        vscode.window.showInformationMessage(
+            "DEBUG MODE: Will auto-restart the reason language server if it recompiles",
+        )
         interval = setInterval(() => {
             try {
                 const stat = fs.statSync(location)
@@ -170,10 +206,10 @@ function activate(context) {
                     restart()
                 }
             } catch (e) {
-                console.warn('Failed to check binary mtime ' + e.message)
+                console.warn("Failed to check binary mtime " + e.message)
             }
-        }, 500);
-        context.subscriptions.push({dispose: () => clearInterval(checkForBinaryChange)})
+        }, 500)
+        context.subscriptions.push({ dispose: () => clearInterval(checkForBinaryChange) })
     }
 
     /**
@@ -188,78 +224,81 @@ function activate(context) {
 
     const restart = () => {
         if (client) {
-            client.stop();
+            client.stop()
         }
         const [command, args] = getLocation(context)
         if (!command) return
 
-        vscode.window.showInformationMessage(`Starting language server: ${command} | ${args}`);
+        vscode.window.showInformationMessage(`Starting language server: ${command} | ${args}`)
         client = new LanguageClient(
-            'reason-language-server',
-            'Reason Language Server',
+            "reason-language-server",
+            "Reason Language Server",
             {
                 command,
                 args,
             },
             Object.assign({}, clientOptions, {
-                revealOutputChannelOn: vscode.workspace.getConfiguration('reason_language_server').get('show_debug_errors')
+                revealOutputChannelOn: vscode.workspace
+                    .getConfiguration("reason_language_server")
+                    .get("show_debug_errors")
                     ? RevealOutputChannelOn.Error
-                    : RevealOutputChannelOn.Never
+                    : RevealOutputChannelOn.Never,
             }),
-        );
+        )
         lastStartTime = Date.now()
-        context.subscriptions.push(client.start());
+        context.subscriptions.push(client.start())
         if (shouldReload()) {
-            vscode.window.showInformationMessage('Reason language server restarted');
+            vscode.window.showInformationMessage("Reason language server restarted")
             if (!interval) {
                 startChecking(location)
             }
         } else if (interval) {
-            vscode.window.showInformationMessage('DEBUG MODE OFF - no longer monitoring reason-language-server binary');
+            vscode.window.showInformationMessage(
+                "DEBUG MODE OFF - no longer monitoring reason-language-server binary",
+            )
             clearInterval(interval)
             interval = null
         }
     }
 
-    vscode.workspace.onDidChangeConfiguration(evt => {
-        if (evt.affectsConfiguration('reason_language_server.location')) {
+    vscode.workspace.onDidChangeConfiguration((evt) => {
+        if (evt.affectsConfiguration("reason_language_server.location")) {
             restart()
         }
-    });
+    })
 
-    vscode.workspace.onDidChangeWorkspaceFolders(_evt => {
-        log('Workspace root changed:' + vscode.workspace.rootPath);
-        restart(); 
-    });
+    vscode.workspace.onDidChangeWorkspaceFolders((_evt) => {
+        log("Workspace root changed:" + vscode.workspace.rootPath)
+        restart()
+    })
 
-    vscode.commands.registerCommand('reason-language-server.restart', restart);
+    vscode.commands.registerCommand("reason-language-server.restart", restart)
 
     const createInterface = (minimal) => {
         if (!client) {
-            return vscode.window.showInformationMessage('Language server not running');
+            return vscode.window.showInformationMessage("Language server not running")
         }
-        const editor = vscode.window.activeTextEditor;
+        const editor = vscode.window.activeTextEditor
         if (!editor) {
-            return vscode.window.showInformationMessage('No active editor');
+            return vscode.window.showInformationMessage("No active editor")
         }
-        if (fs.existsSync(editor.document.uri.fsPath + 'i')) {
-            return vscode.window.showInformationMessage('Interface file already exists');
+        if (fs.existsSync(editor.document.uri.fsPath + "i")) {
+            return vscode.window.showInformationMessage("Interface file already exists")
         }
         client.sendRequest("custom:reasonLanguageServer/createInterface", {
-            "uri": editor.document.uri.toString(),
-            "minimal": minimal
+            uri: editor.document.uri.toString(),
+            minimal: minimal,
         })
-    };
+    }
 
-    vscode.commands.registerCommand('reason-language-server.create_interface', () => {
+    vscode.commands.registerCommand("reason-language-server.create_interface", () => {
         createInterface(false)
-    });
-
+    })
 
     class AstSourceProvider {
         constructor() {
             this.privateOnDidChange = new vscode.EventEmitter()
-            this.onDidChange = this.privateOnDidChange.event;
+            this.onDidChange = this.privateOnDidChange.event
         }
         provideTextDocumentContent(uri, token) {
             if (!client) {
@@ -267,11 +306,11 @@ function activate(context) {
             }
 
             return client.sendRequest("custom:reasonLanguageServer/showAst", {
-                "textDocument": {
-                    "uri": uri.with({scheme: 'file'}).toString(),
+                textDocument: {
+                    uri: uri.with({ scheme: "file" }).toString(),
                 },
                 // unused currently
-                "position": {character: 0, line: 0},
+                position: { character: 0, line: 0 },
             })
         }
     }
@@ -279,7 +318,7 @@ function activate(context) {
     class PpxedSourceProvider {
         constructor() {
             this.privateOnDidChange = new vscode.EventEmitter()
-            this.onDidChange = this.privateOnDidChange.event;
+            this.onDidChange = this.privateOnDidChange.event
         }
         provideTextDocumentContent(uri, token) {
             if (!client) {
@@ -287,11 +326,11 @@ function activate(context) {
             }
 
             return client.sendRequest("custom:reasonLanguageServer/showPpxedSource", {
-                "textDocument": {
-                    "uri": uri.with({scheme: 'file'}).toString(),
+                textDocument: {
+                    uri: uri.with({ scheme: "file" }).toString(),
                 },
                 // unused currently
-                "position": {character: 0, line: 0},
+                position: { character: 0, line: 0 },
             })
         }
     }
@@ -301,79 +340,88 @@ function activate(context) {
 
     context.subscriptions.push(
         vscode.workspace.onDidSaveTextDocument((document) => {
-            const uri = document.uri;
-            provider.privateOnDidChange.fire(uri.with({scheme: 'ppxed-source'}))
-            astProvider.privateOnDidChange.fire(uri.with({scheme: 'ast-source'}))
+            const uri = document.uri
+            provider.privateOnDidChange.fire(uri.with({ scheme: "ppxed-source" }))
+            astProvider.privateOnDidChange.fire(uri.with({ scheme: "ast-source" }))
         }),
-    );
+    )
 
-    context.subscriptions.push(configureLanguage());
+    context.subscriptions.push(configureLanguage())
 
-    vscode.workspace.registerTextDocumentContentProvider("ppxed-source", provider);
-    vscode.workspace.registerTextDocumentContentProvider("ast-source", astProvider);
+    vscode.workspace.registerTextDocumentContentProvider("ppxed-source", provider)
+    vscode.workspace.registerTextDocumentContentProvider("ast-source", astProvider)
 
     const showPpxedSource = () => {
         if (!client) {
-            return vscode.window.showInformationMessage('Language server not running');
+            return vscode.window.showInformationMessage("Language server not running")
         }
-        const editor = vscode.window.activeTextEditor;
+        const editor = vscode.window.activeTextEditor
         if (!editor) {
-            return vscode.window.showInformationMessage('No active editor');
+            return vscode.window.showInformationMessage("No active editor")
         }
-        if (editor.document.languageId !== 'ocaml' && editor.document.languageId !== 'reason') {
-            return vscode.window.showInformationMessage('Not an OCaml or Reason file');
+        if (editor.document.languageId !== "ocaml" && editor.document.languageId !== "reason") {
+            return vscode.window.showInformationMessage("Not an OCaml or Reason file")
         }
 
-        const document = TextDocument.create(editor.document.uri.with({scheme: 'ppxed-source'}), editor.document.languageId, 1, '');
-        vscode.window.showTextDocument(document);
-    };
+        const document = TextDocument.create(
+            editor.document.uri.with({ scheme: "ppxed-source" }),
+            editor.document.languageId,
+            1,
+            "",
+        )
+        vscode.window.showTextDocument(document)
+    }
 
-    vscode.commands.registerCommand('reason-language-server.show_ppxed_source', showPpxedSource);
+    vscode.commands.registerCommand("reason-language-server.show_ppxed_source", showPpxedSource)
 
-    vscode.commands.registerCommand('reason-language-server.dump_file_data', () => {
+    vscode.commands.registerCommand("reason-language-server.dump_file_data", () => {
         if (!client) {
-            return vscode.window.showInformationMessage('Language server not running');
+            return vscode.window.showInformationMessage("Language server not running")
         }
-        const editor = vscode.window.activeTextEditor;
+        const editor = vscode.window.activeTextEditor
         if (!editor) {
-            return vscode.window.showInformationMessage('No active editor');
+            return vscode.window.showInformationMessage("No active editor")
         }
-        if (editor.document.languageId !== 'ocaml' && editor.document.languageId !== 'reason') {
-            return vscode.window.showInformationMessage('Not an OCaml or Reason file');
+        if (editor.document.languageId !== "ocaml" && editor.document.languageId !== "reason") {
+            return vscode.window.showInformationMessage("Not an OCaml or Reason file")
         }
         client.sendRequest("custom:reasonLanguageServer/dumpFileData", {
-            "textDocument": {
-                "uri": editor.document.uri.with({scheme: 'file'}).toString(),
+            textDocument: {
+                uri: editor.document.uri.with({ scheme: "file" }).toString(),
             },
         })
-    });
+    })
 
     const showAst = () => {
         if (!client) {
-            return vscode.window.showInformationMessage('Language server not running');
+            return vscode.window.showInformationMessage("Language server not running")
         }
-        const editor = vscode.window.activeTextEditor;
+        const editor = vscode.window.activeTextEditor
         if (!editor) {
-            return vscode.window.showInformationMessage('No active editor');
+            return vscode.window.showInformationMessage("No active editor")
         }
-        if (editor.document.languageId !== 'ocaml' && editor.document.languageId !== 'reason') {
-            return vscode.window.showInformationMessage('Not an OCaml or Reason file');
+        if (editor.document.languageId !== "ocaml" && editor.document.languageId !== "reason") {
+            return vscode.window.showInformationMessage("Not an OCaml or Reason file")
         }
 
-        const document = TextDocument.create(editor.document.uri.with({scheme: 'ast-source'}), editor.document.languageId, 1, '');
-        vscode.window.showTextDocument(document);
-    };
+        const document = TextDocument.create(
+            editor.document.uri.with({ scheme: "ast-source" }),
+            editor.document.languageId,
+            1,
+            "",
+        )
+        vscode.window.showTextDocument(document)
+    }
 
-    vscode.commands.registerCommand('reason-language-server.show_ast', showAst);
+    vscode.commands.registerCommand("reason-language-server.show_ast", showAst)
 
     // vscode.commands.registerCommand('reason-language-server.create_interface_minimal', () => {
     //     createInterface(true)
     // });
 
-    restart();
+    restart()
 
     // vscode.commands.registerCommand('reason-language-server.expand_switch', () => {
     // });
-
 }
-exports.activate = activate;
+exports.activate = activate


### PR DESCRIPTION
__Issue:__ Onivim bundles a Reason / OCaml extension - by default, it tries to use the `ocamllsp` available via `esy`, and then falls back to `rls`.

__Defect:__ Onivim wasn't handling the OPAM case, or other cases where `ocamllsp` might be available in the environment without `esy`. 

__Fix:__ If we don't have `esy`, or we can't find `ocamllsp` via `esy`, try the `PATH` too

With this change - if I run Onivim from an OPAM project, with or without esy, I get `ocamllsp` provided by the OPAM switch.
![Screenshot_2020-10-29_01-24-34](https://user-images.githubusercontent.com/13532591/97510854-e37ba800-1942-11eb-83ce-4f3752e4b78a.png)

..and then get my nice ocamllsp features like hover (`gh`), go-to-definition (`gd`), completion, etc:

![ocamllsp](https://user-images.githubusercontent.com/13532591/97510992-3a817d00-1943-11eb-8210-8f381614ae81.gif)

Fixes #2641 