### PR TITLE
fix(auto-update): Set default update channel based on build

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -31,6 +31,7 @@
 - #2809 - Extensions: Warn on open-vsx public namespaces (fixes #2345)
 - #2810 - Extensions: Fix intermittent request failure getting extension details
 - #2811 - Extensions: Show logo image for remote extensions
+- #2819 - Auto-Update: Set default update channel based on build type
 
 ### Performance
 

--- a/src/Feature/AutoUpdate/Feature_AutoUpdate.re
+++ b/src/Feature/AutoUpdate/Feature_AutoUpdate.re
@@ -73,7 +73,6 @@ let sub = (~config) => {
   let automaticallyChecksForUpdates =
     Configuration.automaticallyChecksForUpdates.get(config);
   let releaseChannel = Configuration.releaseChannel.get(config);
-  prerr_endline ("RELEASE CHANNEL: " ++ releaseChannel);
 
   Service_AutoUpdate.Sub.autoUpdate(
     ~uniqueId="autoUpdate",

--- a/src/Service/AutoUpdate/Service_AutoUpdate.re
+++ b/src/Service/AutoUpdate/Service_AutoUpdate.re
@@ -2,12 +2,12 @@
 type msg =
   | AutoCheckChanged(bool)
   | LicenseKeyChanged(string)
-  | ReleaseChannelChanged([ | `Nightly | `Master | `Test]);
+  | ReleaseChannelChanged(string);
 
 module Sub = {
   type params = {
     automaticallyChecksForUpdates: bool,
-    releaseChannel: [ | `Nightly | `Master | `Test],
+    releaseChannel: string,
     uniqueId: string,
   };
 
@@ -15,7 +15,7 @@ module Sub = {
     Isolinear.Sub.Make({
       type state = {
         automaticallyChecksForUpdates: bool,
-        releaseChannel: [ | `Nightly | `Master | `Test],
+        releaseChannel: string,
       };
       type nonrec msg = msg;
       type nonrec params = params;

--- a/src/gen_buildinfo/generator.re
+++ b/src/gen_buildinfo/generator.re
@@ -9,6 +9,23 @@ let getCommitId = () => {
   commitId;
 };
 
+let getBranch = () => {
+  let ic = Unix.open_process_in("git rev-parse --abbrev-ref HEAD");
+  let branch = input_line(ic) |> String.trim |> String.lowercase_ascii;
+  let () = close_in(ic);
+  branch;
+};
+
+let getDefaultUpdateChannel = () => {
+  let currentBranch = getBranch();
+
+  if (currentBranch == "staging" || currentBranch == "stable") {
+    currentBranch;
+  } else {
+    "master";
+  };
+};
+
 let getVersion = () => {
   Yojson.Safe.from_file("../../package.json")
   |> Yojson.Safe.Util.member("version")
@@ -22,8 +39,10 @@ Printf.fprintf(
   {|
 let commitId = "%s";
 let version = "%s";
+let defaultUpdateChannel = "%s";
 |},
   getCommitId(),
   getVersion(),
+  getDefaultUpdateChannel(),
 );
 close_out(oc);


### PR DESCRIPTION
__Issue:__ All of our build variations - `master`/`nightly`, `stable`, and `staging` default to using the `master` update channel. However, someone running the `stable` builds would likely prefer the less-frequent-but-more-vetted (and less noisy) `stable` builds for updates.

__Fix:__ Decide, based on the branch we're building from, which default update channel to use.