### PR TITLE
feat(vim): Hook up ':messages' / ':messages clear' ex commands

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25f5466028a9be159308c30240f345de",
+  "checksum": "c61d88aa5195e7b7b68c82e25e4ffcf0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.77@d41d8cd9": {
-      "id": "libvim@8.10869.77@d41d8cd9",
+    "libvim@8.10869.78@d41d8cd9": {
+      "id": "libvim@8.10869.78@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.77",
+      "version": "8.10869.78",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.77.tgz#sha1:906ee07e3d5ed7eef7e97f18361886c07c910079"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
         ]
       },
       "overrides": [],
@@ -1015,7 +1015,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.77@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25f5466028a9be159308c30240f345de",
+  "checksum": "c61d88aa5195e7b7b68c82e25e4ffcf0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.77@d41d8cd9": {
-      "id": "libvim@8.10869.77@d41d8cd9",
+    "libvim@8.10869.78@d41d8cd9": {
+      "id": "libvim@8.10869.78@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.77",
+      "version": "8.10869.78",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.77.tgz#sha1:906ee07e3d5ed7eef7e97f18361886c07c910079"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
         ]
       },
       "overrides": [],
@@ -1014,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.77@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25f5466028a9be159308c30240f345de",
+  "checksum": "c61d88aa5195e7b7b68c82e25e4ffcf0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.77@d41d8cd9": {
-      "id": "libvim@8.10869.77@d41d8cd9",
+    "libvim@8.10869.78@d41d8cd9": {
+      "id": "libvim@8.10869.78@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.77",
+      "version": "8.10869.78",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.77.tgz#sha1:906ee07e3d5ed7eef7e97f18361886c07c910079"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
         ]
       },
       "overrides": [],
@@ -1014,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.77@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.77",
+    "libvim": "8.10869.78",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reason-fzy": "CrossR/reason-fzy#7339d4e",
@@ -256,7 +256,6 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#30bef47",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
+    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#30bef47",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "25f5466028a9be159308c30240f345de",
+  "checksum": "c61d88aa5195e7b7b68c82e25e4ffcf0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.77@d41d8cd9": {
-      "id": "libvim@8.10869.77@d41d8cd9",
+    "libvim@8.10869.78@d41d8cd9": {
+      "id": "libvim@8.10869.78@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.77",
+      "version": "8.10869.78",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.77.tgz#sha1:906ee07e3d5ed7eef7e97f18361886c07c910079"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
         ]
       },
       "overrides": [],
@@ -1014,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.77@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/src/Feature/Notification/Feature_Notification.re
+++ b/src/Feature/Notification/Feature_Notification.re
@@ -538,56 +538,6 @@ module View = {
       </View>;
     };
   };
-
-  module List = {
-    module Styles = {
-      open Style;
-
-      let pane = [flexGrow(1), flexDirection(`Row)];
-
-      let noResultsContainer = [
-        flexGrow(1),
-        alignItems(`Center),
-        justifyContent(`Center),
-      ];
-
-      let container = [
-        position(`Absolute),
-        top(0),
-        bottom(0),
-        left(0),
-        right(0),
-      ];
-
-      let title = (~theme) => [
-        color(Colors.PanelTitle.activeForeground.from(theme)),
-        margin(8),
-      ];
-    };
-
-    let make = (~model, ~theme, ~font: UiFont.t, ~dispatch, ()) => {
-      let items = [];
-      //model.all |> List.map(item => <Item item theme font dispatch />);
-
-      let innerElement =
-        if (items == []) {
-          <View style=Styles.noResultsContainer>
-            <Text
-              style={Styles.title(~theme)}
-              text="No notifications, yet!"
-              fontFamily={font.family}
-              fontSize={font.size}
-            />
-          </View>;
-        } else {
-          <ScrollView style=Styles.container>
-            {items |> React.listToElement}
-          </ScrollView>;
-        };
-
-      <View style=Styles.pane> innerElement </View>;
-    };
-  };
 };
 
 // CONTRIBUTIONS

