### PR TITLE
fix(cli): Fix --trace level not being set correctly

### DIFF
--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -116,7 +116,11 @@ let parse = (~getenv: string => option(string), args) => {
 
   let setAttached = () => {
     attachToForeground := true;
-    logLevel := Some(Timber.Level.info);
+    // Set log level if it hasn't already been set
+    switch (logLevel^) {
+    | None => logLevel := Some(Timber.Level.info)
+    | Some(_) => ()
+    };
   };
 
   getenv("ONI2_LOG_FILE") |> Option.iter(v => logFile := Some(v));

--- a/src/Core/Kernel/Log.re
+++ b/src/Core/Kernel/Log.re
@@ -42,7 +42,9 @@ let enableQuiet = () => {
 };
 
 let init = () =>
-  if (Timber.App.isLevelEnabled(Timber.Level.debug)) {
+  if (Timber.App.isLevelEnabled(Timber.Level.trace)) {
+    enableTrace();
+  } else if (Timber.App.isLevelEnabled(Timber.Level.debug)) {
     enableDebug();
   } else {
     // Even if we're not debugging.... at least emit the exception

--- a/test/Cli/CliTest.re
+++ b/test/Cli/CliTest.re
@@ -48,4 +48,25 @@ describe("CLI", ({describe, test, _}) => {
       );
     })
   });
+  describe("log level", ({test, _}) => {
+    test("--trace should set log level", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "-f", "--trace"|]);
+      expect.equal(options.logLevel, Some(Timber.Level.trace));
+    });
+    test("-f should not override --trace", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "--trace", "-f"|]);
+      expect.equal(options.logLevel, Some(Timber.Level.trace));
+    });
+    test("-f should set info level", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "-f"|]);
+      expect.equal(options.logLevel, Some(Timber.Level.info));
+    });
+    test("no log level set by default", ({expect, _}) => {
+      let (options, _eff) = Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor"|]);
+      expect.equal(options.logLevel, None);
+    });
+  });
 });


### PR DESCRIPTION
__Issue:__ While investigating the OSX 10.13 scaling issues, I noticed the `--trace` log level wasn't working as expected.

__Defect:__ When `--trace` was set, it could get reverted a couple of ways 

__Fix:__ Fix cases where `--trace` could get reset or lowered when specified on CLI, add some tests to cover these.