### PR TITLE
refactor(keybindings): Add API to query current bindings & consumed keys

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -14,3 +14,5 @@
 
 ### Infrastructure / Refactoring
 
+- #2853 - Input: Add APIs for querying contextually available bindings and consumed keys
+

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -34,6 +34,7 @@ module IntMap = Kernel.IntMap;
 module IntSet = Kernel.IntSet;
 module Json = Json;
 module Job = Job;
+module KeyedStringMap = Kernel.KeyedStringMap;
 module LanguageConfiguration = LanguageConfiguration;
 module LazyLoader = LazyLoader;
 module LineNumber = LineNumber;

--- a/src/Core/WhenExpr/ContextKeys.re
+++ b/src/Core/WhenExpr/ContextKeys.re
@@ -98,9 +98,3 @@ let values = lookup =>
 let getValue = (lookup, key) =>
   Lookup.find_opt(Lookup.key(key), lookup)
   |> Option.value(~default=Value.False);
-
-let values = lookup =>
-  lookup
-  |> Lookup.to_seq
-  |> Seq.map(((key, value)) => (Kernel.KeyedStringMap.keyName(key), value))
-  |> List.of_seq;

--- a/src/Core/WhenExpr/ContextKeys.re
+++ b/src/Core/WhenExpr/ContextKeys.re
@@ -98,3 +98,9 @@ let values = lookup =>
 let getValue = (lookup, key) =>
   Lookup.find_opt(Lookup.key(key), lookup)
   |> Option.value(~default=Value.False);
+
+let values = lookup =>
+  lookup
+  |> Lookup.to_seq
+  |> Seq.map(((key, value)) => (Kernel.KeyedStringMap.keyName(key), value))
+  |> List.of_seq;

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -4,6 +4,13 @@ open Oni_Core;
 open Utility;
 module Log = (val Log.withNamespace("Oni2.Feature.Input"));
 
