### PR TITLE
fix(exthost): Document symbols can return undefined or null

### DIFF
--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1776,7 +1776,7 @@ module Request: {
 
     let provideDocumentSymbols:
       (~handle: int, ~resource: Uri.t, Client.t) =>
-      Lwt.t(list(DocumentSymbol.t));
+      Lwt.t(option(list(DocumentSymbol.t)));
 
     let provideDefinition:
       (

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -325,7 +325,7 @@ module LanguageFeatures = {
 
   let provideDocumentSymbols = (~handle, ~resource, client) => {
     Client.request(
-      ~decoder=Json.Decode.(list(DocumentSymbol.decode)),
+      ~decoder=Json.Decode.(nullable(list(DocumentSymbol.decode))),
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$provideDocumentSymbols",

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -864,7 +864,9 @@ module Sub = {
             params.client,
           );
 
-        Lwt.on_success(promise, documentSymbols => dispatch(documentSymbols));
+        Lwt.on_success(promise, maybeDocumentSymbols =>
+          maybeDocumentSymbols |> Option.value(~default=[]) |> dispatch
+        );
 
         Lwt.on_failure(promise, _err => dispatch([]));
 

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -424,7 +424,9 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
       |> Test.withClientRequest(
            ~name="Get symbols",
            ~validate=
-             (symbols: list(Exthost.DocumentSymbol.t)) => {
+             (maybeSymbols: option(list(Exthost.DocumentSymbol.t))) => {
+               expect.equal(Option.is_some(maybeSymbols), true);
+               let symbols = Option.get(maybeSymbols);
                expect.int(List.length(symbols)).toBe(2);
                let symbol0: Exthost.DocumentSymbol.t = List.nth(symbols, 0);
                let symbol1: Exthost.DocumentSymbol.t = List.nth(symbols, 1);


### PR DESCRIPTION
__Issue:__ Occassionally, there could be errors when querying the document symbols via the [`$provideDocumentSymbols`](https://github.com/onivim/vscode-exthost/blob/4b9db577f1e2349ef9073a26182687aa450c2787/src/vs/workbench/api/common/extHost.protocol.ts#L1388) API.

__Defect:__ The API could return `undefined` or a list of symbols - we weren't handling that case.

__Fix:__ Handle the `undefined` case