### PR TITLE
fix(perf/#2407): Part 2 - Move yank highlights to model-based animation

### DIFF
--- a/src/Components/Animation/Component_Animation.re
+++ b/src/Components/Animation/Component_Animation.re
@@ -1,1 +1,26 @@
 module Spring = Spring;
+
+open Revery;
+open Revery.UI;
+
+type t('value) = 
+{
+	animation: Revery.UI.Animation.t('value),
+	startTime: option(Revery.Time.t)
+};
+
+let make = (animation) => {
+	animation,
+	startTime: None,
+};
+
+type msg =
+| Tick({ totalTime: Revery.Time.t});
+
+let update = (_msg, model) => model;
+let isActive = _model => false;
+let get = ({animation, startTime}) => {
+	Animation.valueAt(Time.zero, animation)
+};
+
+let sub = (_model) => Isolinear.Sub.none;

--- a/src/Components/Animation/Component_Animation.re
+++ b/src/Components/Animation/Component_Animation.re
@@ -7,6 +7,7 @@ type t('value) = {
   uniqueId: string,
   animation: Revery.UI.Animation.t('value),
   maybeStartTime: option(Revery.Time.t),
+  duration: Revery.Time.t,
   isComplete: bool,
   tick: int,
 };
@@ -19,6 +20,7 @@ let make = animation => {
     "Service_Animation.animation" ++ (UniqueId.getUniqueId() |> string_of_int),
   animation,
   maybeStartTime: None,
+  duration: Revery.Time.zero,
   isComplete: false,
   tick: 0,
 };
@@ -45,13 +47,13 @@ let update = (msg, model) =>
       ...model,
       maybeStartTime: Some(startTime),
       isComplete,
+      duration: deltaTime,
       tick: model.tick + 1,
     };
   };
 let isComplete = ({isComplete, _}) => isComplete;
-let get = ({animation, maybeStartTime, _}) => {
-  let time = maybeStartTime |> Option.value(~default=Time.zero);
-  Animation.valueAt(time, animation);
+let get = ({animation, duration, _}) => {
+  Animation.valueAt(duration, animation);
 };
 
 let sub = ({isComplete, uniqueId, tick, _}) =>

--- a/src/Components/Animation/Component_Animation.re
+++ b/src/Components/Animation/Component_Animation.re
@@ -3,24 +3,24 @@ module Spring = Spring;
 open Revery;
 open Revery.UI;
 
-type t('value) = 
-{
-	animation: Revery.UI.Animation.t('value),
-	startTime: option(Revery.Time.t)
+type t('value) = {
+  animation: Revery.UI.Animation.t('value),
+  startTime: option(Revery.Time.t),
 };
 
-let make = (animation) => {
-	animation,
-	startTime: None,
-};
+let make = animation => {animation, startTime: None};
+
+type outmsg =
+| Nothing
+| Completed;
 
 type msg =
-| Tick({ totalTime: Revery.Time.t});
+  | Tick({totalTime: Revery.Time.t});
 
-let update = (_msg, model) => model;
+let update = (_msg, model) => (model, Nothing);
 let isActive = _model => false;
 let get = ({animation, startTime}) => {
-	Animation.valueAt(Time.zero, animation)
+  Animation.valueAt(Time.zero, animation);
 };
 
-let sub = (_model) => Isolinear.Sub.none;
+let sub = _model => Isolinear.Sub.none;

--- a/src/Components/Animation/Component_Animation.rei
+++ b/src/Components/Animation/Component_Animation.rei
@@ -16,3 +16,12 @@ module Spring: {
   let get: t => float;
   let getTarget: t => float;
 };
+
+type t('value);
+type msg;
+
+let get: t('value) => 'value;
+let isActive: t(_) => bool;
+let make: (Revery.UI.Animation.t('value)) => t('value);
+let update: (msg, t('value)) => t('value);
+let sub: t(_) => Isolinear.Sub.t(msg);

--- a/src/Components/Animation/Component_Animation.rei
+++ b/src/Components/Animation/Component_Animation.rei
@@ -20,12 +20,8 @@ module Spring: {
 type t('value);
 type msg;
 
-type outmsg =
-| Nothing
-| Completed;
-
 let get: t('value) => 'value;
-let isActive: t(_) => bool;
+let isComplete: t(_) => bool;
 let make: Revery.UI.Animation.t('value) => t('value);
-let update: (msg, t('value)) => (t('value), outmsg);
+let update: (msg, t('value)) => t('value);
 let sub: t(_) => Isolinear.Sub.t(msg);

--- a/src/Components/Animation/Component_Animation.rei
+++ b/src/Components/Animation/Component_Animation.rei
@@ -20,8 +20,12 @@ module Spring: {
 type t('value);
 type msg;
 
+type outmsg =
+| Nothing
+| Completed;
+
 let get: t('value) => 'value;
 let isActive: t(_) => bool;
-let make: (Revery.UI.Animation.t('value)) => t('value);
-let update: (msg, t('value)) => t('value);
+let make: Revery.UI.Animation.t('value) => t('value);
+let update: (msg, t('value)) => (t('value), outmsg);
 let sub: t(_) => Isolinear.Sub.t(msg);

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -89,6 +89,7 @@ module WrapState = {
 type yankHighlight = {
   key: [@opaque] Brisk_reconciler.Key.t,
   pixelRanges: list(PixelRange.t),
+  opacity: [@opaque] Component_Animation.t(float),
 };
 
 let scrollSpringOptions =
@@ -111,6 +112,7 @@ type t = {
   pixelWidth: int,
   pixelHeight: int,
   yankHighlight: option(yankHighlight),
+  yankHighlightDuration: int,
   wrapMode: WrapMode.t,
   wrapState: WrapState.t,
   wrapPadding: option(float),
@@ -214,10 +216,29 @@ let bufferBytePositionToPixelInternal =
 let bufferBytePositionToPixel =
   bufferBytePositionToPixelInternal(~useAnimatedScrollPosition=true);
 
+module Animations = {
+  open Revery.UI;
+  let fadeIn = (~duration) =>
+    Revery.UI.Animation.(
+      animate(Revery.Time.milliseconds(duration))
+      |> ease(Easing.easeIn)
+      |> tween(0.6, 0.0)
+      |> delay(Revery.Time.milliseconds(0))
+    );
+};
+
 let yankHighlight = ({yankHighlight, _}) => yankHighlight;
-let setYankHighlight = (~yankHighlight, editor) => {
+let startYankHighlight = (pixelRanges, editor) => {
   ...editor,
-  yankHighlight: Some(yankHighlight),
+  yankHighlight:
+    Some({
+      pixelRanges,
+      key: Brisk_reconciler.Key.create(),
+      opacity:
+        Component_Animation.make(
+          Animations.fadeIn(~duration=editor.yankHighlightDuration),
+        ),
+    }),
 };
 
 let setWrapPadding = (~padding, editor) => {
@@ -409,7 +430,10 @@ let configure = (~config, editor) => {
     Feature_Configuration.GlobalConfiguration.animation.get(config)
     && EditorConfiguration.smoothScroll.get(config);
 
-  {...editor, isScrollAnimated}
+  let yankHighlightDuration =
+    EditorConfiguration.yankHighlightDuration.get(config);
+
+  {...editor, isScrollAnimated, yankHighlightDuration}
   |> setVerticalScrollMargin(~lines=scrolloff)
   |> setMinimap(
        ~enabled=EditorConfiguration.Minimap.enabled.get(config),
@@ -435,6 +459,9 @@ let create = (~config, ~buffer, ()) => {
   let isScrollAnimated =
     Feature_Configuration.GlobalConfiguration.animation.get(config)
     && EditorConfiguration.smoothScroll.get(config);
+
+  let yankHighlightDuration =
+    EditorConfiguration.yankHighlightDuration.get(config);
 
   {
     editorId: id,
@@ -463,6 +490,7 @@ let create = (~config, ~buffer, ()) => {
     pixelWidth: 1,
     pixelHeight: 1,
     yankHighlight: None,
+    yankHighlightDuration,
     wrapState,
     wrapMode,
     wrapPadding: None,
@@ -1512,10 +1540,25 @@ let lastMouseMoveTime = ({lastMouseMoveTime, _}) => lastMouseMoveTime;
 [@deriving show]
 type msg =
   | ScrollSpringX([@opaque] Spring.msg)
-  | ScrollSpringY([@opaque] Spring.msg);
+  | ScrollSpringY([@opaque] Spring.msg)
+  | YankHighlight([@opaque] Component_Animation.msg);
 
 let update = (msg, editor) => {
   switch (msg) {
+  | YankHighlight(msg) =>
+    let yankHighlight' =
+      yankHighlight(editor)
+      |> OptionEx.flatMap(yankHighlight => {
+           let opacity' =
+             Component_Animation.update(msg, yankHighlight.opacity);
+
+           if (Component_Animation.isComplete(opacity')) {
+             None;
+           } else {
+             Some({...yankHighlight, opacity: opacity'});
+           };
+         });
+    {...editor, yankHighlight: yankHighlight'};
   | ScrollSpringX(msg) => {
       ...editor,
       scrollX: Spring.update(msg, editor.scrollX),
@@ -1528,10 +1571,19 @@ let update = (msg, editor) => {
 };
 
 let sub = editor => {
+  let yankHighlightAnimation =
+    yankHighlight(editor)
+    |> Option.map(({opacity, _}) => {
+         opacity
+         |> Component_Animation.sub
+         |> Isolinear.Sub.map(msg => YankHighlight(msg))
+       })
+    |> Option.value(~default=Isolinear.Sub.none);
   [
     Spring.sub(editor.scrollX) |> Isolinear.Sub.map(msg => ScrollSpringX(msg)),
     Spring.sub(editor.scrollY)
     |> Isolinear.Sub.map(msg => ScrollSpringY(msg)),
+    yankHighlightAnimation,
   ]
   |> Isolinear.Sub.batch;
 };

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -13,6 +13,7 @@ type scrollbarMetrics = {
 type yankHighlight = {
   key: Brisk_reconciler.Key.t,
   pixelRanges: list(PixelRange.t),
+  opacity: Component_Animation.t(float),
 };
 
 module WrapMode: {
@@ -77,7 +78,7 @@ let getTokenAt:
   option(CharacterRange.t);
 
 let yankHighlight: t => option(yankHighlight);
-let setYankHighlight: (~yankHighlight: yankHighlight, t) => t;
+let startYankHighlight: (list(PixelRange.t), t) => t;
 
 let setWrapPadding: (~padding: float, t) => t;
 let setVerticalScrollMargin: (~lines: int, t) => t;

--- a/src/Feature/Editor/Minimap.re
+++ b/src/Feature/Editor/Minimap.re
@@ -255,10 +255,11 @@ let%component make =
 
   let yankHighlightElement =
     maybeYankHighlights
-    |> Option.map(({key, pixelRanges}: Editor.yankHighlight) => {
+    |> Option.map(({key, pixelRanges, opacity}: Editor.yankHighlight) => {
          let pixelRanges = pixelRanges |> List.map(mapPixelRange);
+         let opacity = Component_Animation.get(opacity);
 
-         <YankHighlights config key pixelRanges />;
+         <YankHighlights opacity config key pixelRanges />;
        })
     |> Option.value(~default=React.empty);
 

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -151,6 +151,7 @@ let%component make =
     |> Option.map((highlights: Editor.yankHighlight) =>
          <YankHighlights
            config
+           opacity={Component_Animation.get(highlights.opacity)}
            key={highlights.key}
            pixelRanges={highlights.pixelRanges}
          />

--- a/src/Feature/Editor/YankHighlights.re
+++ b/src/Feature/Editor/YankHighlights.re
@@ -19,27 +19,20 @@ module Styles = {
   ];
 };
 
-module Animations = {
-  let fadeIn = (~duration) =>
-    Revery.UI.Animation.(
-      animate(Revery.Time.milliseconds(duration))
-      |> ease(Easing.easeIn)
-      |> tween(0.6, 0.0)
-      |> delay(Revery.Time.milliseconds(0))
-    );
-};
+// module Animations = {
+//   let fadeIn = (~duration) =>
+//     Revery.UI.Animation.(
+//       animate(Revery.Time.milliseconds(duration))
+//       |> ease(Easing.easeIn)
+//       |> tween(0.6, 0.0)
+//       |> delay(Revery.Time.milliseconds(0))
+//     );
+// };
 
-let%component make = (~config, ~pixelRanges: list(PixelRange.t), ()) => {
+let make = (~key, ~opacity, ~config, ~pixelRanges: list(PixelRange.t), ()) => {
   let ranges = pixelRanges;
 
-  let duration = EditorConfiguration.yankHighlightDuration.get(config);
-
-  let%hook (opacity, _animationState, _reset) =
-    Hooks.animation(
-      ~name="Yank Highlights Animation",
-      Animations.fadeIn(~duration),
-      ~active=true,
-    );
+  //let duration = EditorConfiguration.yankHighlightDuration.get(config);
 
   let bg = EditorConfiguration.yankHighlightColor.get(config);
 
@@ -59,5 +52,7 @@ let%component make = (~config, ~pixelRanges: list(PixelRange.t), ()) => {
        })
     |> React.listToElement;
 
-  <View style=Styles.overlay> <Opacity opacity> elements </Opacity> </View>;
+  <View key style=Styles.overlay>
+    <Opacity opacity> elements </Opacity>
+  </View>;
 };

--- a/src/Feature/Editor/YankHighlights.re
+++ b/src/Feature/Editor/YankHighlights.re
@@ -19,20 +19,8 @@ module Styles = {
   ];
 };
 
-// module Animations = {
-//   let fadeIn = (~duration) =>
-//     Revery.UI.Animation.(
-//       animate(Revery.Time.milliseconds(duration))
-//       |> ease(Easing.easeIn)
-//       |> tween(0.6, 0.0)
-//       |> delay(Revery.Time.milliseconds(0))
-//     );
-// };
-
 let make = (~key, ~opacity, ~config, ~pixelRanges: list(PixelRange.t), ()) => {
   let ranges = pixelRanges;
-
-  //let duration = EditorConfiguration.yankHighlightDuration.get(config);
 
   let bg = EditorConfiguration.yankHighlightColor.get(config);
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1466,11 +1466,11 @@ let update =
         state.layout
         |> Feature_Layout.map(editor =>
              if (Editor.getId(editor) == activeEditorId) {
-               Editor.setYankHighlight(
-                 ~yankHighlight={
-                   key: Brisk_reconciler.Key.create(),
-                   pixelRanges,
-                 },
+               Editor.startYankHighlight(
+                 // ~yankHighlight={
+                 //   key: Brisk_reconciler.Key.create(),
+                 pixelRanges,
+                 // },
                  editor,
                );
              } else {

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1466,13 +1466,7 @@ let update =
         state.layout
         |> Feature_Layout.map(editor =>
              if (Editor.getId(editor) == activeEditorId) {
-               Editor.startYankHighlight(
-                 // ~yankHighlight={
-                 //   key: Brisk_reconciler.Key.create(),
-                 pixelRanges,
-                 // },
-                 editor,
-               );
+               Editor.startYankHighlight(pixelRanges, editor);
              } else {
                editor;
              }


### PR DESCRIPTION
Fixes  another hanging-hook-timer in #2407 - moves the yank highlight animation from hook-based to model-based animation.

In addition to removing the chance of a hanging-hook-timer, this fixes a bug where the yank-highlight animation could be replayed when navigating between editors.

Related to #2407