### PR TITLE
fix(editor/#1444): Promote experimental.editor.wordWrap -> editor.wordWrap

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -74,6 +74,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.wordBasedSuggestions` __(_bool_ default: `true`)__ When `true`, keywords are provided as completion suggestions.
 
+- `editor.wordWrap` __(_bool_ default: `false`)__ When `true`, Onivim will soft-wrap lines at the viewport boundary.
+
 - `editor.rulers` __(_list of int_ default: `[]`)__ - Render vertical rulers at given columns.
 
 - `explorer.autoReveal` __(_string|bool_ default: `true`)__  - When `true`, the file explorer will jump to highlight the file current focused. When `false` the file explorer will remain static. If a string is entered it must be `"focusNoScroll"` which will still highlight the currently focused file in the file explorer but the file explorer will not scroll to it. Any other string supplied will be treated as if `false` was entered and the file explorer will remain static and not highlight the currently focused file. 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -421,7 +421,7 @@ let setWrapMode = (~wrapMode, editor) => {
 
 let configure = (~config, editor) => {
   let wrapMode =
-    EditorConfiguration.Experimental.wordWrap.get(config) == `On
+    EditorConfiguration.wordWrap.get(config) == `On
       ? WrapMode.Viewport : WrapMode.NoWrap;
 
   let scrolloff = EditorConfiguration.scrolloff.get(config);
@@ -451,7 +451,7 @@ let create = (~config, ~buffer, ()) => {
   let key = Brisk_reconciler.Key.create();
 
   let wrapMode =
-    EditorConfiguration.Experimental.wordWrap.get(config) == `On
+    EditorConfiguration.wordWrap.get(config) == `On
       ? WrapMode.Viewport : WrapMode.NoWrap;
 
   let wrapState = WrapState.make(~pixelWidth=1000., ~wrapMode, ~buffer);

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -233,6 +233,7 @@ open CustomDecoders;
 
 let detectIndentation =
   setting("editor.detectIndentation", bool, ~default=true);
+
 let fontFamily =
   setting(
     ~vim=VimSettings.guifont,
@@ -286,6 +287,11 @@ let smoothScroll =
 
 let tabSize = setting("editor.tabSize", int, ~default=4);
 
+let wordWrap =
+  setting("editor.wordWrap", ~vim=VimSettings.wrap, wordWrap, ~default=`Off);
+
+let wordWrapColumn = setting("editor.wordWrapColumn", int, ~default=80);
+
 let yankHighlightEnabled =
   setting("vim.highlightedyank.enable", bool, ~default=true);
 let yankHighlightColor =
@@ -327,17 +333,6 @@ module Experimental = {
       bool,
       ~default=false,
     );
-
-  let wordWrap =
-    setting(
-      "experimental.editor.wordWrap",
-      ~vim=VimSettings.wrap,
-      wordWrap,
-      ~default=`Off,
-    );
-
-  let wordWrapColumn =
-    setting("experimental.editor.wordWrapColumn", int, ~default=80);
 };
 
 let contributions = [
@@ -370,6 +365,4 @@ let contributions = [
   ZenMode.hideTabs.spec,
   ZenMode.singleFile.spec,
   Experimental.cursorSmoothCaretAnimation.spec,
-  Experimental.wordWrap.spec,
-  Experimental.wordWrapColumn.spec,
 ];

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -354,6 +354,8 @@ let contributions = [
   scrolloff.spec,
   smoothScroll.spec,
   tabSize.spec,
+  wordWrap.spec,
+  wordWrapColumn.spec,
   yankHighlightColor.spec,
   yankHighlightDuration.spec,
   yankHighlightEnabled.spec,


### PR DESCRIPTION
We've had an experimental implementation of word wrap - this promotes it to a non-experimental feature.

The configuration setting is:
`editor.wordWrap` and can be `true` or `false` (`"on"` and `"off"` are also accepted - and will extend to support columns as well). In addition, this adds a brief documentation blurb in our settings: https://onivim.github.io/docs/configuration/settings 

This is a breaking change, in that if you were using `experimental.editor.wordWrap`, you'll need to update your configuration to `editor.wordWrap`

Fixes #1444 