### PR TITLE
fix(editor/#2800): Crash on moving mouse in empty buffer

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -22,6 +22,7 @@
 - #2786 - Extensions: Fix download from open-vsx
 - #2785 - Windows: Fix intermittent crash in `Luv.Process.spawn`
 - #2792 - Vim: Handle count for insert mode commands (`i`/`a`, etc) (fixes #809, #2190)
+- #2802 - Editor: Fix crash when moving mouse in empty buffer (fixes #2800)
 
 ### Performance
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1502,14 +1502,16 @@ let getCharacterUnderMouse = editor => {
            editor,
          );
 
-       let bufferLine =
-         EditorBuffer.line(
-           EditorCoreTypes.LineNumber.toZeroBased(bytePosition.line),
-           editor.buffer,
-         );
-       if (BufferLine.lengthInBytes(bufferLine)
-           > ByteIndex.toInt(bytePosition.byte)) {
-         byteToCharacter(bytePosition, editor);
+       let lineIdx =
+         EditorCoreTypes.LineNumber.toZeroBased(bytePosition.line);
+       if (lineIdx < EditorBuffer.numberOfLines(editor.buffer)) {
+         let bufferLine = EditorBuffer.line(lineIdx, editor.buffer);
+         if (BufferLine.lengthInBytes(bufferLine)
+             > ByteIndex.toInt(bytePosition.byte)) {
+           byteToCharacter(bytePosition, editor);
+         } else {
+           None;
+         };
        } else {
          None;
        };

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -259,4 +259,21 @@ describe("Editor", ({describe, _}) => {
       );
     })
   });
+
+  describe("getCharacterUnderMouse", ({test, _}) => {
+    test("#2800 - should not crash on empty buffer", ({expect, _}) => {
+      let (editor, _buffer) = create([||]);
+
+      // Mouse needs to be moved to reproduce #2800
+      let editor' =
+        editor
+        |> Editor.mouseMove(
+             ~time=Revery.Time.zero,
+             ~pixelX=500.,
+             ~pixelY=500.,
+           );
+
+      expect.equal(Editor.getCharacterUnderMouse(editor'), None);
+    })
+  });
 });


### PR DESCRIPTION
__Issue:__ When moving the mouse in an empty buffer, there could be a potential crash

__Defect:__ On getting a mouse move, we look to see if there is an identifier under the cursor (ie, for hover). However, there was a missing bounds check - so it was possible for us to look out of range of the current buffer.

__Fix:__ Verify the byte position is in range before trying to pull out an identifier.

Fixes #2800 