### PR TITLE
fix(extensions): Extensions failing to download from open-vsx

### DIFF
--- a/node/download.js
+++ b/node/download.js
@@ -1,5 +1,5 @@
-const http = require("http")
-const https = require("https")
+const http = require("follow-redirects").http;
+const https = require("follow-redirects").https;
 const fs = require("fs")
 
 const url = new URL(process.argv[2])

--- a/node/download.js
+++ b/node/download.js
@@ -1,5 +1,5 @@
-const http = require("follow-redirects").http;
-const https = require("follow-redirects").https;
+const http = require("follow-redirects").http
+const https = require("follow-redirects").https
 const fs = require("fs")
 
 const url = new URL(process.argv[2])

--- a/node/package.json
+++ b/node/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@onivim/vscode-exthost": "1.50.1000",
+    "follow-redirects": "1.13.0",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
     "yauzl": "^2.5.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -66,6 +66,11 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+follow-redirects@1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"

--- a/src/Core/Kernel/StringSet.re
+++ b/src/Core/Kernel/StringSet.re
@@ -1,0 +1,10 @@
+/*
+ * StringMap.re
+ *
+ * Map from string -> 'a
+ */
+
+include Set.Make({
+  type t = string;
+  let compare = String.compare;
+});

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -6,6 +6,42 @@ open Utility;
 exception TaskFailed;
 module Log = (val Kernel.Log.withNamespace("Oni2.Core.NodeTask"));
 
+module Internal = {
+  let getFilteredEnvironment = () => {
+
+    // Filter out some keys that aren't required
+    // for running node tasks. Primarily needed for Windows -
+    // sometimes the environment can grow too large for node/libuv.
+    let keysToExclude = [
+      "OCAMLPATH",
+      "MAN_PATH",
+      "CAML_LD_LIBRARY_PATH"
+    ] |> Kernel.StringSet.of_list;
+
+    let env =
+      Unix.environment()
+      |> Array.to_list
+      |> List.fold_left(
+           (acc, curr) => {
+             switch (String.split_on_char('=', curr)) {
+             | [] => acc
+             | [_] => acc
+             | [key, ...values] =>
+
+                if (!Kernel.StringSet.mem(key, keysToExclude)) {
+                 let v = String.concat("=", values);
+
+                 [(key, v), ...acc];
+               } else {
+                acc
+               }
+             }
+           },
+           [],
+         );
+    env;
+  };
+};
 let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
   Log.info("Starting task: " ++ name);
   let (promise, resolver) = Lwt.task();
@@ -53,6 +89,7 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
     let%bind _: Luv.Process.t =
       LuvEx.Process.spawn(
         ~on_exit,
+        ~environment=Internal.getFilteredEnvironment(),
         ~redirect=[
           Luv.Process.to_parent_pipe(
             ~fd=Luv.Process.stdout,

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -8,15 +8,12 @@ module Log = (val Kernel.Log.withNamespace("Oni2.Core.NodeTask"));
 
 module Internal = {
   let getFilteredEnvironment = () => {
-
     // Filter out some keys that aren't required
     // for running node tasks. Primarily needed for Windows -
     // sometimes the environment can grow too large for node/libuv.
-    let keysToExclude = [
-      "OCAMLPATH",
-      "MAN_PATH",
-      "CAML_LD_LIBRARY_PATH"
-    ] |> Kernel.StringSet.of_list;
+    let keysToExclude =
+      ["OCAMLPATH", "MAN_PATH", "CAML_LD_LIBRARY_PATH"]
+      |> Kernel.StringSet.of_list;
 
     let env =
       Unix.environment()
@@ -27,13 +24,12 @@ module Internal = {
              | [] => acc
              | [_] => acc
              | [key, ...values] =>
-
-                if (!Kernel.StringSet.mem(key, keysToExclude)) {
+               if (!Kernel.StringSet.mem(key, keysToExclude)) {
                  let v = String.concat("=", values);
 
                  [(key, v), ...acc];
                } else {
-                acc
+                 acc;
                }
              }
            },

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -48,6 +48,7 @@ module Persistence = Persistence;
 module Setup = Setup;
 module ShellUtility = ShellUtility;
 module StringMap = Kernel.StringMap;
+module StringSet = Kernel.StringSet;
 module Subscription = Subscription;
 module SyntaxScope = SyntaxScope;
 module ColorTheme = ColorTheme;

--- a/test/OniUnitTestRunnerCI.re
+++ b/test/OniUnitTestRunnerCI.re
@@ -22,6 +22,13 @@ let initializeRunConfig = runFn => {
   runFn(runConfig);
 };
 
+// On Windows, esy might pollute the environment - exceeding the 8192 character limit.
+// Some applications don't handle this well - like node. Clear it out some of the
+// biggest offenders...
+Unix.putenv("CAML_LD_LIBRARY_PATH", "");
+Unix.putenv("MAN_PATH", "");
+Unix.putenv("OCAMLPATH", "");
+
 Oni_Core_Test.TestFramework.run |> initializeRunConfig;
 
 Oni_Core_Utility_Test.TestFramework.run |> initializeRunConfig;


### PR DESCRIPTION
__Issue:__ Extensions are not downloading correctly from `open-vsx`. This impacts both installing from command-line, and within Onivim.

__Defect:__ The `open-vsx` service updated their download service to be backed by azure blobs, and sends a 302 redirect - we weren't handling redirects in our download logic.

__Fix:__ Handle redirects using the `follow-redirect` node module.