### PR TITLE
fix(codelens): Improve resolve strategy

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -10,7 +10,7 @@
 
 ### Performance
 
-- #2852 - Performance: Batch editor / codelens animations
+- #2852,#2864 - Performance: Batch editor / codelens animations
 
 ### Documentation
 

--- a/src/Core/Utility/LwtEx.re
+++ b/src/Core/Utility/LwtEx.re
@@ -1,4 +1,9 @@
-let all = (~initial: 'acc, join: ('acc, 'cur) => 'acc, promises: list(Lwt.t('cur))) => {
+let all =
+    (
+      ~initial: 'acc,
+      join: ('acc, 'cur) => 'acc,
+      promises: list(Lwt.t('cur)),
+    ) => {
   List.fold_left(
     (accPromise, promise) => {
       let%lwt acc = accPromise;

--- a/src/Core/Utility/LwtEx.re
+++ b/src/Core/Utility/LwtEx.re
@@ -1,11 +1,11 @@
-let all = (join: ('a, 'a) => 'a, promises: list(Lwt.t('a))) => {
+let all = (~initial: 'acc, join: ('acc, 'cur) => 'acc, promises: list(Lwt.t('cur))) => {
   List.fold_left(
     (accPromise, promise) => {
       let%lwt acc = accPromise;
       let%lwt curr = promise;
       Lwt.return(join(acc, curr));
     },
-    Lwt.return([]),
+    Lwt.return(initial),
     promises,
   );
 };
@@ -22,7 +22,7 @@ let some = (~default: 'a, join: ('a, 'a) => 'a, promises: list(Lwt.t('a))) => {
        | _exn => Lwt.return(default)
        }
      })
-  |> all(join);
+  |> all(~initial=[], join);
 };
 
 let flatMap = (f, promise) => Lwt.bind(promise, f);

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -894,7 +894,6 @@ let setInlineElements = (~key, ~elements: list(inlineElement), editor) => {
 };
 
 let replaceInlineElements = (~key, ~startLine, ~stopLine, ~elements, editor) => {
-  
   // TODO
   ignore(startLine);
   ignore(stopLine);

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -883,6 +883,34 @@ let setInlineElements = (~key, ~elements: list(inlineElement), editor) => {
      );
 };
 
+let replaceInlineElements = (~key, ~startLine, ~stopLine, ~elements, editor) => {
+  
+  // TODO
+  ignore(startLine);
+  ignore(stopLine);
+
+  let elements': list(InlineElements.element) =
+    elements
+    |> List.map((inlineElement: inlineElement) =>
+         InlineElements.{
+           key: inlineElement.key,
+           uniqueId: inlineElement.uniqueId,
+           line: inlineElement.lineNumber,
+           height: Component_Animation.make(Animation.expand(0., 0.)),
+           view: inlineElement.view,
+           opacity: Component_Animation.make(Animation.fadeIn),
+         }
+       );
+  editor
+  |> withSteadyCursor(e =>
+       {
+         ...e,
+         inlineElements:
+           InlineElements.set(~key, ~elements=elements', e.inlineElements),
+       }
+     );
+};
+
 let selectionOrCursorRange = editor => {
   switch (selection(editor)) {
   | None =>

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -167,6 +167,10 @@ let overrideAnimation = (~animated, editor) => {
   isAnimationOverride: animated,
 };
 
+let isAnimatingScroll = ({scrollX, scrollY, _}) => {
+  Spring.isActive(scrollX) || Spring.isActive(scrollY);
+};
+
 let getBufferLineCount = ({buffer, _}) =>
   EditorBuffer.numberOfLines(buffer);
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -40,11 +40,15 @@ let makeInlineElement:
 
 let setInlineElements: (~key: string, ~elements: list(inlineElement), t) => t;
 
-let replaceInlineElements: (
-  ~key: string,
-~startLine: EditorCoreTypes.LineNumber.t,
-~stopLine: EditorCoreTypes.LineNumber.t,  ~elements: list(inlineElement), t) => t;
-
+let replaceInlineElements:
+  (
+    ~key: string,
+    ~startLine: EditorCoreTypes.LineNumber.t,
+    ~stopLine: EditorCoreTypes.LineNumber.t,
+    ~elements: list(inlineElement),
+    t
+  ) =>
+  t;
 
 let setInlineElementSize:
   (

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -40,6 +40,12 @@ let makeInlineElement:
 
 let setInlineElements: (~key: string, ~elements: list(inlineElement), t) => t;
 
+let replaceInlineElements: (
+  ~key: string,
+~startLine: EditorCoreTypes.LineNumber.t,
+~stopLine: EditorCoreTypes.LineNumber.t,  ~elements: list(inlineElement), t) => t;
+
+
 let setInlineElementSize:
   (
     ~allowAnimation: bool=?,

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -87,6 +87,8 @@ let setMode: (Vim.Mode.t, t) => t;
 
 let getBufferLineCount: t => int;
 
+let isAnimatingScroll: t => bool;
+
 let getTokenAt:
   (~languageConfiguration: LanguageConfiguration.t, CharacterPosition.t, t) =>
   option(CharacterRange.t);

--- a/src/Feature/LanguageSupport/CodeLens.re
+++ b/src/Feature/LanguageSupport/CodeLens.re
@@ -229,7 +229,14 @@ let update = (msg, model) =>
 // SUBSCRIPTION
 
 module Sub = {
-  let create = (~visibleBuffers, ~visibleBuffersAndRanges, ~client, model) => {
+  let create =
+      (
+        ~topVisibleBufferLine,
+        ~bottomVisibleBufferLine,
+        ~visibleBuffers,
+        ~client,
+        model,
+      ) => {
     let codeLenses =
       visibleBuffers
       |> List.map(buffer => {
@@ -251,8 +258,8 @@ module Sub = {
                 Service_Exthost.Sub.codeLenses(
                   ~handle,
                   ~buffer,
-                  ~startLine=EditorCoreTypes.LineNumber.zero,
-                  ~stopLine=EditorCoreTypes.LineNumber.(zero + 1000),
+                  ~startLine=topVisibleBufferLine,
+                  ~stopLine=bottomVisibleBufferLine,
                   ~toMsg,
                   client,
                 );
@@ -260,70 +267,31 @@ module Sub = {
          })
       |> List.flatten;
 
-    // let codeLensResolve =
-    //   visibleBuffersAndRanges
-    //   |> List.map(((bufferId, ranges: list(EditorCoreTypes.Range.t))) => {
-    //        let lenses =
-    //          model.bufferToUnresolvedLenses
-    //          |> IntMap.find_opt(bufferId)
-    //          |> Option.value(~default=[]);
-
-    //        lenses
-    //        |> List.filter_map(((handle, lens)) => {
-    //             let toMsg = maybeLens => {
-    //               switch (maybeLens) {
-    //               | Ok(resolvedLens) =>
-    //                 CodeLensResolved({
-    //                   handle,
-    //                   bufferId,
-    //                   oldLens: lens,
-    //                   resolvedLens,
-    //                 })
-    //               | Error(msg) =>
-    //                 Log.errorf(m => m("Codelens resolve failed: %s", msg));
-    //                 CodeLensResolveFailed({handle, bufferId, lens, msg});
-    //               };
-    //             };
-
-    //             if (ranges
-    //                 |> List.exists(range => {
-    //                      let startLine =
-    //                        Exthost.(CodeLens.(lens.range.startLineNumber));
-    //                      EditorCoreTypes.(
-    //                        Range.contains(
-    //                          Location.{
-    //                            line: Index.fromOneBased(startLine),
-    //                            column: Index.zero,
-    //                          },
-    //                          range,
-    //                        )
-    //                      );
-    //                    })) {
-    //               Some(
-    //                 Service_Exthost.Sub.codeLens(
-    //                   ~toMsg,
-    //                   ~handle,
-    //                   ~lens,
-    //                   client,
-    //                 ),
-    //               );
-    //             } else {
-    //               None;
-    //             };
-    //           });
-    //      })
-    //   |> List.flatten;
-
-    codeLenses
-    |> Isolinear.Sub.batch;
+    codeLenses |> Isolinear.Sub.batch;
   };
 };
 
 module Configuration = Feature_Configuration.GlobalConfiguration;
 
-let sub = (~config, ~visibleBuffers, ~visibleBuffersAndRanges, ~client, model) =>
-  if (Configuration.Experimental.Editor.codeLensEnabled.get(config)) {
-    Sub.create(~visibleBuffers, ~visibleBuffersAndRanges, ~client, model);
+let sub =
+    (
+      ~config,
+      ~isAnimatingScroll,
+      ~topVisibleBufferLine,
+      ~bottomVisibleBufferLine,
+      ~visibleBuffers,
+      ~client,
+      model,
+    ) =>
+  if (!isAnimatingScroll
+      && Configuration.Experimental.Editor.codeLensEnabled.get(config)) {
+    Sub.create(
+      ~topVisibleBufferLine,
+      ~bottomVisibleBufferLine,
+      ~visibleBuffers,
+      ~client,
+      model,
+    );
   } else {
     Isolinear.Sub.none;
   };

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -61,6 +61,8 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | CodeLensesChanged({
       bufferId: int,
+      startLine: EditorCoreTypes.LineNumber.t,
+      stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.codeLens),
     });
 
@@ -77,8 +79,8 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
     | Outmsg.ReferencesAvailable => ReferencesAvailable
     | Outmsg.OpenFile({filePath, location}) => OpenFile({filePath, location})
     | Outmsg.Effect(eff) => Effect(eff |> Isolinear.Effect.map(f))
-    | Outmsg.CodeLensesChanged({bufferId, lenses}) =>
-      CodeLensesChanged({bufferId, lenses});
+    | Outmsg.CodeLensesChanged({bufferId, lenses, startLine, stopLine}) =>
+      CodeLensesChanged({bufferId, lenses, startLine, stopLine});
 
 module Msg = {
   let exthost = msg => Exthost(msg);
@@ -226,8 +228,8 @@ let update =
     let outmsg =
       switch (eff) {
       | CodeLens.Nothing => Outmsg.Nothing
-      | CodeLens.CodeLensesChanged({bufferId, lenses}) =>
-        Outmsg.CodeLensesChanged({bufferId, lenses})
+      | CodeLens.CodeLensesChanged({bufferId, startLine, stopLine, lenses}) =>
+        Outmsg.CodeLensesChanged({bufferId, startLine, stopLine, lenses})
       };
     ({...model, codeLens: codeLens'}, outmsg |> map(msg => CodeLens(msg)));
 

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -554,10 +554,12 @@ let sub =
     (
       ~config,
       ~isInsertMode,
+      ~isAnimatingScroll,
       ~activeBuffer,
       ~activePosition,
+      ~topVisibleBufferLine,
+      ~bottomVisibleBufferLine,
       ~visibleBuffers,
-      ~visibleBuffersAndRanges,
       ~client,
       {
         codeLens,
@@ -571,8 +573,10 @@ let sub =
   let codeLensSub =
     ShadowedCodeLens.sub(
       ~config,
+      ~isAnimatingScroll,
       ~visibleBuffers,
-      ~visibleBuffersAndRanges,
+      ~topVisibleBufferLine,
+      ~bottomVisibleBufferLine,
       ~client,
       codeLens,
     )

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -115,10 +115,12 @@ let sub:
   (
     ~config: Oni_Core.Config.resolver,
     ~isInsertMode: bool,
+    ~isAnimatingScroll: bool,
     ~activeBuffer: Oni_Core.Buffer.t,
     ~activePosition: CharacterPosition.t,
+    ~topVisibleBufferLine: EditorCoreTypes.LineNumber.t,
+    ~bottomVisibleBufferLine: EditorCoreTypes.LineNumber.t,
     ~visibleBuffers: list(Oni_Core.Buffer.t),
-    ~visibleBuffersAndRanges: list((int, list(EditorCoreTypes.Range.t))),
     ~client: Exthost.Client.t,
     model
   ) =>

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -75,6 +75,8 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | CodeLensesChanged({
       bufferId: int,
+      startLine: EditorCoreTypes.LineNumber.t,
+      stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.t),
     });
 

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -21,6 +21,8 @@ type internalMsg('a) =
   | NotifyFailure(string)
   | CodeLensesChanged({
       bufferId: int,
+      startLine: EditorCoreTypes.LineNumber.t,
+      stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.codeLens),
     })
   | Effect(Isolinear.Effect.t('a));

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -686,14 +686,13 @@ module Sub = {
     stopLine: int // One-based stop line
   };
 
-  let idFromBufferRange = (~handle, ~buffer, ~startLine, ~stopLine) => {
+  let idFromBufferRange = (~handle, ~buffer, ~startLine) => {
     Printf.sprintf(
-      "%d-%d-%d:%d-%d",
+      "%d-%d-%d:%d",
       handle,
       Oni_Core.Buffer.getId(buffer),
       Oni_Core.Buffer.getSaveTick(buffer),
       startLine,
-      stopLine,
     );
   };
 
@@ -705,8 +704,8 @@ module Sub = {
       type state = ref(bool);
 
       let name = "Service_Exthost.CodeLensesSubscription";
-      let id = ({handle, buffer, startLine, stopLine, _}: params) =>
-        idFromBufferRange(~handle, ~buffer, ~startLine, ~stopLine);
+      let id = ({handle, buffer, startLine, _}: params) =>
+        idFromBufferRange(~handle, ~buffer, ~startLine);
 
       let init = (~params, ~dispatch) => {
         let active = ref(true);

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -691,7 +691,7 @@ module Sub = {
       "%d-%d-%d:%d",
       handle,
       Oni_Core.Buffer.getId(buffer),
-      Oni_Core.Buffer.getSaveTick(buffer),
+      Oni_Core.Buffer.getVersion(buffer),
       startLine,
     );
   };
@@ -701,7 +701,10 @@ module Sub = {
       type nonrec msg = result(list(Exthost.CodeLens.t), string);
       type nonrec params = codeLensesParams;
 
-      type state = ref(bool);
+      type state = {
+        isActive: ref(bool),
+        dispose: unit => unit,
+      };
 
       let name = "Service_Exthost.CodeLensesSubscription";
       let id = ({handle, buffer, startLine, _}: params) =>
@@ -709,75 +712,89 @@ module Sub = {
 
       let init = (~params, ~dispatch) => {
         let active = ref(true);
-        let init =
-          Exthost.Request.LanguageFeatures.provideCodeLenses(
-            ~handle=params.handle,
-            ~resource=Oni_Core.Buffer.getUri(params.buffer),
-            params.client,
-          );
+        let dispose =
+          Revery.Tick.timeout(
+            ~name,
+            _ => {
+              let init =
+                Exthost.Request.LanguageFeatures.provideCodeLenses(
+                  ~handle=params.handle,
+                  ~resource=Oni_Core.Buffer.getUri(params.buffer),
+                  params.client,
+                );
 
-        let resolveLens = (codeLens: Exthost.CodeLens.t) =>
-          if (! active^) {
-            // If the subscription is over, don't both resolving...
-            Lwt.return(
-              None,
-            );
-          } else {
-            switch (codeLens.command) {
-            | Some(_) => Lwt.return(Some(codeLens))
-            | None =>
-              Exthost.Request.LanguageFeatures.resolveCodeLens(
-                ~handle=params.handle,
-                ~codeLens,
-                params.client,
-              )
-            };
-          };
-
-        let promise =
-          Lwt.bind(
-            init,
-            initResult => {
-              let unresolvedLenses =
-                initResult
-                |> Option.value(~default=[])
-                |> List.filter((lens: Exthost.CodeLens.t) => {
-                     Exthost.OneBasedRange.(
-                       {
-                         lens.range.startLineNumber >= params.startLine
-                         && lens.range.startLineNumber <= params.stopLine;
-                       }
-                     )
-                   });
-
-              let resolvePromises = unresolvedLenses |> List.map(resolveLens);
-
-              let join:
-                (list(Exthost.CodeLens.t), option(Exthost.CodeLens.t)) =>
-                list(Exthost.CodeLens.t) =
-                (acc, cur) => {
-                  switch (cur) {
-                  | None => acc
-                  | Some(lens) => [lens, ...acc]
+              let resolveLens = (codeLens: Exthost.CodeLens.t) =>
+                if (! active^) {
+                  // If the subscription is over, don't both resolving...
+                  Lwt.return(
+                    None,
+                  );
+                } else {
+                  switch (codeLens.command) {
+                  | Some(_) => Lwt.return(Some(codeLens))
+                  | None =>
+                    Exthost.Request.LanguageFeatures.resolveCodeLens(
+                      ~handle=params.handle,
+                      ~codeLens,
+                      params.client,
+                    )
                   };
                 };
 
-              Utility.LwtEx.all(~initial=[], join, resolvePromises);
+              let promise =
+                Lwt.bind(
+                  init,
+                  initResult => {
+                    let unresolvedLenses =
+                      initResult
+                      |> Option.value(~default=[])
+                      |> List.filter((lens: Exthost.CodeLens.t) => {
+                           Exthost.OneBasedRange.(
+                             {
+                               lens.range.startLineNumber >= params.startLine
+                               && lens.range.startLineNumber <= params.stopLine;
+                             }
+                           )
+                         });
+
+                    let resolvePromises =
+                      unresolvedLenses |> List.map(resolveLens);
+
+                    let join:
+                      (
+                        list(Exthost.CodeLens.t),
+                        option(Exthost.CodeLens.t)
+                      ) =>
+                      list(Exthost.CodeLens.t) =
+                      (acc, cur) => {
+                        switch (cur) {
+                        | None => acc
+                        | Some(lens) => [lens, ...acc]
+                        };
+                      };
+
+                    Utility.LwtEx.all(~initial=[], join, resolvePromises);
+                  },
+                );
+
+              Lwt.on_success(promise, codeLenses => {
+                dispatch(Ok(codeLenses))
+              });
+
+              Lwt.on_failure(promise, exn => {
+                dispatch(Error(Printexc.to_string(exn)))
+              });
             },
+            Revery.Time.milliseconds(250),
           );
-
-        Lwt.on_success(promise, codeLenses => {dispatch(Ok(codeLenses))});
-
-        Lwt.on_failure(promise, exn => {
-          dispatch(Error(Printexc.to_string(exn)))
-        });
-        active;
+        {isActive: active, dispose};
       };
 
       let update = (~params as _, ~state, ~dispatch as _) => state;
 
       let dispose = (~params as _, ~state) => {
-        state := false;
+        state.isActive := false;
+        state.dispose();
       };
     });
 

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -746,7 +746,7 @@ module Sub = {
                      Exthost.OneBasedRange.(
                        {
                          lens.range.startLineNumber >= params.startLine
-                         && lens.range.endLineNumber <= params.stopLine;
+                         && lens.range.startLineNumber <= params.stopLine;
                        }
                      )
                    });

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -146,16 +146,6 @@ module Sub: {
     ) =>
     Isolinear.Sub.t('a);
 
-  // Subscription to resolve a code lens
-  // let codeLens:
-  //   (
-  //     ~handle: int,
-  //     ~lens: Exthost.CodeLens.t,
-  //     ~toMsg: result(Exthost.CodeLens.t, string) => 'msg,
-  //     Exthost.Client.t
-  //   ) =>
-  //   Isolinear.Sub.t('msg);
-
   let completionItems:
     // TODO: ~base: option(string),
     (

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -139,20 +139,22 @@ module Sub: {
     (
       ~handle: int,
       ~buffer: Oni_Core.Buffer.t,
+      ~startLine: EditorCoreTypes.LineNumber.t,
+      ~stopLine: EditorCoreTypes.LineNumber.t,
       ~toMsg: result(list(Exthost.CodeLens.t), string) => 'a,
       Exthost.Client.t
     ) =>
     Isolinear.Sub.t('a);
 
   // Subscription to resolve a code lens
-  let codeLens:
-    (
-      ~handle: int,
-      ~lens: Exthost.CodeLens.t,
-      ~toMsg: result(Exthost.CodeLens.t, string) => 'msg,
-      Exthost.Client.t
-    ) =>
-    Isolinear.Sub.t('msg);
+  // let codeLens:
+  //   (
+  //     ~handle: int,
+  //     ~lens: Exthost.CodeLens.t,
+  //     ~toMsg: result(Exthost.CodeLens.t, string) => 'msg,
+  //     Exthost.Client.t
+  //   ) =>
+  //   Isolinear.Sub.t('msg);
 
   let completionItems:
     // TODO: ~base: option(string),

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -562,7 +562,7 @@ let update =
           state,
           eff |> Isolinear.Effect.map(msg => LanguageSupport(msg)),
         )
-      | CodeLensesChanged({bufferId, lenses}) =>
+      | CodeLensesChanged({bufferId, startLine, stopLine, lenses}) =>
         let inlineElements = editor =>
           lenses
           |> List.map(lens => {
@@ -592,7 +592,9 @@ let update =
           state.layout
           |> Feature_Layout.map(editor =>
                if (Feature_Editor.Editor.getBufferId(editor) == bufferId) {
-                 Feature_Editor.Editor.setInlineElements(
+                 Feature_Editor.Editor.replaceInlineElements(
+                   ~startLine,
+                   ~stopLine,
                    ~key="codelens",
                    ~elements=inlineElements(editor),
                    editor,

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -209,12 +209,13 @@ let start =
     let config = Model.Selectors.configResolver(state);
     let visibleBuffersAndRanges =
       state |> Model.EditorVisibleRanges.getVisibleBuffersAndRanges;
+    let activeEditor = state.layout |> Feature_Layout.activeEditor;
 
     let isInsertMode =
-      state.layout
-      |> Feature_Layout.activeEditor
-      |> Feature_Editor.Editor.mode
-      |> Vim.Mode.isInsert;
+      activeEditor |> Feature_Editor.Editor.mode |> Vim.Mode.isInsert;
+
+    let isAnimatingScroll =
+      activeEditor |> Feature_Editor.Editor.isAnimatingScroll;
 
     let visibleRanges =
       visibleBuffersAndRanges
@@ -223,6 +224,12 @@ let start =
            |> Option.map(buffer => {(buffer, ranges)})
          })
       |> Core.Utility.OptionEx.values;
+
+    let topVisibleBufferLine =
+      activeEditor |> Feature_Editor.Editor.getTopVisibleBufferLine;
+
+    let bottomVisibleBufferLine =
+      activeEditor |> Feature_Editor.Editor.getBottomVisibleBufferLine;
 
     let visibleBuffers =
       visibleBuffersAndRanges
@@ -347,10 +354,12 @@ let start =
            Feature_LanguageSupport.sub(
              ~config,
              ~isInsertMode,
+             ~isAnimatingScroll,
              ~activeBuffer,
              ~activePosition,
+             ~topVisibleBufferLine,
+             ~bottomVisibleBufferLine,
              ~visibleBuffers,
-             ~visibleBuffersAndRanges,
              ~client=extHostClient,
              state.languageSupport,
            )


### PR DESCRIPTION
__Issue:__ For large files, with lots of codelens, we would try and resolve many at once - this would eventually be problematic for performance.

__Fix:__ Only resolve codelens in the viewport, which is more tractable for performance, even for large files with many codelenses present.