### PR TITLE
fix(search/#2821): Default to simple string search for find-in-files

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -34,6 +34,7 @@
 - #2811 - Extensions: Show logo image for remote extensions
 - #2819 - Auto-Update: Set default update channel based on build type
 - #2822 - Build: Use development `Info.plist` that sets `NSSupportsAutomaticGraphicsSwitching` (fixes #2816)
+- #2826 - Search: Default to simple string search for find-in-files (fixes #2821)
 
 ### Performance
 

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -274,7 +274,15 @@ let findInFiles =
     (~executablePath, ~directory, ~query, ~onUpdate, ~onComplete, ~onError) => {
   process(
     executablePath,
-    ["--smart-case", "--hidden", "--json", "--", query, directory],
+    [
+      "--fixed-strings",
+      "--smart-case",
+      "--hidden",
+      "--json",
+      "--",
+      query,
+      directory,
+    ],
     items => {
       items
       |> List.filter_map(Match.fromJsonString)


### PR DESCRIPTION
__Issue:__ The search box defaults to a regex search, which is not obvious and there is no indication to the user that it would default to regex, or feedback from an invalid regex.

__Defect:__ The default `ripgrep` behavior is to use a regex-search (which we use for executing the search) - however, we should use the `--fixed-strings` flag, which does simple string search.

__Fix:__ For find-in-files, add the `--fixed-strings` flag when calling ripgrep.

Fixes #2821

__Future Work:__

- Implement a toggle / button to enable regex search (#2599)