### PR TITLE
fix(ux): Flashing statusbar on startup

### DIFF
--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -955,7 +955,7 @@ module StatusBar = {
   let background =
     define(
       "statusBar.background",
-      {dark: hex("#007ACC"), light: hex("#007ACC"), hc: unspecified},
+      {dark: hex("#000000AA"), light: hex("#FFFFFFAA"), hc: unspecified},
     );
   let foreground = define("statusBar.foreground", all(hex("#FFF")));
 


### PR DESCRIPTION
__Issue:__ On startup, for a couple frames, the statusbar is bright blue - this is jarring on load.

__Defect:__ The bright-blue is the default statusbar color, and is used until the theme is loaded. 

__Fix:__ Use a more subtle, semi-transparent color for light/dark backgrounds, so the transition is smoother.