### PR TITLE
fix(codelens): Deleting line does not remove codelens

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -36,6 +36,7 @@
 - #2819 - Auto-Update: Set default update channel based on build type
 - #2822 - Build: Use development `Info.plist` that sets `NSSupportsAutomaticGraphicsSwitching` (fixes #2816)
 - #2826 - Search: Default to simple string search for find-in-files (fixes #2821)
+- #2839 - Extensions: CodeLens - fix lens persisting when line is deleted
 
 ### Performance
 

--- a/src/Core/Kernel/IntMap.re
+++ b/src/Core/Kernel/IntMap.re
@@ -36,19 +36,17 @@ let shift =
              if (key < startPos) {
                Some((key, v));
              } else {
-               Some((key + delta, v))
+               Some((key + delta, v));
              };
+           } else if (key < startPos) {
+             Some((key, v));
            } else {
-            if (key < startPos) {
-              Some((key, v))
-            } else {
-              let newPosition = key + delta;
-              if (newPosition < startPos) {
-                None
-              } else {
-                Some((newPosition, v))
-              }
-            }
+             let newPosition = key + delta;
+             if (newPosition < startPos) {
+               None;
+             } else {
+               Some((newPosition, v));
+             };
            }
          )
       |> List.to_seq

--- a/src/Core/Kernel/IntMap.re
+++ b/src/Core/Kernel/IntMap.re
@@ -31,17 +31,24 @@ let shift =
     let newMap =
       map
       |> bindings
-      |> List.map(((key, v)) =>
+      |> List.filter_map(((key, v)) =>
            if (delta > 0) {
              if (key < startPos) {
-               (key, v);
+               Some((key, v));
              } else {
-               (key + delta, v);
+               Some((key + delta, v))
              };
-           } else if (key <= endPos) {
-             (key, v);
            } else {
-             (key + delta, v);
+            if (key < startPos) {
+              Some((key, v))
+            } else {
+              let newPosition = key + delta;
+              if (newPosition < startPos) {
+                None
+              } else {
+                Some((newPosition, v))
+              }
+            }
            }
          )
       |> List.to_seq

--- a/test/Core/IntMapTests.re
+++ b/test/Core/IntMapTests.re
@@ -81,5 +81,19 @@ describe("IntMap", ({describe, _}) => {
       expect.string(val0).toEqual("a");
       expect.string(val1).toEqual("c");
     });
+
+    test("remove line in sparse list", ({expect, _}) => {
+      let map = [(1, "b")] |> List.to_seq |> IntMap.of_seq;
+      let newMap =
+        map
+        |> IntMap.shift(~default=_ => None, ~startPos=1, ~endPos=1, ~delta=-1);
+      let val0 = IntMap.find_opt(0, newMap);
+      let val1 = IntMap.find_opt(1, newMap);
+      let val2 = IntMap.find_opt(2, newMap);
+
+      expect.equal(val0, None);
+      expect.equal(val1, None);
+      expect.equal(val2, None);
+    });
   })
 });


### PR DESCRIPTION
__Issue:__ When deleting a line with a codelens, the codelens persists until the file is saved

__Defect:__ There was a bug with our shift logic - if the item would be deleted, there were cases were it could be kept (in a sparse mapping, where it wouldn't be overwritten - like the code lens / inline elements)

__Fix:__ Remove elements that are deleted in `shift`, and case to cover