### PR TITLE
fix(ci): remove unneeded failure in release creation

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -31,9 +31,8 @@ steps:
     displayName: 'Release: install'
   - script: 'esy @release build'
     displayName: 'esy @release build'
-  - script: 'esy @release run -f --version'
-    displayName: 'esy @release run -f --version'
-    continueOnError: true
+  - script: 'esy @release run -f --help'
+    displayName: 'esy @release run -f --help'
   - script: esy @release create --codesign
     displayName: "esy @release create --codesign"
   - script: esy build-env


### PR DESCRIPTION
This changes `esy @release run --version` → `esy @release run --help`

As of right now, when we try to run the binary to create it for release, we get a linking error on macOS since we try to dynlink `Sparkle.framework` in a scenario that is explicitly disallowed by the kernel.

However, since the `--help` CLI flag means the program is terminated before we try to link the framework, we don't get this failure.

It's not a huge deal, but I think it makes more sense to have a failure that actually means failure rather than a failure that means success and we allow it to proceed.