### PR TITLE
fix(workspace/#1983): Open single file should not open folder, too

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+- #2845 - Workspace: Opening a file should not always open a folder (fixes #1983)
+
 ### Performance
 
 ### Documentation

--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -263,10 +263,6 @@ let parse = (~getenv: string => option(string), args) => {
     switch (directories) {
     | [first, ..._] => Some(first)
     | [] => None
-    // switch (filesToOpen) {
-    // | [first, ..._] => Some(Rench.Path.dirname(first))
-    // | [] => None
-    // }
     };
 
   let cli = {

--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -262,11 +262,11 @@ let parse = (~getenv: string => option(string), args) => {
   let folder =
     switch (directories) {
     | [first, ..._] => Some(first)
-    | [] =>
-      switch (filesToOpen) {
-      | [first, ..._] => Some(Rench.Path.dirname(first))
-      | [] => None
-      }
+    | [] => None
+    // switch (filesToOpen) {
+    // | [first, ..._] => Some(Rench.Path.dirname(first))
+    // | [] => None
+    // }
     };
 
   let cli = {

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -76,8 +76,15 @@ switch (eff) {
   let initWorkspace = () => {
     let maybePath =
       switch (Oni_CLI.(cliOptions.folder)) {
+      // If a folder was specified, we should for sure use that
       | Some(folder) => Some(folder)
-      | None => Store.Persistence.Global.workspace()
+
+      // If no files were specified, we can pull from persistence
+      | None when cliOptions.filesToOpen == [] =>
+        Store.Persistence.Global.workspace()
+
+      // If files were specified (#1983), don't open workspace from persistence
+      | None => None
       };
 
     let couldChangeDirectory = ref(false);

--- a/test/Cli/CliTest.re
+++ b/test/Cli/CliTest.re
@@ -33,7 +33,15 @@ describe("CLI", ({describe, test, _}) => {
         Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "README.md"|]);
       expect.equal(eff, Run);
       expect.equal(options.filesToOpen |> List.length, 1);
-    })
+    });
+
+    test("#1983: Specifying a file should not open a folder", ({expect, _}) => {
+      let (options, eff) =
+        Oni_CLI.parse(~getenv=noenv, [|"Oni2_editor", "some-file.md"|]);
+      expect.equal(eff, Run);
+      expect.equal(options.filesToOpen |> List.length, 1);
+      expect.equal(options.folder, None);
+    });
   });
   describe("syntax server", ({test, _}) => {
     test("Syntax server with PID", ({expect, _}) => {


### PR DESCRIPTION
__Issue:__ Opening a single file should be quick and not incur the extra overhead of opening a folder / workspace (ie, initializing our SCM providers in the extension host). Now that we have a no-workspace-opened state, this can be fixed.

__Fix:__ Don't set a folder when a file is specified

Fixes #1983