### PR TITLE
fix(extensions): Intermittent request failure

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #2806 - Windows: Add open-directory command to windows installer (fixes #2046)
 - #2807 - Terminal: Implement paste in insert mode (fixes #2805)
 - #2808 - Auto-Update: Fix changelog display (fixes #2787)
+- #2810 - Extensions: Fix intermittent request failure getting extension details
 
 ### Performance
 

--- a/node/request.js
+++ b/node/request.js
@@ -1,5 +1,5 @@
-const http = require("http")
-const https = require("https")
+const http = require("follow-redirects").http
+const https = require("follow-redirects").https
 
 const url = new URL(process.argv[2])
 

--- a/src/Core/NodeTask.re
+++ b/src/Core/NodeTask.re
@@ -111,6 +111,7 @@ let run = (~name="Anonymous", ~args=[], ~setup: Setup.t, script: string) => {
             hasClosedStdout := true;
             Log.info("Got EOF on stdout");
             Luv.Handle.close(stdoutPipe, ignore);
+            tryToFinish();
           }
         | Error(msg) => Log.error(Luv.Error.strerror(msg))
         | Ok(buffer) => buffers := [buffer, ...buffers^],


### PR DESCRIPTION
__Issue:__ On Windows / OSX, sometimes the extension details would fail to be fetched.

__Defect:__ There was a race condition in our logic to use node for handling requests. If we receive the `on_exit` prior to `stdout` closing, the request will never complete.

__Fix:__ Make sure we complete when the request has exited and stdout has closed.