### PR TITLE
fix(editor): Double-click to select token

### DIFF
--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -53,3 +53,5 @@ let notificationWidth = 300;
  * We'll switch to a native strategy, and bump this up.
  */
 let largeFileLineCountThreshold = 1000;
+
+let doubleClickTime = Revery.Time.milliseconds(500);

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -108,6 +108,7 @@ type t = {
   // The last mouse position, in screen coordinates
   lastMouseScreenPosition: option(PixelPosition.t),
   lastMouseMoveTime: [@opaque] option(Revery.Time.t),
+  lastMouseUpTime: [@opaque] option(Revery.Time.t),
 };
 
 let key = ({key, _}) => key;
@@ -425,6 +426,7 @@ let create = (~config, ~buffer, ()) => {
     hasMouseEntered: false,
     lastMouseMoveTime: None,
     lastMouseScreenPosition: None,
+    lastMouseUpTime: None,
   }
   |> configure(~config);
 };
@@ -1171,7 +1173,7 @@ let mouseDown = (~time, ~pixelX, ~pixelY, editor) => {
 };
 
 let mouseUp = (~time, ~pixelX, ~pixelY, editor) => {
-  ignore(time);
+  // ignore(time);
 
   let isInsertMode = Vim.Mode.isInsert(editor.mode);
   let bytePosition =

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -522,6 +522,17 @@ let characterToByte = (position: CharacterPosition.t, editor) => {
     None;
   };
 };
+
+let characterRangeToByteRange = ({start, stop}: CharacterRange.t, editor) => {
+  let maybeByteStart = characterToByte(start, editor);
+  let maybeByteStop = characterToByte(stop, editor);
+
+  Oni_Core.Utility.OptionEx.map2(
+    (start, stop) => {ByteRange.{start, stop}},
+    maybeByteStart,
+    maybeByteStop,
+  );
+};
 let getCharacterAtPosition = (~position: CharacterPosition.t, {buffer, _}) => {
   let line = EditorCoreTypes.LineNumber.toZeroBased(position.line);
   let bufferLineCount = EditorBuffer.numberOfLines(buffer);
@@ -1172,26 +1183,92 @@ let mouseDown = (~time, ~pixelX, ~pixelY, editor) => {
   {...editor, isMouseDown: true};
 };
 
+let getCharacterUnderMouse = editor => {
+  editor.lastMouseScreenPosition
+  |> OptionEx.flatMap((mousePosition: PixelPosition.t) => {
+       let bytePosition: BytePosition.t =
+         Slow.pixelPositionToBytePosition(
+           ~allowPast=true,
+           ~pixelX=mousePosition.x,
+           ~pixelY=mousePosition.y,
+           editor,
+         );
+
+       let bufferLine =
+         EditorBuffer.line(
+           EditorCoreTypes.LineNumber.toZeroBased(bytePosition.line),
+           editor.buffer,
+         );
+       if (BufferLine.lengthInBytes(bufferLine)
+           > ByteIndex.toInt(bytePosition.byte)) {
+         byteToCharacter(bytePosition, editor);
+       } else {
+         None;
+       };
+     });
+};
+
 let mouseUp = (~time, ~pixelX, ~pixelY, editor) => {
-  // ignore(time);
+  let isDoubleClick =
+    switch (editor.lastMouseUpTime) {
+    | Some(lastMouseUpTime) =>
+      let lastTime = Revery.Time.toFloatSeconds(lastMouseUpTime);
+      let newTime = Revery.Time.toFloatSeconds(time);
+      let doubleClickTime =
+        Revery.Time.toFloatSeconds(Constants.doubleClickTime);
+      newTime -. lastTime < doubleClickTime;
+    | None => false
+    };
 
   let isInsertMode = Vim.Mode.isInsert(editor.mode);
-  let bytePosition =
-    Slow.pixelPositionToBytePosition(
-      // #2463: When we're insert mode, clicking past the end of the line
-      // should move the cursor past the last byte
-      ~allowPast=isInsertMode,
-      ~pixelX,
-      ~pixelY,
-      editor,
-    );
-  let mode =
-    if (Vim.Mode.isInsert(editor.mode)) {
-      Vim.Mode.Insert({cursors: [bytePosition]});
-    } else {
-      Vim.Mode.Normal({cursor: bytePosition});
-    };
-  {...editor, isMouseDown: false, mode};
+  if (isDoubleClick) {
+    let mode =
+      getCharacterUnderMouse(editor)
+      |> OptionEx.flatMap(characterPosition => {
+           getTokenAt(
+             ~languageConfiguration=LanguageConfiguration.default,
+             characterPosition,
+             editor,
+           )
+         })
+      |> OptionEx.flatMap(characterRange =>
+           characterRangeToByteRange(characterRange, editor)
+         )
+      |> Option.map((byteRange: ByteRange.t) => {
+           let visualRange =
+             Vim.VisualRange.{
+               cursor: byteRange.start,
+               anchor: byteRange.stop,
+               visualType: Vim.Types.Character,
+             };
+
+           if (isInsertMode) {
+             Vim.Mode.Select(visualRange);
+           } else {
+             Vim.Mode.Visual(visualRange);
+           };
+         })
+      |> Option.value(~default=editor.mode);
+
+    {...editor, isMouseDown: false, mode, lastMouseUpTime: None};
+  } else {
+    let bytePosition =
+      Slow.pixelPositionToBytePosition(
+        // #2463: When we're insert mode, clicking past the end of the line
+        // should move the cursor past the last byte
+        ~allowPast=isInsertMode,
+        ~pixelX,
+        ~pixelY,
+        editor,
+      );
+    let mode =
+      if (Vim.Mode.isInsert(editor.mode)) {
+        Vim.Mode.Insert({cursors: [bytePosition]});
+      } else {
+        Vim.Mode.Normal({cursor: bytePosition});
+      };
+    {...editor, isMouseDown: false, mode, lastMouseUpTime: Some(time)};
+  };
 };
 
 let mouseMove = (~time, ~pixelX, ~pixelY, editor) => {
@@ -1221,28 +1298,3 @@ let hasMouseEntered = ({hasMouseEntered, _}) => hasMouseEntered;
 let isMouseDown = ({isMouseDown, _}) => isMouseDown;
 
 let lastMouseMoveTime = ({lastMouseMoveTime, _}) => lastMouseMoveTime;
-
-let getCharacterUnderMouse = editor => {
-  editor.lastMouseScreenPosition
-  |> OptionEx.flatMap((mousePosition: PixelPosition.t) => {
-       let bytePosition: BytePosition.t =
-         Slow.pixelPositionToBytePosition(
-           ~allowPast=true,
-           ~pixelX=mousePosition.x,
-           ~pixelY=mousePosition.y,
-           editor,
-         );
-
-       let bufferLine =
-         EditorBuffer.line(
-           EditorCoreTypes.LineNumber.toZeroBased(bytePosition.line),
-           editor.buffer,
-         );
-       if (BufferLine.lengthInBytes(bufferLine)
-           > ByteIndex.toInt(bytePosition.byte)) {
-         byteToCharacter(bytePosition, editor);
-       } else {
-         None;
-       };
-     });
-};


### PR DESCRIPTION
This adds a double-click handler to the editor surface - selecting a token in select mode or visual mode, depending on the current mode.