### PR TITLE
fix(configuration): hook up missing render whitespace option

### DIFF
--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -85,7 +85,7 @@ module CustomDecoders: {
                | "none" => `None
                | "boundary" => `Boundary
                | "selection" => `Selection
-               | "all"
+               | "all" => `All
                | _ => `Selection,
              )
         ),


### PR DESCRIPTION
Possibly I'm missing something here, but this just looks like it wasn't hooked up?