### PR TITLE
fix(osx/#2659): Launching from dock

### DIFF
--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -7,3 +7,10 @@
 - Run `:echo $PATH`
 - Validate full shell path is available
 
+## 1.2 Validate launches from dock in OSX (#2659)
+
+- Update .zshrc to have blocking input: (`read var`, `echo $var`)
+- Update .zshrc to have canary entry in `PATH`
+- Run Onivim 2 from dock
+- Validate Onivim 2 launches and PATH is correct
+

--- a/src/Core/ShellUtility.re
+++ b/src/Core/ShellUtility.re
@@ -116,7 +116,7 @@ module Internal = {
     | Mac =>
       let args = [
         "-ilc",
-        "printf \"_SHELL_ENV_DELIMITER_\n\"; env; printf \"\n_SHELL_ENV_DELIMITER_\n\"; exit",
+        "printf \"\n_SHELL_ENV_DELIMITER_\"; env; printf \"\n_SHELL_ENV_DELIMITER_\n\"; exit",
       ];
       let (inp, out, err) =
         Unix.open_process_args_full(
@@ -124,6 +124,7 @@ module Internal = {
           [shellCmd, ...args] |> Array.of_list,
           [||],
         );
+      // #2659 - Close stdin before reading any data, so we don't get blocked.
       close_out(out);
       let lines = ref([]);
 
@@ -131,8 +132,7 @@ module Internal = {
         try(
           {
             while (true) {
-              let line = input_line(inp);
-              lines := [line, ...lines^];
+              lines := [input_line(inp), ...lines^];
             };
             lines^;
           }

--- a/src/Core/ShellUtility.re
+++ b/src/Core/ShellUtility.re
@@ -116,7 +116,7 @@ module Internal = {
     | Mac =>
       let args = [
         "-ilc",
-        "printf \"\n_SHELL_ENV_DELIMITER_\"; env; printf \"\n_SHELL_ENV_DELIMITER_\n\"; exit",
+        "printf \"_SHELL_ENV_DELIMITER_\n\"; env; printf \"\n_SHELL_ENV_DELIMITER_\n\"; exit",
       ];
       let (inp, out, err) =
         Unix.open_process_args_full(
@@ -124,13 +124,15 @@ module Internal = {
           [shellCmd, ...args] |> Array.of_list,
           [||],
         );
+      close_out(out);
       let lines = ref([]);
 
       let outLines =
         try(
           {
             while (true) {
-              lines := [input_line(inp), ...lines^];
+              let line = input_line(inp);
+              lines := [line, ...lines^];
             };
             lines^;
           }
@@ -140,7 +142,6 @@ module Internal = {
           lines^;
         };
 
-      close_out(out);
       close_in(err);
       environmentLinesToMap(true, outLines);
 


### PR DESCRIPTION
__Issue:__ If the shell initialization script prompts for input, as in #2659 , Onivim 2 would hang when launched from dock or finder.

__Defect:__ When launching from dock or finder, we open up a terminal to query the current PATH (since the PATH isn't available by default for applications). In the case of blocking input, Onivim would hang.

__Fix:__ Close the `stdin` of the terminal process upon launch, before reading any lines, which could block.