### PR TITLE
fix(cli/#2803): Quote arguments in AppRun so they don't get inadvertently split

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -7,7 +7,7 @@
 - #2783 - Promote editor.wordWrap from experimental (fixes #1444)
 - #2774 - Extensions: Implement update check (also fixes #2748)
 - #2801 - Extensions: CodeLens - Handle multiple codelens on same line
-- #2812 - CLI: Add `+` and `-c` arguments to run Vim ex commands (fixes #1861)
+- #2812, #2842 - CLI: Add `+` and `-c` arguments to run Vim ex commands (fixes #1861, #2803)
 - #2817 - Snippets: Initial snippet parser (related #160)
 - #2818 - Vim: Initial `:!` command output implementation (fixes #1889, #1909)
 

--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,10 +1,9 @@
 ### Features
 
-- #2842 - CLI: AppImage - fix argument parsing in `AppRun` (fixes #2803)
-
 ### Bug Fixes
 
 - #2845 - Workspace: Opening a file should not always open a folder (fixes #1983)
+- #2842 - CLI: AppImage - fix argument parsing in `AppRun` (fixes #2803)
 
 ### Performance
 

--- a/scripts/linux/AppRun
+++ b/scripts/linux/AppRun
@@ -4,5 +4,5 @@ export ONI2_ORIG_PATH="$PATH"
 export ONI2_ORIG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 export PATH="${HERE}/usr/bin:$PATH"
 export LD_LIBRARY_PATH="${HERE}/usr/lib/:$LD_LIBRARY_PATH"
-${HERE}/usr/bin/Oni2 $@
+${HERE}/usr/bin/Oni2 "$@"
 


### PR DESCRIPTION
Additional fix for #2803 - the command line arguments were getting split in the AppImage's `AppRun` - this updates the script so that they continue to be grouped when they are passed to Onivim for parsing.