### PR TITLE
fix(hover): Don't pop-up while scrolling with mousewheel

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -12,6 +12,7 @@
 - #2865 - OSX: Fix drag-and-drop on dock icon (fixes #2855)
 - #2867 - Editor: Fix viewport shifting when deleting lines with codelens
 - #2868 - SCM: Diff markers not showing up in gutter (fixes #2857)
+- #2869 - Hover: Fix hover pop up while scrolling via mousewheel
 
 ### Performance
 

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -140,7 +140,14 @@ module CustomDecoders: {
     custom(
       ~decode=Json.Decode.(int |> map(Time.ms)),
       ~encode=
-        Json.Encode.(t => t |> Time.toFloatSeconds |> int_of_float |> int),
+        Json.Encode.(
+          t =>
+            t
+            |> Time.toFloatSeconds
+            |> (t => t *. 1000.)
+            |> int_of_float
+            |> int
+        ),
     );
 };
 

--- a/src/Feature/Editor/Feature_Editor.re
+++ b/src/Feature/Editor/Feature_Editor.re
@@ -177,13 +177,15 @@ module Sub = {
       switch (Editor.lastMouseMoveTime(editor)) {
       | Some(time) when hoverEnabled && !Editor.isMouseDown(editor) =>
         let delay = EditorConfiguration.Hover.delay.get(config);
-        Service_Time.Sub.once(
-          ~uniqueId={
-            string_of_int(Editor.getId(editor))
-            ++ string_of_float(Revery.Time.toFloatSeconds(time));
-          },
-          ~delay,
-          ~msg=(~current as _) =>
+        let uniqueId =
+          Printf.sprintf(
+            "editor:%d.%f.%f.%f",
+            Editor.getId(editor),
+            Revery.Time.toFloatSeconds(time),
+            Editor.scrollX(editor),
+            Editor.scrollY(editor),
+          );
+        Service_Time.Sub.once(~uniqueId, ~delay, ~msg=(~current as _) =>
           Msg.MouseHovered
         );
       | Some(_) => Isolinear.Sub.none


### PR DESCRIPTION
__Issue:__ When scrolling with the mouse wheel, the hover could pop up randomly while scrolling - and sometimes eat subsequent mouse wheel movements 

__Defect:__ There were two issues:
1) We were only considering the mouse-position-in-screen-space for hover, when we should be considering the scroll position as well
2) The delay for `editor.hover.delay` was off due to a units error - seconds were being treated as milliseconds, causing hover to pop up  instantly

__Fix:__
1) Consider scroll space as well for the hovered subscription
2) Fix unit conversion