--- a/src/Feature/Notification/Feature_Notification.re
+++ b/src/Feature/Notification/Feature_Notification.re
@@ -497,7 +497,7 @@ module View = {
       let icon = () =>
         <FontIcon
           icon={iconFor(notification)}
-          fontSize=16.
+          fontSize=12.
           color={colorFor(notification, ~theme)}
         />;
 

--- a/src/Feature/Notification/Feature_Notification.re
+++ b/src/Feature/Notification/Feature_Notification.re
@@ -221,6 +221,7 @@ type msg =
   | Created(internal)
   | Dismissed({id: int})
   | Expire({id: int})
+  | Clear({count: int})
   | AnimateYOffset({
       id: int,
       msg: [@opaque] Component_Animation.msg,
@@ -228,10 +229,23 @@ type msg =
   | AnimateBackground([@opaque] Component_Animation.ColorTransition.msg)
   | AnimateForeground([@opaque] Component_Animation.ColorTransition.msg);
 
+module Msg = {
+  let clear = count => Clear({count: count});
+};
+
 let update = (~theme, ~config, model, msg) => {
   let animationsEnabled =
     Feature_Configuration.GlobalConfiguration.animation.get(config);
   switch (msg) {
+  | Clear({count}) =>
+    let all =
+      if (count == 0) {
+        [];
+      } else {
+        Utility.ListEx.firstk(count, model.all);
+      };
+    {...model, all, activeNotifications: IntSet.empty}
+    |> updateColorTransition(~config, ~theme);
   | Created(item) =>
     let yOffsetAnimation =
       animationsEnabled

--- a/src/Feature/Notification/Feature_Notification.re
+++ b/src/Feature/Notification/Feature_Notification.re
@@ -454,88 +454,92 @@ module View = {
 
   // LIST
 
-  module List = {
-    module Item = {
-      module Styles = {
-        open Style;
+  module Item = {
+    module Styles = {
+      open Style;
 
-        let container = [
-          flexDirection(`Row),
-          alignItems(`Center),
-          paddingHorizontal(10),
-          paddingVertical(5),
-        ];
+      let container = [
+        flexDirection(`Row),
+        alignItems(`Center),
+        paddingHorizontal(10),
+        paddingVertical(5),
+      ];
 
-        let text = (~foreground) => [
-          textWrap(TextWrapping.NoWrap),
-          marginLeft(6),
-          color(foreground),
-        ];
+      let text = (~foreground) => [
+        textWrap(TextWrapping.NoWrap),
+        marginLeft(6),
+        color(foreground),
+      ];
 
-        let message = (~foreground) => [flexGrow(1), ...text(~foreground)];
+      let message = (~foreground) => [flexGrow(1), ...text(~foreground)];
 
-        let closeButton = [alignSelf(`Stretch), paddingHorizontal(5)];
-      };
-
-      let colorFor = (item, ~theme) =>
-        switch (item.kind) {
-        | Warning => Colors.warningBackground.from(theme)
-        | Error => Colors.errorBackground.from(theme)
-        | Info => Colors.infoBackground.from(theme)
-        };
-
-      let iconFor = item =>
-        switch (item.kind) {
-        | Warning => FontAwesome.exclamationTriangle
-        | Error => FontAwesome.exclamationCircle
-        | Info => FontAwesome.infoCircle
-        };
-
-      let make = (~item, ~theme, ~font: UiFont.t, ~dispatch, ()) => {
-        let foreground = Colors.foreground.from(theme);
-
-        let icon = () =>
-          <FontIcon
-            icon={iconFor(item)}
-            fontSize=16.
-            color={colorFor(item, ~theme)}
-          />;
-
-        let source = () =>
-          switch (item.source) {
-          | Some(text) =>
-            let foreground = Color.multiplyAlpha(0.5, foreground);
-            <Text
-              style={Styles.text(~foreground)}
-              fontFamily={font.family}
-              fontSize=11.
-              text
-            />;
-          | None => React.empty
-          };
-
-        let closeButton = () => {
-          let onClick = () => dispatch(Dismissed({id: item.id}));
-
-          <Clickable onClick style=Styles.closeButton>
-            <FontIcon icon=FontAwesome.times fontSize=13. color=foreground />
-          </Clickable>;
-        };
-
-        <View style=Styles.container>
-          <icon />
-          <source />
-          <Text
-            style={Styles.message(~foreground)}
-            fontFamily={font.family}
-            fontSize=11.
-            text={item.message}
-          />
-          <closeButton />
-        </View>;
-      };
+      let closeButton = [alignSelf(`Stretch), paddingHorizontal(5)];
     };
 
+    let colorFor = (item: notification, ~theme) =>
+      switch (item.kind) {
+      | Warning => Colors.warningBackground.from(theme)
+      | Error => Colors.errorBackground.from(theme)
+      | Info => Colors.infoBackground.from(theme)
+      };
+
+    let iconFor = (item: notification) =>
+      switch (item.kind) {
+      | Warning => FontAwesome.exclamationTriangle
+      | Error => FontAwesome.exclamationCircle
+      | Info => FontAwesome.infoCircle
+      };
+
+    let make =
+        (~notification: notification, ~theme, ~font: UiFont.t, ~onDismiss, ()) => {
+      let foreground = Colors.foreground.from(theme);
+
+      let icon = () =>
+        <FontIcon
+          icon={iconFor(notification)}
+          fontSize=16.
+          color={colorFor(notification, ~theme)}
+        />;
+
+      let source = () =>
+        switch (notification.source) {
+        | Some(text) =>
+          let foreground = Color.multiplyAlpha(0.5, foreground);
+          <Text
+            style={Styles.text(~foreground)}
+            fontFamily={font.family}
+            fontSize=11.
+            text
+          />;
+        | None => React.empty
+        };
+
+      let closeButton = () => {
+        // TODO: Bring back
+        //let onClick = () => dispatch(Dismissed({id: item.id}));
+
+        let onClick = onDismiss;
+
+        <Clickable onClick style=Styles.closeButton>
+          <FontIcon icon=FontAwesome.times fontSize=13. color=foreground />
+        </Clickable>;
+      };
+
+      <View style=Styles.container>
+        <icon />
+        <source />
+        <Text
+          style={Styles.message(~foreground)}
+          fontFamily={font.family}
+          fontSize=11.
+          text={notification.message}
+        />
+        <closeButton />
+      </View>;
+    };
+  };
+
+  module List = {
     module Styles = {
       open Style;
 
@@ -562,8 +566,8 @@ module View = {
     };
 
     let make = (~model, ~theme, ~font: UiFont.t, ~dispatch, ()) => {
-      let items =
-        model.all |> List.map(item => <Item item theme font dispatch />);
+      let items = [];
+      //model.all |> List.map(item => <Item item theme font dispatch />);
 
       let innerElement =
         if (items == []) {

--- a/src/Feature/Notification/Feature_Notification.rei
+++ b/src/Feature/Notification/Feature_Notification.rei
@@ -110,18 +110,6 @@ module View: {
       ) =>
       React.element(React.node);
   };
-
-  module List: {
-    let make:
-      (
-        ~model: model,
-        ~theme: ColorTheme.Colors.t,
-        ~font: UiFont.t,
-        ~dispatch: msg => unit,
-        unit
-      ) =>
-      React.element(React.node);
-  };
 };
 
 // CONTRIBUTIONS

--- a/src/Feature/Notification/Feature_Notification.rei
+++ b/src/Feature/Notification/Feature_Notification.rei
@@ -99,6 +99,18 @@ module View: {
       React.element(React.node);
   };
 
+  module Item: {
+    let make:
+      (
+        ~notification: notification,
+        ~theme: ColorTheme.Colors.t,
+        ~font: UiFont.t,
+        ~onDismiss: unit => unit,
+        unit
+      ) =>
+      React.element(React.node);
+  };
+
   module List: {
     let make:
       (

--- a/src/Feature/Notification/Feature_Notification.rei
+++ b/src/Feature/Notification/Feature_Notification.rei
@@ -35,6 +35,8 @@ let statusBarForeground:
 [@deriving show]
 type msg;
 
+module Msg: {let clear: int => msg;};
+
 let update:
   (
     ~theme: Oni_Core.ColorTheme.Colors.t,

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -244,16 +244,15 @@ let diagnosticToLocList =
 
 let setNotifications = (notifications, model) => {
   let searchText = (notification: Feature_Notification.notification) => {
-    notification.message
+    notification.message;
   };
-  let notificationsArray = notifications
-  |> Feature_Notification.all
-  |> Array.of_list;
+  let notificationsArray =
+    notifications |> Feature_Notification.all |> Array.of_list;
 
-  let notificationsView' = 
-  model.notificationsView
-  |> Component_VimList.set(~searchText, notificationsArray);
-  {...model, notificationsView: notificationsView'}
+  let notificationsView' =
+    model.notificationsView
+    |> Component_VimList.set(~searchText, notificationsArray);
+  {...model, notificationsView: notificationsView'};
 };
 
 let setDiagnostics = (diagnostics, model) => {
@@ -361,11 +360,13 @@ let update = (~buffers, ~font, ~languageInfo, msg, model) =>
   | KeyPressed(key) =>
     switch (model.selected) {
     | Notifications => (
-      {
-        ...model,
-        notificationsView:
-          Component_VimList.keyPress(key, model.notificationsView),
-      }, Nothing)
+        {
+          ...model,
+          notificationsView:
+            Component_VimList.keyPress(key, model.notificationsView),
+        },
+        Nothing,
+      )
 
     | Diagnostics => (
         {
@@ -432,12 +433,13 @@ let update = (~buffers, ~font, ~languageInfo, msg, model) =>
     let (notificationsView, outmsg) =
       Component_VimList.update(listMsg, model.notificationsView);
 
-    let eff = switch (outmsg) {
-    | Component_VimList.Nothing => Nothing
-    | Component_VimList.Selected(_) => Nothing
-    };
+    let eff =
+      switch (outmsg) {
+      | Component_VimList.Nothing => Nothing
+      | Component_VimList.Selected(_) => Nothing
+      };
 
-    ({...model, notificationsView}, eff)
+    ({...model, notificationsView}, eff);
 
   | DiagnosticsList(listMsg) =>
     let (diagnosticsView, outmsg) =
@@ -817,12 +819,18 @@ module Contributions = {
       |> List.map(Oni_Core.Command.map(msg => LocationsList(msg)));
 
     let notificationsCommands =
-    (isFocused && model.selected == Notifications
-    ? Component_VimList.Contributions.commands : [])
-    |> List.map(Oni_Core.Command.map(msg => NotificationsList(msg)));
+      (
+        isFocused && model.selected == Notifications
+          ? Component_VimList.Contributions.commands : []
+      )
+      |> List.map(Oni_Core.Command.map(msg => NotificationsList(msg)));
 
     isFocused
-      ? common @ vimWindowCommands @ diagnosticsCommands @ locationsCommands @ notificationsCommands
+      ? common
+        @ vimWindowCommands
+        @ diagnosticsCommands
+        @ locationsCommands
+        @ notificationsCommands
       : common;
   };
 
@@ -845,12 +853,15 @@ module Contributions = {
         ? Component_VimTree.Contributions.contextKeys(model.locationsView)
         : empty;
 
-      let notificationsKeys =
-        isFocused && model.selected == Notifications
-        ? Component_VimList.Contributions.contextKeys(model.notificationsView)
+    let notificationsKeys =
+      isFocused && model.selected == Notifications
+        ? Component_VimList.Contributions.contextKeys(
+            model.notificationsView,
+          )
         : empty;
 
-    [vimNavKeys, diagnosticsKeys, locationsKeys, notificationsKeys] |> unionMany;
+    [vimNavKeys, diagnosticsKeys, locationsKeys, notificationsKeys]
+    |> unionMany;
   };
 
   let keybindings = Keybindings.[toggleProblems, toggleProblemsOSX];

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -678,7 +678,6 @@ module View = {
                   ~languageInfo,
                   ~uiFont,
                   ~dispatch: msg => unit,
-                  ~notificationDispatch: Feature_Notification.msg => unit,
                   ~pane: model,
                   ~workingDirectory: string,
                   (),

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -609,12 +609,13 @@ module View = {
         ~iconTheme,
         ~languageInfo,
         ~uiFont,
-        ~notificationDispatch,
         ~locationsList,
         ~locationsDispatch: Component_VimTree.msg => unit,
         ~diagnosticDispatch: Component_VimTree.msg => unit,
         ~diagnosticsList: Component_VimTree.model(string, LocationListItem.t),
-        ~notifications: Feature_Notification.model,
+        ~notificationsList:
+           Component_VimList.model(Feature_Notification.notification),
+        ~notificationsDispatch: Component_VimList.msg => unit,
         ~workingDirectory,
         (),
       ) =>
@@ -643,11 +644,12 @@ module View = {
         dispatch=diagnosticDispatch
       />
     | Notifications =>
-      <Feature_Notification.View.List
-        model=notifications
+      <NotificationsPaneView
+        isFocused
+        notificationsList
         theme
-        font=uiFont
-        dispatch=notificationDispatch
+        uiFont
+        dispatch=notificationsDispatch
       />
     };
 
@@ -675,7 +677,6 @@ module View = {
                   ~iconTheme,
                   ~languageInfo,
                   ~uiFont,
-                  ~notifications: Feature_Notification.model,
                   ~dispatch: msg => unit,
                   ~notificationDispatch: Feature_Notification.msg => unit,
                   ~pane: model,
@@ -757,13 +758,13 @@ module View = {
           languageInfo
           diagnosticsList={pane.diagnosticsView}
           locationsList={pane.locationsView}
+          notificationsList={pane.notificationsView}
           selected={selected(pane)}
           theme
           uiFont
-          notifications
-          notificationDispatch
           diagnosticDispatch={msg => dispatch(DiagnosticsList(msg))}
           locationsDispatch={msg => dispatch(LocationsList(msg))}
+          notificationsDispatch={msg => dispatch(NotificationsList(msg))}
           workingDirectory
         />
       </View>

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -19,7 +19,8 @@ module Constants = {
 
 [@deriving show({with_path: false})]
 type command =
-  | ToggleProblems;
+  | ToggleProblems
+  | ToggleMessages;
 
 [@deriving show({with_path: false})]
 type msg =
@@ -41,6 +42,8 @@ module Msg = {
   let keyPressed = key => KeyPressed(key);
   let resizeHandleDragged = v => ResizeHandleDragged(v);
   let resizeCommitted = ResizeCommitted;
+
+  let toggleMessages = Command(ToggleMessages);
 };
 
 module Effects = {
@@ -314,6 +317,15 @@ let update = (~buffers, ~font, ~languageInfo, msg, model) =>
       (close(model), ReleaseFocus);
     } else {
       (show(~pane=Diagnostics, model), Nothing);
+    }
+
+  | Command(ToggleMessages) =>
+    if (!model.isOpen) {
+      (show(~pane=Notifications, model), GrabFocus);
+    } else if (model.selected == Notifications) {
+      (close(model), ReleaseFocus);
+    } else {
+      (show(~pane=Notifications, model), Nothing);
     }
 
   | ResizeHandleDragged(delta) => (

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -34,6 +34,7 @@ type msg =
   | DiagnosticsList(Component_VimTree.msg)
   | LocationsList(Component_VimTree.msg)
   | NotificationsList(Component_VimList.msg)
+  | DismissNotificationClicked(Feature_Notification.notification)
   | LocationFileLoaded({
       filePath: string,
       lines: array(string),
@@ -69,6 +70,7 @@ type outmsg =
   | UnhandledWindowMovement(Component_VimWindows.outmsg)
   | GrabFocus
   | ReleaseFocus
+  | NotificationDismissed(Feature_Notification.notification)
   | Effect(Isolinear.Effect.t(msg));
 
 type model = {
@@ -323,6 +325,11 @@ module Focus = {
 let update = (~buffers, ~font, ~languageInfo, msg, model) =>
   switch (msg) {
   | CloseButtonClicked => ({...model, isOpen: false}, ReleaseFocus)
+
+  | DismissNotificationClicked(notification) => (
+      model,
+      NotificationDismissed(notification),
+    )
 
   | TabClicked(pane) => ({...model, selected: pane}, Nothing)
 
@@ -609,6 +616,7 @@ module View = {
         ~iconTheme,
         ~languageInfo,
         ~uiFont,
+        ~dispatch,
         ~locationsList,
         ~locationsDispatch: Component_VimTree.msg => unit,
         ~diagnosticDispatch: Component_VimTree.msg => unit,
@@ -650,6 +658,9 @@ module View = {
         theme
         uiFont
         dispatch=notificationsDispatch
+        onDismiss={notification =>
+          dispatch(DismissNotificationClicked(notification))
+        }
       />
     };
 
@@ -760,6 +771,7 @@ module View = {
           notificationsList={pane.notificationsView}
           selected={selected(pane)}
           theme
+          dispatch
           uiFont
           diagnosticDispatch={msg => dispatch(DiagnosticsList(msg))}
           locationsDispatch={msg => dispatch(LocationsList(msg))}

--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -82,7 +82,6 @@ module View: {
       ~languageInfo: Exthost.LanguageInfo.t,
       ~uiFont: Oni_Core.UiFont.t,
       ~dispatch: msg => unit,
-      ~notificationDispatch: Feature_Notification.msg => unit,
       ~pane: model,
       ~workingDirectory: string,
       unit

--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -69,6 +69,7 @@ let setLocations:
     model
   ) =>
   model;
+let setNotifications: (Feature_Notification.model, model) => model;
 
 module View: {
   let make:
@@ -80,7 +81,6 @@ module View: {
       ~iconTheme: Oni_Core.IconTheme.t,
       ~languageInfo: Exthost.LanguageInfo.t,
       ~uiFont: Oni_Core.UiFont.t,
-      ~notifications: Feature_Notification.model,
       ~dispatch: msg => unit,
       ~notificationDispatch: Feature_Notification.msg => unit,
       ~pane: model,

--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -29,6 +29,7 @@ module Msg: {
   let keyPressed: string => msg;
   let resizeHandleDragged: int => msg;
   let resizeCommitted: msg;
+  let toggleMessages: msg;
 };
 
 type model;

--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -23,6 +23,7 @@ type outmsg =
   | UnhandledWindowMovement(Component_VimWindows.outmsg)
   | GrabFocus
   | ReleaseFocus
+  | NotificationDismissed(Feature_Notification.notification)
   | Effect(Isolinear.Effect.t(msg));
 
 module Msg: {

--- a/src/Feature/Pane/NotificationsPaneView.re
+++ b/src/Feature/Pane/NotificationsPaneView.re
@@ -9,7 +9,6 @@
 open Oni_Core;
 
 open Revery.UI;
-open Oni_Components;
 
 module Colors = Feature_Theme.Colors;
 
@@ -59,7 +58,7 @@ let make =
         model=notificationsList
         dispatch
         render={(
-          ~availableWidth,
+          ~availableWidth as _,
           ~index as _,
           ~hovered as _,
           ~selected as _,

--- a/src/Feature/Pane/NotificationsPaneView.re
+++ b/src/Feature/Pane/NotificationsPaneView.re
@@ -37,6 +37,7 @@ let make =
       ~theme,
       ~uiFont: UiFont.t,
       ~dispatch: Component_VimList.msg => unit,
+      ~onDismiss: Feature_Notification.notification => unit,
       (),
     ) => {
   let innerElement =
@@ -68,7 +69,7 @@ let make =
             notification=item
             font=uiFont
             theme
-            onDismiss={() => prerr_endline("dismiss")}
+            onDismiss={() => onDismiss(item)}
           />
         }
       />;

--- a/src/Feature/Pane/NotificationsPaneView.re
+++ b/src/Feature/Pane/NotificationsPaneView.re
@@ -1,0 +1,79 @@
+/*
+ * Diagnostics.re
+ *
+ * This module is responsible for tracking the state of 'diagnostics'
+ * (usually errors or warnings) that we render in the buffer view
+ * or minimap.
+ */
+
+open Oni_Core;
+
+open Revery.UI;
+open Oni_Components;
+
+module Colors = Feature_Theme.Colors;
+
+module Styles = {
+  open Style;
+
+  let pane = [flexGrow(1), flexDirection(`Row)];
+
+  let noResultsContainer = [
+    flexGrow(1),
+    alignItems(`Center),
+    justifyContent(`Center),
+  ];
+
+  let title = (~theme) => [
+    color(Colors.PanelTitle.activeForeground.from(theme)),
+    margin(8),
+  ];
+};
+
+let make =
+    (
+      ~isFocused: bool,
+      ~notificationsList:
+         Component_VimList.model(Feature_Notification.notification),
+      ~theme,
+      ~uiFont: UiFont.t,
+      ~dispatch: Component_VimList.msg => unit,
+      (),
+    ) => {
+  let innerElement =
+    if (Component_VimList.count(notificationsList) == 0) {
+      <View style=Styles.noResultsContainer>
+        <Text
+          style={Styles.title(~theme)}
+          fontFamily={uiFont.family}
+          fontSize={uiFont.size}
+          text="No notifications."
+        />
+      </View>;
+    } else {
+      <Component_VimList.View
+        font=uiFont
+        isActive=isFocused
+        focusedIndex=None
+        theme
+        model=notificationsList
+        dispatch
+        render={(
+          ~availableWidth,
+          ~index as _,
+          ~hovered as _,
+          ~selected as _,
+          item,
+        ) =>
+          <Feature_Notification.View.Item
+            notification=item
+            font=uiFont
+            theme
+            onDismiss={() => prerr_endline("dismiss")}
+          />
+        }
+      />;
+    };
+
+  <View style=Styles.pane> innerElement </View>;
+};

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1236,7 +1236,8 @@ let update =
     let theme = Feature_Theme.colors(state.colorTheme);
     let model' =
       Feature_Notification.update(~theme, ~config, state.notifications, msg);
-    ({...state, notifications: model'}, Effect.none);
+    let pane' = Feature_Pane.setNotifications(model', state.pane);
+    ({...state, notifications: model', pane: pane'}, Effect.none);
 
   | Modals(msg) =>
     switch (state.modal) {

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -584,6 +584,12 @@ let update =
         Isolinear.Effect.none,
       )
 
+    | NotificationDismissed(notification) => (
+        state,
+        Feature_Notification.Effects.dismiss(notification)
+        |> Isolinear.Effect.map(msg => Notification(msg)),
+      )
+
     | Effect(eff) => (state, eff |> Isolinear.Effect.map(msg => Pane(msg)))
     };
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -100,6 +100,9 @@ let start =
     | Vim.Goto.Outline =>
       dispatch(Actions.SideBar(Feature_SideBar.(Command(GotoOutline))))
 
+    | Vim.Goto.Messages =>
+      dispatch(Actions.Pane(Feature_Pane.Msg.toggleMessages))
+
     | Vim.Goto.Definition
     | Vim.Goto.Declaration =>
       Log.info("Goto definition requested");

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -147,6 +147,17 @@ let start =
       // ideally, all the commands here could be factored to be handled in the same way
       | Scroll(_) => ()
 
+      | Clear({target, count}) =>
+        Vim.Clear.(
+          {
+            switch (target) {
+            | Messages =>
+              dispatch(
+                Actions.Notification(Feature_Notification.Msg.clear(count)),
+              )
+            };
+          }
+        )
       | Map(mapping) =>
         dispatch(Actions.Input(Feature_Input.Msg.vimMap(mapping)))
       | Unmap({mode, keys}) =>

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -198,7 +198,6 @@ let make = (~dispatch, ~state: State.t, ()) => {
         languageInfo={state.languageInfo}
         theme
         uiFont
-        notifications={state.notifications}
         dispatch={msg => dispatch(Actions.Pane(msg))}
         notificationDispatch={msg => dispatch(Actions.Notification(msg))}
         pane={state.pane}

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -199,7 +199,6 @@ let make = (~dispatch, ~state: State.t, ()) => {
         theme
         uiFont
         dispatch={msg => dispatch(Actions.Pane(msg))}
-        notificationDispatch={msg => dispatch(Actions.Notification(msg))}
         pane={state.pane}
         workingDirectory={Feature_Workspace.workingDirectory(state.workspace)}
       />

--- a/src/reason-libvim/Clear.re
+++ b/src/reason-libvim/Clear.re
@@ -1,0 +1,7 @@
+type target =
+  | Messages;
+
+type t = {
+  target,
+  count: int,
+};

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -18,4 +18,5 @@ type t =
   | Unmap({
       mode: Mapping.mode,
       keys: option(string),
-    });
+    })
+  | Clear(Clear.t);

--- a/src/reason-libvim/Goto.re
+++ b/src/reason-libvim/Goto.re
@@ -2,4 +2,5 @@ type effect =
   | Definition
   | Declaration
   | Hover
-  | Outline;
+  | Outline
+  | Messages;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -435,6 +435,12 @@ let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
 };
 
+let _onClear = (target: Clear.target, count: int) => {
+  queue(() =>
+    Event.dispatch(Effect.Clear(Clear.{target, count}), Listeners.effect)
+  );
+};
+
 let _onTabPage = (msg: TabPage.effect) => {
   queue(() => Event.dispatch(Effect.TabPage(msg), Listeners.effect));
 };
@@ -531,6 +537,7 @@ let init = () => {
   Callback.register("lv_onBufferChanged", _onBufferChanged);
   Callback.register("lv_onAutocommand", _onAutocommand);
   Callback.register("lv_onAutoIndent", _onAutoIndent);
+  Callback.register("lv_onClear", _onClear);
   Callback.register("lv_getColorSchemesCallback", _colorSchemesGet);
   Callback.register("lv_onColorSchemeChanged", _onColorSchemeChanged);
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -432,13 +432,11 @@ let _onCursorMoveScreenPosition =
 };
 
 let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
-  queue(() => Event.dispatch(Effect.Goto(gotoType), Listeners.effect));
+  queueEffect(Effect.Goto(gotoType));
 };
 
 let _onClear = (target: Clear.target, count: int) => {
-  queue(() =>
-    Event.dispatch(Effect.Clear(Clear.{target, count}), Listeners.effect)
-  );
+  queueEffect(Effect.Clear(Clear.{target, count}));
 };
 
 let _onTabPage = (msg: TabPage.effect) => {

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -8,6 +8,7 @@ module AutoIndent = AutoIndent;
 module Buffer = Buffer;
 module BufferMetadata = BufferMetadata;
 module BufferUpdate = BufferUpdate;
+module Clear = Clear;
 module Clipboard = Clipboard;
 module ColorScheme = ColorScheme;
 module CommandLine = CommandLine;

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -343,12 +343,23 @@ module Buffer: {
   let onWrite: Listeners.bufferWriteListener => Event.unsubscribe;
 };
 
+module Clear: {
+  type target =
+    | Messages;
+
+  type t = {
+    target,
+    count: int,
+  };
+};
+
 module Goto: {
   type effect =
     | Definition
     | Declaration
     | Hover
-    | Outline;
+    | Outline
+    | Messages;
 };
 
 module TabPage: {
@@ -474,7 +485,8 @@ module Effect: {
     | Unmap({
         mode: Mapping.mode,
         keys: option(string),
-      });
+      })
+    | Clear(Clear.t);
 };
 
 /**

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -270,6 +270,9 @@ int onGoto(gotoRequest_T gotoInfo) {
   case OUTLINE:
     target = 3;
     break;
+  case MESSAGES:
+    target = 4;
+    break;
   default:
     target = 0;
   }
@@ -277,6 +280,28 @@ int onGoto(gotoRequest_T gotoInfo) {
   caml_callback3(*lv_onGoto, Val_int(line), Val_int(col), Val_int(target));
 
   return target;
+}
+
+void onClear(clearRequest_T clearRequest) {
+  static const value *lv_onClear = NULL;
+
+  if (lv_onClear == NULL) {
+    lv_onClear = caml_named_value("lv_onClear");
+  }
+
+  int count = clearRequest.count;
+  int target = 0;
+  switch (clearRequest.target) {
+  case CLEAR_MESSAGES:
+    target = 0;
+    break;
+  default:
+    target = 0;
+  }
+
+  caml_callback2(*lv_onClear, Val_int(target), Val_int(count));
+
+  return;
 }
 
 int onTabPage(tabPageRequest_T request) {
@@ -850,6 +875,7 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetDisplayIntroCallback(&onIntro);
   vimSetDisplayVersionCallback(&onVersion);
   vimSetFormatCallback(&onFormat);
+  vimSetClearCallback(&onClear);
   vimSetGotoCallback(&onGoto);
   vimSetOptionSetCallback(&onSettingChanged);
   vimSetTabPageCallback(&onTabPage);

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d066c266aeaf71c381b6d4b2a0f39cd",
+  "checksum": "16693ff03c35baa9ce845c64a2c31308",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.77@d41d8cd9": {
-      "id": "libvim@8.10869.77@d41d8cd9",
+    "libvim@8.10869.78@d41d8cd9": {
+      "id": "libvim@8.10869.78@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.77",
+      "version": "8.10869.78",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.77.tgz#sha1:906ee07e3d5ed7eef7e97f18361886c07c910079"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
         ]
       },
       "overrides": [],
@@ -1014,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.77@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test/reason-libvim/MessageTest.re
+++ b/test/reason-libvim/MessageTest.re
@@ -5,7 +5,7 @@ let reset = () => Helpers.resetBuffer("test/testfile.txt");
 let input = s => ignore(Vim.input(s));
 
 describe("Messages", ({describe, test, _}) => {
-  describe("ex cmds", ({describe, test, _}) => {
+  describe("ex cmds", ({test, _}) => {
     test(":messages produces Goto Messages effect", ({expect, _}) => {
       let _ = reset();
 

--- a/test/reason-libvim/MessageTest.re
+++ b/test/reason-libvim/MessageTest.re
@@ -4,7 +4,37 @@ open Vim;
 let reset = () => Helpers.resetBuffer("test/testfile.txt");
 let input = s => ignore(Vim.input(s));
 
-describe("Messages", ({test, _}) => {
+describe("Messages", ({describe, test, _}) => {
+  describe("ex cmds", ({describe, test, _}) => {
+    test(":messages produces Goto Messages effect", ({expect, _}) => {
+      let _ = reset();
+
+      let (_: Context.t, effects) = command("messages");
+
+      expect.equal(effects, [Vim.(Effect.Goto(Goto.Messages))]);
+    });
+    test(":messages clear produces clear effect with 0 count", ({expect, _}) => {
+      let _ = reset();
+
+      let (_: Context.t, effects) = command("messages clear");
+
+      expect.equal(
+        effects,
+        [Vim.(Effect.Clear(Clear.{target: Messages, count: 0}))],
+      );
+    });
+    test(
+      ":5messages clear produces clear effect with 5 count", ({expect, _}) => {
+      let _ = reset();
+
+      let (_: Context.t, effects) = command("5messages clear");
+
+      expect.equal(
+        effects,
+        [Vim.(Effect.Clear(Clear.{target: Messages, count: 5}))],
+      );
+    });
+  });
   test("echo dispatches message", ({expect, _}) => {
     let _ = reset();
 


### PR DESCRIPTION
This integrates the `messages` ex command with the pane view, and sets up keyboard navigation for the message elements:

![ex-messages](https://user-images.githubusercontent.com/13532591/100286088-ff18a500-2f26-11eb-96f2-ba35e8507613.gif)
(...need to adjust FPS settings on my gif recorder - much smoother in real-time)

 __Todo:__
- [x] Add `reason-libvim` tests for the new goto/clear APIs 
- [x] Remove the `Feature_Notification.View.List` module as it is now unused
- [x] Wire the `dismiss` gesture back up

