### PR TITLE
fix(clipboard/#2694) - change operator being treated like yank instead of delete

### DIFF
--- a/integration_test/ClipboardChangeTest.re
+++ b/integration_test/ClipboardChangeTest.re
@@ -1,0 +1,106 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// Regression test for #2694
+runTest(~name="ClipboardChangeTest", (dispatch, wait, runEffects) => {
+  wait(
+    ~name="Set configuration to always yank to clipboard", (state: State.t) => {
+    let configuration = state.configuration;
+    dispatch(
+      ConfigurationSet({
+        ...configuration,
+        default: {
+          ...configuration.default,
+          vimUseSystemClipboard: {
+            yank: true,
+            delete: false,
+            paste: false,
+          },
+        },
+      }),
+    );
+    runEffects();
+    true;
+  });
+
+  dispatch(KeyboardInput({isText: true, input: "i"}));
+  wait(~name="Mode switches to insert", (state: State.t) =>
+    Feature_Vim.mode(state.vim) |> Vim.Mode.isInsert
+  );
+
+  dispatch(KeyboardInput({isText: true, input: "abc"}));
+  dispatch(KeyboardInput({isText: false, input: "<esc>"}));
+  runEffects();
+
+  wait(~name="Mode switches back to normal", (state: State.t) =>
+    Feature_Vim.mode(state.vim) |> Vim.Mode.isNormal
+  );
+
+  // Clear clipboard prior to test
+  setClipboard(None);
+
+  /* Validate yank w/ no register sets clipboard */
+  dispatch(KeyboardInput({isText: true, input: "yy"}));
+  runEffects();
+
+  wait(~name="Yank 1 is sent to clipboard", _ => {
+    getClipboard() == Some("abc\n")
+  });
+
+  setClipboard(None);
+
+  /* Validate change does NOT set the clipbaord, with just 'yank' true
+     should be treated as a delete (#2694) */
+  dispatch(KeyboardInput({isText: true, input: "0"}));
+  dispatch(KeyboardInput({isText: true, input: "c"}));
+  dispatch(KeyboardInput({isText: true, input: "w"}));
+  runEffects();
+
+  wait(~name="Yank 2 is not sent to the clipboard", _ => {
+    getClipboard() == None
+  });
+
+  // Undo change, bring back text
+  dispatch(KeyboardInput({isText: false, input: "<esc>"}));
+  dispatch(KeyboardInput({isText: false, input: "<esc>"}));
+  dispatch(KeyboardInput({isText: true, input: "u"}));
+  runEffects();
+
+  wait(~name="Mode switches back to normal", (state: State.t) =>
+    Feature_Vim.mode(state.vim) |> Vim.Mode.isNormal
+  );
+
+  wait(~name="Set configuration to yank on deletes", (state: State.t) => {
+    let configuration = state.configuration;
+    dispatch(
+      ConfigurationSet({
+        ...configuration,
+        default: {
+          ...configuration.default,
+          vimUseSystemClipboard: {
+            yank: false,
+            delete: true,
+            paste: false,
+          },
+        },
+      }),
+    );
+    runEffects();
+    true;
+  });
+
+  setClipboard(None);
+  /* Validate yank w/ no register doesn't set clipboard */
+  dispatch(KeyboardInput({isText: true, input: "0"}));
+  dispatch(KeyboardInput({isText: true, input: "c"}));
+  dispatch(KeyboardInput({isText: true, input: "w"}));
+  runEffects();
+
+  wait(~name="Change should now be sent to the clipboard", _ => {
+    switch (getClipboard()) {
+    | Some(cur) => prerr_endline(cur)
+    | None => prerr_endline("(None)")
+    };
+    getClipboard() == Some("abc");
+  });
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -20,7 +20,8 @@
    SCMGitTest SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
    AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
    TypingBatchedTest TypingUnbatchedTest VimSimpleRemapTest
-   VimScriptLocalFunctionTest ZenModeSingleFileModeTest ZenModeSplitTest)
+   ClipboardChangeTest VimScriptLocalFunctionTest ZenModeSingleFileModeTest
+   ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
@@ -53,5 +54,6 @@
    TerminalConfigurationTest.exe AddRemoveSplitTest.exe TypingBatchedTest.exe
    TypingUnbatchedTest.exe VimScriptLocalFunctionTest.exe
    VimSimpleRemapTest.exe ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe
-   large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
-   test.lf utf8.txt utf8-test-file.htm PlugScriptLocal.vim))
+   ClipboardChangeTest.exe large-c-file.c lsan.supp some-test-file.json
+   some-test-file.txt test.crlf test.lf utf8.txt utf8-test-file.htm
+   PlugScriptLocal.vim))

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -253,7 +253,7 @@ let start =
         isClipboardRegister
         || operator == Vim.Yank.Yank
         && allYanks
-        || operator == Vim.Yank.Delete
+        || (operator == Vim.Yank.Delete || operator == Vim.Yank.Change)
         && allDeletes;
       if (shouldPropagateToClipboard) {
         let text =

--- a/src/reason-libvim/Yank.re
+++ b/src/reason-libvim/Yank.re
@@ -4,6 +4,7 @@ type yankType =
   | Char;
 
 type yankOperator =
+  | Change
   | Delete
   | Yank;
 
@@ -17,8 +18,6 @@ type t = {
   endLine: int,
   endColumn: int,
 };
-
-let dCode = Char.code('d');
 
 let create =
     (
@@ -45,7 +44,8 @@ let create =
 
   let op =
     switch (operator) {
-    | v when v == dCode => Delete
+    | v when v == Char.code('d') => Delete
+    | v when v == Char.code('c') => Change
     | _ => Yank
     };
 


### PR DESCRIPTION
__Issue:__ When the `vim.useSystemClipboard` setting is set to yank-only, changes are still pushed to the clipboard - in other words, changes are treated like yanks instead of deletes.

__Fix:__ Treat changes as a separate entity when it comes to yanks; use the same setting as deletes. If there is a use-case, we could also add another option to specify whether changes should be pushed to the clipboard independently of deletes, but in the meantime, it certainly makes more sense to treat them as deletes instead of yanks.

Fixes #2694 
