### PR TITLE
fix(editor): Fix bug in selection rendering when wordWrap is enabled

### DIFF
--- a/src/Feature/Editor/Selection.re
+++ b/src/Feature/Editor/Selection.re
@@ -121,19 +121,7 @@ let getRangesForBlockSelection =
     incr(pos);
   };
 
-  let hasValue = v =>
-    switch (v) {
-    | Some(_) => true
-    | None => false
-    };
-
-  let getValue = v =>
-    switch (v) {
-    | Some(v) => v
-    | None => failwith("Should've been filtered out")
-    };
-
-  ranges^ |> List.filter(hasValue) |> List.map(getValue);
+  ranges^ |> List.filter_map(v => v);
 };
 
 /*


### PR DESCRIPTION
__Issue:__ When word wrap is enabled, and we're at the bottom of a document w/ a bunch of wrapped lines, sometimes the selection rendering would behave unexpectedly or not render fully.

__Defect:__ When rendering the selection (and some other content, like diagnostics...) we'd be treating _view lines_ as _buffer lines_. When word wrap is off, those are 1 to 1, so the bug is hidden - but when it is on, it causes the bug described - depending on the delta between view lines and buffer lines, the selection may be rendered partially or not at all.

__Fix:__ Convert the view line to buffer line for the necessary APIs