### PR TITLE
fix(vim/#2753): Fix tabnew/new/vnew behavior

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -38,6 +38,7 @@
 - #2822 - Build: Use development `Info.plist` that sets `NSSupportsAutomaticGraphicsSwitching` (fixes #2816)
 - #2826 - Search: Default to simple string search for find-in-files (fixes #2821)
 - #2841 - UX: Tone down shadow color for light themes
+- #2844 - Vim: Fix `:tabnew`/`:new`/`:vnew` behavior (fixes #1455, #2753, #2843)
 
 ### Performance
 

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b9c0e9fbdbd78562d3101d5626a9f6b7",
+  "checksum": "3a239db5a902f26769b360d9e46f0c70",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.81@d41d8cd9": {
-      "id": "libvim@8.10869.81@d41d8cd9",
+    "libvim@8.10869.82@d41d8cd9": {
+      "id": "libvim@8.10869.82@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.81",
+      "version": "8.10869.82",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.81.tgz#sha1:5eadf97cc49c05838bd261d2e265f1b7e5b3beb9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.82.tgz#sha1:1b8b2d7a99a6dac9caebdad625e5c6cc3673e523"
         ]
       },
       "overrides": [],
@@ -1001,7 +1001,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.81@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.82@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b9c0e9fbdbd78562d3101d5626a9f6b7",
+  "checksum": "3a239db5a902f26769b360d9e46f0c70",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.81@d41d8cd9": {
-      "id": "libvim@8.10869.81@d41d8cd9",
+    "libvim@8.10869.82@d41d8cd9": {
+      "id": "libvim@8.10869.82@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.81",
+      "version": "8.10869.82",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.81.tgz#sha1:5eadf97cc49c05838bd261d2e265f1b7e5b3beb9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.82.tgz#sha1:1b8b2d7a99a6dac9caebdad625e5c6cc3673e523"
         ]
       },
       "overrides": [],
@@ -1000,7 +1000,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.81@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.82@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b9c0e9fbdbd78562d3101d5626a9f6b7",
+  "checksum": "3a239db5a902f26769b360d9e46f0c70",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.81@d41d8cd9": {
-      "id": "libvim@8.10869.81@d41d8cd9",
+    "libvim@8.10869.82@d41d8cd9": {
+      "id": "libvim@8.10869.82@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.81",
+      "version": "8.10869.82",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.81.tgz#sha1:5eadf97cc49c05838bd261d2e265f1b7e5b3beb9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.82.tgz#sha1:1b8b2d7a99a6dac9caebdad625e5c6cc3673e523"
         ]
       },
       "overrides": [],
@@ -1000,7 +1000,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.81@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.82@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.81",
+    "libvim": "8.10869.82",
     "ocaml": "4.10.0",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#38c8f00",
     "reason-fzy": "CrossR/reason-fzy#7339d4e",
@@ -254,7 +254,6 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#dd47c70",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/package.json
+++ b/package.json
@@ -254,6 +254,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
+    "libvim": "link:../libvim/src",
     "revery": "revery-ui/revery#dd47c70",
     "esy-skia": "revery-ui/esy-skia#60e0260",
     "rench": "bryphe/rench#a976fe5",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b9c0e9fbdbd78562d3101d5626a9f6b7",
+  "checksum": "3a239db5a902f26769b360d9e46f0c70",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.81@d41d8cd9": {
-      "id": "libvim@8.10869.81@d41d8cd9",
+    "libvim@8.10869.82@d41d8cd9": {
+      "id": "libvim@8.10869.82@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.81",
+      "version": "8.10869.82",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.81.tgz#sha1:5eadf97cc49c05838bd261d2e265f1b7e5b3beb9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.82.tgz#sha1:1b8b2d7a99a6dac9caebdad625e5c6cc3673e523"
         ]
       },
       "overrides": [],
@@ -1000,7 +1000,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.81@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.82@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -415,6 +415,29 @@ module Effects = {
     });
   };
 
