### PR TITLE
fix(exthost): $provideDocumentHighlights - update API to allow for null / undefined return

### DIFF
--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1766,7 +1766,7 @@ module Request: {
         ~position: OneBasedPosition.t,
         Client.t
       ) =>
-      Lwt.t(list(DocumentHighlight.t));
+      Lwt.t(option(list(DocumentHighlight.t)));
 
     let provideDocumentSymbols:
       (~handle: int, ~resource: Uri.t, Client.t) =>

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -309,7 +309,7 @@ module LanguageFeatures = {
   };
   let provideDocumentHighlights = (~handle, ~resource, ~position, client) => {
     Client.request(
-      ~decoder=Json.Decode.(list(DocumentHighlight.decode)),
+      ~decoder=Json.Decode.(nullable(list(DocumentHighlight.decode))),
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$provideDocumentHighlights",

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -640,8 +640,8 @@ module Sub = {
             params.client,
           );
 
-        Lwt.on_success(promise, documentHighlights =>
-          dispatch(documentHighlights)
+        Lwt.on_success(promise, maybeDocumentHighlights =>
+          maybeDocumentHighlights |> Option.value(~default=[]) |> dispatch
         );
 
         Lwt.on_failure(promise, _ => dispatch([]));

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -311,7 +311,8 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
       |> Test.withClientRequest(
            ~name="Get highlights",
            ~validate=
-             (highlights: list(Exthost.DocumentHighlight.t)) => {
+             (maybeHighlights: option(list(Exthost.DocumentHighlight.t))) => {
+               let highlights = Option.get(maybeHighlights);
                expect.int(List.length(highlights)).toBe(2);
                let highlight0: Exthost.DocumentHighlight.t =
                  List.nth(highlights, 0);


### PR DESCRIPTION
__Issue:__ Some extensions would show an error like:
```
[ERROR] [16.666s] Exthost.Client : Request 26 for $provideDocumentHighlights failed with error: ParseFailedException("Expected a list, but got null")
```
in the console.

__Defect:__ `$provideDocumentHighlights` can return `undefined`, but we were expecting it to always return with a `list`.

__Fix:__ Model `undefined` in the API