### PR TITLE
fix(completion/#2752): Don't clear out items on details error

### DIFF
--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -205,22 +205,21 @@ module Session = {
                | Completed({providerModel, meet, _})
                | Pending({providerModel, meet, _}) =>
                  open CompletionMeet;
-                 let providerModel' =
+                 let (providerModel', _outmsg) =
                    ProviderImpl.update(
                      ~isFuzzyMatching=meet.base != "",
                      internalMsg,
                      providerModel,
                    );
                  switch (ProviderImpl.items(providerModel')) {
-                 | Ok([]) => Pending({meet, providerModel: providerModel'})
-                 | Ok(items) =>
+                 | [] => Pending({meet, providerModel: providerModel'})
+                 | items =>
                    Completed({
                      meet,
                      allItems: items,
                      filteredItems: filter(~query=meet.base, items),
                      providerModel: providerModel',
                    })
-                 | Error(msg) => Failure(msg)
                  };
                | _ => state
                };
@@ -329,15 +328,14 @@ module Session = {
              let items = ProviderImpl.items(model);
              let state =
                switch (items) {
-               | Ok([]) => Pending({meet, providerModel: model})
-               | Ok(items) =>
+               | [] => Pending({meet, providerModel: model})
+               | items =>
                  Completed({
                    meet,
                    allItems: items,
                    filteredItems: filter(~query=meet.base, items),
                    providerModel: model,
                  })
-               | Error(msg) => Failure(msg)
                };
 
              Session({...session, state});

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -205,6 +205,7 @@ module Session = {
                | Completed({providerModel, meet, _})
                | Pending({providerModel, meet, _}) =>
                  open CompletionMeet;
+                 // TODO: What to do with the error `_outmsg` case?
                  let (providerModel', _outmsg) =
                    ProviderImpl.update(
                      ~isFuzzyMatching=meet.base != "",
@@ -669,7 +670,7 @@ let tryToMaintainSelected = (~previousIndex, ~previousLabel, model) => {
 
   // Sanity check - make sure there is a valid position.
   // Completions list might be empty...
-  if (idxToReplace >= len) {
+  if (idxToReplace >= len || len == 0) {
     model;
   } else if
     // Nothing to do - still in a good spot!

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -6,7 +6,11 @@ module type S = {
   type msg;
   type model;
 
-  let update: (~isFuzzyMatching: bool, msg, model) => model;
+  type outmsg =
+    | Nothing
+    | ProviderError(string);
+
+  let update: (~isFuzzyMatching: bool, msg, model) => (model, outmsg);
 
   let create:
     (
@@ -19,7 +23,7 @@ module type S = {
     ) =>
     option(model);
 
-  let items: model => result(list(CompletionItem.t), string);
+  let items: model => list(CompletionItem.t);
 
   let handle: unit => option(int);
 
@@ -37,7 +41,7 @@ module type S = {
 type provider('model, 'msg) = (module S with
                                   type model = 'model and type msg = 'msg);
 
-type exthostModel = result(list(CompletionItem.t), string);
+type exthostModel = list(CompletionItem.t);
 [@deriving show]
 type exthostMsg =
   | ResultAvailable({
@@ -72,6 +76,10 @@ module ExthostCompletionProvider =
   type msg = exthostMsg;
   type model = exthostModel;
 
+  type outmsg =
+    | Nothing
+    | ProviderError(string);
+
   let create =
       (
         ~config as _,
@@ -84,7 +92,7 @@ module ExthostCompletionProvider =
     if (!Exthost.DocumentSelector.matchesBuffer(~buffer, Config.selector)) {
       None;
     } else {
-      Some(Ok([]));
+      Some([]);
     };
 
   let handle = () => Some(providerHandle);
@@ -98,28 +106,31 @@ module ExthostCompletionProvider =
         |> List.map(
              CompletionItem.create(~isFuzzyMatching, ~handle=providerHandle),
            );
-      Ok(completions);
+      (completions, Nothing);
     | DetailsAvailable({handle, item}) when handle == providerHandle =>
-      model
-      |> Result.map(items => {
-           items
-           |> List.map((previousItem: CompletionItem.t) =>
-                if (previousItem.chainedCacheId == item.chainedCacheId) {
-                  CompletionItem.create(
-                    ~isFuzzyMatching=previousItem.isFuzzyMatching,
-                    ~handle=providerHandle,
-                    item,
-                  );
-                } else {
-                  previousItem;
-                }
-              )
-         })
-    | DetailsError({handle, errorMsg}) when handle == providerHandle =>
-      Error(errorMsg)
-    | ResultError({handle, errorMsg}) when handle == providerHandle =>
-      Error(errorMsg)
-    | _ => model
+      let model' =
+        model
+        |> List.map((previousItem: CompletionItem.t) =>
+             if (previousItem.chainedCacheId == item.chainedCacheId) {
+               CompletionItem.create(
+                 ~isFuzzyMatching=previousItem.isFuzzyMatching,
+                 ~handle=providerHandle,
+                 item,
+               );
+             } else {
+               previousItem;
+             }
+           );
+      (model', Nothing);
+    | DetailsError({handle, errorMsg}) when handle == providerHandle => (
+        model,
+        ProviderError(errorMsg),
+      )
+    | ResultError({handle, errorMsg}) when handle == providerHandle => (
+        model,
+        ProviderError(errorMsg),
+      )
+    | _ => (model, Nothing)
     };
 
   let items = model => model;
@@ -164,11 +175,12 @@ module ExthostCompletionProvider =
                     ~handle=providerHandle,
                     ~chainedCacheId,
                     ~toMsg=
-                      fun
-                      | Ok(item) =>
-                        DetailsAvailable({handle: providerHandle, item})
-                      | Error(errorMsg) =>
-                        DetailsError({handle: providerHandle, errorMsg}),
+                      _ =>
+                        fun
+                        | Ok(item) =>
+                          DetailsAvailable({handle: providerHandle, item})
+                        | Error(errorMsg) =>
+                          DetailsError({handle: providerHandle, errorMsg}),
                     client,
                   );
 
@@ -210,6 +222,10 @@ module KeywordCompletionProvider =
   type msg = keywordMsg;
   type model = keywordModel;
 
+  type outmsg =
+    | Nothing
+    | ProviderError(string);
+
   let handle = () => None;
 
   let create =
@@ -245,9 +261,12 @@ module KeywordCompletionProvider =
     };
   };
 
-  let update = (~isFuzzyMatching as _, _msg: msg, model: model) => model;
+  let update = (~isFuzzyMatching as _, _msg: msg, model: model) => (
+    model,
+    Nothing,
+  );
 
-  let items = model => Ok(model);
+  let items = model => model;
 
   let sub =
       (~client as _, ~position as _, ~buffer as _, ~selectedItem as _, _model) => Isolinear.Sub.none;

--- a/src/Feature/LanguageSupport/CompletionProvider.re
+++ b/src/Feature/LanguageSupport/CompletionProvider.re
@@ -175,12 +175,11 @@ module ExthostCompletionProvider =
                     ~handle=providerHandle,
                     ~chainedCacheId,
                     ~toMsg=
-                      _ =>
-                        fun
-                        | Ok(item) =>
-                          DetailsAvailable({handle: providerHandle, item})
-                        | Error(errorMsg) =>
-                          DetailsError({handle: providerHandle, errorMsg}),
+                      fun
+                      | Ok(item) =>
+                        DetailsAvailable({handle: providerHandle, item})
+                      | Error(errorMsg) =>
+                        DetailsError({handle: providerHandle, errorMsg}),
                     client,
                   );
 

--- a/src/Feature/LanguageSupport/CompletionProvider.rei
+++ b/src/Feature/LanguageSupport/CompletionProvider.rei
@@ -6,7 +6,11 @@ module type S = {
   type msg;
   type model;
 
-  let update: (~isFuzzyMatching: bool, msg, model) => model;
+  type outmsg =
+    | Nothing
+    | ProviderError(string);
+
+  let update: (~isFuzzyMatching: bool, msg, model) => (model, outmsg);
 
   let create:
     (
@@ -19,7 +23,7 @@ module type S = {
     ) =>
     option(model);
 
-  let items: model => result(list(CompletionItem.t), string);
+  let items: model => list(CompletionItem.t);
 
   let handle: unit => option(int);
 


### PR DESCRIPTION
__Issue:__ When there is a failure getting details for a completion item - as in #2752 - Onivim crashes.

__Defect:__ When there is a `DetailsError`, we were clearing out the set of completion items. This broke our logic in trying to maintain the selected item - causing an array out-of-bounds exception to be thrown. 

__Fix:__ In the case of an error getting details, we should not crash, and we should maintain the current set of items.

Fixes #2752 