### PR TITLE
refactor(infra): Fix versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.5.1
+## 0.5.2 (Jan 2021)
 
 ### Features
 
@@ -59,7 +59,7 @@
 - #2759 - Fix `esy @release run` command on CI (thanks @zbaylin)
 - #2831 - Upgrade `ocaml-lsp` to 966a28f
 
-## 0.5.1
+## 0.5.1 (Dec 2020)
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Oni2",
-  "version": "0.5.2-nightly",
+  "version": "0.5.9-nightly",
   "description": "Lightweight code editor",
   "license": "SEE LICENSE IN Outrun-Labs-EULA-v1.1.md",
   "esy": {

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -134,7 +134,11 @@ let%component make = (~theme, ~uiFont: UiFont.t, ~editorFont, ()) => {
           style={Styles.version(~theme)}
           fontFamily={uiFont.family}
           fontSize=12.
-          text={Printf.sprintf("Version %s", Oni_Core.BuildInfo.version)}
+          text={Printf.sprintf(
+            "Version %s | %s",
+            Oni_Core.BuildInfo.version,
+            Oni_Core.BuildInfo.commitId,
+          )}
         />
       </View>
       <View style=Styles.controls>


### PR DESCRIPTION
Some tweaking to help facilitate monthly releases soon - `0.5.9-nightly` will be the current working build, and we'll ship `0.5.1` (december), `0.5.2` (january), etc, off of that - working towards the goals on the [timeline](https://v2.onivim.io/index.html#timeline) for `0.6.0.`