### PR TITLE
chore(ci): Investigate Sys_blocked_io - reduce log output for CI tests

### DIFF
--- a/test/OniUnitTestRunnerCI.re
+++ b/test/OniUnitTestRunnerCI.re
@@ -7,6 +7,9 @@ Printexc.set_uncaught_exception_handler((exn, bt) => {
   prerr_endline(Printexc.raw_backtrace_to_string(bt));
 });
 
+// For CI tests - set the log level low to avoid `Sys_blocked_io` calls on OSX when running.
+Timber.App.setLevel(Timber.Level.error);
+
 let initializeRunConfig = runFn => {
   let runConfig =
     Rely.RunConfig.initialize()


### PR DESCRIPTION
I've been seeing intermittent failures on OSX with an `Exception Sys_blocked_io` when running the unit tests: https://dev.azure.com/onivim/oni2/_build/results?buildId=14135&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=c46197d7-212e-55e5-cfb1-808ec43d5033&l=2626

I've never seen this error running tests locally, so I suspect it may be due to the Azure Pipelines agent and the way logs are consumed. This change experiments with turning down the log level when running CI tests, to see if that hypothesis is correct and to avoid that error.

If this works - the tests could log to a file, and then in the case of an error, they could be output.