### PR TITLE
fix(cli/#1861): Add CLI command to execute vim ex commands

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #2806 - Windows: Add open-directory command to windows installer (fixes #2046)
 - #2807 - Terminal: Implement paste in insert mode (fixes #2805)
 - #2808 - Auto-Update: Fix changelog display (fixes #2787)
+- #2812 - CLI: Add `+` and `-c` arguments to run Vim ex commands (fixes #1861)
 
 ### Performance
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,8 +77,6 @@ jobs:
   - template: .ci/use-node.yml
   - script: sudo apt-get update
   - script: sudo apt-get install -y libncurses5-dev libacl1-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev nasm xvfb
-  # Try installing software renderer, to run tests
-  - script: sudo apt-get install libgl1-mesa-swx11
   - template: .ci/run-xvfb.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/use-esy.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,8 @@ jobs:
   - template: .ci/use-node.yml
   - script: sudo apt-get update
   - script: sudo apt-get install -y libncurses5-dev libacl1-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev nasm xvfb
+  # Try installing software renderer, to run tests
+  - script: sudo apt-get install libgl1-mesa-swx11
   - template: .ci/run-xvfb.yml
   - template: .ci/js-build-steps.yml
   - template: .ci/use-esy.yml

--- a/docs/docs/using-onivim/command-line.md
+++ b/docs/docs/using-onivim/command-line.md
@@ -129,3 +129,7 @@ oni2 -f --checkhealth
 - `-force-device-scale-factor` overrides the current scaling.
 
 > Example: `oni2 --force-device-scale-factor 2`
+
+- `-c` or `+` runs a Vim ex command, after loading files.
+
+> Example: `oni2 +100 src/my-file.txt` would run the `:100` ex command, meaning the editor would start with line 100 focused.

--- a/integration_test/EchoNotificationTest.re
+++ b/integration_test/EchoNotificationTest.re
@@ -6,7 +6,9 @@ runTest(~name="EchoNotificationTest", (dispatch, wait, _runEffects) => {
     Selectors.mode(state) |> Vim.Mode.isNormal
   );
 
-  dispatch(VimExecuteCommand("echo 'hi from test'"));
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "echo 'hi from test'"}),
+  );
 
   wait(~name="notification shows up", (state: State.t) => {
     let notifications = Feature_Notification.all(state.notifications);

--- a/integration_test/InputContextKeysTest.re
+++ b/integration_test/InputContextKeysTest.re
@@ -29,7 +29,7 @@ runTest(~name="InputContextKeys", (dispatch, wait, _) => {
   });
 
   // Create a terminal - verify we have new context keys
-  dispatch(VimExecuteCommand(":term"));
+  dispatch(VimExecuteCommand({allowAnimation: true, command: ":term"}));
 
   wait(
     ~name=

--- a/integration_test/LineEndingsCRLFTest.re
+++ b/integration_test/LineEndingsCRLFTest.re
@@ -24,7 +24,9 @@ runTest(~name="LineEndingsCRLFTest", (dispatch, wait, _runEffects) => {
   });
 
   // Switch line endings
-  dispatch(Actions.VimExecuteCommand("set ff=unix"));
+  dispatch(
+    Actions.VimExecuteCommand({allowAnimation: true, command: "set ff=unix"}),
+  );
 
   // Verify buffer now has LF line endings...
   wait(

--- a/integration_test/LineEndingsLFTest.re
+++ b/integration_test/LineEndingsLFTest.re
@@ -30,7 +30,9 @@ runTest(~name="LineEndingsLFTest", (dispatch, wait, _runEffects) => {
   });
 
   // Switch line endings
-  dispatch(Actions.VimExecuteCommand("set ff=dos"));
+  dispatch(
+    Actions.VimExecuteCommand({allowAnimation: true, command: "set ff=dos"}),
+  );
 
   wait(
     ~name="Verify buffer is switched to CRLF", ~timeout=10.0, (state: State.t) => {

--- a/integration_test/Regression2349EnewTest.re
+++ b/integration_test/Regression2349EnewTest.re
@@ -14,7 +14,9 @@ runTest(~name="Regression: Command line no completions", (dispatch, wait, _) => 
     true;
   });
 
-  dispatch(Actions.VimExecuteCommand("enew"));
+  dispatch(
+    Actions.VimExecuteCommand({allowAnimation: true, command: "enew"}),
+  );
 
   wait(~name="New editor created", (state: State.t) => {
     let currentEditorId =

--- a/integration_test/RegressionVspEmptyExistingBufferTest.re
+++ b/integration_test/RegressionVspEmptyExistingBufferTest.re
@@ -12,7 +12,9 @@ runTest(~name="RegressionVspEmpty", (dispatch, wait, _) => {
     splitCount == 1;
   });
 
-  dispatch(Actions.VimExecuteCommand("e test.txt"));
+  dispatch(
+    Actions.VimExecuteCommand({allowAnimation: true, command: "e test.txt"}),
+  );
   wait(~name="Wait for file to get editor", (state: State.t) => {
     let currentBuffer =
       state.layout |> Feature_Layout.activeEditor |> Editor.getBufferId;
@@ -21,7 +23,9 @@ runTest(~name="RegressionVspEmpty", (dispatch, wait, _) => {
   });
 
   /* :vsp with no arguments should create a second split w/ same buffer */
-  dispatch(Actions.VimExecuteCommand("vsp"));
+  dispatch(
+    Actions.VimExecuteCommand({allowAnimation: true, command: "vsp"}),
+  );
 
   wait(~name="Wait for split to be created", (state: State.t) => {
     let splitCount =

--- a/integration_test/VimScriptLocalFunctionTest.re
+++ b/integration_test/VimScriptLocalFunctionTest.re
@@ -8,11 +8,21 @@ runTest(~name="VimScriptLocalFunctionTest", (dispatch, wait, runEffects) => {
 
   let plugScript = getAssetPath("PlugScriptLocal.vim");
 
-  dispatch(VimExecuteCommand("source " ++ plugScript));
+  dispatch(
+    VimExecuteCommand({
+      allowAnimation: true,
+      command: "source " ++ plugScript,
+    }),
+  );
   runEffects();
 
   // set up a binding to the <Plug>Hello1 command provided by the script
-  dispatch(VimExecuteCommand("nnoremap j <Plug>Hello1"));
+  dispatch(
+    VimExecuteCommand({
+      allowAnimation: true,
+      command: "nnoremap j <Plug>Hello1",
+    }),
+  );
   runEffects();
 
   let input = key => {

--- a/integration_test/VimSimpleRemapTest.re
+++ b/integration_test/VimSimpleRemapTest.re
@@ -7,7 +7,9 @@ runTest(~name="VimSimpleRemapTest", (dispatch, wait, runEffects) => {
   );
 
   // Use inoremap to set up jj -> <ESC> binding
-  dispatch(VimExecuteCommand("inoremap jj <ESC>"));
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "inoremap jj <ESC>"}),
+  );
   runEffects();
 
   let input = key => {

--- a/src/CLI/Oni_CLI.rei
+++ b/src/CLI/Oni_CLI.rei
@@ -13,6 +13,7 @@ type t = {
   logFilter: option(string),
   logColorsEnabled: option(bool),
   needsConsole: bool,
+  vimExCommands: list(string),
 };
 
 let default: t;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -126,6 +126,8 @@ type t = {
   lastMouseScreenPosition: option(PixelPosition.t),
   lastMouseMoveTime: [@opaque] option(Revery.Time.t),
   lastMouseUpTime: [@opaque] option(Revery.Time.t),
+  // Animation
+  isAnimationOverride: option(bool),
 };
 
 let key = ({key, _}) => key;
@@ -157,6 +159,11 @@ let setMinimap = (~enabled, ~maxColumn, editor) => {
   ...editor,
   isMinimapEnabled: enabled,
   minimapMaxColumnWidth: maxColumn,
+};
+
+let overrideAnimation = (~animated, editor) => {
+  ...editor,
+  isAnimationOverride: animated,
 };
 
 let getBufferLineCount = ({buffer, _}) =>
@@ -501,6 +508,7 @@ let create = (~config, ~buffer, ()) => {
     lastMouseMoveTime: None,
     lastMouseScreenPosition: None,
     lastMouseUpTime: None,
+    isAnimationOverride: None,
   }
   |> configure(~config);
 };
@@ -912,6 +920,13 @@ let hasSetSize = editor => {
   editor.pixelWidth > 1 && editor.pixelHeight > 1;
 };
 
+let isScrollAnimated = ({isScrollAnimated, isAnimationOverride, _}) => {
+  switch (isAnimationOverride) {
+  | Some(v) => v
+  | None => isScrollAnimated
+  };
+};
+
 let exposePrimaryCursor = editor =>
   if (!hasSetSize(editor)) {
     // If the size hasn't been set yet - don't try to expose the cursor.
@@ -974,7 +989,7 @@ let exposePrimaryCursor = editor =>
         && Float.abs(adjustedScrollY -. scrollY) < lineHeightInPixels(editor)
         *. 1.1;
 
-      let animated = editor.isScrollAnimated;
+      let animated = editor |> isScrollAnimated;
       {
         ...editor,
         scrollX:
@@ -1059,7 +1074,7 @@ let getContentPixelWidth = editor => {
 
 let scrollToPixelY = (~animated, ~pixelY as newScrollY, editor) => {
   let originalScrollY = Spring.getTarget(editor.scrollY);
-  let animated = editor.isScrollAnimated && animated;
+  let animated = editor |> isScrollAnimated && animated;
   let {pixelHeight, _} = editor;
   let viewLines = editor |> totalViewLines;
   let newScrollY = max(0., newScrollY);
@@ -1103,7 +1118,7 @@ let scrollToLine = (~line, view) => {
 };
 
 let scrollToPixelX = (~animated, ~pixelX as newScrollX, editor) => {
-  let animated = editor.isScrollAnimated && animated;
+  let animated = editor |> isScrollAnimated && animated;
   let maxLineLength = editor |> maxLineLength;
   let newScrollX = max(0., newScrollX);
 
@@ -1338,7 +1353,10 @@ let setSize = (~pixelWidth, ~pixelHeight, originalEditor) => {
 
   // If we hadn't measured before, make sure the cursor is in view
   if (!hasSetSize(originalEditor)) {
-    scrollCursorTop(editor');
+    editor'
+    |> overrideAnimation(~animated=Some(false))
+    |> scrollCursorTop
+    |> overrideAnimation(~animated=None);
   } else {
     editor';
   };

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -80,6 +80,7 @@ let getTokenAt:
   (~languageConfiguration: LanguageConfiguration.t, CharacterPosition.t, t) =>
   option(CharacterRange.t);
 
+let overrideAnimation: (~animated: option(bool), t) => t;
 let yankHighlight: t => option(yankHighlight);
 let startYankHighlight: (list(PixelRange.t), t) => t;
 

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -123,17 +123,8 @@ let update = (editor, msg) => {
   | MouseHovered =>
     let maybeCharacter = Editor.getCharacterUnderMouse(editor);
     (editor, MouseHovered(maybeCharacter));
-  //  | MouseMoved({bytePosition}) => (
-  //      editor,
-  //      {
-  //        Editor.byteToCharacter(bytePosition, editor)
-  //        |> Option.map(characterPosition => {
-  //             MouseMoved({bytePosition, characterPosition})
-  //           })
-  //        |> Option.value(~default=Nothing);
-  //      },
-  //    )
-  | ModeChanged({mode, effects}) =>
+
+  | ModeChanged({allowAnimation, mode, effects}) =>
     let handleScrollEffect = (~count, ~direction, editor) => {
       let count = max(count, 1);
       Vim.Scroll.(
@@ -153,6 +144,14 @@ let update = (editor, msg) => {
       );
     };
 
+    // Apply animation override, if disabled
+    let editor =
+      if (!allowAnimation) {
+        editor |> Editor.overrideAnimation(~animated=Some(false));
+      } else {
+        editor;
+      };
+
     let editor' = Editor.setMode(mode, editor);
     let editor'' =
       effects
@@ -165,7 +164,8 @@ let update = (editor, msg) => {
              }
            },
            editor',
-         );
+         )
+      |> Editor.overrideAnimation(~animated=None);
     (editor'', Nothing);
   };
 };

--- a/src/Feature/Editor/Msg.re
+++ b/src/Feature/Editor/Msg.re
@@ -40,6 +40,7 @@ type t =
   | MouseHovered
   //  | MouseMoved({bytePosition: BytePosition.t})
   | ModeChanged({
+      allowAnimation: bool,
       mode: [@opaque] Vim.Mode.t,
       effects: [@opaque] list(Vim.Effect.t),
     })

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -13,6 +13,7 @@ let subMode: model => Vim.SubMode.t;
 [@deriving show]
 type msg =
   | ModeChanged({
+      allowAnimation: bool,
       mode: [@opaque] Vim.Mode.t,
       subMode: [@opaque] Vim.SubMode.t,
       effects: list(Vim.Effect.t),
@@ -28,6 +29,7 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | SettingsChanged
   | ModeDidChange({
+      allowAnimation: bool,
       mode: Vim.Mode.t,
       effects: list(Vim.Effect.t),
     });

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -130,7 +130,10 @@ type t =
   | Terminal(Feature_Terminal.msg)
   | Theme(Feature_Theme.msg)
   | Pane(Feature_Pane.msg)
-  | VimExecuteCommand(string)
+  | VimExecuteCommand({
+      allowAnimation: bool,
+      command: string,
+    })
   | VimMessageReceived({
       priority: [@opaque] Vim.Types.msgPriority,
       title: string,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -164,7 +164,14 @@ module Internal = {
       {...state, sideBar, layout};
     };
 
-  let updateMode = (~extHostClient, state: State.t, mode: Vim.Mode.t, effects) => {
+  let updateMode =
+      (
+        ~extHostClient,
+        ~allowAnimation,
+        state: State.t,
+        mode: Vim.Mode.t,
+        effects,
+      ) => {
     let prevCursor =
       state.layout
       |> Feature_Layout.activeEditor
@@ -197,7 +204,8 @@ module Internal = {
       };
     let activeEditorId = editor |> Feature_Editor.Editor.getId;
 
-    let msg: Feature_Editor.msg = ModeChanged({mode, effects});
+    let msg: Feature_Editor.msg =
+      ModeChanged({allowAnimation, mode, effects});
     let scope = EditorScope.Editor(activeEditorId);
     let (layout, editorEffect) = updateEditors(~scope, ~msg, state.layout);
 
@@ -1603,8 +1611,14 @@ let update =
         state |> Internal.updateConfiguration,
         Isolinear.Effect.none,
       )
-    | ModeDidChange({mode, effects}) =>
-      Internal.updateMode(~extHostClient, state, mode, effects)
+    | ModeDidChange({allowAnimation, mode, effects}) =>
+      Internal.updateMode(
+        ~extHostClient,
+        ~allowAnimation,
+        state,
+        mode,
+        effects,
+      )
     };
 
   | Workspace(msg) =>

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -128,7 +128,7 @@ let start = (window: option(Revery.Window.t), runEffects) => {
   let effectToActions = (state, effect) =>
     switch (effect) {
     | Feature_Input.(Execute(VimExCommand(command))) => [
-        Actions.VimExecuteCommand(command),
+        Actions.VimExecuteCommand({allowAnimation: true, command}),
       ]
     | Feature_Input.(Execute(NamedCommand(command))) => [
         Actions.KeybindingInvoked({command: command}),

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -91,7 +91,7 @@ let start = maybeKeyBindingsFilePath => {
   let executeExCommandEffect = command =>
     Isolinear.Effect.createWithDispatch(
       ~name="keybindings.executeExCommand", dispatch =>
-      dispatch(Actions.VimExecuteCommand(command))
+      dispatch(Actions.VimExecuteCommand({allowAnimation: true, command}))
     );
 
   let updater = (state: State.t, action: Actions.t) => {

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -476,8 +476,10 @@ switch (eff) {
     );
 
     List.iter(
-      v => {
-        dispatch(Model.Actions.VimExecuteCommand(v));
+      command => {
+        dispatch(
+          Model.Actions.VimExecuteCommand({allowAnimation: false, command}),
+        );
         runEffects();
       },
       cliOptions.vimExCommands,

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -474,6 +474,14 @@ switch (eff) {
       v => dispatch(Model.Actions.OpenFileByPath(v, None, None)),
       cliOptions.filesToOpen,
     );
+
+    List.iter(
+      v => {
+        dispatch(Model.Actions.VimExecuteCommand(v));
+        runEffects();
+      },
+      cliOptions.vimExCommands,
+    );
   };
 
   /* Let's get this party started! */

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -16,6 +16,7 @@ let passthroughStringAndStayAttached = Arg.String(_ => stayAttached := true);
 
 let spec =
   Arg.align([
+    ("-c", passthroughString, "Execute an :ex command after loading files"),
     (
       "-f",
       Arg.Set(stayAttached),

--- a/test/Cli/CliTest.re
+++ b/test/Cli/CliTest.re
@@ -69,4 +69,38 @@ describe("CLI", ({describe, test, _}) => {
       expect.equal(options.logLevel, None);
     });
   });
+
+  describe("vim ex commands", ({test, _}) => {
+    test("-c should add ex command", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "-c", "term"|]);
+
+      expect.equal(options.vimExCommands, ["term"]);
+    });
+    test("multiple -c commands should be handled, in order", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(
+          ~getenv=noenv,
+          [|"Oni2_editor", "-c", "term", "-c", "xa!"|],
+        );
+
+      expect.equal(options.vimExCommands, ["term", "xa!"]);
+    });
+    test("+ anonymous arg should add ex command", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "+term"|]);
+
+      expect.equal(options.vimExCommands, ["term"]);
+      expect.equal(options.filesToOpen, []);
+      expect.equal(options.folder, None);
+    });
+    test("multiple + anonymous arg should add ex commands", ({expect, _}) => {
+      let (options, _eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "+term", "+xa!"|]);
+
+      expect.equal(options.vimExCommands, ["term", "xa!"]);
+      expect.equal(options.filesToOpen, []);
+      expect.equal(options.folder, None);
+    });
+  });
 });

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -84,9 +84,8 @@ describe("CLI Integration Tests", ({describe, _}) => {
     })
   });
 
-  describe("ex commands", ({test, _}) => {
-
-    // On Linux Azure CI, this test fails when creating a window - 
+  describe("ex commands", ({test, _}) =>
+    // On Linux Azure CI, this test fails when creating a window -
     // need to find a workaround to allow `SDL_CreateWindow` to succeed on CI machines.
     if (Revery.Environment.os != Revery.Environment.Linux) {
       test("run ex commands with '+'", ({expect, _}) => {
@@ -99,7 +98,12 @@ describe("CLI Integration Tests", ({describe, _}) => {
               );
 
             let () =
-              startEditorWithArgs(["-f", "+new " ++ filePath, "+norm! oabc", "+xa!"])
+              startEditorWithArgs([
+                "-f",
+                "+new " ++ filePath,
+                "+norm! oabc",
+                "+xa!",
+              ])
               |> validateExitStatus(WEXITED(0))
               |> finish;
 
@@ -108,7 +112,7 @@ describe("CLI Integration Tests", ({describe, _}) => {
             expect.equal(lines, ["", "abc"]);
           }
         )
-      })
+      });
     }
-  });
+  );
 });

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -85,25 +85,30 @@ describe("CLI Integration Tests", ({describe, _}) => {
   });
 
   describe("ex commands", ({test, _}) => {
-    test("run ex commands with '+'", ({expect, _}) => {
-      TestRunner.(
-        {
-          let filePath =
-            Rench.Path.join(
-              Sys.getcwd(),
-              "test-" ++ string_of_int(Luv.Pid.getpid()),
-            );
 
-          let () =
-            startEditorWithArgs(["-f", "+new " ++ filePath, "+norm! oabc", "+xa!"])
-            |> validateExitStatus(WEXITED(0))
-            |> finish;
+    // On Linux Azure CI, this test fails when creating a window - 
+    // need to find a workaround to allow `SDL_CreateWindow` to succeed on CI machines.
+    if (Revery.Environment.os != Revery.Environment.Linux) {
+      test("run ex commands with '+'", ({expect, _}) => {
+        TestRunner.(
+          {
+            let filePath =
+              Rench.Path.join(
+                Sys.getcwd(),
+                "test-" ++ string_of_int(Luv.Pid.getpid()),
+              );
 
-          let lines = Oni_Core.Utility.File.readAllLines(filePath);
+            let () =
+              startEditorWithArgs(["-f", "+new " ++ filePath, "+norm! oabc", "+xa!"])
+              |> validateExitStatus(WEXITED(0))
+              |> finish;
 
-          expect.equal(lines, ["", "abc"]);
-        }
-      )
-    })
+            let lines = Oni_Core.Utility.File.readAllLines(filePath);
+
+            expect.equal(lines, ["", "abc"]);
+          }
+        )
+      })
+    }
   });
 });

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -95,7 +95,7 @@ describe("CLI Integration Tests", ({describe, _}) => {
             );
 
           let () =
-            startEditorWithArgs(["+new " ++ filePath, "+norm! oabc", "+xa!"])
+            startEditorWithArgs(["-f", "+new " ++ filePath, "+norm! oabc", "+xa!"])
             |> validateExitStatus(WEXITED(0))
             |> finish;
 

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -84,35 +84,36 @@ describe("CLI Integration Tests", ({describe, _}) => {
     })
   });
 
-  describe("ex commands", ({test, _}) =>
+  describe("ex commands", ({test, _})
     // On Linux Azure CI, this test fails when creating a window -
     // need to find a workaround to allow `SDL_CreateWindow` to succeed on CI machines.
-    if (Revery.Environment.os != Revery.Environment.Linux) {
-      test("run ex commands with '+'", ({expect, _}) => {
-        TestRunner.(
-          {
-            let filePath =
-              Rench.Path.join(
-                Sys.getcwd(),
-                "test-" ++ string_of_int(Luv.Pid.getpid()),
-              );
+    =>
+      if (Revery.Environment.os != Revery.Environment.Linux) {
+        test("run ex commands with '+'", ({expect, _}) => {
+          TestRunner.(
+            {
+              let filePath =
+                Rench.Path.join(
+                  Sys.getcwd(),
+                  "test-" ++ string_of_int(Luv.Pid.getpid()),
+                );
 
-            let () =
-              startEditorWithArgs([
-                "-f",
-                "+new " ++ filePath,
-                "+norm! oabc",
-                "+xa!",
-              ])
-              |> validateExitStatus(WEXITED(0))
-              |> finish;
+              let () =
+                startEditorWithArgs([
+                  "-f",
+                  "+new " ++ filePath,
+                  "+norm! oabc",
+                  "+xa!",
+                ])
+                |> validateExitStatus(WEXITED(0))
+                |> finish;
 
-            let lines = Oni_Core.Utility.File.readAllLines(filePath);
+              let lines = Oni_Core.Utility.File.readAllLines(filePath);
 
-            expect.equal(lines, ["", "abc"]);
-          }
-        )
-      });
-    }
-  );
+              expect.equal(lines, ["", "abc"]);
+            }
+          )
+        });
+      }
+    );
 });

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -45,6 +45,7 @@ describe("CLI Integration Tests", ({describe, _}) => {
       )
     })
   });
+
   describe("install / uninstall extensions", ({test, _}) => {
     test("install / uninstall extension from file system", _ => {
       TestRunner.(
@@ -78,6 +79,29 @@ describe("CLI Integration Tests", ({describe, _}) => {
             |> validateExitStatus(WEXITED(0))
             |> finish;
           ();
+        }
+      )
+    })
+  });
+
+  describe("ex commands", ({test, _}) => {
+    test("run ex commands with '+'", ({expect, _}) => {
+      TestRunner.(
+        {
+          let filePath =
+            Rench.Path.join(
+              Sys.getcwd(),
+              "test-" ++ string_of_int(Luv.Pid.getpid()),
+            );
+
+          let () =
+            startEditorWithArgs(["+new " ++ filePath, "+norm! oabc", "+xa!"])
+            |> validateExitStatus(WEXITED(0))
+            |> finish;
+
+          let lines = Oni_Core.Utility.File.readAllLines(filePath);
+
+          expect.equal(lines, ["", "abc"]);
         }
       )
     })


### PR DESCRIPTION
Fixes #1861 & #2803 

__TODO:__
- [x] Disable animations when running these initial commands. For a case like `Oni2 +1000 src/some-file.ts`, it's jarring and unnecessary to have the scroll animation on startup.
- [x] Add documentation
- [x] Fix Ubuntu test failure