+  let openNewBuffer = (~font, ~languageInfo, ~split, model) => {
+    Isolinear.Effect.createWithDispatch(
+      ~name="Feature_Buffers.openNewBuffer", dispatch => {
+      let buffer = Vim.Buffer.make();
+
+      let handler = (~alreadyLoaded as _, buffer) =>
+        // if (alreadyLoaded) {
+        //   dispatch(EditorRequested({buffer, split, position, grabFocus}));
+        // } else {
+        dispatch(
+          NewBufferAndEditorRequested({
+            buffer,
+            split,
+            position: None,
+            grabFocus: true,
+          }),
+        );
+      // };
+
+      openCommon(~vimBuffer=buffer, ~languageInfo, ~font, ~model, handler);
+    });
+  };
+
   let openBufferInEditor = (~font, ~languageInfo, ~bufferId, model) => {
     Isolinear.Effect.createWithDispatch(
       ~name="Feature_Buffers.openBufferInEditor", dispatch => {

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -421,9 +421,6 @@ module Effects = {
       let buffer = Vim.Buffer.make();
 
       let handler = (~alreadyLoaded as _, buffer) =>
-        // if (alreadyLoaded) {
-        //   dispatch(EditorRequested({buffer, split, position, grabFocus}));
-        // } else {
         dispatch(
           NewBufferAndEditorRequested({
             buffer,
@@ -432,7 +429,6 @@ module Effects = {
             grabFocus: true,
           }),
         );
-      // };
 
       openCommon(~vimBuffer=buffer, ~languageInfo, ~font, ~model, handler);
     });

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -434,14 +434,13 @@ module Effects = {
     });
   };
 
-  let openBufferInEditor = (~font, ~languageInfo, ~bufferId, model) => {
+  let openBufferInEditor = (~font, ~languageInfo, ~split, ~bufferId, model) => {
     Isolinear.Effect.createWithDispatch(
       ~name="Feature_Buffers.openBufferInEditor", dispatch => {
       switch (Vim.Buffer.getById(bufferId)) {
       | None => Log.warnf(m => m("Unable to open buffer: %d", bufferId))
       | Some(vimBuffer) =>
         let handler = (~alreadyLoaded, buffer) => {
-          let split = `Current;
           let position = None;
           let grabFocus = true;
 

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -90,6 +90,15 @@ module Effects: {
     ) =>
     Isolinear.Effect.t('msg);
 
+  let openNewBuffer:
+    (
+      ~font: Service_Font.font,
+      ~languageInfo: Exthost.LanguageInfo.t,
+      ~split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      model
+    ) =>
+    Isolinear.Effect.t(msg);
+
   let openFileInEditor:
     (
       ~font: Service_Font.font,

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -115,6 +115,7 @@ module Effects: {
     (
       ~font: Service_Font.font,
       ~languageInfo: Exthost.LanguageInfo.t,
+      ~split: [ | `Current | `Horizontal | `Vertical | `NewTab],
       ~bufferId: int,
       model
     ) =>

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -90,10 +90,13 @@ type t =
   | ListSelect
   | ListSelectBackground
   | NewBuffer({direction: [ | `Current | `Horizontal | `Vertical | `NewTab]})
-  | OpenBufferById({bufferId: int})
+  | OpenBufferById({
+      bufferId: int,
+      direction: [ | `Current | `Horizontal | `Vertical | `NewTab],
+    })
   | OpenFileByPath(
       string,
-      option([ | `Horizontal | `Vertical | `NewTab]),
+      option([ | `Current | `Horizontal | `Vertical | `NewTab]),
       option(CharacterPosition.t),
     )
   | OpenConfigFile(string)

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -89,6 +89,7 @@ type t =
   | ListFocusDown
   | ListSelect
   | ListSelectBackground
+  | NewBuffer({direction: [ | `Current | `Horizontal | `Vertical | `NewTab]})
   | OpenBufferById({bufferId: int})
   | OpenFileByPath(
       string,

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -345,7 +345,13 @@ module Sub = {
 
       let name = "Service_Exthost.BufferSubscription";
       let id = params => {
-        params.buffer |> Oni_Core.Buffer.getId |> string_of_int;
+        Printf.sprintf(
+          "%d:%s",
+          params.buffer |> Oni_Core.Buffer.getId,
+          // Use the buffer path, too, so that if it changes, we subscribe to the new file
+          Buffer.getFilePath(params.buffer)
+          |> Option.value(~default="(null)"),
+        );
       };
 
       let init = (~params, ~dispatch) => {

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1254,12 +1254,13 @@ let update =
 
     (state, effect);
 
-  | OpenBufferById({bufferId}) =>
+  | OpenBufferById({bufferId, direction}) =>
     let effect =
       Feature_Buffers.Effects.openBufferInEditor(
         ~languageInfo=state.languageInfo,
         ~font=state.editorFont,
         ~bufferId,
+        ~split=direction,
         state.buffers,
       )
       |> Isolinear.Effect.map(msg => Actions.Buffers(msg));
@@ -1280,6 +1281,7 @@ let update =
     let split =
       switch (direction) {
       | None => `Current
+      | Some(`Current) => `Current
       | Some(`Horizontal) => `Horizontal
       | Some(`Vertical) => `Vertical
       | Some(`NewTab) => `NewTab

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1265,6 +1265,17 @@ let update =
       |> Isolinear.Effect.map(msg => Actions.Buffers(msg));
     (state, effect);
 
+  | NewBuffer({direction}) =>
+    let effect =
+      Feature_Buffers.Effects.openNewBuffer(
+        ~split=direction,
+        ~languageInfo=state.languageInfo,
+        ~font=state.editorFont,
+        state.buffers,
+      )
+      |> Isolinear.Effect.map(msg => Actions.Buffers(msg));
+    (state, effect);
+
   | OpenFileByPath(filePath, direction, position) =>
     let split =
       switch (direction) {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -393,37 +393,6 @@ let start =
       );
     });
 
-  // let _: unit => unit =
-  //   Vim.Window.onSplit((splitType, maybeBuffer) => {
-  // TODO: This logic needs to be revised to handle the differentation between new / split,
-  // and handling filenames in both cases.
-
-  //     /* If buf wasn't specified, use the filepath from the current buffer */
-  //     let command =
-  //       switch (maybeBuffer) {
-  //       | "" =>
-  //         Log.trace("Vim.Window.onSplit - creating new buffer.");
-  //         switch (splitType) {
-  //         | Vim.Types.Vertical => Actions.NewBuffer({direction: `Vertical})
-  //         | Vim.Types.Horizontal =>
-  //           Actions.NewBuffer({direction: `Horizontal})
-  //         | Vim.Types.TabPage => Actions.NewBuffer({direction: `NewTab})
-  //         };
-  //       | filePath =>
-  //         Log.tracef(m => m("Vim.Window.onSplit: %s", filePath));
-  //         switch (splitType) {
-  //         | Vim.Types.Vertical =>
-  //           Actions.OpenFileByPath(filePath, Some(`Vertical), None)
-  //         | Vim.Types.Horizontal =>
-  //           Actions.OpenFileByPath(filePath, Some(`Horizontal), None)
-  //         | Vim.Types.TabPage =>
-  //           Actions.OpenFileByPath(filePath, Some(`NewTab), None)
-  //         };
-  //       };
-
-  //     dispatch(command);
-  //   });
-
   let _: unit => unit =
     Vim.Buffer.onUpdate(update => {
       open Vim.BufferUpdate;

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -371,13 +371,8 @@ let start =
 
   let _: unit => unit =
     Vim.Window.onSplit((splitType, maybeBuffer) => {
-      prerr_endline("SPLIT!");
-
-      // switch (buf) {
-      // | "" => prerr_endline ("no buffer!");
-      // | b =>
-      //   prerr_endline ("PATH: " ++ b);
-      // };
+      // TODO: This logic needs to be revised to handle the differentation between new / split,
+      // and handling filenames in both cases.
 
       /* If buf wasn't specified, use the filepath from the current buffer */
       let command =

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -6,6 +6,8 @@
  * - Translates Actions into Effects that should run against vim
  */
 
+
+
 open EditorCoreTypes;
 open Oni_Model;
 
@@ -204,7 +206,9 @@ let start =
         )
 
       | MacroRecordingStopped(_) =>
-        dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped)),
+        dispatch(Actions.Vim(Feature_Vim.MacroRecordingStopped))
+
+      | WindowSplit(_split) => () // TODO
     );
 
   let _: unit => unit =
@@ -369,36 +373,36 @@ let start =
       );
     });
 
