### PR TITLE
fix(perf/#2407): Part 1 - Replace smoothscroll timer hook with model-based animation

### DIFF
--- a/src/Components/Animation/Component_Animation.re
+++ b/src/Components/Animation/Component_Animation.re
@@ -1,0 +1,1 @@
+module Spring = Spring;

--- a/src/Components/Animation/Component_Animation.rei
+++ b/src/Components/Animation/Component_Animation.rei
@@ -1,0 +1,15 @@
+module Spring: {
+    type t;
+
+    type msg;
+
+    let make: (~restThreshold:float=?, ~options: Revery.UI.Spring.Options.t =?, float) => t;
+
+    let update: (~time: Revery.Time.t, msg, t) => t;
+    let sub: (t) => Isolinear.Sub.t(msg);
+
+    let isActive: t => bool;
+    
+    let set: (~position: float, t) => t;
+    let get: (t) => float;
+}

--- a/src/Components/Animation/Component_Animation.rei
+++ b/src/Components/Animation/Component_Animation.rei
@@ -1,15 +1,18 @@
 module Spring: {
-    type t;
+  type t;
 
-    type msg;
+  type msg;
 
-    let make: (~restThreshold:float=?, ~options: Revery.UI.Spring.Options.t =?, float) => t;
+  let make:
+    (~restThreshold: float=?, ~options: Revery.UI.Spring.Options.t=?, float) =>
+    t;
 
-    let update: (~time: Revery.Time.t, msg, t) => t;
-    let sub: (t) => Isolinear.Sub.t(msg);
+  let update: (msg, t) => t;
+  let sub: t => Isolinear.Sub.t(msg);
 
-    let isActive: t => bool;
-    
-    let set: (~position: float, t) => t;
-    let get: (t) => float;
-}
+  let isActive: t => bool;
+
+  let set: (~instant: bool, ~position: float, t) => t;
+  let get: t => float;
+  let getTarget: t => float;
+};

--- a/src/Components/Animation/Spring.re
+++ b/src/Components/Animation/Spring.re
@@ -1,0 +1,55 @@
+open Revery;
+open Revery.UI;
+
+// MODEL
+
+type msg =
+| Tick;
+
+module UniqueId = UniqueId.Make({});
+
+type t = {
+    options: Spring.Options.t,
+    spring: Spring.t,
+    target: float,
+    restThreshold: float,
+    uniqueId: string,
+};
+
+let make = (~restThreshold=1.0, ~options=Spring.Options.default, position) => {
+    options,
+    target: position,
+    spring: Spring.create(position, Time.zero),
+    restThreshold,
+    uniqueId: "Service_Animation.spring" ++ string_of_int(UniqueId.getUniqueId()),
+};
+
+// UPDATE
+
+let update = (~time, msg, model) => {
+    switch (msg) {
+    | Tick =>
+        let spring = Spring.tick(model.target, model.spring, model.options, time);
+        {...model, spring}
+    }
+}
+
+let get = ({spring, _}) => Spring.(spring.value);
+
+let set = (~position: float, model) => {
+    ({...model, target: position})
+};
+
+let isActive = ({spring, restThreshold, _}) => {
+    !Spring.isAtRest(~restThreshold, spring)
+};
+
+// SUB
+let sub = (model) => {
+    if (isActive(model)) {
+        Service_Time.Sub.once(~uniqueId=model.uniqueId, ~delay=Revery.Time.zero, ~msg=Tick);
+    } else {
+        Isolinear.Sub.none
+    }
+};
+