+let keyCodeToString=Sdl2.Keycode.getName;
+
+let keyPressToString = EditorInput.KeyPress.toString(
+  ~meta="Meta",
+  ~keyCodeToString
+);
+
 // CONFIGURATION
 module Configuration = {
   open Oni_Core;
@@ -191,7 +198,6 @@ type effect =
 
 let keyCodeToString = Sdl2.Keycode.getName;
 
-let keyPressToString = EditorInput.KeyPress.toString(~keyCodeToString);
 
 let keyDown =
     (
@@ -263,6 +269,14 @@ let keyUp = (~config, ~key, ~context, {inputStateMachine, _} as model) => {
     InputStateMachine.keyUp(~leaderKey, ~key, ~context, inputStateMachine);
   ({...model, inputStateMachine: inputStateMachine'}, effects);
 };
+
+let candidates = (~config, ~context, {inputStateMachine, _}) => {
+  let leaderKey = Configuration.leaderKey.get(config);
+  InputStateMachine.candidates(~leaderKey, ~context, inputStateMachine);
+}
+
+let consumedKeys =({inputStateMachine, _}) => inputStateMachine
+|> InputStateMachine.consumedKeys;
 
 let addKeyBinding = (~binding, {inputStateMachine, _} as model) => {
   open Schema;
@@ -525,4 +539,24 @@ module View = {
       };
     };
   };
+
+  module Matcher = {
+      open EditorInput;
+      open EditorInput.Matcher;
+    let make = (~matcher: EditorInput.Matcher.t, ~font: UiFont.t, ()) => {
+      switch (matcher) {
+      | AllKeysReleased => React.empty
+      | Sequence(matchers) =>
+        let text = matchers
+        |> List.map(KeyPress.toString(
+          ~keyCodeToString,
+        ))
+        |> String.concat(", ");
+        <Text
+          text
+          fontFamily=font.family
+          fontSize=font.size />
+      }
+    }
+  }
 };

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -4,12 +4,10 @@ open Oni_Core;
 open Utility;
 module Log = (val Log.withNamespace("Oni2.Feature.Input"));
 
-let keyCodeToString=Sdl2.Keycode.getName;
+let keyCodeToString = Sdl2.Keycode.getName;
 
-let keyPressToString = EditorInput.KeyPress.toString(
-  ~meta="Meta",
-  ~keyCodeToString
-);
+let keyPressToString =
+  EditorInput.KeyPress.toString(~meta="Meta", ~keyCodeToString);
 
 // CONFIGURATION
 module Configuration = {
@@ -198,7 +196,6 @@ type effect =
 
 let keyCodeToString = Sdl2.Keycode.getName;
 
-
 let keyDown =
     (
       ~config,
@@ -273,10 +270,10 @@ let keyUp = (~config, ~key, ~context, {inputStateMachine, _} as model) => {
 let candidates = (~config, ~context, {inputStateMachine, _}) => {
   let leaderKey = Configuration.leaderKey.get(config);
   InputStateMachine.candidates(~leaderKey, ~context, inputStateMachine);
-}
+};
 
-let consumedKeys =({inputStateMachine, _}) => inputStateMachine
-|> InputStateMachine.consumedKeys;
+let consumedKeys = ({inputStateMachine, _}) =>
+  inputStateMachine |> InputStateMachine.consumedKeys;
 
 let addKeyBinding = (~binding, {inputStateMachine, _} as model) => {
   open Schema;
@@ -541,22 +538,18 @@ module View = {
   };
 
   module Matcher = {
-      open EditorInput;
-      open EditorInput.Matcher;
+    open EditorInput;
+    open EditorInput.Matcher;
     let make = (~matcher: EditorInput.Matcher.t, ~font: UiFont.t, ()) => {
       switch (matcher) {
       | AllKeysReleased => React.empty
       | Sequence(matchers) =>
-        let text = matchers
-        |> List.map(KeyPress.toString(
-          ~keyCodeToString,
-        ))
-        |> String.concat(", ");
-        <Text
-          text
-          fontFamily=font.family
-          fontSize=font.size />
-      }
-    }
-  }
+        let text =
+          matchers
+          |> List.map(KeyPress.toString(~keyCodeToString))
+          |> String.concat(", ");
+        <Text text fontFamily={font.family} fontSize={font.size} />;
+      };
+    };
+  };
 };

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -63,8 +63,8 @@ let keyDown:
 let text:
   (~text: string, ~time: Revery.Time.t, model) => (model, list(effect));
 
-let candidates: (~config: Config.resolver, 
-  ~context: WhenExpr.ContextKeys.t, model) => 
+let candidates:
+  (~config: Config.resolver, ~context: WhenExpr.ContextKeys.t, model) =>
   list((EditorInput.Matcher.t, execute));
 
 let keyPressToString: EditorInput.KeyPress.t => string;
@@ -84,7 +84,6 @@ type uniqueId;
 
 let addKeyBinding:
   (~binding: Schema.resolvedKeybinding, model) => (model, uniqueId);
-
 
 let remove: (uniqueId, model) => model;
 
@@ -117,8 +116,8 @@ module View: {
   };
 
   module Matcher: {
-    let make: 
-    (~matcher: EditorInput.Matcher.t, ~font: UiFont.t, unit) =>
-    Revery.UI.element;
-  }
+    let make:
+      (~matcher: EditorInput.Matcher.t, ~font: UiFont.t, unit) =>
+      Revery.UI.element;
+  };
 };

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -63,6 +63,14 @@ let keyDown:
 let text:
   (~text: string, ~time: Revery.Time.t, model) => (model, list(effect));
 
