### PR TITLE
refactor(test): Exthost - Additional logging for tests

### DIFF
--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -74,12 +74,12 @@ let startWithExtensions =
   let logFile = Filename.temp_file("test", "log") |> Uri.fromPath;
   let logsLocation = Filename.get_temp_dir_name() |> Uri.fromPath;
 
-  print_endline(
-    Printf.sprintf(
+  Log.errorf(m =>
+    m(
       "Log location: %s Log file: %s",
       logFile |> Uri.toString,
       logsLocation |> Uri.toString,
-    ),
+    )
   );
 
   let parentPid = pid;

--- a/test/Exthost/Test.re
+++ b/test/Exthost/Test.re
@@ -44,6 +44,7 @@ let startWithExtensions =
       ~onError=noopErrorHandler,
       extensions,
     ) => {
+  Log.info("Starting test!");
   let messages = ref([]);
 
   let errorHandler = err => {
@@ -70,8 +71,16 @@ let startWithExtensions =
 
   extensions |> List.iter(m => m |> InitData.Extension.show |> prerr_endline);
 
-  let logsLocation = Filename.temp_file("test", "log") |> Uri.fromPath;
-  let logFile = Filename.get_temp_dir_name() |> Uri.fromPath;
+  let logFile = Filename.temp_file("test", "log") |> Uri.fromPath;
+  let logsLocation = Filename.get_temp_dir_name() |> Uri.fromPath;
+
+  print_endline(
+    Printf.sprintf(
+      "Log location: %s Log file: %s",
+      logFile |> Uri.toString,
+      logsLocation |> Uri.toString,
+    ),
+  );
 
   let parentPid = pid;
 
@@ -79,6 +88,7 @@ let startWithExtensions =
     InitData.create(
       ~version="9.9.9",
       ~parentPid,
+      ~logLevel=1, // DEBUG
       ~logsLocation,
       ~logFile,
       extensions,
@@ -120,6 +130,8 @@ let startWithExtensions =
           "AMD_ENTRYPOINT",
           "vs/workbench/services/extensions/node/extensionHostProcess",
         ),
+        ("PIPE_LOGGING", "true"), // Pipe logging to parent
+        ("VERBOSE_LOGGING", "true"), // Pipe logging to parent
         ("VSCODE_IPC_HOOK_EXTHOST", pipeStr),
         ("VSCODE_PARENT_PID", parentPid |> string_of_int),
       ],
@@ -148,14 +160,20 @@ let executeContributedCommand = (~command, context) => {
   context;
 };
 
+let fail = (~name, msg) => {
+  prerr_endline(Printf.sprintf("== CONDITION %s FAILED: %s", name, msg));
+  exit(2);
+};
+
 let waitForProcessClosed = ({processHasExited, _}) => {
-  Waiter.wait(~timeout=15.0, ~name="Wait for node process to close", () =>
+  Waiter.wait(
+    ~onFail=fail, ~timeout=15.0, ~name="Wait for node process to close", () =>
     processHasExited^
   );
 };
 
 let waitForMessage = (~name, f, {messages, _} as context) => {
-  Waiter.wait(~name="Wait for message: " ++ name, () =>
+  Waiter.wait(~onFail=fail, ~name="Wait for message: " ++ name, () =>
     List.exists(f, messages^)
   );
 
@@ -194,19 +212,14 @@ let withClientRequest = (~name, ~validate, f, context) => {
 
   let validator = returnValue => {
     if (!validate(returnValue)) {
-      failwith("Validation failed: " ++ name);
+      fail(~name, "Validation failed");
     };
     hasValidated := true;
   };
   let () = Lwt.on_success(response, validator);
-  Waiter.wait(
-    ~timeout=10.0,
-    ~name="Waiter: " ++ name,
-    () => {
-      prerr_endline("Waiting...");
-      hasValidated^;
-    },
-  );
+  Waiter.wait(~onFail=fail, ~timeout=10.0, ~name="Waiter: " ++ name, () => {
+    hasValidated^
+  });
 
   context;
 };
@@ -222,7 +235,7 @@ let activate = (~extensionId, ~reason, context) => {
 
 let validateNoPendingRequests = context => {
   if (Client.Testing.getPendingRequestCount(context.client) > 0) {
-    failwith("There are still pending requests");
+    fail(~name="Pending Requests", "There are still pending requests");
   };
   context;
 };

--- a/test/Exthost/lib/Node.re
+++ b/test/Exthost/lib/Node.re
@@ -16,7 +16,7 @@ let spawn = (~env=[], ~onExit, args) => {
       ),
       Luv.Process.inherit_fd(
         ~fd=Luv.Process.stdout,
-        ~from_parent_fd=Luv.Process.stderr,
+        ~from_parent_fd=Luv.Process.stdout,
         (),
       ),
       Luv.Process.inherit_fd(

--- a/test/OniUnitTestRunnerCI.re
+++ b/test/OniUnitTestRunnerCI.re
@@ -1,139 +1,52 @@
-Oni_Core_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+let initializeRunConfig = runFn => {
+  let runConfig =
+    Rely.RunConfig.initialize()
+    |> Rely.RunConfig.withReporters([Default, JUnit("./junit.xml")])
+    |> Rely.RunConfig.onTestFrameworkFailure(() => {
+         prerr_endline("Exiting test due to failure...");
+         exit(2);
+       });
 
-Oni_Core_Utility_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+  runFn(runConfig);
+};
 
-Oni_Input_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Oni_Core_Test.TestFramework.run |> initializeRunConfig;
 
-Oni_Model_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Oni_Core_Utility_Test.TestFramework.run |> initializeRunConfig;
 
-Oni_Syntax_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Oni_Input_Test.TestFramework.run |> initializeRunConfig;
 
-Feature_Editor_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Oni_Model_Test.TestFramework.run |> initializeRunConfig;
 
-Feature_Diagnostics_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Oni_Syntax_Test.TestFramework.run |> initializeRunConfig;
 
-Feature_LanguageSupport_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Feature_Editor_Test.TestFramework.run |> initializeRunConfig;
 
-EditorCoreTypes_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Feature_Diagnostics_Test.TestFramework.run |> initializeRunConfig;
 
-EditorInput_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Feature_LanguageSupport_Test.TestFramework.run |> initializeRunConfig;
 
-Exthost_Transport_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+EditorCoreTypes_Test.TestFramework.run |> initializeRunConfig;
 
-Exthost_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+EditorInput_Test.TestFramework.run |> initializeRunConfig;
+
+Exthost_Transport_Test.TestFramework.run |> initializeRunConfig;
+
+Exthost_Test.TestFramework.run |> initializeRunConfig;
 
 Vim.init();
-Libvim_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
 
-Oniguruma_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Libvim_Test.TestFramework.run |> initializeRunConfig;
 
-Service_Extensions_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Oniguruma_Test.TestFramework.run |> initializeRunConfig;
 
-Service_Net_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Service_Extensions_Test.TestFramework.run |> initializeRunConfig;
 
-Service_OS_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
-Textmate_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Service_Net_Test.TestFramework.run |> initializeRunConfig;
 
-TreeSitter_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+Service_OS_Test.TestFramework.run |> initializeRunConfig;
+Textmate_Test.TestFramework.run |> initializeRunConfig;
 
-Oni_Cli_Test.TestFramework.run(
-  Rely.RunConfig.withReporters(
-    [Default, JUnit("./junit.xml")],
-    Rely.RunConfig.initialize(),
-  ),
-);
+TreeSitter_Test.TestFramework.run |> initializeRunConfig;
+
+Oni_Cli_Test.TestFramework.run |> initializeRunConfig;

--- a/test/OniUnitTestRunnerCI.re
+++ b/test/OniUnitTestRunnerCI.re
@@ -1,3 +1,12 @@
+Printexc.record_backtrace(true);
+
+Printexc.set_uncaught_exception_handler((exn, bt) => {
+  prerr_endline(" == UNHANDLED EXCEPTION:");
+  prerr_endline(Printexc.to_string(exn));
+  prerr_endline(" -- Backtrace:");
+  prerr_endline(Printexc.raw_backtrace_to_string(bt));
+});
+
 let initializeRunConfig = runFn => {
   let runConfig =
     Rely.RunConfig.initialize()


### PR DESCRIPTION
There's some flakiness in the exthost test - intermittently, on CI, the extension host tests will fail.

This change adds some more logging to track down and get closer to the issue (as well as failing fast in the test, to help make it easier to investigate)