### PR TITLE
fix(input/#2604): Ex keybinding fails

### DIFF
--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -89,8 +89,9 @@ let start = maybeKeyBindingsFilePath => {
     );
 
   let executeExCommandEffect = command =>
-    Isolinear.Effect.create(~name="keybindings.executeExCommand", () =>
-      ignore(Vim.command(command): (Vim.Context.t, list(Vim.Effect.t)))
+    Isolinear.Effect.createWithDispatch(
+      ~name="keybindings.executeExCommand", dispatch =>
+      dispatch(Actions.VimExecuteCommand(command))
     );
 
   let updater = (state: State.t, action: Actions.t) => {


### PR DESCRIPTION
__Issue:__ Binding to some ex commands - like `:enew` - aren't working as expected. In the `:enew` case, no buffer is opened.

__Defect:__ The effects are being ignored, so there is no buffer transition

__Fix:__ Re-use the effect logic in `VimStoreConnector` to handle this (use the `VimExecuteCommand` action).

Fixes #2604 