### PR TITLE
fix(extensions/#2698): Install fails for sianglim.slim extension

### DIFF
--- a/src/Service/Extensions/Catalog.re
+++ b/src/Service/Extensions/Catalog.re
@@ -60,7 +60,7 @@ module Details = {
   [@deriving show]
   type t = {
     downloadUrl: string,
-    repositoryUrl: string,
+    repositoryUrl: option(string),
     homepageUrl: string,
     manifestUrl: string,
     iconUrl: option(string),
@@ -124,7 +124,7 @@ module Details = {
           manifestUrl: whatever(manifestUrl),
           iconUrl: whatever(iconUrl),
           readmeUrl: whatever(readmeUrl),
-          repositoryUrl: field.required("repository", string),
+          repositoryUrl: field.optional("repository", string),
           homepageUrl: whatever(homepageUrl),
           licenseName: field.optional("license", string),
           displayName: field.optional("displayName", string),

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -24,7 +24,7 @@ module Catalog: {
     [@deriving show]
     type t = {
       downloadUrl: string,
-      repositoryUrl: string,
+      repositoryUrl: option(string),
       homepageUrl: string,
       manifestUrl: string,
       iconUrl: option(string),


### PR DESCRIPTION
__Issue:__ As described in #2698 - installation fails when installing the `sianglim.slim` open-vsx extension

__Defect:__ Our parser for the extension details was expecting a required `repositoryUrl` property, but it should be optional.

__Fix:__ Make `repositoryUrl` and optional parameter.

It looks like I'm getting some syntax highlights with it, as well:

![image](https://user-images.githubusercontent.com/13532591/98865925-f8673980-2420-11eb-82af-ee55cf760aba.png)

Fixes #2698 