### PR TITLE
fix(extensions/#2345): Implement warning if the namespace is public

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #2806 - Windows: Add open-directory command to windows installer (fixes #2046)
 - #2807 - Terminal: Implement paste in insert mode (fixes #2805)
 - #2808 - Auto-Update: Fix changelog display (fixes #2787)
+- #2809 - Extensions: Warn on open-vsx public namespaces (fixes #2345)
 
 ### Performance
 

--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -173,6 +173,7 @@ module Manifest: {
   let decode: Oni_Core.Json.decoder(t);
 
   let identifier: t => string;
+  let publisher: t => string;
   let getDisplayName: t => string;
 };
 

--- a/src/Exthost/Extension/Manifest.re
+++ b/src/Exthost/Extension/Manifest.re
@@ -88,6 +88,10 @@ let identifier = manifest => {
   };
 };
 
+let publisher = manifest => {
+  manifest.publisher |> Option.value(~default="Unknown");
+};
+
 let displayName = ({displayName, _}) => {
   displayName |> Option.map(LocalizedToken.toString);
 };

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -34,6 +34,13 @@ module Styles = {
     marginLeft(8),
   ];
 
+  let warningRow = [
+    flexGrow(0),
+    flexDirection(`Row),
+    alignItems(`Center),
+    justifyContent(`FlexStart),
+  ];
+
   let headerButton = [padding(8)];
 
   let headerTextContainer = [marginHorizontal(8), marginVertical(4)];
@@ -197,6 +204,73 @@ let header =
   </View>;
 };
 
+let warning = (~displayName, ~namespace, ~font: UiFont.t, ()) => {
+  let bg = Revery.Color.hex("#FFDD57");
+  let foregroundColor = Revery.Color.hex("#333");
+  <View style=Styles.warningRow>
+    <View
+      style=Style.[
+        backgroundColor(bg),
+        flexGrow(1),
+        padding(8),
+        flexDirection(`Row),
+      ]>
+      <View
+        style=Style.[
+          flexShrink(0),
+          flexGrow(0),
+          justifyContent(`Center),
+          alignItems(`Center),
+          marginHorizontal(8),
+        ]>
+        <Codicon
+          icon=Codicon.warning
+          fontSize=16.
+          color={Revery.Color.hex("#333")}
+        />
+      </View>
+      <View style=Style.[flexGrow(1), flexShrink(1)]>
+        <Text
+          fontFamily={font.family}
+          fontSize=12.
+          fontWeight=Revery.Font.Weight.Bold
+          style=[Style.color(foregroundColor)]
+          text={Printf.sprintf(
+            "The namespace %s is public, which means anyone can publish a new version of the %s extension. Please verify you trust the source before installing.",
+            namespace,
+            displayName,
+          )}
+        />
+      </View>
+      <View
+        style=Style.[
+          flexShrink(0),
+          flexGrow(0),
+          justifyContent(`Center),
+          alignItems(`Center),
+        ]>
+        <Revery.UI.Components.Link
+          fontFamily={font.family}
+          fontSize=12.
+          fontWeight=Revery.Font.Weight.Bold
+          inactiveStyle=Style.[
+            marginHorizontal(8),
+            color(foregroundColor),
+            opacity(0.9),
+          ]
+          activeStyle=Style.[
+            marginHorizontal(8),
+            color(foregroundColor),
+            opacity(1.0),
+          ]
+          text="More info"
+          href="https://github.com/eclipse/openvsx/wiki/Namespace-Access#why-is-a-warning-shown"
+        />
+      </View>
+    </View>
+  </View>;
+};
+
 let make =
     (~model: Model.model, ~theme, ~tokenTheme, ~font: UiFont.t, ~dispatch, ()) => {
   switch (model.selected) {
@@ -204,6 +278,7 @@ let make =
   | Some(selected) =>
     let maybeLogo = selected |> Selected.logo;
     let displayName = selected |> Selected.displayName;
+    let namespace = selected |> Selected.namespace;
     let description =
       selected |> Selected.description |> Option.value(~default="");
 
@@ -214,6 +289,11 @@ let make =
       |> Selected.version
       |> Option.map(Semver.to_string)
       |> Option.value(~default="0.0.0");
+
+    let isPublicNamespace = selected |> Selected.isPublicNamespace;
+
+    let warningElement =
+      isPublicNamespace ? <warning displayName namespace font /> : React.empty;
 
     let contents =
       switch (maybeReadmeUrl) {
@@ -255,6 +335,7 @@ let make =
         dispatch
         model
       />
+      warningElement
       contents
     </View>;
   };

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -147,6 +147,16 @@ module Selected = {
     | Local(scanResult) => scanResult.manifest |> Manifest.identifier
     | Remote(details) => details.namespace ++ "." ++ details.name;
 
+  let namespace =
+    fun
+    | Local(scanResult) => scanResult.manifest |> Manifest.publisher
+    | Remote(details) => details.namespace;
+
+  let isPublicNamespace =
+    fun
+    | Local(_) => false
+    | Remote({isPublicNamespace, _}) => isPublicNamespace;
+
   let logo =
     fun
     | Local(scanResult) => scanResult.manifest.icon

--- a/src/Service/Extensions/Catalog.re
+++ b/src/Service/Extensions/Catalog.re
@@ -75,6 +75,7 @@ module Details = {
     //      licenseUrl: string,
     name: string,
     namespace: string,
+    isPublicNamespace: bool,
     //      downloadCount: int,
     displayName: option(string),
     description: option(string),
@@ -135,6 +136,12 @@ module Details = {
           licenseName: field.optional("license", string),
           displayName: field.optional("displayName", string),
           description: field.optional("description", string),
+          isPublicNamespace:
+            field.withDefault(
+              "namespaceAccess",
+              true,
+              string |> map(str => {String.lowercase_ascii(str) == "public"}),
+            ),
           name: field.required("name", string),
           namespace: field.required("namespace", string),
           version:

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -33,6 +33,7 @@ module Catalog: {
       //      licenseUrl: string,
       name: string,
       namespace: string,
+      isPublicNamespace: bool,
       //      downloadCount: int,
       displayName: option(string),
       description: option(string),


### PR DESCRIPTION
__Issue:__ Some of the extensions posted on `open-vsx` have a public namespace - meaning anyone can  publish to it. 

__Fix:__ We should display a notification letting the user know about this, so they can decide if they want to verify the extension further. This adds a UI on the details page:

![image](https://user-images.githubusercontent.com/13532591/101556888-ab6b7a00-3970-11eb-9a55-aa17aa613edc.png)

Fixes #2345 

Thanks @fanantoxa for logging the bug!