### PR TITLE
fix: Tab bug

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -6,6 +6,7 @@
 - #2842 - CLI: AppImage - fix argument parsing in `AppRun` (fixes #2803)
 - #2839 - Extensions: CodeLens - fix lens persisting when line is deleted
 - #2844 - Vim: Fix `:tabnew`/`:new`/`:vnew` behavior (fixes #1455, #2753, #2843)
+- #2846 - UX: Editor Tabs - horizontal scrolling on trackpad is reversed (thanks @SeitaHigashi!)
 
 ### Performance
 

--- a/src/Components/Tabs.re
+++ b/src/Components/Tabs.re
@@ -96,7 +96,7 @@ let make =
       setScrollLeft(actualScrollLeft => {
         let newScrollLeft =
           actualScrollLeft
-          - int_of_float((wheelEvent.deltaX +. wheelEvent.deltaY) *. 25.);
+          - int_of_float((-. wheelEvent.deltaX +. wheelEvent.deltaY) *. 25.);
 
         newScrollLeft |> max(0) |> min(maxOffset);
       });


### PR DESCRIPTION
Fixed the problem that the left and right scroll directions are reversed on the trackpad.

When I was using onivim on my Mac, I noticed that the scrolling of the tabs was reversed to the left and right of the trackpad. This means that you are not aware that you are using a mouse that only scrolls up and down.
I can't check it with OS other than mac, so it would be helpful if you could check it.