### PR TITLE
docs(language): Fix documentation for C - add namespace/publisher

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -20,6 +20,8 @@
 
 ### Documentation
 
+- #2874 - Languages: Fix extension ids for `exuberant-ctags` and `clangd` (fixes #2872)
+
 ### Infrastructure / Refactoring
 
 - #2853 - Input: Add APIs for querying contextually available bindings and consumed keys

--- a/docs/docs/languages/c.md
+++ b/docs/docs/languages/c.md
@@ -39,7 +39,7 @@ The following features are supported:
 
 Install via the command-line:
 
-- `oni2 --install-extension vscode-clangd`
+- `oni2 --install-extension llvm-vs-code-extensions.vscode-clangd`
 
 For best results, you'll need to generate a `compile_commands.json` file.
 

--- a/docs/docs/languages/c.md
+++ b/docs/docs/languages/c.md
@@ -18,7 +18,7 @@ The following features are supported:
 
 Install via the command-line:
 
-- `oni2 --install-extension exuberant-ctags`
+- `oni2 --install-extension chriswheeldon.exuberant-ctags`
 
 Once installed, there will be a status bar entry showing the state of the CTags index:
 


### PR DESCRIPTION
Fix extension ids for C in documentation - fixes #2872 