### PR TITLE
chore(ci): Populate esy cache for Ubuntu builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,8 +56,6 @@ jobs:
 
 - job: Linux
   displayName: 'Linux - Ubuntu 18.04'
-  # Run if not master
-  condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
   timeoutInMinutes: 90
   pool:
     vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
Set up the Ubuntu builds to run on `master`, and save the cache - to help speed up PR builds