-  let _: unit => unit =
-    Vim.Window.onSplit((splitType, maybeBuffer) => {
+  // let _: unit => unit =
+  //   Vim.Window.onSplit((splitType, maybeBuffer) => {
       // TODO: This logic needs to be revised to handle the differentation between new / split,
       // and handling filenames in both cases.
 
-      /* If buf wasn't specified, use the filepath from the current buffer */
-      let command =
-        switch (maybeBuffer) {
-        | "" =>
-          Log.trace("Vim.Window.onSplit - creating new buffer.");
-          switch (splitType) {
-          | Vim.Types.Vertical => Actions.NewBuffer({direction: `Vertical})
-          | Vim.Types.Horizontal =>
-            Actions.NewBuffer({direction: `Horizontal})
-          | Vim.Types.TabPage => Actions.NewBuffer({direction: `NewTab})
-          };
-        | filePath =>
-          Log.tracef(m => m("Vim.Window.onSplit: %s", filePath));
-          switch (splitType) {
-          | Vim.Types.Vertical =>
-            Actions.OpenFileByPath(filePath, Some(`Vertical), None)
-          | Vim.Types.Horizontal =>
-            Actions.OpenFileByPath(filePath, Some(`Horizontal), None)
-          | Vim.Types.TabPage =>
-            Actions.OpenFileByPath(filePath, Some(`NewTab), None)
-          };
-        };
+  //     /* If buf wasn't specified, use the filepath from the current buffer */
+  //     let command =
+  //       switch (maybeBuffer) {
+  //       | "" =>
+  //         Log.trace("Vim.Window.onSplit - creating new buffer.");
+  //         switch (splitType) {
+  //         | Vim.Types.Vertical => Actions.NewBuffer({direction: `Vertical})
+  //         | Vim.Types.Horizontal =>
+  //           Actions.NewBuffer({direction: `Horizontal})
+  //         | Vim.Types.TabPage => Actions.NewBuffer({direction: `NewTab})
+  //         };
+  //       | filePath =>
+  //         Log.tracef(m => m("Vim.Window.onSplit: %s", filePath));
+  //         switch (splitType) {
+  //         | Vim.Types.Vertical =>
+  //           Actions.OpenFileByPath(filePath, Some(`Vertical), None)
+  //         | Vim.Types.Horizontal =>
+  //           Actions.OpenFileByPath(filePath, Some(`Horizontal), None)
+  //         | Vim.Types.TabPage =>
+  //           Actions.OpenFileByPath(filePath, Some(`NewTab), None)
+  //         };
+  //       };
 
-      dispatch(command);
-    });
+  //     dispatch(command);
+  //   });
 
   let _: unit => unit =
     Vim.Buffer.onUpdate(update => {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -370,29 +370,38 @@ let start =
     });
 
   let _: unit => unit =
