### PR TITLE
fix(vim/#941): Normal command across range

### DIFF
--- a/test/reason-libvim/EvalTest.re
+++ b/test/reason-libvim/EvalTest.re
@@ -20,13 +20,22 @@ describe("Eval", ({describe, test, _}) => {
   });
 
   describe(":normal", ({test, _}) => {
-    test("operators across range", ({expect, _}) => {
+    test("#941: operates across range", ({expect, _}) => {
       let buf = Helpers.resetBuffer("test/reason-libvim/testfile.txt");
       let (_: Context.t, _: list(Effect.t)) = Vim.command("1,3 norm! ^ia");
 
-      expect.equal(Buffer.getLine(buf, LineNumber.zero), "aThis is the first line of a test file");
-      expect.equal(Buffer.getLine(buf, LineNumber.(zero + 1)), "aThis is the second line of a test file");
-      expect.equal(Buffer.getLine(buf, LineNumber.(zero + 2)), "aThis is the third line of a test file");
+      expect.equal(
+        Buffer.getLine(buf, LineNumber.zero),
+        "aThis is the first line of a test file",
+      );
+      expect.equal(
+        Buffer.getLine(buf, LineNumber.(zero + 1)),
+        "aThis is the second line of a test file",
+      );
+      expect.equal(
+        Buffer.getLine(buf, LineNumber.(zero + 2)),
+        "aThis is the third line of a test file",
+      );
     })
-  })
+  });
 });

--- a/test/reason-libvim/EvalTest.re
+++ b/test/reason-libvim/EvalTest.re
@@ -1,3 +1,4 @@
+open EditorCoreTypes;
 open Vim;
 open TestFramework;
 
@@ -17,4 +18,15 @@ describe("Eval", ({describe, test, _}) => {
       expect.equal(eval(_ => 'a', "getchar()"), Ok("97"))
     });
   });
+
+  describe(":normal", ({test, _}) => {
+    test("operators across range", ({expect, _}) => {
+      let buf = Helpers.resetBuffer("test/reason-libvim/testfile.txt");
+      let (_: Context.t, _: list(Effect.t)) = Vim.command("1,3 norm! ^ia");
+
+      expect.equal(Buffer.getLine(buf, LineNumber.zero), "aThis is the first line of a test file");
+      expect.equal(Buffer.getLine(buf, LineNumber.(zero + 1)), "aThis is the second line of a test file");
+      expect.equal(Buffer.getLine(buf, LineNumber.(zero + 2)), "aThis is the third line of a test file");
+    })
+  })
 });


### PR DESCRIPTION
https://github.com/onivim/libvim/pull/247 picked up in #2697 actually fixes #941 as well - this adds a test case to cover it, too, though.