### PR TITLE
fix(ux/#1131): Remove initial dock animation

### DIFF
--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -165,20 +165,19 @@ let onExtensionsClick = _ => {
 };
 
 let make =
-              (
-                ~key: Brisk_reconciler.Key.t=?,
-                ~theme: ColorTheme.Colors.t,
-                ~sideBar: Feature_SideBar.model,
-                ~extensions: Feature_Extensions.model,
-                ~font: UiFont.t,
-                (),
-              ) => {
+    (
+      ~theme: ColorTheme.Colors.t,
+      ~sideBar: Feature_SideBar.model,
+      ~extensions: Feature_Extensions.model,
+      ~font: UiFont.t,
+      (),
+    ) => {
   let isSidebarVisible = it => Feature_SideBar.isVisible(it, sideBar);
 
   let extensionNotification =
     Feature_Extensions.isBusy(extensions) ? Some(InProgress) : None;
 
-  <View ?key style={Styles.container(~theme)}>
+  <View style={Styles.container(~theme)}>
     <item
       font
       onClick=onExplorerClick

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -18,12 +18,11 @@ type notification =
 module Styles = {
   open Style;
 
-  let container = (~theme, ~offsetX) => [
+  let container = (~theme) => [
     top(0),
     bottom(0),
     backgroundColor(Colors.background.from(theme)),
     alignItems(`Center),
-    transform(Transform.[TranslateX(offsetX)]),
   ];
 
   let item = (~isHovered, ~isActive, ~theme, ~sideBar) => {
@@ -165,31 +164,21 @@ let onExtensionsClick = _ => {
   GlobalContext.current().dispatch(Actions.SideBar(ExtensionsClicked));
 };
 
-let animation =
-  Revery.UI.Animation.(
-    animate(Revery.Time.milliseconds(150))
-    |> ease(Easing.ease)
-    |> tween(-50.0, 0.)
-    |> delay(Revery.Time.milliseconds(75))
-  );
-
-let%component make =
+let make =
               (
+                ~key: Brisk_reconciler.Key.t=?,
                 ~theme: ColorTheme.Colors.t,
                 ~sideBar: Feature_SideBar.model,
                 ~extensions: Feature_Extensions.model,
                 ~font: UiFont.t,
                 (),
               ) => {
-  let%hook (offsetX, _animationState, _reset) =
-    Hooks.animation(~name="Dock Notification Animation", animation);
-
   let isSidebarVisible = it => Feature_SideBar.isVisible(it, sideBar);
 
   let extensionNotification =
     Feature_Extensions.isBusy(extensions) ? Some(InProgress) : None;
 
-  <View style={Styles.container(~theme, ~offsetX)}>
+  <View ?key style={Styles.container(~theme)}>
     <item
       font
       onClick=onExplorerClick


### PR DESCRIPTION
Fixes #1131 , removes another case that could leave a hanging timer like #2407 