### PR TITLE
fix(extension/#2862): Show download count and ratings for extensions

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,5 +1,7 @@
 ### Features
 
+- #2866 - Extensions: Show ratings / download count in details view (fixes #2866)
+
 ### Bug Fixes
 
 - #2845 - Workspace: Opening a file should not always open a folder (fixes #1983)

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -271,14 +271,7 @@ let header =
         maybeRatingElement
       </View>
       <View style=Styles.headerRow>
-        <View style=Styles.headerTextContainer>
-          <Text
-            style=Style.[color(fg)]
-            fontFamily={font.family}
-            fontSize=14.
-            text=description
-          />
-        </View>
+        <headerText text=description />
       </View>
       <View style=Styles.headerRow> buttonElements </View>
     </View>

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -46,6 +46,43 @@ module Styles = {
   let headerTextContainer = [marginHorizontal(8), marginVertical(4)];
 };
 
+module Rating = {
+  let make = (~rating: int, ~font: UiFont.t, ~fontSize, ~ratingCount, ()) => {
+    <View style=Styles.[Style.flexDirection(`Row), ...headerTextContainer]>
+      <Codicon
+        icon=Codicon.starEmpty
+        fontSize=16.
+        color={Revery.Color.hex("#333")}
+      />
+      <Codicon
+        icon=Codicon.starEmpty
+        fontSize=16.
+        color={Revery.Color.hex("#333")}
+      />
+      <Codicon
+        icon=Codicon.starEmpty
+        fontSize=16.
+        color={Revery.Color.hex("#333")}
+      />
+      <Codicon
+        icon=Codicon.starEmpty
+        fontSize=16.
+        color={Revery.Color.hex("#333")}
+      />
+      <Codicon
+        icon=Codicon.starEmpty
+        fontSize=16.
+        color={Revery.Color.hex("#333")}
+      />
+      <Text
+        fontFamily={font.family}
+        fontSize
+        text={"(" ++ string_of_int(ratingCount) ++ ")"}
+      />
+    </View>;
+  };
+};
+
 let installButton = (~font, ~extensionId, ~dispatch, ()) => {
   <View style=Styles.headerButton>
     <ItemView.ActionButton
@@ -110,6 +147,7 @@ let header =
     (
       ~model: Model.model,
       ~font: UiFont.t,
+      ~publisher,
       ~maybeLogo,
       ~displayName,
       ~description,
@@ -176,24 +214,33 @@ let header =
             text=displayName
           />
         </View>
-      </View>
-      <View style=Styles.headerRow>
         <View
           style=Style.[
             backgroundColor(Revery.Color.rgba_int(128, 128, 128, 64)),
             marginLeft(8),
             padding(4),
           ]>
-          <Text
-            fontFamily={font.family}
-            fontSize=16.
-            fontWeight=Revery.Font.Weight.Bold
-            text=extensionId
-          />
+          <View style=Style.[marginTop(4)]>
+            <Text
+              fontFamily={font.family}
+              fontSize=16.
+              fontWeight=Revery.Font.Weight.Bold
+              text=extensionId
+            />
+          </View>
+        </View>
+      </View>
+      <View style=Styles.headerRow>
+        <View style=Styles.headerTextContainer>
+          <Text fontFamily={font.family} fontSize=14. text=publisher />
         </View>
         <View style=Styles.headerTextContainer>
           <Text fontFamily={font.family} fontSize=14. text=version />
         </View>
+        <View style=Styles.headerTextContainer>
+          <Text fontFamily={font.family} fontSize=14. text="5.4K downloads" />
+        </View>
+        <Rating rating=5 font fontSize=14. ratingCount=1 />
       </View>
       <View style=Styles.headerRow>
         <View style=Styles.headerTextContainer>
@@ -329,6 +376,7 @@ let make =
       <header
         font
         maybeLogo
+        publisher=namespace
         displayName
         description
         extensionId

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -180,12 +180,13 @@ let header =
   let fg = color;
 
   let buttonElements = buttons' |> React.listToElement;
-  let headerText = (~text, ()) => {
+  let headerText = (~fontWeight=Revery.Font.Weight.Normal, ~text, ()) => {
     <View style=Styles.headerTextContainer>
       <Text
         style=Style.[color(fg)]
         fontFamily={font.family}
         fontSize=14.
+        fontWeight
         text
       />
     </View>;
@@ -271,7 +272,7 @@ let header =
         maybeRatingElement
       </View>
       <View style=Styles.headerRow>
-        <headerText text=description />
+        <headerText fontWeight=Revery.Font.Weight.SemiBold text=description />
       </View>
       <View style=Styles.headerRow> buttonElements </View>
     </View>

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -140,7 +140,7 @@ module RatingInfo = {
     downloadCount: int,
     rating: int,
     ratingCount: int,
-  }
+  };
 };
 
 module Selected = {
@@ -150,17 +150,21 @@ module Selected = {
     | Local(Scanner.ScanResult.t)
     | Remote(Service_Extensions.Catalog.Details.t);
 
-  let ratings = 
-  fun 
-  | Local(_) => None
-  | Remote(details) => RatingInfo.({
-    open Service_Extensions.Catalog.Details;
-    Some({
-    downloadCount: details |> downloadCount,
-    rating: details |> averageRating |> int_of_float,
-    ratingCount: details |> reviewCount
-    })
-  })
+  let ratings =
+    fun
+    | Local(_) => None
+    | Remote(details) =>
+      RatingInfo.(
+        {
+          Service_Extensions.Catalog.Details.(
+            Some({
+              downloadCount: details |> downloadCount,
+              rating: details |> averageRating |> int_of_float,
+              ratingCount: details |> reviewCount,
+            })
+          );
+        }
+      );
 
   let identifier =
     fun

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -135,12 +135,32 @@ type outmsg =
   | SelectTheme({themes: list(Exthost.Extension.Contributions.Theme.t)})
   | UnhandledWindowMovement(Component_VimWindows.outmsg);
 
+module RatingInfo = {
+  type t = {
+    downloadCount: int,
+    rating: int,
+    ratingCount: int,
+  }
+};
+
 module Selected = {
   open Exthost_Extension;
   open Exthost_Extension.Manifest;
   type t =
     | Local(Scanner.ScanResult.t)
     | Remote(Service_Extensions.Catalog.Details.t);
+
+  let ratings = 
+  fun 
+  | Local(_) => None
+  | Remote(details) => RatingInfo.({
+    open Service_Extensions.Catalog.Details;
+    Some({
+    downloadCount: details |> downloadCount,
+    rating: details |> averageRating |> int_of_float,
+    ratingCount: details |> reviewCount
+    })
+  })
 
   let identifier =
     fun

--- a/src/Service/Extensions/Catalog.re
+++ b/src/Service/Extensions/Catalog.re
@@ -82,6 +82,9 @@ module Details = {
     //      categories: list(string),
     version: [@opaque] option(Semver.t),
     versions: list(VersionInfo.t),
+    downloadCount: option(int),
+    averageRating: option(float),
+    reviewCount: option(int),
   };
 
   let id = ({namespace, name, _}) => {
@@ -91,6 +94,15 @@ module Details = {
   let displayName = ({displayName, _} as details) => {
     displayName |> Option.value(~default=id(details));
   };
+
+  let averageRating = ({averageRating, _}) =>
+    averageRating |> Option.value(~default=0.);
+
+  let downloadCount = ({downloadCount, _}) =>
+    downloadCount |> Option.value(~default=0);
+
+  let reviewCount = ({reviewCount, _}) =>
+    reviewCount |> Option.value(~default=0);
 
   let toString =
       ({downloadUrl, description, homepageUrl, versions, _} as details) => {
@@ -136,6 +148,9 @@ module Details = {
           licenseName: field.optional("license", string),
           displayName: field.optional("displayName", string),
           description: field.optional("description", string),
+          downloadCount: field.optional("downloadCount", int),
+          averageRating: field.optional("averageRating", float),
+          reviewCount: field.optional("reviewCount", int),
           isPublicNamespace:
             field.withDefault(
               "namespaceAccess",

--- a/src/Service/Extensions/Service_Extensions.rei
+++ b/src/Service/Extensions/Service_Extensions.rei
@@ -40,7 +40,14 @@ module Catalog: {
       //      categories: list(string),
       version: option(Semver.t),
       versions: list(VersionInfo.t),
+      downloadCount: option(int),
+      averageRating: option(float),
+      reviewCount: option(int),
     };
+
+    let downloadCount: t => int;
+    let averageRating: t => float;
+    let reviewCount: t => int;
 
     let toString: t => string;
   };


### PR DESCRIPTION
This adds rating count, download count, and average rating UI for extension details:

![image](https://user-images.githubusercontent.com/13532591/102910330-3f3c4c00-442f-11eb-91c6-3f1a3f2c1a39.png)

(Currently, this doesn't pull the data for installed extensions - only ones that user hasn't installed yet)

Fixes #2862