### PR TITLE
fix(vim/#809): Insert-mode repeat count not handled correctly

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
+  "checksum": "dd6b7acd4247186956e912d2058de5bb",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,11 +428,16 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@link:../libvim/src": {
-      "id": "libvim@link:../libvim/src",
+    "libvim@8.10869.79@d41d8cd9": {
+      "id": "libvim@8.10869.79@d41d8cd9",
       "name": "libvim",
-      "version": "link:../libvim/src",
-      "source": { "type": "link", "path": "../libvim/src" },
+      "version": "8.10869.79",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.79.tgz#sha1:49a6c6898dcfd89335228d62ff85cc0566afaee5"
+        ]
+      },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1010,7 +1015,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.79@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "170db5955aa9758fbd0d112fcbe9ff6f",
+  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,16 +428,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.78@d41d8cd9": {
-      "id": "libvim@8.10869.78@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.78",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1015,7 +1010,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "170db5955aa9758fbd0d112fcbe9ff6f",
+  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,16 +428,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.78@d41d8cd9": {
-      "id": "libvim@8.10869.78@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.78",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1014,7 +1009,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
+  "checksum": "dd6b7acd4247186956e912d2058de5bb",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,11 +428,16 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@link:../libvim/src": {
-      "id": "libvim@link:../libvim/src",
+    "libvim@8.10869.79@d41d8cd9": {
+      "id": "libvim@8.10869.79@d41d8cd9",
       "name": "libvim",
-      "version": "link:../libvim/src",
-      "source": { "type": "link", "path": "../libvim/src" },
+      "version": "8.10869.79",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.79.tgz#sha1:49a6c6898dcfd89335228d62ff85cc0566afaee5"
+        ]
+      },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1009,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.79@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "170db5955aa9758fbd0d112fcbe9ff6f",
+  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,16 +428,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.78@d41d8cd9": {
-      "id": "libvim@8.10869.78@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.78",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1014,7 +1009,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
+  "checksum": "dd6b7acd4247186956e912d2058de5bb",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,11 +428,16 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@link:../libvim/src": {
-      "id": "libvim@link:../libvim/src",
+    "libvim@8.10869.79@d41d8cd9": {
+      "id": "libvim@8.10869.79@d41d8cd9",
       "name": "libvim",
-      "version": "link:../libvim/src",
-      "source": { "type": "link", "path": "../libvim/src" },
+      "version": "8.10869.79",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.79.tgz#sha1:49a6c6898dcfd89335228d62ff85cc0566afaee5"
+        ]
+      },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1009,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.79@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.78",
+    "libvim": "8.10869.79",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reason-fzy": "CrossR/reason-fzy#7339d4e",

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
+    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#30bef47",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,6 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#30bef47",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "170db5955aa9758fbd0d112fcbe9ff6f",
+  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,16 +428,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.78@d41d8cd9": {
-      "id": "libvim@8.10869.78@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.78",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1014,7 +1009,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "533bc14ea4893f52a034e9578a3d2f0a",
+  "checksum": "dd6b7acd4247186956e912d2058de5bb",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,11 +428,16 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@link:../libvim/src": {
-      "id": "libvim@link:../libvim/src",
+    "libvim@8.10869.79@d41d8cd9": {
+      "id": "libvim@8.10869.79@d41d8cd9",
       "name": "libvim",
-      "version": "link:../libvim/src",
-      "source": { "type": "link", "path": "../libvim/src" },
+      "version": "8.10869.79",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.79.tgz#sha1:49a6c6898dcfd89335228d62ff85cc0566afaee5"
+        ]
+      },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1009,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.79@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7d83639821ea82afda9f665e0157e163",
+  "checksum": "f9d16a4519b1cb7ae4d2098f9bd4d5f6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,11 +428,16 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@link:../libvim/src": {
-      "id": "libvim@link:../libvim/src",
+    "libvim@8.10869.79@d41d8cd9": {
+      "id": "libvim@8.10869.79@d41d8cd9",
       "name": "libvim",
-      "version": "link:../libvim/src",
-      "source": { "type": "link", "path": "../libvim/src" },
+      "version": "8.10869.79",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.79.tgz#sha1:49a6c6898dcfd89335228d62ff85cc0566afaee5"
+        ]
+      },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1009,7 +1014,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.79@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2f48160a9c977c12b40f17acc671522e",
+  "checksum": "7d83639821ea82afda9f665e0157e163",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,16 +428,11 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.78@d41d8cd9": {
-      "id": "libvim@8.10869.78@d41d8cd9",
+    "libvim@link:../libvim/src": {
+      "id": "libvim@link:../libvim/src",
       "name": "libvim",
-      "version": "8.10869.78",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.78.tgz#sha1:f1fb90f092bacf1e47cef5973857cd02853a0e90"
-        ]
-      },
+      "version": "link:../libvim/src",
+      "source": { "type": "link", "path": "../libvim/src" },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
@@ -1014,7 +1009,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.78@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@link:../libvim/src",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test/reason-libvim/InsertModeEdit.re
+++ b/test/reason-libvim/InsertModeEdit.re
@@ -102,6 +102,6 @@ describe("InsertModeEdit", ({describe, _}) => {
       expect.string(line).toEqual(
         "abcabcabcabcabcThis is the first line of a test file",
       );
-    });
-  })
+    })
+  });
 });

--- a/test/reason-libvim/InsertModeEdit.re
+++ b/test/reason-libvim/InsertModeEdit.re
@@ -89,4 +89,19 @@ describe("InsertModeEdit", ({describe, _}) => {
       expect.int(newChangedTick).toBe(startChangedTick + 3);
     });
   });
+  describe("count", ({test, _}) => {
+    test("count + i", ({expect, _}) => {
+      let buffer = resetBuffer();
+
+      input("5");
+      input("i");
+      input("abc");
+      key("<esc>");
+
+      let line = Buffer.getLine(buffer, LineNumber.zero);
+      expect.string(line).toEqual(
+        "abcabcabcabcabcThis is the first line of a test file",
+      );
+    });
+  })
 });


### PR DESCRIPTION
This picks up https://github.com/onivim/libvim/pull/252, which fixes the repeat-count for `i`, `a`, `A`, `o`, etc, and adds a simple test case here.

Fixes #809
Fixes #2190 