### PR TITLE
fix(extensions): Show image in details

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #2806 - Windows: Add open-directory command to windows installer (fixes #2046)
 - #2807 - Terminal: Implement paste in insert mode (fixes #2805)
 - #2808 - Auto-Update: Fix changelog display (fixes #2787)
+- #2811 - Extensions: Show logo image for remote extensions
 
 ### Performance
 

--- a/src/Components/RemoteAsset.re
+++ b/src/Components/RemoteAsset.re
@@ -78,7 +78,7 @@ module Make =
                 url,
               );
             } else {
-              localDispatch(Reset);
+              //localDispatch(Reset);
               Log.infof(m => m("Mounted or src changed: %s", url));
 
               url
@@ -101,8 +101,11 @@ module Make =
                })
             |> LwtEx.flatMap(filePath => Config.mapper(~filePath));
 
+          let active = ref(true);
           Lwt.on_success(promise, res => {
-            localDispatch(DownloadSuccess(res))
+            if (active^) {
+              localDispatch(DownloadSuccess(res))
+            }
           });
 
           Lwt.on_failure(
@@ -110,10 +113,12 @@ module Make =
             exn => {
               let errMsg = exn |> Printexc.to_string;
               Log.errorf(m => m("Download failed %s with %s", url, errMsg));
-              localDispatch(DownloadFailed(errMsg));
+              if (active^) {
+                localDispatch(DownloadFailed(errMsg));
+              }
             },
           );
-          None;
+          Some(() => active := false);
         },
       );
 

--- a/src/Components/RemoteAsset.re
+++ b/src/Components/RemoteAsset.re
@@ -78,7 +78,7 @@ module Make =
                 url,
               );
             } else {
-              //localDispatch(Reset);
+              localDispatch(Reset);
               Log.infof(m => m("Mounted or src changed: %s", url));
 
               url
@@ -101,11 +101,8 @@ module Make =
                })
             |> LwtEx.flatMap(filePath => Config.mapper(~filePath));
 
-          let active = ref(true);
           Lwt.on_success(promise, res => {
-            if (active^) {
-              localDispatch(DownloadSuccess(res))
-            }
+            localDispatch(DownloadSuccess(res))
           });
 
           Lwt.on_failure(
@@ -113,12 +110,10 @@ module Make =
             exn => {
               let errMsg = exn |> Printexc.to_string;
               Log.errorf(m => m("Download failed %s with %s", url, errMsg));
-              if (active^) {
-                localDispatch(DownloadFailed(errMsg));
-              }
+              localDispatch(DownloadFailed(errMsg));
             },
           );
-          Some(() => active := false);
+          None;
         },
       );
 

--- a/src/Components/RemoteImage.re
+++ b/src/Components/RemoteImage.re
@@ -17,9 +17,7 @@ let make = (~width: int, ~height: int, ~url: string, ()) => {
              <Image width height src={`File(filePath)} />
            </Container>
          | FilePathDownloader.DownloadFailed({errorMsg}) =>
-           <Container width height>
-             <Text text=errorMsg />
-           </Container>
+           <Container width height> <Text text=errorMsg /> </Container>
        }
   </FilePathDownloader>;
 };

--- a/src/Components/RemoteImage.re
+++ b/src/Components/RemoteImage.re
@@ -1,4 +1,5 @@
 open Revery.UI;
+open Revery.UI.Components;
 
 module FilePathDownloader =
   RemoteAsset.Make({
@@ -10,11 +11,15 @@ let make = (~width: int, ~height: int, ~url: string, ()) => {
   <FilePathDownloader url>
     ...{
          fun
-         | FilePathDownloader.Downloading => <View />
+         | FilePathDownloader.Downloading => <Container width height />
          | FilePathDownloader.Downloaded(filePath) =>
-           <Image width height src={`File(filePath)} />
+           <Container width height>
+             <Image width height src={`File(filePath)} />
+           </Container>
          | FilePathDownloader.DownloadFailed({errorMsg}) =>
-           <Text text=errorMsg />
+           <Container width height>
+             <Text text=errorMsg />
+           </Container>
        }
   </FilePathDownloader>;
 };

--- a/src/Components/RemoteMarkdown.re
+++ b/src/Components/RemoteMarkdown.re
@@ -33,6 +33,7 @@ let make =
              fontFamily
              codeFontFamily
              headerMargin=16
+             baseFontSize=12.
            />
          | FileContentsDownloader.DownloadFailed({errorMsg}) =>
            <Text text=errorMsg />

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -113,7 +113,7 @@ let header =
     ) => {
   let logo =
     switch (maybeLogo) {
-    | Some(src) => <Image width=96 height=96 src={`File(src)} />
+    | Some(src) => <RemoteImage width=96 height=96 url={src} />
     // TODO: Replace with real logo
     | None => <Container color=Revery.Colors.gray height=96 width=96 />
     };

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -113,7 +113,7 @@ let header =
     ) => {
   let logo =
     switch (maybeLogo) {
-    | Some(src) => <RemoteImage width=96 height=96 url={src} />
+    | Some(src) => <RemoteImage width=96 height=96 url=src />
     // TODO: Replace with real logo
     | None => <Container color=Revery.Colors.gray height=96 width=96 />
     };

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -155,6 +155,7 @@ let header =
         justifyContent(`Center),
         alignItems(`Center),
         margin(8),
+        paddingLeft(12),
       ]>
       logo
     </View>
@@ -178,18 +179,18 @@ let header =
           ]>
           <Text
             fontFamily={font.family}
-            fontSize=18.
+            fontSize=16.
             fontWeight=Revery.Font.Weight.Bold
             text=extensionId
           />
         </View>
         <View style=Styles.headerTextContainer>
-          <Text fontFamily={font.family} fontSize=18. text=version />
+          <Text fontFamily={font.family} fontSize=14. text=version />
         </View>
       </View>
       <View style=Styles.headerRow>
         <View style=Styles.headerTextContainer>
-          <Text fontFamily={font.family} fontSize=18. text=description />
+          <Text fontFamily={font.family} fontSize=14. text=description />
         </View>
       </View>
       <View style=Styles.headerRow> buttonElements </View>


### PR DESCRIPTION
This fixes a bug where we were not showing the logo image for extensions correctly.

Now, when browsing, the logo image gets loaded:
![image](https://user-images.githubusercontent.com/13532591/101559449-ff2c9200-3975-11eb-80c8-e0243e1d4126.png)
