### PR TITLE
fix(build/#2816): Use development Info.plist on OSX

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -32,6 +32,7 @@
 - #2809 - Extensions: Warn on open-vsx public namespaces (fixes #2345)
 - #2810 - Extensions: Fix intermittent request failure getting extension details
 - #2811 - Extensions: Show logo image for remote extensions
+- #2822 - Build: Use development `Info.plist` that sets `NSSupportsAutomaticGraphicsSwitching` (fixes #2816)
 
 ### Performance
 

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleName</key>
+    <string>Onivim2Dev</string>
+    <key>CFBundleDisplayName</key>
+    <string>Onivim 2 - Development</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.outrunlabs.onivim2-dev</string>
+    <key>CFBundleIconFile</key>
+    <string>Onivim2</string>
+    <key>CFBundleVersion</key>
+    <string>9.9.9999</string>
+    <key>CFBundleShortVersionString</key>
+    <string>9.9.9</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleExecutable</key>
+    <string>Oni2_editor</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+  </dict>
+</plist>

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>CFBundleName</key>
-    <string>Onivim2Dev</string>
+    <string>Onivim 2</string>
     <key>CFBundleDisplayName</key>
     <string>Onivim 2 - Development</string>
     <key>CFBundleIdentifier</key>

--- a/assets/dune
+++ b/assets/dune
@@ -1,0 +1,4 @@
+(install
+    (section bin)
+    (package Oni2)
+    (files Info.plist))

--- a/assets/dune
+++ b/assets/dune
@@ -1,4 +1,4 @@
 (install
-    (section bin)
-    (package Oni2)
-    (files Info.plist))
+ (section bin)
+ (package Oni2)
+ (files Info.plist))

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -144,7 +144,7 @@ if (process.platform == "linux") {
     const bundleVersion = `${semvers[0]}.${semvers[1]}.${numCommits}`
 
     const plistContents = {
-        CFBundleName: "Onivim2",
+        CFBundleName: "Onivim 2",
         CFBundleDisplayName: "Onivim 2",
         CFBundleIdentifier: "com.outrunlabs.onivim2",
         CFBundleIconFile: "Onivim2",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -205,6 +205,8 @@ if (process.platform == "linux") {
     // Remove setup.json prior to remapping bundled files,
     // so it doesn't get symlinked.
     fs.removeSync(path.join(binaryDirectory, "setup.json"))
+    // Remove development plist file
+    fs.removeSync(path.join(binaryDirectory, "Info.plist"))
 
     // We need to remap the binary files - we end up with font files, images, and configuration files in the bin folder
     // These should be in 'Resources' instead. Move everything that is _not_ a binary out, and symlink back in.


### PR DESCRIPTION
Fix #2816 - Use a development `Info.plist` that specifies the `NSSupportsAutomaticGraphicsSwitching` setting.