### PR TITLE
Move package definitions to dune-project

### DIFF
--- a/Oni2.opam
+++ b/Oni2.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]

--- a/OniBench.opam
+++ b/OniBench.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]

--- a/OniIntegrationTests.opam
+++ b/OniIntegrationTests.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]

--- a/OniUnitTestRunner.opam
+++ b/OniUnitTestRunner.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]

--- a/dune-project
+++ b/dune-project
@@ -2,3 +2,24 @@
 (using menhir 2.0)
 
 (name oni2)
+
+(package
+ (name Oni2))
+
+(package
+ (name OniBench))
+
+(package
+ (name OniIntegrationTests))
+
+(package
+ (name OniUnitTestRunner))
+
+(package
+ (name libvim))
+
+(package
+ (name textmate))
+
+(package
+ (name treesitter))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,4 @@
 (lang dune 2.5)
 (using menhir 2.0)
+
+(name oni2)

--- a/libvim.opam
+++ b/libvim.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]

--- a/textmate.opam
+++ b/textmate.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]

--- a/treesitter.opam
+++ b/treesitter.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "dev"
-maintainer: "bryphe@outrunlabs.com"
-author: ["Bryan Phelps"]
-build: [
-
-]


### PR DESCRIPTION
Instead of listing dummy .opam files, it's possible to define packages in the
dune-project file.