### PR TITLE
fix(exthost): Intermittent environment issue

### DIFF
--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -7,13 +7,17 @@ module Log = (val Log.withNamespace("Oni2.Extension.ClientStore"));
 let create = (~attachStdio, ~config, ~extensions, ~setup: Setup.t) => {
   let (stream, dispatch) = Isolinear.Stream.create();
 
+  Log.infof(m =>
+    m("ExtensionClient.create called with attachStdio: %b", attachStdio)
+  );
+
+  let maybeClientRef = ref(None);
+
   let extensionInfo =
     extensions |> List.map(Exthost.Extension.InitData.Extension.ofScanResult);
   open Exthost;
   open Exthost.Extension;
   open Exthost.Msg;
-
-  let maybeClientRef = ref(None);
 
   let handler: Msg.t => Lwt.t(Reply.t) =
     msg => {
@@ -236,8 +240,8 @@ let create = (~attachStdio, ~config, ~extensions, ~setup: Setup.t) => {
 
   let tempDir = Filename.get_temp_dir_name();
 
-  let logsLocation = tempDir |> Uri.fromPath;
-  let logFile =
+  let logFile = tempDir |> Uri.fromPath;
+  let logsLocation =
     Filename.temp_file(~temp_dir=tempDir, "onivim2", "exthost.log")
     |> Uri.fromPath;
 
@@ -247,7 +251,6 @@ let create = (~attachStdio, ~config, ~extensions, ~setup: Setup.t) => {
       ~parentPid,
       ~logsLocation,
       ~logFile,
-      ~logLevel=0,
       extensionInfo,
     );
 
@@ -270,7 +273,26 @@ let create = (~attachStdio, ~config, ~extensions, ~setup: Setup.t) => {
       (),
     );
 
-  let env = Luv.Env.environ() |> Result.get_ok;
+  // INVESTIGATE: Why does using `Luv.Env.environ()` sometimes not work correctly when calling Process.spawn?
+  // In some cases - intermittently - the spawned process will not have the environment variables set.
+  // let env = Luv.Env.environ() |> Result.get_ok;
+  // ...in the meantime, fall-back to Unix.environment:
+  let env =
+    Unix.environment()
+    |> Array.to_list
+    |> List.fold_left(
+         (acc, curr) => {
+           switch (String.split_on_char('=', curr)) {
+           | [] => acc
+           | [_] => acc
+           | [key, ...values] =>
+             let v = String.concat("=", values);
+
+             [(key, v), ...acc];
+           }
+         },
+         [],
+       );
   let environment = [
     (
       "AMD_ENTRYPOINT",


### PR DESCRIPTION
__Issue:__ Intermittently - on both my developer machines (and, I believe, the same failure causing the extension host unit tests to fail in investigating #2675) - the extension host can fail to start. The `node` process is created, and `bootstrap-fork.js` is run - but the `AMD_ENTRYPOINT` environment variable is not set in this particular case.

__Defect:__ It seems that the problem stems from some interaction between `Luv.Env.environ()` and passing those environment arguments to `Luv.Process.spawn`. I suspect that it is some GC issue - the manifestation was dependent on allocated bytes. This made it a bit tricky to investigate, as turning on logging (either to a file or to the terminal) - would actually make the problem go away! 

I fell back to investigating via pushing logs to a native C channel, outside the GC, which allowed the problem to continue to manifest. My suspicion is that a GC compaction is shuffling the string pointers around between when `Luv.Env.environ()` is called and when they are passed to `Luv.Process.spawn`, but I need to investigate further - would be nice to have a more minimal repro.

__Fix:__ For now, as a workaround, using the `Unix.environment()` API seems to be more reliable - at least in places I could reproduce on my dev machine (but will see if this problem still comes up in test runs).