### PR TITLE
fix(workspace/#730): Open Folder button

### DIFF
--- a/src/Feature/Workspace/Feature_Workspace.re
+++ b/src/Feature/Workspace/Feature_Workspace.re
@@ -115,7 +115,10 @@ module Commands = {
     );
 
   let all = model =>
-    model.openedFolder == None ? [openFolder] : [closeFolder];
+    model.openedFolder == None
+      ? [openFolder]
+      // Always show open folder, so the user can switch folders from command palette
+      : [openFolder, closeFolder];
 };
 
 module Contributions = {


### PR DESCRIPTION
With #2711 , we now have an 'Open Folder' button when no workspace is opened:

![open-folder](https://user-images.githubusercontent.com/13532591/100265104-96203580-2f04-11eb-9db3-79154c03192d.gif)

This just implements a small tweak to always have the `Workspace: Open Folder` option available in the command palette, even when one is currently opened (for changing folders).

Fixes #730 