### PR TITLE
docs: Add explorer contexts to key-bindings.md

### DIFF
--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -101,12 +101,12 @@ For conditional expressions, you can use the following conditional operators:
 
 | Operator | Symbol | Example |
 | --- | --- | --- |
-| Or | <code>&#124;&#124;</code> | <code>menuFocus &#124;&#124; textInputFocus</code> |
+| Or | <code>&#124;&#124;</code> | <code>listFocus &#124;&#124; textInputFocus</code> |
 | And | `&&` | `insertMode && suggestWidgetVisible` |
 
 Expressions may be grouped with `()`, for example:
 ```
-(menuFocus && !insertMode) || suggestWidgetVisible
+(editorTextFocus && !insertMode) || suggestWidgetVisible
 ```
 
 #### Contexts

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -129,7 +129,9 @@ Onivim-specific contexts:
 | `visualMode` |  The active editor is in `visual` mode |
 | `sneakMode` | Sneak mode is active |
 | `commandLineFocus` | The Vim commandline is open |
-| `menuFocus` | A pop-up menu has focus |
+| `listFocus` | A list of items (like a pop-up menu) is focused |
+| `vimListNavigation` | Inside a Vim-navigable list |
+| `vimTreeNavigation` | Inside the file explorer |
 
 ## Commands
 


### PR DESCRIPTION
Also see second commit that removes references to `menuFocus`