### PR TITLE
fix(osx/#2855): Dock icon drag-and-drop

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -7,6 +7,7 @@
 - #2839 - Extensions: CodeLens - fix lens persisting when line is deleted
 - #2844 - Vim: Fix `:tabnew`/`:new`/`:vnew` behavior (fixes #1455, #2753, #2843)
 - #2846 - UX: Editor Tabs - horizontal scrolling on trackpad is reversed (thanks @SeitaHigashi!)
+- #2865 - OSX: Fix drag-and-drop on dock icon (fixes #2855)
 
 ### Performance
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -160,6 +160,12 @@ if (process.platform == "linux") {
                 CFBundleTypeExtensions: fileAssoc.ext.map((ext) => ext.substr(1)),
                 CFBundleTypeName: fileAssoc.name,
                 CFBundleTypeRole: fileAssoc.role,
+                CFBundleTypeOSTypes: [
+                    "TEXT",
+                    "utxt",
+                    "TUTX",
+                    "****"
+                ],
                 CFBundleTypeIconFile: "macDocumentIcons/" + fileAssoc.icon.mac,
             }
         }),

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -160,12 +160,7 @@ if (process.platform == "linux") {
                 CFBundleTypeExtensions: fileAssoc.ext.map((ext) => ext.substr(1)),
                 CFBundleTypeName: fileAssoc.name,
                 CFBundleTypeRole: fileAssoc.role,
-                CFBundleTypeOSTypes: [
-                    "TEXT",
-                    "utxt",
-                    "TUTX",
-                    "****"
-                ],
+                CFBundleTypeOSTypes: ["TEXT", "utxt", "TUTX", "****"],
                 CFBundleTypeIconFile: "macDocumentIcons/" + fileAssoc.icon.mac,
             }
         }),

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -61,6 +61,8 @@ let selected = ({selected, _}) => selected;
 let isOpen = ({isOpen, _}) => isOpen;
 let location = ({location, _}) => location;
 
+let isOpenByDefault = ({openByDefault, _}) => openByDefault;
+
 let initial = {
   openByDefault: false,
   isOpen: false,

--- a/src/Feature/SideBar/Feature_SideBar.rei
+++ b/src/Feature/SideBar/Feature_SideBar.rei
@@ -49,6 +49,7 @@ let initial: model;
 
 let width: model => int;
 let isOpen: model => bool;
+let isOpenByDefault: model => bool;
 let selected: model => pane;
 let location: model => location;
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1659,6 +1659,16 @@ let update =
           state.fileExplorer,
         );
 
+      // Pop open and focus sidebar
+      let sideBar =
+        if (!Feature_SideBar.isOpen(state.sideBar)
+            || Feature_SideBar.selected(state.sideBar)
+            !== Feature_SideBar.FileExplorer) {
+          Feature_SideBar.toggle(FileExplorer, state.sideBar);
+        } else {
+          state.sideBar;
+        };
+
       let extWorkspace =
         maybeWorkspaceFolder |> Option.map(Exthost.WorkspaceData.fromPath);
       let eff =
@@ -1666,7 +1676,11 @@ let update =
           ~workspace=extWorkspace,
           extHostClient,
         );
-      ({...state, fileExplorer}, eff);
+
+      let state' =
+        {...state, fileExplorer, sideBar}
+        |> FocusManager.push(Focus.FileExplorer);
+      (state', eff);
     };
 
   | AutoUpdate(msg) =>

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -434,7 +434,7 @@ switch (eff) {
 
     let _: App.unsubscribe =
       App.onFileOpen(app, path => {
-        dispatch(Model.Actions.OpenFileByPath(path, None, None))
+        dispatch(Model.Actions.FilesDropped({paths: [path]}))
       });
     let _: Window.unsubscribe =
       Window.onMaximized(window, () =>


### PR DESCRIPTION
__Issue:__ Some files/folders could not be dragged-and-dropped to the dock icon for Onivim 2.

__Defect:__
1) We were missing some `plist` entries to allow arbitrary document/folder drops
2) When a folder is dropped, it'd be treating as a file

__Fix:__
1) Add the `CFBundleTypeOSTypes` plist entries
2) Use the same code path for dropping a folder on dock as we do for dragging onto the surface 

In addition, when we drop a folder, open up the explorer pane so there is some feedback on the action

Fixes #2855 