### PR TITLE
fix(vim/#2870): Remove conflicting 'ctrl+b' binding

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -15,6 +15,7 @@
 - #2869 - Hover: Fix hover pop up while scrolling via mousewheel
 - #2871 - Vim: Fix `ctrl+o` behavior in insert mode (fixes #2425)
 - #2854 - Extensions: Signature Help - fix overlay staying open in normal mode
+- #2877 - Vim: Remove conflicting `ctrl+b` binding on Windows / Linux (fixes #2870)
 
 ### Performance
 

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -296,7 +296,7 @@ module Keybindings = {
   };
 
   let toggleSidebar = {
-    key: "<C-B>",
+    key: "<C-S-B>",
     command: Commands.toggleSidebar.id,
     condition: "!isMac" |> WhenExpr.parse,
   };


### PR DESCRIPTION
__Issue:__ On Windows/Linux, the 'Toggle Sidebar' action was bound to `Ctrl+B`, which conflicts with the vim default of scrolling up a page.

__Fix:__ Remove conflict; switch toggle sidebar binding to `Ctrl+Shift+B`

Related #2870 