-    Vim.Window.onSplit((splitType, buf) => {
+    Vim.Window.onSplit((splitType, maybeBuffer) => {
+      prerr_endline("SPLIT!");
+
+      // switch (buf) {
+      // | "" => prerr_endline ("no buffer!");
+      // | b =>
+      //   prerr_endline ("PATH: " ++ b);
+      // };
+
       /* If buf wasn't specified, use the filepath from the current buffer */
-      let buf =
-        switch (buf) {
-        | "" =>
-          switch (Vim.Buffer.getFilename(Vim.Buffer.getCurrent())) {
-          | None => ""
-          | Some(v) => v
-          }
-        | v => v
-        };
-
-      Log.trace("Vim.Window.onSplit: " ++ buf);
-
       let command =
-        switch (splitType) {
-        | Vim.Types.Vertical =>
-          Actions.OpenFileByPath(buf, Some(`Vertical), None)
-        | Vim.Types.Horizontal =>
-          Actions.OpenFileByPath(buf, Some(`Horizontal), None)
-        | Vim.Types.TabPage =>
-          Actions.OpenFileByPath(buf, Some(`NewTab), None)
+        switch (maybeBuffer) {
+        | "" =>
+          Log.trace("Vim.Window.onSplit - creating new buffer.");
+          switch (splitType) {
+          | Vim.Types.Vertical => Actions.NewBuffer({direction: `Vertical})
+          | Vim.Types.Horizontal =>
+            Actions.NewBuffer({direction: `Horizontal})
+          | Vim.Types.TabPage => Actions.NewBuffer({direction: `NewTab})
+          };
+        | filePath =>
+          Log.tracef(m => m("Vim.Window.onSplit: %s", filePath));
+          switch (splitType) {
+          | Vim.Types.Vertical =>
+            Actions.OpenFileByPath(filePath, Some(`Vertical), None)
+          | Vim.Types.Horizontal =>
+            Actions.OpenFileByPath(filePath, Some(`Horizontal), None)
+          | Vim.Types.TabPage =>
+            Actions.OpenFileByPath(filePath, Some(`NewTab), None)
+          };
         };
+
       dispatch(command);
     });
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -6,8 +6,6 @@
  * - Translates Actions into Effects that should run against vim
  */
 
-
-
 open EditorCoreTypes;
 open Oni_Model;
 
@@ -375,8 +373,8 @@ let start =
 
   // let _: unit => unit =
   //   Vim.Window.onSplit((splitType, maybeBuffer) => {
-      // TODO: This logic needs to be revised to handle the differentation between new / split,
-      // and handling filenames in both cases.
+  // TODO: This logic needs to be revised to handle the differentation between new / split,
+  // and handling filenames in both cases.
 
   //     /* If buf wasn't specified, use the filepath from the current buffer */
   //     let command =

--- a/src/reason-libvim/Buffer.re
+++ b/src/reason-libvim/Buffer.re
@@ -13,6 +13,8 @@ let loadFile = (filePath: string) => {
   Native.vimBufferLoad(filePath);
 };
 
+let make = Native.vimBufferNew;
+
 let getFilename = (buffer: t) => {
   Native.vimBufferGetFilename(buffer);
 };

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -22,4 +22,5 @@ type t =
   | Output({
       cmd: string,
       output: option(string),
-    });
+    })
+  | WindowSplit(Split.t);

--- a/src/reason-libvim/Listeners.re
+++ b/src/reason-libvim/Listeners.re
@@ -13,7 +13,6 @@ type directoryChangedListener = string => unit;
 type messageListener = (Types.msgPriority, string, string) => unit;
 type quitListener = (Types.quitType, bool) => unit;
 type windowMovementListener = (Types.windowMovementType, int) => unit;
-type windowSplitListener = (Types.windowSplitType, string) => unit;
 type yankListener = Yank.t => unit;
 type writeFailureListener = (writeFailureReason, buffer) => unit;
 type noopListener = unit => unit;
@@ -43,6 +42,5 @@ let terminalRequested: Event.t(Types.terminalRequest => unit) =
 let unhandledEscape: ref(list(noopListener)) = ref([]);
 let version: ref(list(noopListener)) = ref([]);
 let windowMovement: ref(list(windowMovementListener)) = ref([]);
-let windowSplit: ref(list(windowSplitListener)) = ref([]);
 let yank: ref(list(yankListener)) = ref([]);
 let writeFailure: ref(list(writeFailureListener)) = ref([]);

--- a/src/reason-libvim/Native.re
+++ b/src/reason-libvim/Native.re
@@ -82,6 +82,8 @@ external vimBufferGetFilename: buffer => option(string) =
 external vimBufferGetFiletype: buffer => option(string) =
   "libvim_vimBufferGetFiletype";
 
+external vimBufferNew: unit => buffer = "libvim_vimBufferNew";
+
 external vimBufferGetFileFormat: buffer => option(lineEnding) =
   "libvim_vimBufferGetFileFormat";
 external vimBufferSetFileFormat: (buffer, lineEnding) => unit =

--- a/src/reason-libvim/Split.re
+++ b/src/reason-libvim/Split.re
@@ -1,34 +1,34 @@
-type t = 
-| NewHorizontal
-| Horizontal({ filePath: option(string) } )
-| NewVertical
-| Vertical({ filePath: option(string) })
-| NewTabPage
-| TabPage({ filePath: option(string) });
+type t =
+  | NewHorizontal
+  | Horizontal({filePath: option(string)})
+  | NewVertical
+  | Vertical({filePath: option(string)})
+  | NewTabPage
+  | TabPage({filePath: option(string)});
 
 let ofNative = (splitType: Types.windowSplitType, path: string) => {
-	let hasPath = path != "";
-	switch (splitType) {
+  let hasPath = path != "";
+  switch (splitType) {
+  // Horizontal
+  | Types.HorizontalNew when !hasPath => NewHorizontal
+  | Types.HorizontalNew when hasPath => Horizontal({filePath: Some(path)})
+  | Types.Horizontal when !hasPath => Horizontal({filePath: None})
+  | Types.Horizontal when hasPath => Horizontal({filePath: Some(path)})
 
-	// Horizontal
-	| Types.HorizontalNew when !hasPath => NewHorizontal
-	| Types.HorizontalNew when hasPath => Horizontal({ filePath: Some(path)})
-	| Types.Horizontal when !hasPath => Horizontal({ filePath: None })
-	| Types.Horizontal when hasPath => Horizontal({ filePath: Some(path)})
+  // Vertical
+  | Types.VerticalNew when !hasPath => NewVertical
+  | Types.VerticalNew when hasPath => Vertical({filePath: Some(path)})
+  | Types.Vertical when !hasPath => Vertical({filePath: None})
+  | Types.Vertical when hasPath => Vertical({filePath: Some(path)})
 
-	// Vertical
-	| Types.VerticalNew when !hasPath => NewVertical
-	| Types.VerticalNew when hasPath => Vertical({ filePath: Some(path)})
-	| Types.Vertical when !hasPath => Vertical({ filePath: None })
-	| Types.Vertical when hasPath => Vertical({ filePath: Some(path)})
+  // TabPage
+  | Types.TabPageNew when !hasPath => NewTabPage
+  | Types.TabPageNew when hasPath => TabPage({filePath: Some(path)})
+  | Types.TabPage when !hasPath => TabPage({filePath: None})
+  | Types.TabPage when hasPath => TabPage({filePath: Some(path)})
 
-	// TabPage
-	| Types.TabPageNew when !hasPath => NewTabPage
-	| Types.TabPageNew when hasPath => TabPage({ filePath: Some(path)})
-	| Types.TabPage when !hasPath => TabPage({ filePath: None })
-	| Types.TabPage when hasPath => TabPage({ filePath: Some(path)})
-	
-	| _ => // This should never be hit, but the compiler doesn't know the above check is exhaustive
-		NewHorizontal
-	}
-}
+  | _ =>
+    // This should never be hit, but the compiler doesn't know the above check is exhaustive
+    NewHorizontal
+  };
+};

--- a/src/reason-libvim/Split.re
+++ b/src/reason-libvim/Split.re
@@ -1,0 +1,34 @@
+type t = 
+| NewHorizontal
+| Horizontal({ filePath: option(string) } )
+| NewVertical
+| Vertical({ filePath: option(string) })
+| NewTabPage
+| TabPage({ filePath: option(string) });
+
+let ofNative = (splitType: Types.windowSplitType, path: string) => {
+	let hasPath = path != "";
+	switch (splitType) {
+
+	// Horizontal
+	| Types.HorizontalNew when !hasPath => NewHorizontal
+	| Types.HorizontalNew when hasPath => Horizontal({ filePath: Some(path)})
+	| Types.Horizontal when !hasPath => Horizontal({ filePath: None })
+	| Types.Horizontal when hasPath => Horizontal({ filePath: Some(path)})
+
+	// Vertical
+	| Types.VerticalNew when !hasPath => NewVertical
+	| Types.VerticalNew when hasPath => Vertical({ filePath: Some(path)})
+	| Types.Vertical when !hasPath => Vertical({ filePath: None })
+	| Types.Vertical when hasPath => Vertical({ filePath: Some(path)})
+
+	// TabPage
+	| Types.TabPageNew when !hasPath => NewTabPage
+	| Types.TabPageNew when hasPath => TabPage({ filePath: Some(path)})
+	| Types.TabPage when !hasPath => TabPage({ filePath: None })
+	| Types.TabPage when hasPath => TabPage({ filePath: Some(path)})
+	
+	| _ => // This should never be hit, but the compiler doesn't know the above check is exhaustive
+		NewHorizontal
+	}
+}

--- a/src/reason-libvim/Types.re
+++ b/src/reason-libvim/Types.re
@@ -46,6 +46,7 @@ type quitType =
 type windowSplitType =
   | Horizontal
   | HorizontalNew
+  | Vertical
   | VerticalNew
   | TabPage
   | TabPageNew;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -23,6 +23,7 @@ module Goto = Goto;
 module Mapping = Mapping;
 module Operator = Operator;
 module Scroll = Scroll;
+module Split = Split;
 module TabPage = TabPage;
 module Mode = Mode;
 module SubMode = SubMode;
@@ -279,12 +280,9 @@ let _onWindowMovement = (mt, c) => {
 };
 
 let _onWindowSplit = (st, p) => {
-  queue(() => Event.dispatch2(st, p, Listeners.windowSplit));
+  queueEffect(Effect.WindowSplit(Split.ofNative(st, p)));
 };
 
-let _onWindowSplit = (st, p) => {
-  queue(() => Event.dispatch2(st, p, Listeners.windowSplit));
-};
 
 let _onYank =
     (

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -283,7 +283,6 @@ let _onWindowSplit = (st, p) => {
   queueEffect(Effect.WindowSplit(Split.ofNative(st, p)));
 };
 
-
 let _onYank =
     (
       lines,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -123,6 +123,16 @@ module Mode: {
   let cursors: t => list(BytePosition.t);
 };
 
+module Split: {
+  type t = 
+  | NewHorizontal
+  | Horizontal({ filePath: option(string) } )
+  | NewVertical
+  | Vertical({ filePath: option(string) })
+  | NewTabPage
+  | TabPage({ filePath: option(string) });
+};
+
 module SubMode: {
   type t =
     | None
@@ -498,7 +508,8 @@ module Effect: {
     | Output({
         cmd: string,
         output: option(string),
-      });
+      })
+    | WindowSplit(Split.t);
 };
 
 /**

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -124,13 +124,13 @@ module Mode: {
 };
 
 module Split: {
-  type t = 
-  | NewHorizontal
-  | Horizontal({ filePath: option(string) } )
-  | NewVertical
-  | Vertical({ filePath: option(string) })
-  | NewTabPage
-  | TabPage({ filePath: option(string) });
+  type t =
+    | NewHorizontal
+    | Horizontal({filePath: option(string)})
+    | NewVertical
+    | Vertical({filePath: option(string)})
+    | NewTabPage
+    | TabPage({filePath: option(string)});
 };
 
 module SubMode: {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -217,6 +217,8 @@ module Buffer: {
   */
   let openFile: string => t;
 
+  let make: unit => t;
+
   /**
   [loadFile(path)] opens a file and returns a handle to the buffer.
   */

--- a/src/reason-libvim/Window.re
+++ b/src/reason-libvim/Window.re
@@ -5,23 +5,8 @@ let getTopLine = Native.vimWindowGetTopLine;
 let setWidth = Native.vimWindowSetWidth;
 let setHeight = Native.vimWindowSetHeight;
 let setTopLeft = (top, left) => {
-  //  let prevTop = getTopLine();
-  //  let prevLeft = getLeftColumn();
   Native.vimWindowSetTopLeft(
     top,
     left,
-    //  let newTop = getTopLine();
-    //  let newLeft = getLeftColumn();
-    //  if (prevTop != newTop) {
-    //    Event.dispatch(newTop, Listeners.topLineChanged);
-    //  };
-    //
-    //  if (prevLeft != newLeft) {
-    //    Event.dispatch(newLeft, Listeners.leftColumnChanged);
-    //  };
   );
 };
-
-//let onLeftColumnChanged = f => Event.add(f, Listeners.leftColumnChanged);
-//let onTopLineChanged = f => Event.add(f, Listeners.topLineChanged);
-let onSplit = f => Event.add2(f, Listeners.windowSplit);

--- a/src/reason-libvim/Window.re
+++ b/src/reason-libvim/Window.re
@@ -5,8 +5,5 @@ let getTopLine = Native.vimWindowGetTopLine;
 let setWidth = Native.vimWindowSetWidth;
 let setHeight = Native.vimWindowSetHeight;
 let setTopLeft = (top, left) => {
-  Native.vimWindowSetTopLeft(
-    top,
-    left,
-  );
+  Native.vimWindowSetTopLeft(top, left);
 };

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -1079,6 +1079,14 @@ CAMLprim value libvim_vimBufferLoad(value v) {
   CAMLreturn(vbuf);
 }
 
+CAMLprim value libvim_vimBufferNew(value vUnit) {
+  CAMLparam1(vUnit);
+
+  buf_T *buf = vimBufferNew(BLN_NEW);
+  value vbuf = (value)buf;
+  CAMLreturn(vbuf);
+}
+
 CAMLprim value libvim_vimBufferGetById(value v) {
   CAMLparam1(v);
   CAMLlocal1(ret);

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "41b4a3e05d694ed93399208895837c63",
+  "checksum": "eca5ec7ea88722ce0907396ee99b733a",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -428,14 +428,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.81@d41d8cd9": {
-      "id": "libvim@8.10869.81@d41d8cd9",
+    "libvim@8.10869.82@d41d8cd9": {
+      "id": "libvim@8.10869.82@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.81",
+      "version": "8.10869.82",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.81.tgz#sha1:5eadf97cc49c05838bd261d2e265f1b7e5b3beb9"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.82.tgz#sha1:1b8b2d7a99a6dac9caebdad625e5c6cc3673e523"
         ]
       },
       "overrides": [],
@@ -1000,7 +1000,7 @@
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "reason-fzy@github:CrossR/reason-fzy#7339d4e@d41d8cd9",
-        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.81@d41d8cd9",
+        "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.82@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",

--- a/test/reason-libvim/WindowTest.re
+++ b/test/reason-libvim/WindowTest.re
@@ -39,23 +39,138 @@ describe("Window", ({describe, _}) => {
     })
   );
 
-  describe("onSplit", ({test, _}) => {
-    test("vsp creates split", ({expect, _}) => {
-      let _ = resetBuffer();
+  describe("tabpages", ({describe, test, _}) => {
+    describe(":tabnew", ({test, _}) => {
+      test("tabnew w/o file creates new tabpage", ({expect, _}) => {
+        let _ = resetBuffer();
 
-      let (_context: Context.t, effects: list(Vim.Effect.t)) =
-        command("vsp test.txt");
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("tabnew");
 
-      expect.equal(effects, [WindowSplit(Split.Vertical({filePath: Some("test.txt")}))])
+        expect.equal(effects, [WindowSplit(Split.NewTabPage)]);
+      });
+      test("tabnew w/ file creates tabpage pointing to file", ({expect, _}) => {
+        let _ = resetBuffer();
 
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("tabnew new-file-in-tab.txt");
+
+        expect.equal(
+          effects,
+          [
+            WindowSplit(
+              Split.TabPage({filePath: Some("new-file-in-tab.txt")}),
+            ),
+          ],
+        );
+      });
+      test("tabe creates new tab pages", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("tabe newtab.txt");
+
+        expect.equal(
+          effects,
+          [WindowSplit(Split.TabPage({filePath: Some("newtab.txt")}))],
+        );
+      });
+    })
+  });
+
+  describe("splits", ({describe, test, _}) => {
+    describe(":new", ({test, _}) => {
+      test("new creates new horizontal split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("new");
+
+        expect.equal(effects, [WindowSplit(Split.NewHorizontal)]);
+      });
+
+      test("new w/ path creates horizontal split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("new testnew.txt");
+
+        expect.equal(
+          effects,
+          [WindowSplit(Split.Horizontal({filePath: Some("testnew.txt")}))],
+        );
+      });
     });
 
-    test("sp creates split", ({expect, _}) => {
-      let _ = resetBuffer();
+    describe(":vnew", ({test, _}) => {
+      test("vnew creates new vertical split", ({expect, _}) => {
+        let _ = resetBuffer();
 
-      let (_context: Context.t, effects: list(Vim.Effect.t)) =
-        command("sp test2.txt");
-      expect.equal(effects, [WindowSplit(Split.Horizontal({filePath: Some("test2.txt")}))])
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("vnew");
+
+        expect.equal(effects, [WindowSplit(Split.NewVertical)]);
+      });
+
+      test("vnew w/ path creates horizontal split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("vnew testvnew.txt");
+
+        expect.equal(
+          effects,
+          [WindowSplit(Split.Vertical({filePath: Some("testvnew.txt")}))],
+        );
+      });
+    });
+
+    describe(":vsp", ({test, _}) => {
+      test("vsp w/ argument creates split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("vsp test.txt");
+
+        expect.equal(
+          effects,
+          [WindowSplit(Split.Vertical({filePath: Some("test.txt")}))],
+        );
+      });
+      test("vsp w/o argument creates split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("vsp");
+
+        expect.equal(
+          effects,
+          [WindowSplit(Split.Vertical({filePath: None}))],
+        );
+      });
+    });
+
+    describe(":sp", ({test, _}) => {
+      test("sp creates split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("sp test2.txt");
+        expect.equal(
+          effects,
+          [WindowSplit(Split.Horizontal({filePath: Some("test2.txt")}))],
+        );
+      });
+      test("sp w/o argument creates split", ({expect, _}) => {
+        let _ = resetBuffer();
+
+        let (_context: Context.t, effects: list(Vim.Effect.t)) =
+          command("sp");
+        expect.equal(
+          effects,
+          [WindowSplit(Split.Horizontal({filePath: None}))],
+        );
+      });
     });
 
     test("<C-w>v creates split, with same buffer", ({expect, _}) => {
@@ -65,7 +180,10 @@ describe("Window", ({describe, _}) => {
 
       key("<c-w>");
       let (_context: Context.t, effects) = Vim.input("v");
-      expect.equal(effects, [WindowSplit(Split.Vertical({filePath: filePath}))])
+      expect.equal(
+        effects,
+        [WindowSplit(Split.Vertical({filePath: filePath}))],
+      );
 
       let newBuf = Vim.Buffer.getCurrent();
 
@@ -79,7 +197,10 @@ describe("Window", ({describe, _}) => {
       key("<c-w>");
       let (_context, effects) = Vim.input("s");
 
-      expect.equal(effects, [WindowSplit(Split.Horizontal({filePath: filePath}))])
+      expect.equal(
+        effects,
+        [WindowSplit(Split.Horizontal({filePath: filePath}))],
+      );
 
       let newBuf = Vim.Buffer.getCurrent();
       expect.int(Vim.Buffer.getId(newBuf)).toBe(Vim.Buffer.getId(buf));

--- a/test/reason-libvim/WindowTest.re
+++ b/test/reason-libvim/WindowTest.re
@@ -43,93 +43,46 @@ describe("Window", ({describe, _}) => {
     test("vsp creates split", ({expect, _}) => {
       let _ = resetBuffer();
 
-      let splits = ref([]);
-      let dispose =
-        Window.onSplit((splitType, name) =>
-          splits := [(splitType, name), ...splits^]
-        );
-
-      let (_context: Context.t, _effects: list(Vim.Effect.t)) =
+      let (_context: Context.t, effects: list(Vim.Effect.t)) =
         command("vsp test.txt");
 
-      expect.int(List.length(splits^)).toBe(1);
+      expect.equal(effects, [WindowSplit(Split.Vertical({filePath: Some("test.txt")}))])
 
-      let (splitType, name) = List.hd(splits^);
-
-      expect.bool(splitType == Types.Vertical).toBe(true);
-      expect.string(name).toEqual("test.txt");
-
-      dispose();
     });
 
     test("sp creates split", ({expect, _}) => {
       let _ = resetBuffer();
 
-      let splits = ref([]);
-      let dispose =
-        Window.onSplit((splitType, name) =>
-          splits := [(splitType, name), ...splits^]
-        );
-
-      let (_context: Context.t, _effects: list(Vim.Effect.t)) =
+      let (_context: Context.t, effects: list(Vim.Effect.t)) =
         command("sp test2.txt");
-
-      expect.int(List.length(splits^)).toBe(1);
-
-      let (splitType, name) = List.hd(splits^);
-
-      expect.bool(splitType == Types.Horizontal).toBe(true);
-      expect.string(name).toEqual("test2.txt");
-
-      dispose();
+      expect.equal(effects, [WindowSplit(Split.Horizontal({filePath: Some("test2.txt")}))])
     });
 
     test("<C-w>v creates split, with same buffer", ({expect, _}) => {
       let buf = resetBuffer();
 
-      let splits = ref([]);
-      let dispose =
-        Window.onSplit((splitType, name) =>
-          splits := [(splitType, name), ...splits^]
-        );
+      let filePath = Buffer.getFilename(buf);
 
       key("<c-w>");
-      input("v");
-
-      expect.int(List.length(splits^)).toBe(1);
-
-      let (splitType, _) = List.hd(splits^);
+      let (_context: Context.t, effects) = Vim.input("v");
+      expect.equal(effects, [WindowSplit(Split.Vertical({filePath: filePath}))])
 
       let newBuf = Vim.Buffer.getCurrent();
 
-      expect.bool(splitType == Types.Vertical).toBe(true);
       expect.int(Vim.Buffer.getId(newBuf)).toBe(Vim.Buffer.getId(buf));
-
-      dispose();
     });
 
     test("<C-w>s creates split, with same buffer", ({expect, _}) => {
       let buf = resetBuffer();
-
-      let splits = ref([]);
-      let dispose =
-        Window.onSplit((splitType, name) =>
-          splits := [(splitType, name), ...splits^]
-        );
+      let filePath = Buffer.getFilename(buf);
 
       key("<c-w>");
-      input("s");
+      let (_context, effects) = Vim.input("s");
 
-      expect.int(List.length(splits^)).toBe(1);
-
-      let (splitType, _) = List.hd(splits^);
+      expect.equal(effects, [WindowSplit(Split.Horizontal({filePath: filePath}))])
 
       let newBuf = Vim.Buffer.getCurrent();
-
-      expect.bool(splitType == Types.Horizontal).toBe(true);
       expect.int(Vim.Buffer.getId(newBuf)).toBe(Vim.Buffer.getId(buf));
-
-      dispose();
     });
   });
 });

--- a/test/reason-libvim/WindowTest.re
+++ b/test/reason-libvim/WindowTest.re
@@ -39,7 +39,7 @@ describe("Window", ({describe, _}) => {
     })
   );
 
-  describe("tabpages", ({describe, test, _}) => {
+  describe("tabpages", ({describe, _}) => {
     describe(":tabnew", ({test, _}) => {
       test("tabnew w/o file creates new tabpage", ({expect, _}) => {
         let _ = resetBuffer();


### PR DESCRIPTION
__Issue:__ The various new-buffer commands (`tabnew`, `new`, `vnew`) weren't creating a new buffer - they were splitting the existing buffer (behaving more like `vsp`, `sp`, etc).

__Defect:__ We weren't differentiating between `vsp` and `vnew` (and others) - we were treating them equivalently.

__Fix:__ Differentiate them in `libvim` - requires https://github.com/onivim/libvim/pull/254 . Then, handle creating and using new buffers.

__TODO:__
- [x] Update the variant for split types in `bindings.c`
- [x] Add test case for `tabnew` and `new` w/o filenames, and with filenames
- [x] Verify previous `sp`, `vsp`, and `tabedit` works as expected, w/ and w/o filenames specified
- [x] Publish libvim with https://github.com/onivim/libvim/pull/254 
- [x] Fix language services / text model sync when `:new` and then switching filetype

Fixes #1455
Fixes #2753 
Fixes #2843 