+let candidates: (~config: Config.resolver, 
+  ~context: WhenExpr.ContextKeys.t, model) => 
+  list((EditorInput.Matcher.t, execute));
+
+let keyPressToString: EditorInput.KeyPress.t => string;
+
+let consumedKeys: model => list(EditorInput.KeyPress.t);
+
 let keyUp:
   (
     ~config: Config.resolver,
@@ -76,6 +84,7 @@ type uniqueId;
 
 let addKeyBinding:
   (~binding: Schema.resolvedKeybinding, model) => (model, uniqueId);
+
 
 let remove: (uniqueId, model) => model;
 
@@ -106,4 +115,10 @@ module View: {
       (~input: model, ~uiFont: UiFont.t, ~bottom: int, ~right: int, unit) =>
       Revery.UI.element;
   };
+
+  module Matcher: {
+    let make: 
+    (~matcher: EditorInput.Matcher.t, ~font: UiFont.t, unit) =>
+    Revery.UI.element;
+  }
 };

--- a/src/UI/DebugInputView.re
+++ b/src/UI/DebugInputView.re
@@ -5,6 +5,7 @@
  */
 
 open Revery.UI;
+open Revery.UI.Components;
 
 module Model = Oni_Model;
 
@@ -13,12 +14,15 @@ module Colors = Feature_Theme.Colors;
 module Styles = {
   open Style;
 
-  let row = [flexDirection(`Row)];
+  let row = [flexDirection(`Row), flexGrow(1)];
 
-  let column = [flexDirection(`Column)];
+  let column = [flexDirection(`Column), flexGrow(1)];
+
+  let section = [padding(16)];
 };
 
 let make = (~state: Model.State.t, ()) => {
+  let context=Model.ContextKeys.all(state);
   let contextKeys =
     Model.ContextKeys.all(state)
     |> WhenExpr.ContextKeys.values
@@ -29,8 +33,32 @@ let make = (~state: Model.State.t, ()) => {
     |> List.map(text => <Text text />)
     |> React.listToElement;
 
-  <View style=Styles.row>
-    <View style=Styles.column>
+  let config = Model.Selectors.configResolver(state);
+
+  let availableBindings = 
+    Feature_Input.candidates(~config, ~context, state.input);
+
+  let bindingElems = availableBindings
+  |> List.map(((matcher, command)) => {
+    let cmd = switch (command) {
+    | Feature_Input.VimExCommand(ex) => ex
+    | Feature_Input.NamedCommand(cmd) => cmd
+    };
+    <View style=Styles.row>
+    <View style=Style.[marginHorizontal(8)]>
+      <Feature_Input.View.Matcher matcher font={state.uiFont} />
+    </View>
+      <Text text=cmd />
+    </View>
+  })
+  |> React.listToElement;
+
+  let consumedKeys = Feature_Input.consumedKeys(state.input)
+  |> List.map(Feature_Input.keyPressToString)
+  |> String.concat(", ");
+
+  <ScrollView style=Styles.row>
+    <View style=Styles.section>
       <Text
         text={
           "Focus: "
@@ -40,5 +68,13 @@ let make = (~state: Model.State.t, ()) => {
       <Text text="Context Keys:" />
       contextKeys
     </View>
-  </View>;
+    <View style=Styles.section>
+      <Text text="Consumed keys:" />
+      <Text text=consumedKeys />
+    </View>
+    <View style=Styles.section>
+      <Text text="Available bindings:" />
+      bindingElems
+    </View>
+  </ScrollView>;
 };

--- a/src/UI/DebugInputView.re
+++ b/src/UI/DebugInputView.re
@@ -22,7 +22,7 @@ module Styles = {
 };
 
 let make = (~state: Model.State.t, ()) => {
-  let context=Model.ContextKeys.all(state);
+  let context = Model.ContextKeys.all(state);
   let contextKeys =
     Model.ContextKeys.all(state)
     |> WhenExpr.ContextKeys.values
@@ -35,27 +35,30 @@ let make = (~state: Model.State.t, ()) => {
 
   let config = Model.Selectors.configResolver(state);
 
-  let availableBindings = 
+  let availableBindings =
     Feature_Input.candidates(~config, ~context, state.input);
 
-  let bindingElems = availableBindings
-  |> List.map(((matcher, command)) => {
-    let cmd = switch (command) {
-    | Feature_Input.VimExCommand(ex) => ex
-    | Feature_Input.NamedCommand(cmd) => cmd
-    };
-    <View style=Styles.row>
-    <View style=Style.[marginHorizontal(8)]>
-      <Feature_Input.View.Matcher matcher font={state.uiFont} />
-    </View>
-      <Text text=cmd />
-    </View>
-  })
-  |> React.listToElement;
+  let bindingElems =
+    availableBindings
+    |> List.map(((matcher, command)) => {
+         let cmd =
+           switch (command) {
+           | Feature_Input.VimExCommand(ex) => ex
+           | Feature_Input.NamedCommand(cmd) => cmd
+           };
+         <View style=Styles.row>
+           <View style=Style.[marginHorizontal(8)]>
+             <Feature_Input.View.Matcher matcher font={state.uiFont} />
+           </View>
+           <Text text=cmd />
+         </View>;
+       })
+    |> React.listToElement;
 
-  let consumedKeys = Feature_Input.consumedKeys(state.input)
-  |> List.map(Feature_Input.keyPressToString)
-  |> String.concat(", ");
+  let consumedKeys =
+    Feature_Input.consumedKeys(state.input)
+    |> List.map(Feature_Input.keyPressToString)
+    |> String.concat(", ");
 
   <ScrollView style=Styles.row>
     <View style=Styles.section>

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -176,7 +176,8 @@ module type Input = {
 
   // [candidates] returns a list of available matcher / command
   // candidates, based on the current context and input state.
-  let candidates: (~leaderKey: option(PhysicalKey.t), ~context: context, t) =>
+  let candidates:
+    (~leaderKey: option(PhysicalKey.t), ~context: context, t) =>
     list((Matcher.t, command));
 
   // [consumedKeys(model)] returns a list of keys

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -174,6 +174,15 @@ module type Input = {
     ) =>
     (t, list(effect));
 
+  // [candidates] returns a list of available matcher / command
+  // candidates, based on the current context and input state.
+  let candidates: (~leaderKey: option(PhysicalKey.t), ~context: context, t) =>
+    list((Matcher.t, command));
+
+  // [consumedKeys(model)] returns a list of keys
+  // that are currently consumed by the state machine.
+  let consumedKeys: t => list(KeyPress.t);
+
   let remove: (uniqueId, t) => t;
 
   /**

--- a/src/editor-input/KeyPress.re
+++ b/src/editor-input/KeyPress.re
@@ -110,7 +110,7 @@ let toString = (~meta="Meta", ~keyCodeToString, key) => {
     Printf.sprintf("Special(%s)", SpecialKey.show(special))
   | PhysicalKey({keycode, modifiers, _}) =>
     let buffer = Buffer.create(16);
-    let separator = " + ";
+    let separator = "+";
 
     let keyString = keyCodeToString(keycode);
 


### PR DESCRIPTION
This refactors the `EditorInput` and `Feature_Input` modules to expose some additional information, answering the questions:
- What keybindings are currently available, given my context?
- What keys are currently consumed?

This will be useful in a couple ways:
- For the menu work in #2849 - this API can be used to dynamically look up shortcut keys
- For a feature like https://github.com/onivim/oni2/issues/756 , we can show a set of available bindings (just need to decide on the best UX) - useful as a learning feature
- For supercharging sneak (Control+g) - in cases where the gesture would map to a bound command, we could show the shortcut key for it - helping to teach some of the Onivim-specific shortcut keys.

This isn't surfaced, yet, although some of the information is available in the (ugly...) debug input view:
![2020-12-16 15 56 58](https://user-images.githubusercontent.com/13532591/102420651-7df97e80-3fb7-11eb-9758-6623bf162732.gif)

Note that when I press `Control+w`, the list of available bindings is refined to the ones available with a subsequent key press. Likewise, in insert mode, I have a binding for `jj` -> `Escape`. So I think taking this information, augmenting it with some of the built-in Vim keybindings, and bubbling it up to the user in a more useful way could help ease the learning curve
