### PR TITLE
fix(codelens): Match indent to bufferline

### DIFF
--- a/src/Core/BufferLine.re
+++ b/src/Core/BufferLine.re
@@ -287,6 +287,22 @@ let traverse = (~maxDistance=250, ~f, ~direction, ~index, bufferLine) => {
   loop(index, index, 0);
 };
 
+let getLeadingWhitespacePixels = bufferLine => {
+  let lastWhitespaceIdx =
+    traverse(
+      ~f=Uucp.White.is_white_space,
+      ~direction=`Forwards,
+      ~index=CharacterIndex.zero,
+      bufferLine,
+    );
+  let firstNonWhitespaceIdx =
+    lastWhitespaceIdx == CharacterIndex.zero
+      ? CharacterIndex.zero : CharacterIndex.(lastWhitespaceIdx + 1);
+  let (pos, _width) =
+    getPixelPositionAndWidth(~index=firstNonWhitespaceIdx, bufferLine);
+  pos;
+};
+
 module Slow = {
   let getIndexFromPixel = (~pixel, bufferLine) => {
     let characterLength = lengthSlow(bufferLine);

--- a/src/Core/BufferLine.rei
+++ b/src/Core/BufferLine.rei
@@ -57,6 +57,8 @@ let subExn: (~index: CharacterIndex.t, ~length: int, t) => string;
 
 let getPixelPositionAndWidth: (~index: CharacterIndex.t, t) => (float, float);
 
+let getLeadingWhitespacePixels: t => float;
+
 let traverse:
   (
     ~maxDistance: int=?,

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1509,6 +1509,10 @@ let isMouseDown = ({isMouseDown, _}) => isMouseDown;
 
 let lastMouseMoveTime = ({lastMouseMoveTime, _}) => lastMouseMoveTime;
 
+let getLeadingWhitespacePixels = (_lineNumber, _editor) => {
+  25.;
+};
+
 [@deriving show]
 type msg =
   | ScrollSpringX([@opaque] Spring.msg)

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1509,8 +1509,16 @@ let isMouseDown = ({isMouseDown, _}) => isMouseDown;
 
 let lastMouseMoveTime = ({lastMouseMoveTime, _}) => lastMouseMoveTime;
 
-let getLeadingWhitespacePixels = (_lineNumber, _editor) => {
-  25.;
+let getLeadingWhitespacePixels = (lineNumber, editor) => {
+  let buffer = editor.buffer;
+  let lineCount = EditorBuffer.numberOfLines(buffer);
+  let line = lineNumber |> EditorCoreTypes.LineNumber.toZeroBased;
+  if (line < 0 || line >= lineCount) {
+    0.;
+  } else {
+    let bufferLine = buffer |> EditorBuffer.line(line);
+    BufferLine.getLeadingWhitespacePixels(bufferLine);
+  };
 };
 
 [@deriving show]

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -67,6 +67,9 @@ let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getCursors: t => list(BytePosition.t);
 let setWrapMode: (~wrapMode: WrapMode.t, t) => t;
 
+// Get the horizontal width in pixels of the tab/space whitespace in front of a line.
+let getLeadingWhitespacePixels: (EditorCoreTypes.LineNumber.t, t) => float;
+
 let mode: t => Vim.Mode.t;
 let setMode: (Vim.Mode.t, t) => t;
 

--- a/src/Feature/LanguageSupport/CodeLens.re
+++ b/src/Feature/LanguageSupport/CodeLens.re
@@ -216,13 +216,14 @@ module Contributions = {
 module View = {
   module CodeLensColors = Colors;
   open Revery.UI;
-  let make = (~theme, ~uiFont: Oni_Core.UiFont.t, ~codeLens, ()) => {
+  let make = (~leftMargin, ~theme, ~uiFont: Oni_Core.UiFont.t, ~codeLens, ()) => {
     let foregroundColor = CodeLensColors.foreground.from(theme);
     let text = text(codeLens);
     <View
       style=Style.[
         marginTop(4),
         marginBottom(0),
+        marginLeft(leftMargin),
         flexGrow(1),
         flexShrink(0),
       ]>

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -42,6 +42,7 @@ module CodeLens: {
   module View: {
     let make:
       (
+        ~leftMargin: int,
         ~theme: Oni_Core.ColorTheme.Colors.t,
         ~uiFont: UiFont.t,
         ~codeLens: t,


### PR DESCRIPTION
__Issue:__ The codelens would also be positioned at the beginning of the line - it doesn't look correct on indented lines:

![image](https://user-images.githubusercontent.com/13532591/99152754-96911480-2658-11eb-96c0-497dcb9d7f27.png)

__Fix:__ Position the codelens in-line with leading whitespace

![image](https://user-images.githubusercontent.com/13532591/99152850-4a929f80-2659-11eb-835b-ef5ce0b42100.png)