--- a/src/Components/Animation/Spring.re
+++ b/src/Components/Animation/Spring.re
@@ -60,9 +60,6 @@ let get = ({spring, target, _} as model) =>
 let getTarget = ({target, _}) => target;
 
 let set = (~instant: bool, ~position: float, model) => {
-  // prerr_endline(
-  //     Printf.sprintf("Setting - instant: %b position: %f", instant, position)
-  // );
   switch (model.startTime) {
   | None => {
       ...model,
@@ -93,6 +90,5 @@ let sub = model =>
       Tick(current)
     );
   } else {
-    //prerr_endline ("--spring - not active!");
     Isolinear.Sub.none;
   };

--- a/src/Components/Animation/dune
+++ b/src/Components/Animation/dune
@@ -2,6 +2,7 @@
  (name Component_Animation)
  (public_name Oni2.component.animation)
  (inline_tests)
- (libraries Oni2.core Oni2.components Oni2.service.time Revery isolinear Oni2.feature.commands)
+ (libraries Oni2.core Oni2.components Oni2.service.time Revery isolinear
+   Oni2.feature.commands)
  (preprocess
   (pps ppx_inline_test ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Components/Animation/dune
+++ b/src/Components/Animation/dune
@@ -1,0 +1,7 @@
+(library
+ (name Component_Animation)
+ (public_name Oni2.component.animation)
+ (inline_tests)
+ (libraries Oni2.core Oni2.components Oni2.service.time Revery isolinear Oni2.feature.commands)
+ (preprocess
+  (pps ppx_inline_test ppx_let ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1,6 +1,7 @@
 open EditorCoreTypes;
 open Oni_Core;
 open Utility;
+open Component_Animation;
 
 module GlobalState = {
   let lastId = ref(0);
@@ -90,6 +91,8 @@ type yankHighlight = {
   pixelRanges: list(PixelRange.t),
 };
 
+let scrollSpringOptions =
+  Revery.UI.Spring.Options.create(~stiffness=310., ~damping=30., ());
 [@deriving show]
 type t = {
   key: [@opaque] Brisk_reconciler.Key.t,
@@ -97,10 +100,9 @@ type t = {
   editorId: EditorId.t,
   lineNumbers: [ | `Off | `On | `Relative | `RelativeOnly],
   lineHeight: LineHeight.t,
-  scrollX: float,
-  scrollY: float,
+  scrollX: [@opaque] Component_Animation.Spring.t,
+  scrollY: [@opaque] Component_Animation.Spring.t,
   inlineElements: InlineElements.t,
-  isScrollAnimated: bool,
   isMinimapEnabled: bool,
   minimapMaxColumnWidth: int,
   minimapScrollY: float,
@@ -132,8 +134,8 @@ let selection = ({mode, _}) =>
   };
 let visiblePixelWidth = ({pixelWidth, _}) => pixelWidth;
 let visiblePixelHeight = ({pixelHeight, _}) => pixelHeight;
-let scrollY = ({scrollY, _}) => scrollY;
-let scrollX = ({scrollX, _}) => scrollX;
+let scrollY = ({scrollY, _}) => Spring.get(scrollY);
+let scrollX = ({scrollX, _}) => Spring.get(scrollX);
 let minimapScrollY = ({minimapScrollY, _}) => minimapScrollY;
 let lineHeightInPixels = ({buffer, lineHeight, _}) =>
   lineHeight
@@ -158,13 +160,19 @@ let getBufferLineCount = ({buffer, _}) =>
   EditorBuffer.numberOfLines(buffer);
 
 let isMinimapEnabled = ({isMinimapEnabled, _}) => isMinimapEnabled;
-let isScrollAnimated = ({isScrollAnimated, _}) => isScrollAnimated;
 
-let bufferBytePositionToPixel =
+let bufferBytePositionToPixelInternal =
     (
+      ~useAnimatedScrollPosition: bool,
       ~position: BytePosition.t,
       {scrollX, scrollY, buffer, wrapState, _} as editor,
     ) => {
+  let (scrollX, scrollY) =
+    if (useAnimatedScrollPosition) {
+      (Spring.get(scrollX), Spring.get(scrollY));
+    } else {
+      (Spring.getTarget(scrollX), Spring.getTarget(scrollY));
+    };
   let lineCount = EditorBuffer.numberOfLines(buffer);
   let line = position.line |> EditorCoreTypes.LineNumber.toZeroBased;
   if (line < 0 || line >= lineCount) {
@@ -201,6 +209,9 @@ let bufferBytePositionToPixel =
     ({x: pixelX, y: pixelY}: PixelPosition.t, width);
   };
 };
+
+let bufferBytePositionToPixel =
+  bufferBytePositionToPixelInternal(~useAnimatedScrollPosition=true);
 
 let yankHighlight = ({yankHighlight, _}) => yankHighlight;
 let setYankHighlight = (~yankHighlight, editor) => {
@@ -329,11 +340,16 @@ let viewTokens = (~line, ~scrollX, ~colorizer, editor) => {
   // However, there may be a scroll applied, and we need to account for
   // shifting the tokens if the scroll position is not exactly aligned to
   // a character.
-  let ({x: startIndexPixel, _}: PixelPosition.t, _width) =
+  let ({x: startIndexPixel, _}: PixelPosition.t, _width) = {
+    let editorWithScrollApplied = {
+      ...editor,
+      scrollX: Spring.set(~instant=true, ~position=scrollX, editor.scrollX),
+    };
     bufferBytePositionToPixel(
       ~position=BytePosition.{line: bufferPosition.line, byte: viewStartByte},
-      {...editor, scrollX},
+      editorWithScrollApplied,
     );
+  };
 
   let pixelOffset = startIndexPixel;
 
@@ -417,10 +433,9 @@ let create = (~config, ~buffer, ()) => {
     lineHeight: LineHeight.default,
     lineNumbers: `On,
     isMinimapEnabled: true,
-    isScrollAnimated: false,
     buffer,
-    scrollX: 0.,
-    scrollY: 0.,
+    scrollX: Spring.make(~restThreshold=1., ~options=scrollSpringOptions, 0.),
+    scrollY: Spring.make(~restThreshold=1., ~options=scrollSpringOptions, 0.),
     minimapMaxColumnWidth: 99,
     minimapScrollY: 0.,
     /*
@@ -507,7 +522,7 @@ let getViewLineFromPixelY = (~pixelY, editor) => {
 };
 
 let getTopViewLine = editor => {
-  getViewLineFromPixelY(~pixelY=editor.scrollY, editor);
+  getViewLineFromPixelY(~pixelY=Spring.get(editor.scrollY), editor);
 };
 
 let getTopVisibleBufferLine = editor => {
@@ -518,7 +533,7 @@ let getTopVisibleBufferLine = editor => {
 let getBottomViewLine = editor => {
   let absoluteBottomLine =
     getViewLineFromPixelY(
-      ~pixelY=editor.scrollY +. float_of_int(editor.pixelHeight),
+      ~pixelY=Spring.get(editor.scrollY) +. float_of_int(editor.pixelHeight),
       editor,
     );
 
@@ -716,8 +731,11 @@ let withSteadyCursor = (f, editor) => {
   let editor' = f(editor);
 
   let newOffset = calculateOffset(bytePosition, editor');
-  let scrollY = editor.scrollY +. (newOffset -. originalOffset);
-  {...editor', scrollY, isScrollAnimated: false};
+  let scrollYValue =
+    Spring.getTarget(editor.scrollY) +. (newOffset -. originalOffset);
+  let scrollY =
+    Spring.set(~instant=true, ~position=scrollYValue, editor.scrollY);
+  {...editor', scrollY};
 };
 
 let makeInlineElement = (~key, ~uniqueId, ~lineNumber, ~view) => {
@@ -815,7 +833,7 @@ let getVerticalScrollbarMetrics = (view, scrollBarHeight) => {
   let thumbSize =
     int_of_float(thumbPercentage *. float_of_int(scrollBarHeight));
 
-  let topF = view.scrollY /. totalViewSizeInPixels;
+  let topF = Spring.get(view.scrollY) /. totalViewSizeInPixels;
   let thumbOffset = int_of_float(topF *. float_of_int(scrollBarHeight));
 
   {thumbSize, thumbOffset, visible: true};
@@ -834,7 +852,7 @@ let getHorizontalScrollbarMetrics = (editor, availableWidth) => {
       let thumbPercentage = availableWidthF /. totalViewWidthInPixels;
       let thumbSize = int_of_float(thumbPercentage *. availableWidthF);
 
-      let topF = editor.scrollX /. totalViewWidthInPixels;
+      let topF = Spring.get(editor.scrollX) /. totalViewWidthInPixels;
       let thumbOffset = int_of_float(topF *. availableWidthF);
 
       {thumbSize, thumbOffset, visible: true};
@@ -873,7 +891,11 @@ let exposePrimaryCursor = editor =>
       let pixelHeight = float(pixelHeight);
 
       let ({x: pixelX, y: pixelY}: PixelPosition.t, _width) =
-        bufferBytePositionToPixel(~position=primaryCursor, editor);
+        bufferBytePositionToPixelInternal(
+          ~useAnimatedScrollPosition=false,
+          ~position=primaryCursor,
+          editor,
+        );
 
       let scrollOffX = getCharacterWidth(editor) *. 2.;
       let scrollOffY =
@@ -883,6 +905,7 @@ let exposePrimaryCursor = editor =>
       let availableX = pixelWidth -. scrollOffX;
       let availableY = pixelHeight -. scrollOffY;
 
+      let scrollX = Spring.getTarget(scrollX);
       let adjustedScrollX =
         max(
           if (pixelX < 0.) {
@@ -895,6 +918,7 @@ let exposePrimaryCursor = editor =>
           0.,
         );
 
+      let scrollY = Spring.getTarget(scrollY);
       let adjustedScrollY =
         max(
           if (pixelY < scrollOffY) {
@@ -909,9 +933,18 @@ let exposePrimaryCursor = editor =>
 
       {
         ...editor,
-        scrollX: adjustedScrollX,
-        scrollY: adjustedScrollY,
-        isScrollAnimated: true,
+        scrollX:
+          Spring.set(
+            ~instant=false,
+            ~position=adjustedScrollX,
+            editor.scrollX,
+          ),
+        scrollY:
+          Spring.set(
+            ~instant=false,
+            ~position=adjustedScrollY,
+            editor.scrollY,
+          ),
       };
 
     | _ => editor
@@ -925,7 +958,7 @@ let setMode = (mode, editor) => {
 };
 
 let getLeftVisibleColumn = view => {
-  int_of_float(view.scrollX /. getCharacterWidth(view));
+  int_of_float(Spring.get(view.scrollX) /. getCharacterWidth(view));
 };
 
 let getTokenAt =
@@ -967,7 +1000,7 @@ let getContentPixelWidth = editor => {
   layout.bufferWidthInPixels;
 };
 
-let scrollToPixelY = (~pixelY as newScrollY, editor) => {
+let scrollToPixelY = (~animated, ~pixelY as newScrollY, editor) => {
   let {pixelHeight, _} = editor;
   let viewLines = editor |> totalViewLines;
   let newScrollY = max(0., newScrollY);
@@ -989,51 +1022,55 @@ let scrollToPixelY = (~pixelY as newScrollY, editor) => {
 
   {
     ...editor,
-    isScrollAnimated: false,
     minimapScrollY: newMinimapScroll,
-    scrollY: newScrollY,
+    scrollY:
+      Spring.set(~instant=!animated, ~position=newScrollY, editor.scrollY),
   };
 };
 
-let animateScroll = editor => {...editor, isScrollAnimated: true};
+//let animateScroll = editor => {...editor, isScrollAnimated: true};
 
 let scrollToLine = (~line, view) => {
   let pixelY = float_of_int(line) *. lineHeightInPixels(view);
-  {...scrollToPixelY(~pixelY, view), isScrollAnimated: true};
+  scrollToPixelY(~animated=true, ~pixelY, view);
 };
 
-let scrollToPixelX = (~pixelX as newScrollX, editor) => {
+let scrollToPixelX = (~animated, ~pixelX as newScrollX, editor) => {
   let maxLineLength = editor |> maxLineLength;
   let newScrollX = max(0., newScrollX);
 
   let availableScroll =
     max(0., float_of_int(maxLineLength) *. getCharacterWidth(editor));
-  let scrollX = min(newScrollX, availableScroll);
+  let newScrollX = min(newScrollX, availableScroll);
+  let scrollX =
+    Spring.set(~instant=!animated, ~position=newScrollX, editor.scrollX);
 
-  {...editor, isScrollAnimated: false, scrollX};
+  {...editor, scrollX};
 };
 
-let scrollDeltaPixelX = (~pixelX, editor) => {
-  let pixelX = editor.scrollX +. pixelX;
-  scrollToPixelX(~pixelX, editor);
+let scrollDeltaPixelX = (~animated, ~pixelX, editor) => {
+  let pixelX = Spring.getTarget(editor.scrollX) +. pixelX;
+  scrollToPixelX(~animated, ~pixelX, editor);
 };
 
-let scrollDeltaPixelY = (~pixelY, view) => {
-  let pixelY = view.scrollY +. pixelY;
-  scrollToPixelY(~pixelY, view);
+let scrollDeltaPixelY = (~animated, ~pixelY, editor) => {
+  let pixelY = Spring.getTarget(editor.scrollY) +. pixelY;
+  scrollToPixelY(~animated, ~pixelY, editor);
 };
 
-let scrollToPixelXY = (~pixelX as newScrollX, ~pixelY as newScrollY, view) => {
-  let {scrollX, _} = scrollToPixelX(~pixelX=newScrollX, view);
+let scrollToPixelXY =
+    (~animated, ~pixelX as newScrollX, ~pixelY as newScrollY, view) => {
+  let {scrollX, _} = scrollToPixelX(~animated, ~pixelX=newScrollX, view);
   let {scrollY, minimapScrollY, _} =
-    scrollToPixelY(~pixelY=newScrollY, view);
+    scrollToPixelY(~animated, ~pixelY=newScrollY, view);
 
   {...view, scrollX, scrollY, minimapScrollY};
 };
 
-let scrollDeltaPixelXY = (~pixelX, ~pixelY, view) => {
-  let {scrollX, _} = scrollDeltaPixelX(~pixelX, view);
-  let {scrollY, minimapScrollY, _} = scrollDeltaPixelY(~pixelY, view);
+let scrollDeltaPixelXY = (~animated, ~pixelX, ~pixelY, view) => {
+  let {scrollX, _} = scrollDeltaPixelX(~animated, ~pixelX, view);
+  let {scrollY, minimapScrollY, _} =
+    scrollDeltaPixelY(~animated, ~pixelY, view);
 
   {...view, scrollX, scrollY, minimapScrollY};
 };
@@ -1080,52 +1117,71 @@ let scrollAndMoveCursor = (~deltaViewLines, editor) => {
   let newCursor = getPrimaryCursorByte(editor');
   // Figure out the delta in scrollY
   let ({y: oldY, _}: PixelPosition.t, _) =
-    bufferBytePositionToPixel(~position=oldCursor, editor);
+    bufferBytePositionToPixelInternal(
+      ~useAnimatedScrollPosition=false,
+      ~position=oldCursor,
+      editor,
+    );
 
   let ({y: newY, _}: PixelPosition.t, _) =
-    bufferBytePositionToPixel(~position=newCursor, editor');
+    bufferBytePositionToPixelInternal(
+      ~useAnimatedScrollPosition=false,
+      ~position=newCursor,
+      editor',
+    );
 
   // Adjust scroll to compensate cursor position - keeping the cursor in the same
   // relative spot to scroll, after moving it.
   // TODO: Bring back
-  editor' |> scrollDeltaPixelY(~pixelY=newY -. oldY) |> animateScroll;
+  editor' |> scrollDeltaPixelY(~animated=true, ~pixelY=newY -. oldY);
 };
 
 let scrollCenterCursorVertically = editor => {
   let cursor = getPrimaryCursorByte(editor);
   let (pixelPosition: PixelPosition.t, _) =
-    bufferBytePositionToPixel(~position=cursor, editor);
+    bufferBytePositionToPixelInternal(
+      ~useAnimatedScrollPosition=false,
+      ~position=cursor,
+      editor,
+    );
 
   let heightInPixels = float(editor.pixelHeight);
-  let pixelY = pixelPosition.y +. editor.scrollY -. heightInPixels /. 2.;
-  scrollToPixelY(~pixelY, editor) |> animateScroll;
+  let pixelY =
+    pixelPosition.y
+    +. Spring.getTarget(editor.scrollY)
+    -. heightInPixels
+    /. 2.;
+  scrollToPixelY(~animated=true, ~pixelY, editor);
 };
 
 let scrollCursorTop = editor => {
   let cursor = getPrimaryCursorByte(editor);
   let (pixelPosition: PixelPosition.t, _) =
-    bufferBytePositionToPixel(~position=cursor, editor);
+    bufferBytePositionToPixelInternal(
+      ~useAnimatedScrollPosition=false,
+      ~position=cursor,
+      editor,
+    );
 
-  let pixelY = pixelPosition.y +. editor.scrollY;
-  editor
-  |> scrollToPixelY(~pixelY)
-  |> exposePrimaryCursor  // account for scrolloff
-  |> animateScroll;
+  let pixelY = pixelPosition.y +. Spring.getTarget(editor.scrollY);
+  editor |> scrollToPixelY(~animated=true, ~pixelY) |> exposePrimaryCursor; // account for scrolloff
 };
 
 let scrollCursorBottom = editor => {
   let cursor = getPrimaryCursorByte(editor);
   let (pixelPosition: PixelPosition.t, _) =
-    bufferBytePositionToPixel(~position=cursor, editor);
+    bufferBytePositionToPixelInternal(
+      ~useAnimatedScrollPosition=false,
+      ~position=cursor,
+      editor,
+    );
 
   let heightInPixels = float(editor.pixelHeight);
   let pixelY =
     pixelPosition.y
-    +. editor.scrollY
+    +. Spring.getTarget(editor.scrollY)
     -. (heightInPixels -. lineHeightInPixels(editor));
-  scrollToPixelY(~pixelY, editor)
-  |> exposePrimaryCursor  // account for scrolloff
-  |> animateScroll;
+  scrollToPixelY(~animated=true, ~pixelY, editor) |> exposePrimaryCursor; // account for scrolloff
 };
 
 let scrollLines = (~count, editor) => {
@@ -1250,7 +1306,11 @@ let configurationChanged = (~perFileTypeConfig, editor) => {
 module Slow = {
   let pixelPositionToBytePosition =
       (~allowPast=false, ~pixelX: float, ~pixelY: float, view) => {
-    let rawLine = getViewLineFromPixelY(~pixelY=pixelY +. view.scrollY, view);
+    let rawLine =
+      getViewLineFromPixelY(
+        ~pixelY=pixelY +. Spring.get(view.scrollY),
+        view,
+      );
 
     let wrapping = view.wrapState |> WrapState.wrapping;
     let rawLine =
@@ -1270,7 +1330,7 @@ module Slow = {
       let byteIndex =
         BufferLine.Slow.getByteFromPixel(
           ~relativeToByte=byteOffset,
-          ~pixelX=pixelX +. view.scrollX,
+          ~pixelX=pixelX +. Spring.get(view.scrollX),
           bufferLine,
         );
 
@@ -1435,3 +1495,30 @@ let hasMouseEntered = ({hasMouseEntered, _}) => hasMouseEntered;
 let isMouseDown = ({isMouseDown, _}) => isMouseDown;
 
 let lastMouseMoveTime = ({lastMouseMoveTime, _}) => lastMouseMoveTime;
+
+[@deriving show]
+type msg =
+  | ScrollSpringX([@opaque] Spring.msg)
+  | ScrollSpringY([@opaque] Spring.msg);
+
+let update = (msg, editor) => {
+  switch (msg) {
+  | ScrollSpringX(msg) => {
+      ...editor,
+      scrollX: Spring.update(msg, editor.scrollX),
+    }
+  | ScrollSpringY(msg) => {
+      ...editor,
+      scrollY: Spring.update(msg, editor.scrollY),
+    }
+  };
+};
+
+let sub = editor => {
+  [
+    Spring.sub(editor.scrollX) |> Isolinear.Sub.map(msg => ScrollSpringX(msg)),
+    Spring.sub(editor.scrollY)
+    |> Isolinear.Sub.map(msg => ScrollSpringY(msg)),
+  ]
+  |> Isolinear.Sub.batch;
+};

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -138,16 +138,16 @@ let selectionOrCursorRange: t => ByteRange.t;
 
 let totalViewLines: t => int;
 
-let isScrollAnimated: t => bool;
-let scrollToPixelX: (~pixelX: float, t) => t;
-let scrollDeltaPixelX: (~pixelX: float, t) => t;
+let scrollToPixelX: (~animated: bool, ~pixelX: float, t) => t;
+let scrollDeltaPixelX: (~animated: bool, ~pixelX: float, t) => t;
 
 let scrollToLine: (~line: int, t) => t;
-let scrollToPixelY: (~pixelY: float, t) => t;
-let scrollDeltaPixelY: (~pixelY: float, t) => t;
+let scrollToPixelY: (~animated: bool, ~pixelY: float, t) => t;
+let scrollDeltaPixelY: (~animated: bool, ~pixelY: float, t) => t;
 
-let scrollToPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
-let scrollDeltaPixelXY: (~pixelX: float, ~pixelY: float, t) => t;
+let scrollToPixelXY: (~animated: bool, ~pixelX: float, ~pixelY: float, t) => t;
+let scrollDeltaPixelXY:
+  (~animated: bool, ~pixelX: float, ~pixelY: float, t) => t;
 
 let scrollCenterCursorVertically: t => t;
 let scrollCursorTop: t => t;
@@ -234,3 +234,10 @@ module Slow: {
     // the end of the line.
     (~allowPast: bool=?, ~pixelX: float, ~pixelY: float, t) => BytePosition.t;
 };
+
+[@deriving show]
+type msg;
+
+let update: (msg, t) => t;
+
+let sub: t => Isolinear.Sub.t(msg);

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -248,30 +248,30 @@ let%component make =
     lineCount < Constants.diffMarkersMaxLineCount && showDiffMarkers
       ? EditorDiffMarkers.generate(~scm, buffer) : None;
 
-  let smoothScroll = Config.smoothScroll.get(config);
-  let isScrollAnimated = Editor.isScrollAnimated(editor);
+  // let smoothScroll = Config.smoothScroll.get(config);
+  // let isScrollAnimated = Editor.isScrollAnimated(editor);
 
-  let%hook (scrollY, _setScrollYImmediately) =
-    Hooks.spring(
-      ~name="Editor ScrollY Spring",
-      ~target=Editor.scrollY(editor),
-      ~restThreshold=10.,
-      ~enabled=smoothScroll && isScrollAnimated,
-      scrollSpringOptions,
-    );
-  let%hook (scrollX, _setScrollXImmediately) =
-    Hooks.spring(
-      ~name="Editor ScrollX Spring",
-      ~target=Editor.scrollX(editor),
-      ~restThreshold=10.,
-      ~enabled=smoothScroll && isScrollAnimated,
-      scrollSpringOptions,
-    );
+  // let%hook (scrollY, _setScrollYImmediately) =
+  //   Hooks.spring(
+  //     ~name="Editor ScrollY Spring",
+  //     ~target=Editor.scrollY(editor),
+  //     ~restThreshold=10.,
+  //     ~enabled=smoothScroll && isScrollAnimated,
+  //     scrollSpringOptions,
+  //   );
+  // let%hook (scrollX, _setScrollXImmediately) =
+  //   Hooks.spring(
+  //     ~name="Editor ScrollX Spring",
+  //     ~target=Editor.scrollX(editor),
+  //     ~restThreshold=10.,
+  //     ~enabled=smoothScroll && isScrollAnimated,
+  //     scrollSpringOptions,
+  //   );
 
-  let editor =
-    editor
-    |> Editor.scrollToPixelX(~pixelX=scrollX)
-    |> Editor.scrollToPixelY(~pixelY=scrollY);
+  // let editor =
+  //   editor
+  //   |> Editor.scrollToPixelX(~pixelX=scrollX)
+  //   |> Editor.scrollToPixelY(~pixelY=scrollY);
 
   let pixelHeight = Editor.getTotalHeightInPixels(editor);
 

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -132,8 +132,6 @@ let minimap =
 };
 
 // VIEW
-let scrollSpringOptions =
-  Spring.Options.create(~stiffness=310., ~damping=30., ());
 
 let%component make =
               (
@@ -247,31 +245,6 @@ let%component make =
   let diffMarkers =
     lineCount < Constants.diffMarkersMaxLineCount && showDiffMarkers
       ? EditorDiffMarkers.generate(~scm, buffer) : None;
-
-  // let smoothScroll = Config.smoothScroll.get(config);
-  // let isScrollAnimated = Editor.isScrollAnimated(editor);
-
-  // let%hook (scrollY, _setScrollYImmediately) =
-  //   Hooks.spring(
-  //     ~name="Editor ScrollY Spring",
-  //     ~target=Editor.scrollY(editor),
-  //     ~restThreshold=10.,
-  //     ~enabled=smoothScroll && isScrollAnimated,
-  //     scrollSpringOptions,
-  //   );
-  // let%hook (scrollX, _setScrollXImmediately) =
-  //   Hooks.spring(
-  //     ~name="Editor ScrollX Spring",
-  //     ~target=Editor.scrollX(editor),
-  //     ~restThreshold=10.,
-  //     ~enabled=smoothScroll && isScrollAnimated,
-  //     scrollSpringOptions,
-  //   );
-
-  // let editor =
-  //   editor
-  //   |> Editor.scrollToPixelX(~pixelX=scrollX)
-  //   |> Editor.scrollToPixelY(~pixelY=scrollY);
 
   let pixelHeight = Editor.getTotalHeightInPixels(editor);
 

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -47,4 +47,5 @@ type t =
       key: string,
       uniqueId: string,
       height: int,
-    });
+    })
+  | Internal(Editor.msg);

--- a/src/Feature/Editor/dune
+++ b/src/Feature/Editor/dune
@@ -3,9 +3,9 @@
  (public_name Oni2.feature.editor)
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.core Oni2.components Oni2.exthost
-   Oni2.syntax Oni2.feature.configuration Oni2.feature.diagnostics
-   Oni2.feature.scm Oni2.feature.theme Oni2.feature.language_support
-   Oni2.feature.syntax Oni2.service.font Oni2.service.os Oni2.service.time
-   Revery libvim)
+   Oni2.component.animation Oni2.syntax Oni2.feature.configuration
+   Oni2.feature.diagnostics Oni2.feature.scm Oni2.feature.theme
+   Oni2.feature.language_support Oni2.feature.syntax Oni2.service.font
+   Oni2.service.os Oni2.service.time Revery libvim)
  (preprocess
   (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Service/Time/Service_Time.re
+++ b/src/Service/Time/Service_Time.re
@@ -6,7 +6,7 @@ module Sub = {
 
   module TimerOnceSubscription =
     Isolinear.Sub.Make({
-      type nonrec msg = unit;
+      type nonrec msg = Revery.Time.t;
       type nonrec params = timerOnceParams;
       type state = unit => unit;
 
@@ -16,7 +16,7 @@ module Sub = {
       let init = (~params, ~dispatch) => {
         Revery.Tick.timeout(
           ~name="Service_Time.once: " ++ params.uniqueId,
-          () => dispatch(),
+          () => {dispatch(Revery.Time.now())},
           params.delay,
         );
       };
@@ -32,6 +32,6 @@ module Sub = {
 
   let once = (~uniqueId: string, ~delay, ~msg) => {
     TimerOnceSubscription.create({delay, uniqueId})
-    |> Isolinear.Sub.map(() => msg);
+    |> Isolinear.Sub.map(current => msg(~current));
   };
 };

--- a/src/Service/Time/Service_Time.rei
+++ b/src/Service/Time/Service_Time.rei
@@ -1,5 +1,9 @@
 module Sub: {
   let once:
-    (~uniqueId: string, ~delay: Revery.Time.t, ~msg: 'a) =>
+    (
+      ~uniqueId: string,
+      ~delay: Revery.Time.t,
+      ~msg: (~current: Revery.Time.t) => 'a
+    ) =>
     Isolinear.Sub.t('a);
 };


### PR DESCRIPTION
This is the first part of the fix for #2407 - addressing the hanging scroll timers. This moves away from the hook-based timers, which can potentially leave timers hanging (and have a complicated timing dependency), and replaces it with a model/subscription based approach, which should be more reliable. In particular, the subscriptions used here never leave an `interval` hanging - it's always a one-off fire when the spring animation is active.

This uses the `Spring` model from Revery, but wraps it in a component module (`Component_Animation`), and provides a wrapper model and subscriptions to use. It's sort of a baby-step into migrating our animations from hook-based to model-based.

__TODO:__
- [x] Hook up configuration for `smoothScroll` and `ui.animations`

__Next steps:__
- Replace additional problematic hook-based animations (color transition, status bar animation) with these model-based animations, eventually migrating all of these animations to hook-based if these are successful at mitigating #2407.

Related #2407 