### PR TITLE
fix(ux): Adjust shadow for themes

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -36,6 +36,7 @@
 - #2819 - Auto-Update: Set default update channel based on build type
 - #2822 - Build: Use development `Info.plist` that sets `NSSupportsAutomaticGraphicsSwitching` (fixes #2816)
 - #2826 - Search: Default to simple string search for find-in-files (fixes #2821)
+- #2841 - UX: Tone down shadow color for light themes
 
 ### Performance
 

--- a/src/Components/ScrollShadow.re
+++ b/src/Components/ScrollShadow.re
@@ -74,12 +74,22 @@ module Shadow = {
     | Down
     | Up;
 
-  let render = (~opacity, ~direction, ~x, ~y, ~width, ~height, ~context) => {
+  let render =
+      (
+        ~color=shadowStartColor,
+        ~opacity,
+        ~direction,
+        ~x,
+        ~y,
+        ~width,
+        ~height,
+        ~context,
+      ) => {
     switch (direction) {
     | Right =>
       Gradient.drawLeftToRight(
         ~opacity,
-        ~leftColor=shadowStartColor,
+        ~leftColor=color,
         ~rightColor=shadowStopColor,
         ~x,
         ~y,
@@ -91,7 +101,7 @@ module Shadow = {
       Gradient.drawLeftToRight(
         ~opacity,
         ~leftColor=shadowStopColor,
-        ~rightColor=shadowStartColor,
+        ~rightColor=color,
         ~x,
         ~y,
         ~width,
@@ -101,7 +111,7 @@ module Shadow = {
     | Down =>
       Gradient.drawTopToBottom(
         ~opacity,
-        ~topColor=shadowStartColor,
+        ~topColor=color,
         ~bottomColor=shadowStopColor,
         ~x,
         ~y,
@@ -113,7 +123,7 @@ module Shadow = {
       Gradient.drawTopToBottom(
         ~opacity,
         ~topColor=shadowStopColor,
-        ~bottomColor=shadowStartColor,
+        ~bottomColor=color,
         ~x,
         ~y,
         ~width,
@@ -125,7 +135,8 @@ module Shadow = {
 };
 
 module Top = {
-  let make = (~opacity=1.0, ~height as h=12, ()) => {
+  let make = (~theme, ~opacity=1.0, ~height as h=12, ()) => {
+    let destColor = Feature_Theme.Colors.shadow.from(theme);
     <Canvas
       style=Style.[
         position(`Absolute),
@@ -138,6 +149,7 @@ module Top = {
       render={(canvasContext, dimensions) => {
         Shadow.render(
           ~opacity,
+          ~color=destColor,
           ~direction=Shadow.Down,
           ~x=0.,
           ~y=0.,
@@ -151,7 +163,8 @@ module Top = {
 };
 
 module Bottom = {
-  let make = (~opacity=1.0, ~height as h=12, ()) => {
+  let make = (~theme, ~opacity=1.0, ~height as h=12, ()) => {
+    let destColor = Feature_Theme.Colors.shadow.from(theme);
     <Canvas
       style=Style.[
         position(`Absolute),
@@ -164,6 +177,7 @@ module Bottom = {
       render={(canvasContext, dimensions) => {
         Shadow.render(
           ~opacity,
+          ~color=destColor,
           ~direction=Shadow.Up,
           ~x=0.,
           ~y=0.,

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -947,11 +947,11 @@ module View = {
 
         let topShadow =
           model |> showTopScrollShadow
-            ? <Oni_Components.ScrollShadow.Top /> : React.empty;
+            ? <Oni_Components.ScrollShadow.Top theme /> : React.empty;
 
         let bottomShadow =
           model |> showBottomScrollShadow
-            ? <Oni_Components.ScrollShadow.Bottom /> : React.empty;
+            ? <Oni_Components.ScrollShadow.Bottom theme /> : React.empty;
 
         (
           <View style=Style.[flexGrow(1), flexDirection(`Column)]>

--- a/src/Feature/Editor/InlineElementView.re
+++ b/src/Feature/Editor/InlineElementView.re
@@ -131,10 +131,12 @@ module Container = {
             <Oni_Components.ScrollShadow.Top
               opacity={maxOpacity *. 0.8}
               height=5
+              theme
             />
             <Oni_Components.ScrollShadow.Bottom
               opacity={maxOpacity *. 0.8}
               height=5
+              theme
             />
           </View>
         : React.empty;

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -34,6 +34,16 @@ let activeContrastBorder =
     {light: unspecified, dark: unspecified, hc: ref(focusBorder)},
   );
 
+let shadow =
+  define(
+    "shadow",
+    {
+      light: transparent(0.1, hex("#000F")),
+      dark: transparent(0.20, hex("#000F")),
+      hc: unspecified,
+    },
+  );
+
 module ActivityBar = {
   let background =
     define(
@@ -1439,4 +1449,4 @@ module TitleBar = {
   ];
 };
 
-let defaults = [foreground, contrastBorder];
+let defaults = [foreground, contrastBorder, shadow];


### PR DESCRIPTION
__Issue:__ We use the same shadow color for both dark and light themes. It ends up being too harsh on light themes.

__Fix:__ Tone down shadow color for light themes (and make themable).