### PR TITLE
fix(editor): Fix several bugs with the active-indent renderer

### DIFF
--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -18,6 +18,19 @@ let contains = (query, str) => {
   };
 };
 
+let isWhitespaceOnly = str => {
+  let len = String.length(str);
+  let rec loop = idx =>
+    if (idx >= len) {
+      true;
+    } else if (!isSpace(str.[idx])) {
+      false;
+    } else {
+      loop(idx + 1);
+    };
+  loop(0);
+};
+
 let explode = str =>
   str |> String.to_seq |> List.of_seq |> List.map(c => String.make(1, c));
 

--- a/src/Feature/Editor/IndentLineRenderer.re
+++ b/src/Feature/Editor/IndentLineRenderer.re
@@ -193,7 +193,7 @@ let render =
     };
 
     let (x, topY) = bufferPositionToPixel(topLine^);
-    let (_, bottomY) = bufferPositionToPixel(bottomLine^);
+    let (_, bottomY) = bufferPositionToPixel(bottomLine^ - 1);
 
     if (cursorLineIndentLevel^ >= 1) {
       Skia.Paint.setColor(
@@ -205,7 +205,7 @@ let render =
           x +. indentationWidthInPixels *. float(cursorLineIndentLevel^ - 1),
         ~top=topY +. lineHeight,
         ~width=1.,
-        ~height=bottomY -. topY -. lineHeight,
+        ~height=bottomY -. topY,
         ~paint,
         context.canvasContext,
       );

--- a/src/Feature/Editor/IndentLineRenderer.re
+++ b/src/Feature/Editor/IndentLineRenderer.re
@@ -158,10 +158,6 @@ let render =
     Hashtbl.find_opt(GlobalMutable.cachedIndentLevel, cursorLine)
     |> Option.value(~default=0);
 
-  prerr_endline(
-    "cursor line indent level: " ++ string_of_int(cursorLineIndentLevel),
-  );
-
   let maybeActiveIndentRange =
     if (showActive && cursorLineIndentLevel >= 1) {
       getActiveIndentLevelAndRange(

--- a/src/Feature/Editor/IndentLineRenderer.re
+++ b/src/Feature/Editor/IndentLineRenderer.re
@@ -31,8 +31,7 @@ let rec getIndentLevel =
    * to 0.
    */
 
-  // TODO: Speed this up - no need to copy / allocate to check this!
-  if (String.trim(lineText) != "") {
+  if (!Utility.StringEx.isWhitespaceOnly(lineText)) {
     Indentation.getLevel(indentationSettings, lineText);
   } else {
     let newLine = reverse ? line - 1 : line + 1;
@@ -61,7 +60,61 @@ let rec getIndentLevel =
   };
 };
 
-let paint = Skia.Paint.make();
+let getActiveIndentLevelAndRange =
+    (
+      ~indentLevelCache,
+      ~cursorLineIndentLevel,
+      ~cursorLine,
+      ~buffer,
+      ~startLine,
+      ~endLine,
+    ) => {
+  let bufferLineCount = Buffer.getNumberOfLines(buffer);
+  if (cursorLine < bufferLineCount) {
+    let topFinished = ref(false);
+    let topLine = ref(cursorLine - 1);
+    let bottomLine = ref(cursorLine + 1);
+    let bottomFinished = ref(false);
+    let previousIndentLevel = ref(cursorLineIndentLevel);
+
+    while (topLine^ >= startLine && ! topFinished^) {
+      let indentLevel =
+        Hashtbl.find_opt(indentLevelCache, topLine^)
+        |> Option.value(~default=0);
+
+      if (indentLevel < cursorLineIndentLevel) {
+        topFinished := true;
+      } else {
+        decr(topLine);
+        previousIndentLevel := indentLevel;
+      };
+    };
+
+    previousIndentLevel := cursorLineIndentLevel;
+
+    while (bottomLine^ <= endLine && ! bottomFinished^) {
+      let indentLevel =
+        Hashtbl.find_opt(indentLevelCache, bottomLine^)
+        |> Option.value(~default=0);
+
+      if (indentLevel < cursorLineIndentLevel) {
+        bottomFinished := true;
+      } else {
+        incr(bottomLine);
+        previousIndentLevel := indentLevel;
+      };
+    };
+    Some((topLine^, bottomLine^));
+  } else {
+    None;
+  };
+};
+
+module GlobalMutable = {
+  let inactivePaint = Skia.Paint.make();
+  let activePaint = Skia.Paint.make();
+  let cachedIndentLevel = Hashtbl.create(100);
+};
 
 let render =
     (
@@ -74,7 +127,8 @@ let render =
       ~showActive: bool,
       indentationSettings: IndentationSettings.t,
     ) => {
-  /* First, render *all* indent guides */
+  /* First, calculate indentation level for all relevant lines*/
+  Hashtbl.clear(GlobalMutable.cachedIndentLevel);
 
   let startLine = EditorCoreTypes.LineNumber.toZeroBased(startLine);
   let endLine = EditorCoreTypes.LineNumber.toZeroBased(endLine) + 1;
@@ -83,9 +137,46 @@ let render =
     EditorCoreTypes.LineNumber.toZeroBased(cursorPosition.line);
   let startLine = max(0, startLine);
   let endLine = min(bufferLineCount, endLine);
-
-  let cursorLineIndentLevel = ref(0);
   let previousIndentLevel = ref(0);
+  for (line in startLine to endLine - 1) {
+    let level =
+      getIndentLevel(
+        indentationSettings,
+        buffer,
+        startLine,
+        endLine,
+        line,
+        previousIndentLevel^,
+      );
+
+    previousIndentLevel := level;
+
+    Hashtbl.add(GlobalMutable.cachedIndentLevel, line, level);
+  };
+
+  let cursorLineIndentLevel =
+    Hashtbl.find_opt(GlobalMutable.cachedIndentLevel, cursorLine)
+    |> Option.value(~default=0);
+
+  prerr_endline(
+    "cursor line indent level: " ++ string_of_int(cursorLineIndentLevel),
+  );
+
+  let maybeActiveIndentRange =
+    if (showActive && cursorLineIndentLevel >= 1) {
+      getActiveIndentLevelAndRange(
+        ~indentLevelCache=GlobalMutable.cachedIndentLevel,
+        ~cursorLineIndentLevel,
+        ~cursorLine,
+        ~buffer,
+        ~startLine,
+        ~endLine,
+      );
+    } else {
+      None;
+    };
+
+  /* Next, render *all* indent guides */
 
   let indentationWidthInPixels =
     float(indentationSettings.tabSize) *. context.charWidth;
@@ -107,25 +198,37 @@ let render =
     (x, y);
   };
 
+  Skia.Paint.setColor(
+    GlobalMutable.inactivePaint,
+    Revery.Color.toSkia(colors.indentGuideBackground),
+  );
+  Skia.Paint.setColor(
+    GlobalMutable.activePaint,
+    Revery.Color.toSkia(colors.indentGuideActiveBackground),
+  );
+
   let lineHeight = Editor.lineHeightInPixels(editor);
   for (line in startLine to endLine - 1) {
     let level =
-      getIndentLevel(
-        indentationSettings,
-        buffer,
-        startLine,
-        endLine,
-        line,
-        previousIndentLevel^,
-      );
+      Hashtbl.find_opt(GlobalMutable.cachedIndentLevel, line)
+      |> Option.value(~default=0);
 
     let (x, y) = bufferPositionToPixel(line);
 
     for (i in 0 to level - 1) {
-      Skia.Paint.setColor(
-        paint,
-        Revery.Color.toSkia(colors.indentGuideBackground),
-      );
+      let isActive =
+        if (i == cursorLineIndentLevel - 1) {
+          switch (maybeActiveIndentRange) {
+          | Some((top, bottom)) => line >= top && line < bottom
+          | None => false
+          };
+        } else {
+          false;
+        };
+
+      let paint =
+        isActive ? GlobalMutable.activePaint : GlobalMutable.inactivePaint;
+
       CanvasContext.drawRectLtwh(
         ~left=x +. indentationWidthInPixels *. float(i),
         ~top=y,
@@ -137,78 +240,5 @@ let render =
     };
 
     previousIndentLevel := level;
-
-    if (line == cursorLine) {
-      cursorLineIndentLevel := level;
-    };
-  };
-
-  /* Next, render _active_ indent guide */
-  if (cursorLine < bufferLineCount && showActive) {
-    let topFinished = ref(false);
-    let topLine = ref(cursorLine - 1);
-    let bottomLine = ref(cursorLine + 1);
-    let bottomFinished = ref(false);
-    let previousIndentLevel = ref(cursorLineIndentLevel^);
-
-    while (topLine^ >= 0 && ! topFinished^) {
-      let indentLevel =
-        getIndentLevel(
-          ~reverse=true,
-          indentationSettings,
-          buffer,
-          startLine,
-          endLine,
-          topLine^,
-          previousIndentLevel^,
-        );
-
-      if (indentLevel < cursorLineIndentLevel^) {
-        topFinished := true;
-      } else {
-        decr(topLine);
-        previousIndentLevel := indentLevel;
-      };
-    };
-
-    previousIndentLevel := cursorLineIndentLevel^;
-
-    while (bottomLine^ < bufferLineCount && ! bottomFinished^) {
-      let indentLevel =
-        getIndentLevel(
-          indentationSettings,
-          buffer,
-          startLine,
-          endLine,
-          bottomLine^,
-          previousIndentLevel^,
-        );
-
-      if (indentLevel < cursorLineIndentLevel^) {
-        bottomFinished := true;
-      } else {
-        incr(bottomLine);
-        previousIndentLevel := indentLevel;
-      };
-    };
-
-    let (x, topY) = bufferPositionToPixel(topLine^);
-    let (_, bottomY) = bufferPositionToPixel(bottomLine^ - 1);
-
-    if (cursorLineIndentLevel^ >= 1) {
-      Skia.Paint.setColor(
-        paint,
-        Revery.Color.toSkia(colors.indentGuideActiveBackground),
-      );
-      CanvasContext.drawRectLtwh(
-        ~left=
-          x +. indentationWidthInPixels *. float(cursorLineIndentLevel^ - 1),
-        ~top=topY +. lineHeight,
-        ~width=1.,
-        ~height=bottomY -. topY,
-        ~paint,
-        context.canvasContext,
-      );
-    };
   };
 };


### PR DESCRIPTION
__Issue:__ There were several visual glitches with the active-indent renderer (visible in a screenshot posted in #2353)

Issue 1:

The indent guide would overlap some text

![image](https://user-images.githubusercontent.com/13532591/100487457-8ef05780-30bd-11eb-8409-af5abdab4a95.png)

Issue 2:

When word-wrapping is active, the indent guide would go through wrapped lines:
![image](https://user-images.githubusercontent.com/13532591/100487482-bd6e3280-30bd-11eb-9771-19a3006f21cb.png)

When codelens is active, the indent guide would go through the lens:
![image](https://user-images.githubusercontent.com/13532591/100487538-02926480-30be-11eb-8e48-e73bcdb5a69e.png)


__Defect:__

All of these issues stem from two core problems:
1) If the indentation goes to the end of the file, we'd treat the end coordinate as being at 0 pixels - causing us to draw upward instead of downward (issue 1)
2) When drawing the active line, we'd just draw over all the buffer lines, with no context about word wrap or codelens (issue 2 & 3)

__Fix:__

Tweak the algorithm a bit - it was a two-pass algorithm before, where we'd draw the inactive, and then draw the active line over it.

This is still a two pass algorithm, but first, we calculate the indent levels for visible lines, and then draw the computed indent levels - including the active. The per-buffer-line rendering solves all of the issues - we just needed it to know about the active indent level.

