### PR TITLE
refactor(vim): Move mode context to Feature_Vim

### DIFF
--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -10,7 +10,11 @@ let recordingMacro: model => option(char);
 
 [@deriving show]
 type msg =
-  | ModeChanged([@opaque] Vim.Mode.t)
+  // TODO: sub-mode for insert-literal
+  | ModeChanged({
+      mode: [@opaque] Vim.Mode.t,
+      effects: list(Vim.Effect.t),
+    })
   | PasteCompleted({mode: [@opaque] Vim.Mode.t})
   | Pasted(string)
   | SettingChanged(Vim.Setting.t)
@@ -21,13 +25,26 @@ type outmsg =
   | Nothing
   | Effect(Isolinear.Effect.t(msg))
   | SettingsChanged
-  | ModeUpdated(Vim.Mode.t);
+  | ModeDidChange({
+      mode: Vim.Mode.t,
+      effects: list(Vim.Effect.t),
+    });
 
 // UPDATE
 
 let update: (msg, model) => (model, outmsg);
 
 module CommandLine: {let getCompletionMeet: string => option(int);};
+
+module Effects: {
+  let applyCompletion:
+    (
+      ~meetColumn: EditorCoreTypes.CharacterIndex.t,
+      ~insertText: string,
+      ~additionalEdits: list(Vim.Edit.t)
+    ) =>
+    Isolinear.Effect.t(msg);
+};
 
 // CONFIGURATION
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -180,9 +180,6 @@ let start =
             ),
           ),
         )
-      | ModeChanged(newMode) => {
-          dispatch(Actions.Vim(Feature_Vim.ModeChanged(newMode)));
-        }
       | SettingChanged(setting) =>
         dispatch(Actions.Vim(Feature_Vim.SettingChanged(setting)))
 
@@ -568,15 +565,7 @@ let start =
     });
 
   let updateActiveEditorMode = (mode, effects) => {
-    let editorId =
-      Feature_Layout.activeEditor(getState().layout) |> Editor.getId;
-
-    dispatch(
-      Actions.Editor({
-        scope: EditorScope.Editor(editorId),
-        msg: ModeChanged({mode, effects}),
-      }),
-    );
+    dispatch(Actions.Vim(Feature_Vim.ModeChanged({mode, effects})));
   };
 
   let isVimKey = key => {
@@ -601,14 +590,7 @@ let start =
       if (newContext.bufferId != prevContext.bufferId) {
         dispatch(Actions.OpenBufferById({bufferId: newContext.bufferId}));
       } else {
-        let editorId =
-          Feature_Layout.activeEditor(state.layout) |> Editor.getId;
-        dispatch(
-          Actions.Editor({
-            scope: EditorScope.Editor(editorId),
-            msg: ModeChanged({mode: newContext.mode, effects}),
-          }),
-        );
+        updateActiveEditorMode(newContext.mode, effects);
       };
     });
   };
@@ -618,8 +600,8 @@ let start =
       if (isVimKey(key)) {
         // Set cursors based on current editor
         let state = getState();
-        let editorId =
-          Feature_Layout.activeEditor(state.layout) |> Editor.getId;
+        // let editorId =
+        //   Feature_Layout.activeEditor(state.layout) |> Editor.getId;
 
         let context = Oni_Model.VimContext.current(state);
         let previousBufferId = context.bufferId;
@@ -634,13 +616,7 @@ let start =
           dispatch(Actions.OpenBufferById({bufferId: bufferId}));
         };
 
-        dispatch(
-          Actions.Editor({
-            scope: EditorScope.Editor(editorId),
-            msg: ModeChanged({mode, effects}),
-          }),
-        );
-
+        updateActiveEditorMode(mode, effects);
         Log.debug("handled key: " ++ key);
       }
     );

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -2,7 +2,6 @@ type t =
   | Goto(Goto.effect)
   | TabPage(TabPage.effect)
   | Format(Format.effect)
-  | ModeChanged(Mode.t)
   | SettingChanged(Setting.t)
   | ColorSchemeChanged(option(string))
   | MacroRecordingStarted({register: char})

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -196,8 +196,6 @@ let runWith = (~context: Context.t, f) => {
   BufferInternal.checkCurrentBufferForUpdate();
 
   if (newMode != prevMode) {
-    Event.dispatch(Effect.ModeChanged(newMode), Listeners.effect);
-
     if (newMode == CommandLine) {
       Event.dispatch(
         CommandLineInternal.getState(),
@@ -569,7 +567,6 @@ let init = () => {
 
   Native.vimInit();
 
-  Event.dispatch(Effect.ModeChanged(Mode.current()), Listeners.effect);
   BufferInternal.checkCurrentBufferForUpdate();
 };
 

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -469,7 +469,6 @@ module Effect: {
     | Goto(Goto.effect)
     | TabPage(TabPage.effect)
     | Format(Format.effect)
-    | ModeChanged(Mode.t)
     | SettingChanged(Setting.t)
     | ColorSchemeChanged(option(string))
     | MacroRecordingStarted({register: char})


### PR DESCRIPTION
This is some refactoring to make it easier to pick up some ambient state around the current `libvim` environment - this is needed for #2758 . 

Once https://github.com/onivim/libvim/pull/250 is integrated, we'll use this revised plumbing to track when we're in a 'sub-mode' - like insert literal - and handle the input in a special way for that case (always forwarding it to Vim, ignoring key bindings).

Previously, the mode changes would only be tracked in the active editor, which means they could get missed when we're in command line mode or other global states.

This will also be useful in addressing https://github.com/onivim/oni2/issues/1159, as we can also use a 'sub-mode' to represent the substitute-with-confirmation case.

