### PR TITLE
fix(input/#2368): Recognize Ctrl-[ as Esc across the UI

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -15,6 +15,7 @@
 - #2869 - Hover: Fix hover pop up while scrolling via mousewheel
 - #2871 - Vim: Fix `ctrl+o` behavior in insert mode (fixes #2425)
 - #2854 - Extensions: Signature Help - fix overlay staying open in normal mode
+- #2878 - Input: Treat `Ctrl+[` as `Escape` everywhere
 
 ### Performance
 

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -505,111 +505,159 @@ module Keybindings = {
   let keybindings =
     Feature_Input.Schema.[
       // NORMAL MODE MOVEMENT
-      {key: "gg", command: Commands.gg.id, condition: commandCondition},
-      {key: "<S-G>", command: Commands.g.id, condition: commandCondition},
-      {key: "j", command: Commands.j.id, condition: commandCondition},
-      {key: "k", command: Commands.k.id, condition: commandCondition},
-      {key: "<DOWN>", command: Commands.j.id, condition: commandCondition},
-      {key: "<UP>", command: Commands.k.id, condition: commandCondition},
-      {key: "<CR>", command: Commands.enter.id, condition: commandCondition},
+      bind(~key="gg", ~command=Commands.gg.id, ~condition=commandCondition),
+      bind(~key="<S-G>", ~command=Commands.g.id, ~condition=commandCondition),
+      bind(~key="j", ~command=Commands.j.id, ~condition=commandCondition),
+      bind(~key="k", ~command=Commands.k.id, ~condition=commandCondition),
+      bind(
+        ~key="<DOWN>",
+        ~command=Commands.j.id,
+        ~condition=commandCondition,
+      ),
+      bind(~key="<UP>", ~command=Commands.k.id, ~condition=commandCondition),
+      bind(
+        ~key="<CR>",
+        ~command=Commands.enter.id,
+        ~condition=commandCondition,
+      ),
       // Scroll alignment
-      {key: "zz", command: Commands.zz.id, condition: commandCondition},
-      {key: "zb", command: Commands.zb.id, condition: commandCondition},
-      {key: "zt", command: Commands.zt.id, condition: commandCondition},
+      bind(~key="zz", ~command=Commands.zz.id, ~condition=commandCondition),
+      bind(~key="zb", ~command=Commands.zb.id, ~condition=commandCondition),
+      bind(~key="zt", ~command=Commands.zt.id, ~condition=commandCondition),
       // Scroll downwards
-      {
-        key: "<C-e>",
-        command: Commands.scrollDownLine.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-d>",
-        command: Commands.scrollDownWindow.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<S-DOWN>",
-        command: Commands.scrollDownWindow.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<PageDown>",
-        command: Commands.scrollDownWindow.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-f>",
-        command: Commands.scrollDownWindow.id,
-        condition: commandCondition,
-      },
+      bind(
+        ~key="<C-e>",
+        ~command=Commands.scrollDownLine.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-d>",
+        ~command=Commands.scrollDownWindow.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<S-DOWN>",
+        ~command=Commands.scrollDownWindow.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<PageDown>",
+        ~command=Commands.scrollDownWindow.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-f>",
+        ~command=Commands.scrollDownWindow.id,
+        ~condition=commandCondition,
+      ),
       // Scroll upwards
-      {
-        key: "<C-y>",
-        command: Commands.scrollUpLine.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-u>",
-        command: Commands.scrollUpWindow.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<S-UP>",
-        command: Commands.scrollUpWindow.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<PageUp>",
-        command: Commands.scrollUpWindow.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-b>",
-        command: Commands.scrollUpWindow.id,
-        condition: commandCondition,
-      },
+      bind(
+        ~key="<C-y>",
+        ~command=Commands.scrollUpLine.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-u>",
+        ~command=Commands.scrollUpWindow.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<S-UP>",
+        ~command=Commands.scrollUpWindow.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<PageUp>",
+        ~command=Commands.scrollUpWindow.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-b>",
+        ~command=Commands.scrollUpWindow.id,
+        ~condition=commandCondition,
+      ),
       // MULTIPLIER
-      {key: "0", command: Commands.digit0.id, condition: commandCondition},
-      {key: "1", command: Commands.digit1.id, condition: commandCondition},
-      {key: "2", command: Commands.digit2.id, condition: commandCondition},
-      {key: "3", command: Commands.digit3.id, condition: commandCondition},
-      {key: "4", command: Commands.digit4.id, condition: commandCondition},
-      {key: "5", command: Commands.digit5.id, condition: commandCondition},
-      {key: "6", command: Commands.digit6.id, condition: commandCondition},
-      {key: "7", command: Commands.digit7.id, condition: commandCondition},
-      {key: "8", command: Commands.digit8.id, condition: commandCondition},
-      {key: "9", command: Commands.digit9.id, condition: commandCondition},
+      bind(
+        ~key="0",
+        ~command=Commands.digit0.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="1",
+        ~command=Commands.digit1.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="2",
+        ~command=Commands.digit2.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="3",
+        ~command=Commands.digit3.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="4",
+        ~command=Commands.digit4.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="5",
+        ~command=Commands.digit5.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="6",
+        ~command=Commands.digit6.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="7",
+        ~command=Commands.digit7.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="8",
+        ~command=Commands.digit8.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="9",
+        ~command=Commands.digit9.id,
+        ~condition=commandCondition,
+      ),
       // SEARCH
-      {
-        key: "/",
-        command: Commands.searchForward.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<S-/>",
-        command: Commands.searchBackward.id,
-        condition: commandCondition,
-      },
-      {
-        key: "n",
-        command: Commands.nextSearchResult.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<S-N>",
-        command: Commands.previousSearchResult.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<CR>",
-        command: Commands.commitSearch.id,
-        condition: searchActiveCommandCondition,
-      },
-      {
-        key: "<ESC>",
-        command: Commands.cancelSearch.id,
-        condition: searchActiveCommandCondition,
-      },
+      bind(
+        ~key="/",
+        ~command=Commands.searchForward.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<S-/>",
+        ~command=Commands.searchBackward.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="n",
+        ~command=Commands.nextSearchResult.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<S-N>",
+        ~command=Commands.previousSearchResult.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<CR>",
+        ~command=Commands.commitSearch.id,
+        ~condition=searchActiveCommandCondition,
+      ),
+      bind(
+        ~key="<ESC>",
+        ~command=Commands.cancelSearch.id,
+        ~condition=searchActiveCommandCondition,
+      ),
     ];
 };
 

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -364,16 +364,16 @@ module Keybindings = {
 
   let keybindings =
     Feature_Input.Schema.[
-      {
-        key: "h",
-        command: Commands.toggleExpanded.id,
-        condition: commandCondition,
-      },
-      {
-        key: "l",
-        command: Commands.toggleExpanded.id,
-        condition: commandCondition,
-      },
+      bind(
+        ~key="h",
+        ~command=Commands.toggleExpanded.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="l",
+        ~command=Commands.toggleExpanded.id,
+        ~condition=commandCondition,
+      ),
     ];
 };
 

--- a/src/Components/VimWindows/Component_VimWindows.re
+++ b/src/Components/VimWindows/Component_VimWindows.re
@@ -70,76 +70,76 @@ module Keybindings = {
 
   let keybindings =
     Feature_Input.Schema.[
-      {
-        key: "<C-W>H",
-        command: Commands.moveLeft.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><C-H>",
-        command: Commands.moveLeft.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><LEFT>",
-        command: Commands.moveLeft.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W>L",
-        command: Commands.moveRight.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><C-L>",
-        command: Commands.moveRight.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><RIGHT>",
-        command: Commands.moveRight.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W>K",
-        command: Commands.moveUp.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><C-K>",
-        command: Commands.moveUp.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><UP>",
-        command: Commands.moveUp.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W>J",
-        command: Commands.moveDown.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><C-J>",
-        command: Commands.moveDown.id,
-        condition: commandCondition,
-      },
-      {
-        key: "<C-W><DOWN>",
-        command: Commands.moveDown.id,
-        condition: commandCondition,
-      },
-      {
-        key: "gt",
-        command: Commands.nextTab.id,
-        condition: noTextInputCondition,
-      },
-      {
-        key: "gT",
-        command: Commands.previousTab.id,
-        condition: noTextInputCondition,
-      },
+      bind(
+        ~key="<C-W>H",
+        ~command=Commands.moveLeft.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-H>",
+        ~command=Commands.moveLeft.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><LEFT>",
+        ~command=Commands.moveLeft.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W>L",
+        ~command=Commands.moveRight.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-L>",
+        ~command=Commands.moveRight.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><RIGHT>",
+        ~command=Commands.moveRight.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W>K",
+        ~command=Commands.moveUp.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-K>",
+        ~command=Commands.moveUp.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><UP>",
+        ~command=Commands.moveUp.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W>J",
+        ~command=Commands.moveDown.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-J>",
+        ~command=Commands.moveDown.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="<C-W><DOWN>",
+        ~command=Commands.moveDown.id,
+        ~condition=commandCondition,
+      ),
+      bind(
+        ~key="gt",
+        ~command=Commands.nextTab.id,
+        ~condition=noTextInputCondition,
+      ),
+      bind(
+        ~key="gT",
+        ~command=Commands.previousTab.id,
+        ~condition=noTextInputCondition,
+      ),
     ];
 };
 

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -94,14 +94,23 @@ module Schema = {
         key: string,
         command: string,
         condition: WhenExpr.t,
-      });
+      })
+    | Remap({
+      fromKeys: string,
+      toKeys: string,
+    });
 
   type resolvedKeybinding =
     | ResolvedBinding({
         matcher: EditorInput.Matcher.t,
         command: InputStateMachine.execute,
         condition: WhenExpr.ContextKeys.t => bool,
-      });
+      })
+    | ResolvedRemap({
+      matcher: EditorInput.Matcher.t,
+      toKeys: list(EditorInput.KeyPress.t),
+      condition: WhenExpr.ContextKeys.t => bool,
+    })
 
   let bind = (~key, ~command, ~condition) =>
     Binding({key, command, condition});
@@ -109,12 +118,16 @@ module Schema = {
   let mapCommand = (~f, keybinding: keybinding) => {
     switch (keybinding) {
     | Binding(binding) => Binding({...binding, command: f(binding.command)})
+    | Remap(_) as remap => remap
     };
   };
 
   let clear = (~key as _) => failwith("Not implemented");
 
-  let remap = (~remap as _, ~toKeys as _) => failwith("Not implemented");
+  let remap = (~remap, ~toKeys) => Remap({
+    fromKeys: remap,
+    toKeys
+  })
 
   let resolve = keybinding => {
     switch (keybinding) {
@@ -141,6 +154,8 @@ module Schema = {
              condition: evaluateCondition(condition),
            })
          });
+
+    | Remap(_) => failwith("nope");
     };
   };
 };
@@ -194,11 +209,17 @@ let initial = keybindings => {
                )
              );
              ism;
+
            | Ok(ResolvedBinding({matcher, condition, command})) =>
              let (ism, _bindingId) =
                InputStateMachine.addBinding(matcher, condition, command, ism);
              ism;
-           }
+
+           | Ok(ResolvedRemap({matcher, condition, toKeys})) => 
+            let (ism, _bindingId) =
+              InputStateMachine.addMapping(matcher, condition, toKeys, ism);
+              ism;
+          }
          },
          InputStateMachine.empty,
        );
@@ -305,6 +326,16 @@ let addKeyBinding = (~binding, {inputStateMachine, _} as model) => {
           inputStateMachine,
         );
       ({...model, inputStateMachine: inputStateMachine'}, uniqueId);
+
+    | ResolvedRemap(remap) =>
+      let (inputStateMachine', uniqueId) =
+        InputStateMachine.addMapping(
+          remap.matcher,
+          remap.condition,
+          remap.toKeys,
+          inputStateMachine
+        );
+      ({...model, inputStateMachine: inputStateMachine'}, uniqueId);
     }
   );
 };
@@ -365,11 +396,20 @@ module Internal = {
              let (ism, bindings) = acc;
              let (ism', bindingId) =
                switch (resolvedBinding) {
+
                | ResolvedBinding({matcher, condition, command}) =>
                  InputStateMachine.addBinding(
                    matcher,
                    condition,
                    command,
+                   ism,
+                 )
+
+              | ResolvedRemap({matcher, condition, toKeys}) =>
+                 InputStateMachine.addMapping(
+                   matcher,
+                   condition,
+                   toKeys,
                    ism,
                  )
                };

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -101,6 +101,17 @@ module Schema = {
     condition: WhenExpr.ContextKeys.t => bool,
   };
 
+  let bind = (~key, ~command, ~condition) => {key, command, condition};
+
+  let mapCommand = (~f, binding: keybinding) => {
+    ...binding,
+    command: f(binding.command),
+  };
+
+  let clear = (~key as _) => failwith("Not implemented");
+
+  let remap = (~remap as _, ~toKeys as _) => failwith("Not implemented");
+
   let resolve = ({key, command, condition}) => {
     let evaluateCondition = (whenExpr, contextKeys) => {
       WhenExpr.evaluate(

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -26,7 +26,8 @@ module Schema: {
   let clear: (~key: string) => keybinding;
 
   // Remap a key -> to another key
-  let remap: (~remap: string, ~toKeys: string) => keybinding;
+  let remap:
+    (~fromKeys: string, ~toKeys: string, ~condition: WhenExpr.t) => keybinding;
 
   let mapCommand: (~f: string => string, keybinding) => keybinding;
 

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -16,11 +16,19 @@ type command;
 // MODEL
 
 module Schema: {
-  type keybinding = {
-    key: string,
-    command: string,
-    condition: WhenExpr.t,
-  };
+  type keybinding;
+
+  // Bind a key to a command
+  let bind:
+    (~key: string, ~command: string, ~condition: WhenExpr.t) => keybinding;
+
+  // Clear all bindings for a key
+  let clear: (~key: string) => keybinding;
+
+  // Remap a key -> to another key
+  let remap: (~remap: string, ~toKeys: string) => keybinding;
+
+  let mapCommand: (~f: string => string, keybinding) => keybinding;
 
   type resolvedKeybinding;
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -892,68 +892,79 @@ module KeyBindings = {
   let triggerSuggestCondition =
     "editorTextFocus && insertMode && !suggestWidgetVisible" |> WhenExpr.parse;
 
-  let triggerSuggestControlSpace = {
-    key: "<C-Space>",
-    command: Commands.triggerSuggest.id,
-    condition: triggerSuggestCondition,
-  };
-  let triggerSuggestControlN = {
-    key: "<C-N>",
-    command: Commands.triggerSuggest.id,
-    condition: triggerSuggestCondition,
-  };
-  let triggerSuggestControlP = {
-    key: "<C-P>",
-    command: Commands.triggerSuggest.id,
-    condition: triggerSuggestCondition,
-  };
+  let triggerSuggestControlSpace =
+    bind(
+      ~key="<C-Space>",
+      ~command=Commands.triggerSuggest.id,
+      ~condition=triggerSuggestCondition,
+    );
+  let triggerSuggestControlN =
+    bind(
+      ~key="<C-N>",
+      ~command=Commands.triggerSuggest.id,
+      ~condition=triggerSuggestCondition,
+    );
+  let triggerSuggestControlP =
+    bind(
+      ~key="<C-P>",
+      ~command=Commands.triggerSuggest.id,
+      ~condition=triggerSuggestCondition,
+    );
 
-  let nextSuggestion = {
-    key: "<C-N>",
-    command: Commands.selectNextSuggestion.id,
-    condition: suggestWidgetVisible,
-  };
+  let nextSuggestion =
+    bind(
+      ~key="<C-N>",
+      ~command=Commands.selectNextSuggestion.id,
+      ~condition=suggestWidgetVisible,
+    );
 
-  let nextSuggestionArrow = {
-    key: "<DOWN>",
-    command: Commands.selectNextSuggestion.id,
-    condition: suggestWidgetVisible,
-  };
+  let nextSuggestionArrow =
+    bind(
+      ~key="<DOWN>",
+      ~command=Commands.selectNextSuggestion.id,
+      ~condition=suggestWidgetVisible,
+    );
 
-  let previousSuggestion = {
-    key: "<C-P>",
-    command: Commands.selectPrevSuggestion.id,
-    condition: suggestWidgetVisible,
-  };
-  let previousSuggestionArrow = {
-    key: "<UP>",
-    command: Commands.selectPrevSuggestion.id,
-    condition: suggestWidgetVisible,
-  };
+  let previousSuggestion =
+    bind(
+      ~key="<C-P>",
+      ~command=Commands.selectPrevSuggestion.id,
+      ~condition=suggestWidgetVisible,
+    );
+  let previousSuggestionArrow =
+    bind(
+      ~key="<UP>",
+      ~command=Commands.selectPrevSuggestion.id,
+      ~condition=suggestWidgetVisible,
+    );
 
-  let acceptSuggestionEnter = {
-    key: "<CR>",
-    command: Commands.acceptSelected.id,
-    condition: acceptOnEnter,
-  };
+  let acceptSuggestionEnter =
+    bind(
+      ~key="<CR>",
+      ~command=Commands.acceptSelected.id,
+      ~condition=acceptOnEnter,
+    );
 
-  let acceptSuggestionTab = {
-    key: "<TAB>",
-    command: Commands.acceptSelected.id,
-    condition: suggestWidgetVisible,
-  };
+  let acceptSuggestionTab =
+    bind(
+      ~key="<TAB>",
+      ~command=Commands.acceptSelected.id,
+      ~condition=suggestWidgetVisible,
+    );
 
-  let acceptSuggestionShiftTab = {
-    key: "<S-TAB>",
-    command: Commands.acceptSelected.id,
-    condition: suggestWidgetVisible,
-  };
+  let acceptSuggestionShiftTab =
+    bind(
+      ~key="<S-TAB>",
+      ~command=Commands.acceptSelected.id,
+      ~condition=suggestWidgetVisible,
+    );
 
-  let acceptSuggestionShiftEnter = {
-    key: "<S-CR>",
-    command: Commands.acceptSelected.id,
-    condition: suggestWidgetVisible,
-  };
+  let acceptSuggestionShiftEnter =
+    bind(
+      ~key="<S-CR>",
+      ~command=Commands.acceptSelected.id,
+      ~condition=suggestWidgetVisible,
+    );
 };
 
 module Contributions = {

--- a/src/Feature/LanguageSupport/Definition.re
+++ b/src/Feature/LanguageSupport/Definition.re
@@ -154,11 +154,8 @@ module Keybindings = {
 
   let condition = "normalMode" |> WhenExpr.parse;
 
-  let goToDefinition = {
-    key: "<F12>",
-    command: Commands.gotoDefinition.id,
-    condition,
-  };
+  let goToDefinition =
+    bind(~key="<F12>", ~command=Commands.gotoDefinition.id, ~condition);
 };
 
 module Contributions = {

--- a/src/Feature/LanguageSupport/References.re
+++ b/src/Feature/LanguageSupport/References.re
@@ -98,7 +98,8 @@ module Keybindings = {
   let condition = "editorTextFocus && normalMode" |> WhenExpr.parse;
 
   // TODO: Fix this
-  let shiftF12 = {key: "<S-F12>", command: Commands.findAll.id, condition};
+  let shiftF12 =
+    bind(~key="<S-F12>", ~command=Commands.findAll.id, ~condition);
 };
 
 module Contributions = {

--- a/src/Feature/LanguageSupport/Rename.re
+++ b/src/Feature/LanguageSupport/Rename.re
@@ -123,20 +123,22 @@ module Keybindings = {
 
   let condition = "normalMode" |> WhenExpr.parse;
 
-  let rename = {key: "<F2>", command: Commands.rename.id, condition};
+  let rename = bind(~key="<F2>", ~command=Commands.rename.id, ~condition);
 
   let activeCondition = "renameInputVisible" |> WhenExpr.parse;
 
-  let cancel = {
-    key: "<ESC>",
-    command: Commands.cancel.id,
-    condition: activeCondition,
-  };
-  let commit = {
-    key: "<CR>",
-    command: Commands.commit.id,
-    condition: activeCondition,
-  };
+  let cancel =
+    bind(
+      ~key="<ESC>",
+      ~command=Commands.cancel.id,
+      ~condition=activeCondition,
+    );
+  let commit =
+    bind(
+      ~key="<CR>",
+      ~command=Commands.commit.id,
+      ~condition=activeCondition,
+    );
 };
 
 module Contributions = {

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -875,23 +875,26 @@ module Commands = {
 
 module Keybindings = {
   open Feature_Input.Schema;
-  let toggleProblems = {
-    key: "<S-C-M>",
-    command: Commands.problems.id,
-    condition: WhenExpr.Value(True),
-  };
+  let toggleProblems =
+    bind(
+      ~key="<S-C-M>",
+      ~command=Commands.problems.id,
+      ~condition=WhenExpr.Value(True),
+    );
 
-  let toggleProblemsOSX = {
-    key: "<D-S-M>",
-    command: Commands.problems.id,
-    condition: "isMac" |> WhenExpr.parse,
-  };
+  let toggleProblemsOSX =
+    bind(
+      ~key="<D-S-M>",
+      ~command=Commands.problems.id,
+      ~condition="isMac" |> WhenExpr.parse,
+    );
 
-  let escKey = {
-    key: "<ESC>",
-    command: Commands.closePane.id,
-    condition: "paneFocus" |> WhenExpr.parse,
-  };
+  let escKey =
+    bind(
+      ~key="<ESC>",
+      ~command=Commands.closePane.id,
+      ~condition="paneFocus" |> WhenExpr.parse,
+    );
 };
 
 module Contributions = {

--- a/src/Feature/Registers/Feature_Registers.re
+++ b/src/Feature/Registers/Feature_Registers.re
@@ -175,18 +175,19 @@ module Keybindings = {
 
   let condition = "registerEvaluationFocus" |> WhenExpr.parse;
 
-  let cancel = {key: "<ESC>", command: Commands.cancel.id, condition};
+  let cancel = bind(~key="<ESC>", ~command=Commands.cancel.id, ~condition);
 
-  let commit = {key: "<CR>", command: Commands.commit.id, condition};
+  let commit = bind(~key="<CR>", ~command=Commands.commit.id, ~condition);
 
-  let insert = {
-    key: "<C-R>",
-    command: Commands.insert.id,
-    condition:
+  let insert =
+    bind(
+      ~key="<C-R>",
+      ~command=Commands.insert.id,
       // !terminalFocus - #2205 - we should not override the '<C-R>' terminal behavior.
-      "!terminalFocus && insertMode || commandLineMode || inQuickOpen"
-      |> WhenExpr.parse,
-  };
+      ~condition=
+        "!terminalFocus && insertMode || commandLineMode || inQuickOpen"
+        |> WhenExpr.parse,
+    );
 };
 
 module Contributions = {

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -252,60 +252,69 @@ module Commands = {
 module Keybindings = {
   open Feature_Input.Schema;
 
-  let findInFiles = {
-    key: "<S-C-F>",
-    command: Commands.openSearchPane.id,
-    condition: "!isMac" |> WhenExpr.parse,
-  };
+  let findInFiles =
+    bind(
+      ~key="<S-C-F>",
+      ~command=Commands.openSearchPane.id,
+      ~condition="!isMac" |> WhenExpr.parse,
+    );
 
-  let findInFilesMac = {
-    key: "<D-S-F>",
-    command: Commands.openSearchPane.id,
-    condition: "isMac" |> WhenExpr.parse,
-  };
+  let findInFilesMac =
+    bind(
+      ~key="<D-S-F>",
+      ~command=Commands.openSearchPane.id,
+      ~condition="isMac" |> WhenExpr.parse,
+    );
 
-  let openExtensions = {
-    key: "<S-C-X>",
-    command: Commands.openExtensionsPane.id,
-    condition: "!isMac" |> WhenExpr.parse,
-  };
+  let openExtensions =
+    bind(
+      ~key="<S-C-X>",
+      ~command=Commands.openExtensionsPane.id,
+      ~condition="!isMac" |> WhenExpr.parse,
+    );
 
-  let openExtensionsMac = {
-    key: "<D-S-X>",
-    command: Commands.openExtensionsPane.id,
-    condition: "isMac" |> WhenExpr.parse,
-  };
+  let openExtensionsMac =
+    bind(
+      ~key="<D-S-X>",
+      ~command=Commands.openExtensionsPane.id,
+      ~condition="isMac" |> WhenExpr.parse,
+    );
 
-  let openExplorer = {
-    key: "<S-C-E>",
-    command: Commands.openExplorerPane.id,
-    condition: "!isMac" |> WhenExpr.parse,
-  };
+  let openExplorer =
+    bind(
+      ~key="<S-C-E>",
+      ~command=Commands.openExplorerPane.id,
+      ~condition="!isMac" |> WhenExpr.parse,
+    );
 
-  let openExplorerMac = {
-    key: "<D-S-E>",
-    command: Commands.openExplorerPane.id,
-    condition: "isMac" |> WhenExpr.parse,
-  };
+  let openExplorerMac =
+    bind(
+      ~key="<D-S-E>",
+      ~command=Commands.openExplorerPane.id,
+      ~condition="isMac" |> WhenExpr.parse,
+    );
 
   // This keybinding is used in both MacOS & Windows
-  let openSCM = {
-    key: "<S-C-G>",
-    command: Commands.openSCMPane.id,
-    condition: WhenExpr.Value(True),
-  };
+  let openSCM =
+    bind(
+      ~key="<S-C-G>",
+      ~command=Commands.openSCMPane.id,
+      ~condition=WhenExpr.Value(True),
+    );
 
-  let toggleSidebar = {
-    key: "<C-B>",
-    command: Commands.toggleSidebar.id,
-    condition: "!isMac" |> WhenExpr.parse,
-  };
+  let toggleSidebar =
+    bind(
+      ~key="<C-B>",
+      ~command=Commands.toggleSidebar.id,
+      ~condition="!isMac" |> WhenExpr.parse,
+    );
 
-  let toggleSidebarMac = {
-    key: "<D-B>",
-    command: Commands.toggleSidebar.id,
-    condition: "isMac" |> WhenExpr.parse,
-  };
+  let toggleSidebarMac =
+    bind(
+      ~key="<D-B>",
+      ~command=Commands.toggleSidebar.id,
+      ~condition="isMac" |> WhenExpr.parse,
+    );
 };
 
 module ContextKeys = {

--- a/src/Feature/SignatureHelp/Feature_SignatureHelp.re
+++ b/src/Feature/SignatureHelp/Feature_SignatureHelp.re
@@ -354,23 +354,26 @@ module Commands = {
 module Keybindings = {
   open Feature_Input.Schema;
 
-  let decrementSignature = {
-    key: "<A-DOWN>",
-    command: Commands.decrementSignature.id,
-    condition: "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
-  };
+  let decrementSignature =
+    bind(
+      ~key="<A-DOWN>",
+      ~command=Commands.decrementSignature.id,
+      ~condition="editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
+    );
 
-  let incrementSignature = {
-    key: "<A-UP>",
-    command: Commands.incrementSignature.id,
-    condition: "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
-  };
+  let incrementSignature =
+    bind(
+      ~key="<A-UP>",
+      ~command=Commands.incrementSignature.id,
+      ~condition="editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
+    );
 
-  let close = {
-    key: "<ESC>",
-    command: Commands.close.id,
-    condition: "editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
-  };
+  let close =
+    bind(
+      ~key="<ESC>",
+      ~command=Commands.close.id,
+      ~condition="editorTextFocus && parameterHintsVisible" |> WhenExpr.parse,
+    );
 };
 
 module Contributions = {

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -564,65 +564,65 @@ module Contributions = {
   let keybindings = {
     Feature_Input.Schema.[
       // Insert mode -> normal mdoe
-      {
-        key: "<C-\\><C-N>",
-        command: Commands.Oni.normalMode.id,
-        condition: "terminalFocus && insertMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-\\>n",
-        command: Commands.Oni.normalMode.id,
-        condition: "terminalFocus && insertMode" |> WhenExpr.parse,
-      },
+      bind(
+        ~key="<C-\\><C-N>",
+        ~command=Commands.Oni.normalMode.id,
+        ~condition="terminalFocus && insertMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-\\>n",
+        ~command=Commands.Oni.normalMode.id,
+        ~condition="terminalFocus && insertMode" |> WhenExpr.parse,
+      ),
       // Normal mode -> insert mode
-      {
-        key: "o",
-        command: Commands.Oni.insertMode.id,
-        condition: "terminalFocus && normalMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<S-O>",
-        command: Commands.Oni.insertMode.id,
-        condition: "terminalFocus && normalMode" |> WhenExpr.parse,
-      },
-      {
-        key: "Shift+a",
-        command: Commands.Oni.insertMode.id,
-        condition: "terminalFocus && normalMode" |> WhenExpr.parse,
-      },
-      {
-        key: "a",
-        command: Commands.Oni.insertMode.id,
-        condition: "terminalFocus && normalMode" |> WhenExpr.parse,
-      },
-      {
-        key: "i",
-        command: Commands.Oni.insertMode.id,
-        condition: "terminalFocus && normalMode" |> WhenExpr.parse,
-      },
-      {
-        key: "Shift+i",
-        command: Commands.Oni.insertMode.id,
-        condition: "terminalFocus && normalMode" |> WhenExpr.parse,
-      },
+      bind(
+        ~key="o",
+        ~command=Commands.Oni.insertMode.id,
+        ~condition="terminalFocus && normalMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<S-O>",
+        ~command=Commands.Oni.insertMode.id,
+        ~condition="terminalFocus && normalMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="Shift+a",
+        ~command=Commands.Oni.insertMode.id,
+        ~condition="terminalFocus && normalMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="a",
+        ~command=Commands.Oni.insertMode.id,
+        ~condition="terminalFocus && normalMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="i",
+        ~command=Commands.Oni.insertMode.id,
+        ~condition="terminalFocus && normalMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="Shift+i",
+        ~command=Commands.Oni.insertMode.id,
+        ~condition="terminalFocus && normalMode" |> WhenExpr.parse,
+      ),
       // Paste - Windows:
-      {
-        key: "<C-V>",
-        command: Feature_Clipboard.Commands.paste.id,
-        condition: "terminalFocus && insertMode && isWin" |> WhenExpr.parse,
-      },
+      bind(
+        ~key="<C-V>",
+        ~command=Feature_Clipboard.Commands.paste.id,
+        ~condition="terminalFocus && insertMode && isWin" |> WhenExpr.parse,
+      ),
       // Paste - Linux:
-      {
-        key: "<C-S-V>",
-        command: Feature_Clipboard.Commands.paste.id,
-        condition: "terminalFocus && insertMode && isLinux" |> WhenExpr.parse,
-      },
+      bind(
+        ~key="<C-S-V>",
+        ~command=Feature_Clipboard.Commands.paste.id,
+        ~condition="terminalFocus && insertMode && isLinux" |> WhenExpr.parse,
+      ),
       // Paste - Mac:
-      {
-        key: "<D-V>",
-        command: Feature_Clipboard.Commands.paste.id,
-        condition: "terminalFocus && insertMode && isMac" |> WhenExpr.parse,
-      },
+      bind(
+        ~key="<D-V>",
+        ~command=Feature_Clipboard.Commands.paste.id,
+        ~condition="terminalFocus && insertMode && isMac" |> WhenExpr.parse,
+      ),
     ];
   };
 };

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -147,3 +147,17 @@ module Configuration = {
     settings |> StringMap.find_opt(settingName);
   };
 };
+
+module Keybindings = {
+  open Feature_Input.Schema;
+  let controlSquareBracketRemap =
+    remap(
+      ~fromKeys="<C-[>",
+      ~toKeys="<ESC>",
+      ~condition=WhenExpr.Value(True),
+    );
+};
+
+module Contributions = {
+  let keybindings = Keybindings.[controlSquareBracketRemap];
+};

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -65,3 +65,6 @@ module Configuration: {
 
   let resolver: model => resolver;
 };
+
+module Contributions: {let keybindings: list(Feature_Input.Schema.keybinding);
+};

--- a/src/Feature/Vim/dune
+++ b/src/Feature/Vim/dune
@@ -2,6 +2,7 @@
  (name Feature_Vim)
  (public_name Oni2.feature.vim)
  (inline_tests)
- (libraries libvim Oni2.core Oni2.service.vim Revery isolinear)
+ (libraries libvim Oni2.core Oni2.service.vim Oni2.feature.input Revery
+   isolinear)
  (preprocess
   (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Input/Keybindings.re
+++ b/src/Input/Keybindings.re
@@ -28,7 +28,7 @@ module Keybinding = {
           ~key=field.required("key", string),
           ~command=field.required("command", string),
           ~condition=
-            field.withDefault("condition", WhenExpr.Value(True), condition),
+            field.withDefault("when", WhenExpr.Value(True), condition),
         )
       });
   };

--- a/src/Input/Keybindings.re
+++ b/src/Input/Keybindings.re
@@ -3,45 +3,40 @@ open Feature_Input.Schema;
 module Json = Oni_Core.Json;
 
 module Keybinding = {
-  let parseSimple =
-    fun
-    | `String(s) => WhenExpr.Defined(s)
-    | _ => WhenExpr.Value(False);
+  module Decode = {
+    open Json.Decode;
 
-  let parseAndExpression =
-    fun
-    | `String(expr) => WhenExpr.Defined(expr)
-    | `List(andExpressions) =>
-      WhenExpr.And(List.map(parseSimple, andExpressions))
-    | _ => WhenExpr.Value(False);
+    let andExpressions =
+      list(
+        one_of([
+          ("string", string |> map(str => WhenExpr.Defined(str))),
+          ("fallback", succeed(WhenExpr.Value(False))),
+        ]),
+      )
+      |> map(items => WhenExpr.And(items));
 
-  let condition_of_yojson =
-    fun
-    | `List(orExpressions) =>
-      Ok(WhenExpr.Or(List.map(parseAndExpression, orExpressions)))
-    | `String(v) => Ok(WhenExpr.parse(v))
-    | `Null => Ok(WhenExpr.Value(True))
-    | _ => Error("Expected string for condition");
+    let condition =
+      one_of([
+        ("list", list(andExpressions) |> map(items => WhenExpr.Or(items))),
+        ("string", string |> map(WhenExpr.parse)),
+        ("null", null |> map(_ => WhenExpr.Value(True))),
+      ]);
+
+    let binding =
+      obj(({field, _}) => {
+        Feature_Input.Schema.bind(
+          ~key=field.required("key", string),
+          ~command=field.required("command", string),
+          ~condition=
+            field.withDefault("condition", WhenExpr.Value(True), condition),
+        )
+      });
+  };
 
   let of_yojson = (json: Yojson.Safe.t) => {
-    let key = Yojson.Safe.Util.member("key", json);
-    let command = Yojson.Safe.Util.member("command", json);
-    let condition =
-      Yojson.Safe.Util.member("when", json) |> condition_of_yojson;
-
-    let wrapError = msg => Error(msg ++ ": " ++ Yojson.Safe.to_string(json));
-
-    switch (condition) {
-    | Ok(condition) =>
-      switch (key, command) {
-      | (`String(key), `String(command)) => Ok({key, command, condition})
-      | (`String(_), _) => wrapError("'command' is required")
-      | (_, `String(_)) => wrapError("'key' is required")
-      | _ => wrapError("'key' and 'command' are required")
-      }
-
-    | Error(_) as err => err
-    };
+    json
+    |> Json.Decode.decode_value(Decode.binding)
+    |> Result.map_error(Json.Decode.string_of_error);
   };
 };
 
@@ -89,17 +84,14 @@ module Legacy = {
     list(Feature_Input.Schema.keybinding) =
     keys => {
       let upgradeBinding = (binding: Feature_Input.Schema.keybinding) => {
-        switch (binding.command) {
-        | "quickOpen.open" => {
-            ...binding,
-            command: "workbench.action.quickOpen",
-          }
-        | "commandPalette.open" => {
-            ...binding,
-            command: "workbench.action.showCommands",
-          }
-        | _ => binding
-        };
+        let f = cmd =>
+          switch (cmd) {
+          | "quickOpen.open" => "workbench.action.quickOpen"
+          | "commandPalette.open" => "workbench.action.showCommands"
+          | str => str
+          };
+
+        Feature_Input.Schema.mapCommand(~f, binding);
       };
 
       keys |> List.map(upgradeBinding);

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -407,7 +407,14 @@ let defaultKeyBindings =
   @ Feature_SignatureHelp.Contributions.keybindings
   @ Component_VimWindows.Contributions.keybindings
   @ Component_VimList.Contributions.keybindings
-  @ Component_VimTree.Contributions.keybindings;
+  @ Component_VimTree.Contributions.keybindings
+  @ Feature_Input.Schema.[
+      remap(
+        ~fromKeys="<C-[>",
+        ~toKeys="<ESC>",
+        ~condition=WhenExpr.Value(True),
+      ),
+    ];
 
 type windowDisplayMode =
   | Minimized

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -13,57 +13,57 @@ let windowCommandCondition = "!insertMode || terminalFocus" |> WhenExpr.parse;
 let isMacCondition = "isMac" |> WhenExpr.parse;
 let defaultKeyBindings =
   Feature_Input.Schema.[
-    {
-      key: "<UP>",
-      command: Commands.List.focusUp.id,
-      condition: "listFocus || textInputFocus" |> WhenExpr.parse,
-    },
-    {
-      key: "<DOWN>",
-      command: Commands.List.focusDown.id,
-      condition: "listFocus || textInputFocus" |> WhenExpr.parse,
-    },
-    {
-      key: "<RIGHT>",
-      command: Commands.List.selectBackground.id,
-      condition: "quickmenuCursorEnd" |> WhenExpr.parse,
-    },
+    bind(
+      ~key="<UP>",
+      ~command=Commands.List.focusUp.id,
+      ~condition="listFocus || textInputFocus" |> WhenExpr.parse,
+    ),
+    bind(
+      ~key="<DOWN>",
+      ~command=Commands.List.focusDown.id,
+      ~condition="listFocus || textInputFocus" |> WhenExpr.parse,
+    ),
+    bind(
+      ~key="<RIGHT>",
+      ~command=Commands.List.selectBackground.id,
+      ~condition="quickmenuCursorEnd" |> WhenExpr.parse,
+    ),
   ]
   @ Feature_SideBar.Contributions.keybindings
   @ Feature_Input.Schema.[
-      {
-        key: "<C-TAB>",
-        command:
+      bind(
+        ~key="<C-TAB>",
+        ~command=
           Commands.Workbench.Action.openNextRecentlyUsedEditorInGroup.id,
-        condition: "editorTextFocus || terminalFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-P>",
-        command: Commands.Workbench.Action.quickOpen.id,
-        condition: "editorTextFocus || terminalFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-P>",
-        command: Commands.Workbench.Action.quickOpen.id,
-        condition: "isMac" |> WhenExpr.parse,
-      },
-      {
-        key: "<S-C-P>",
-        command: Commands.Workbench.Action.showCommands.id,
-        condition: "!isMac" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-S-P>",
-        command: Commands.Workbench.Action.showCommands.id,
-        condition: "isMac" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-V>",
-        command: Feature_Clipboard.Commands.paste.id,
-        condition:
-          // The WhenExpr parser doesn't support precedence, so we manually construct it here...
-          // It'd be nice to bring back explicit precedence via '(' and ')'
-          // Alternatively, a manual construction could be done with separate bindings for !isMac OR each condition
+        ~condition="editorTextFocus || terminalFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-P>",
+        ~command=Commands.Workbench.Action.quickOpen.id,
+        ~condition="editorTextFocus || terminalFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-P>",
+        ~command=Commands.Workbench.Action.quickOpen.id,
+        ~condition="isMac" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<S-C-P>",
+        ~command=Commands.Workbench.Action.showCommands.id,
+        ~condition="!isMac" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-S-P>",
+        ~command=Commands.Workbench.Action.showCommands.id,
+        ~condition="isMac" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-V>",
+        ~command=Feature_Clipboard.Commands.paste.id,
+        // The WhenExpr parser doesn't support precedence, so we manually construct it here...
+        // It'd be nice to bring back explicit precedence via '(' and ')'
+        // Alternatively, a manual construction could be done with separate bindings for !isMac OR each condition
+        ~condition=
           WhenExpr.(
             And([
               Not(Defined("isMac")),
@@ -74,318 +74,318 @@ let defaultKeyBindings =
               ]),
             ])
           ),
-      },
-      {
-        key: "<D-V>",
-        command: Feature_Clipboard.Commands.paste.id,
-        condition: isMacCondition,
-      },
-      {
-        key: "<ESC>",
-        command: Commands.Workbench.Action.closeQuickOpen.id,
+      ),
+      bind(
+        ~key="<D-V>",
+        ~command=Feature_Clipboard.Commands.paste.id,
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<ESC>",
+        ~command=Commands.Workbench.Action.closeQuickOpen.id,
         // When in command-line mode, we should let Vim control when it is closed
         // (The <esc> key might not always trigger closing, like if 'insert literal' (Ctrl-v/Ctrl-q) is active)
-        condition: "!commandLineFocus && inQuickOpen" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-N>",
-        command: Commands.List.focusDown.id,
-        condition: "listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-P>",
-        command: Commands.List.focusUp.id,
-        condition: "listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-N>",
-        command: Commands.List.focusDown.id,
-        condition: "isMac && listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-P>",
-        command: Commands.List.focusUp.id,
-        condition: "isMac && listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<TAB>",
-        command: Commands.List.focusDown.id,
-        condition: "listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<S-TAB>",
-        command: Commands.List.focusUp.id,
-        condition: "listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-TAB>",
-        command:
+        ~condition="!commandLineFocus && inQuickOpen" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-N>",
+        ~command=Commands.List.focusDown.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-P>",
+        ~command=Commands.List.focusUp.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-N>",
+        ~command=Commands.List.focusDown.id,
+        ~condition="isMac && listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-P>",
+        ~command=Commands.List.focusUp.id,
+        ~condition="isMac && listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<TAB>",
+        ~command=Commands.List.focusDown.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<S-TAB>",
+        ~command=Commands.List.focusUp.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-TAB>",
+        ~command=
           Commands.Workbench.Action.quickOpenNavigateNextInEditorPicker.id,
-        condition: "inEditorsPicker" |> WhenExpr.parse,
-      },
-      {
-        key: "<S-C-TAB>",
-        command:
+        ~condition="inEditorsPicker" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<S-C-TAB>",
+        ~command=
           Commands.Workbench.Action.quickOpenNavigatePreviousInEditorPicker.id,
-        condition: "inEditorsPicker" |> WhenExpr.parse,
-      },
-      {
-        key: "<release>",
-        command: Commands.List.select.id,
-        condition: "inEditorsPicker" |> WhenExpr.parse,
-      },
+        ~condition="inEditorsPicker" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<release>",
+        ~command=Commands.List.select.id,
+        ~condition="inEditorsPicker" |> WhenExpr.parse,
+      ),
     ]
   @ Feature_Registers.Contributions.keybindings
   @ Feature_LanguageSupport.Contributions.keybindings
   @ Feature_Input.Schema.[
-      {
-        key: "<CR>",
-        command: Commands.List.select.id,
-        condition: "listFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-Z>",
-        command: Commands.undo.id,
-        condition: "isMac && editorTextFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-S-Z>",
-        command: Commands.redo.id,
-        condition: "isMac && editorTextFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-S>",
-        command: Commands.Workbench.Action.Files.save.id,
-        condition: "isMac && editorTextFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-S>",
-        command: Commands.Workbench.Action.Files.save.id,
-        condition: "editorTextFocus" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-]>",
-        command: Commands.Editor.Action.indentLines.id,
-        condition: "visualMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-[>",
-        command: Commands.Editor.Action.outdentLines.id,
-        condition: "visualMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-]>",
-        command: Commands.Editor.Action.indentLines.id,
-        condition: "isMac && visualMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<D-[>",
-        command: Commands.Editor.Action.outdentLines.id,
-        condition: "isMac && visualMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<TAB>",
-        command: Commands.indent.id,
-        condition: "visualMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<S-TAB>",
-        command: Commands.outdent.id,
-        condition: "visualMode" |> WhenExpr.parse,
-      },
-      {
-        key: "<C-G>",
-        command: Feature_Sneak.Commands.start.id,
-        condition: WhenExpr.Value(True),
-      },
-      {
-        key: "<ESC>",
-        command: Feature_Sneak.Commands.stop.id,
-        condition: "sneakMode" |> WhenExpr.parse,
-      },
+      bind(
+        ~key="<CR>",
+        ~command=Commands.List.select.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-Z>",
+        ~command=Commands.undo.id,
+        ~condition="isMac && editorTextFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-S-Z>",
+        ~command=Commands.redo.id,
+        ~condition="isMac && editorTextFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-S>",
+        ~command=Commands.Workbench.Action.Files.save.id,
+        ~condition="isMac && editorTextFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-S>",
+        ~command=Commands.Workbench.Action.Files.save.id,
+        ~condition="editorTextFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-]>",
+        ~command=Commands.Editor.Action.indentLines.id,
+        ~condition="visualMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-[>",
+        ~command=Commands.Editor.Action.outdentLines.id,
+        ~condition="visualMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-]>",
+        ~command=Commands.Editor.Action.indentLines.id,
+        ~condition="isMac && visualMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-[>",
+        ~command=Commands.Editor.Action.outdentLines.id,
+        ~condition="isMac && visualMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<TAB>",
+        ~command=Commands.indent.id,
+        ~condition="visualMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<S-TAB>",
+        ~command=Commands.outdent.id,
+        ~condition="visualMode" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-G>",
+        ~command=Feature_Sneak.Commands.start.id,
+        ~condition=WhenExpr.Value(True),
+      ),
+      bind(
+        ~key="<ESC>",
+        ~command=Feature_Sneak.Commands.stop.id,
+        ~condition="sneakMode" |> WhenExpr.parse,
+      ),
     ]
   @ Feature_Pane.Contributions.keybindings
   @ Feature_Input.Schema.[
-      {
-        key: "<D-W>",
-        command: Feature_Layout.Commands.closeActiveEditor.id,
-        condition: isMacCondition,
-      },
-      {
-        key: "<C-PAGEDOWN>",
-        command: Feature_Layout.Commands.nextEditor.id,
-        condition: WhenExpr.Value(True),
-      },
-      {
-        key: "<D-S-]>",
-        command: Feature_Layout.Commands.nextEditor.id,
-        condition: isMacCondition,
-      },
-      {
-        key: "<C-PAGEUP>",
-        command: Feature_Layout.Commands.previousEditor.id,
-        condition: WhenExpr.Value(True),
-      },
-      {
-        key: "<D-S-[>",
-        command: Feature_Layout.Commands.previousEditor.id,
-        condition: isMacCondition,
-      },
-      {
-        key: "<D-=>",
-        command: "workbench.action.zoomIn",
-        condition: isMacCondition,
-      },
-      {
-        key: "<C-=>",
-        command: "workbench.action.zoomIn",
-        condition: WhenExpr.Value(True),
-      },
-      {
-        key: "<D-->",
-        command: "workbench.action.zoomOut",
-        condition: isMacCondition,
-      },
-      {
-        key: "<C-->",
-        command: "workbench.action.zoomOut",
-        condition: WhenExpr.Value(True),
-      },
-      {
-        key: "<D-0>",
-        command: "workbench.action.zoomReset",
-        condition: isMacCondition,
-      },
-      {
-        key: "<C-0>",
-        command: "workbench.action.zoomReset",
-        condition: WhenExpr.Value(True),
-      },
+      bind(
+        ~key="<D-W>",
+        ~command=Feature_Layout.Commands.closeActiveEditor.id,
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<C-PAGEDOWN>",
+        ~command=Feature_Layout.Commands.nextEditor.id,
+        ~condition=WhenExpr.Value(True),
+      ),
+      bind(
+        ~key="<D-S-]>",
+        ~command=Feature_Layout.Commands.nextEditor.id,
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<C-PAGEUP>",
+        ~command=Feature_Layout.Commands.previousEditor.id,
+        ~condition=WhenExpr.Value(True),
+      ),
+      bind(
+        ~key="<D-S-[>",
+        ~command=Feature_Layout.Commands.previousEditor.id,
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<D-=>",
+        ~command="workbench.action.zoomIn",
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<C-=>",
+        ~command="workbench.action.zoomIn",
+        ~condition=WhenExpr.Value(True),
+      ),
+      bind(
+        ~key="<D-->",
+        ~command="workbench.action.zoomOut",
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<C-->",
+        ~command="workbench.action.zoomOut",
+        ~condition=WhenExpr.Value(True),
+      ),
+      bind(
+        ~key="<D-0>",
+        ~command="workbench.action.zoomReset",
+        ~condition=isMacCondition,
+      ),
+      bind(
+        ~key="<C-0>",
+        ~command="workbench.action.zoomReset",
+        ~condition=WhenExpr.Value(True),
+      ),
     ]
   @ Feature_Terminal.Contributions.keybindings
   //LAYOUT
   @ Feature_Input.Schema.[
-      {
-        key: "<C-W>H",
-        command: Feature_Layout.Commands.moveLeft.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-H>",
-        command: Feature_Layout.Commands.moveLeft.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><LEFT>",
-        command: Feature_Layout.Commands.moveLeft.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>L",
-        command: Feature_Layout.Commands.moveRight.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-L>",
-        command: Feature_Layout.Commands.moveRight.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-S>",
-        command: Feature_Layout.Commands.splitHorizontal.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>S",
-        command: Feature_Layout.Commands.splitHorizontal.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-V>",
-        command: Feature_Layout.Commands.splitVertical.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>V",
-        command: Feature_Layout.Commands.splitVertical.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><RIGHT>",
-        command: Feature_Layout.Commands.moveRight.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>K",
-        command: Feature_Layout.Commands.moveUp.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-K>",
-        command: Feature_Layout.Commands.moveUp.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><UP>",
-        command: Feature_Layout.Commands.moveUp.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>J",
-        command: Feature_Layout.Commands.moveDown.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-J>",
-        command: Feature_Layout.Commands.moveDown.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><DOWN>",
-        command: Feature_Layout.Commands.moveDown.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>R",
-        command: Feature_Layout.Commands.rotateForward.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-R>",
-        command: Feature_Layout.Commands.rotateForward.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><C-S-R>",
-        command: Feature_Layout.Commands.rotateBackward.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>-",
-        command: Feature_Layout.Commands.decreaseVerticalSize.id,
-        condition: windowCommandCondition,
-      },
+      bind(
+        ~key="<C-W>H",
+        ~command=Feature_Layout.Commands.moveLeft.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-H>",
+        ~command=Feature_Layout.Commands.moveLeft.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><LEFT>",
+        ~command=Feature_Layout.Commands.moveLeft.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>L",
+        ~command=Feature_Layout.Commands.moveRight.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-L>",
+        ~command=Feature_Layout.Commands.moveRight.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-S>",
+        ~command=Feature_Layout.Commands.splitHorizontal.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>S",
+        ~command=Feature_Layout.Commands.splitHorizontal.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-V>",
+        ~command=Feature_Layout.Commands.splitVertical.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>V",
+        ~command=Feature_Layout.Commands.splitVertical.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><RIGHT>",
+        ~command=Feature_Layout.Commands.moveRight.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>K",
+        ~command=Feature_Layout.Commands.moveUp.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-K>",
+        ~command=Feature_Layout.Commands.moveUp.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><UP>",
+        ~command=Feature_Layout.Commands.moveUp.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>J",
+        ~command=Feature_Layout.Commands.moveDown.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-J>",
+        ~command=Feature_Layout.Commands.moveDown.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><DOWN>",
+        ~command=Feature_Layout.Commands.moveDown.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>R",
+        ~command=Feature_Layout.Commands.rotateForward.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-R>",
+        ~command=Feature_Layout.Commands.rotateForward.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-S-R>",
+        ~command=Feature_Layout.Commands.rotateBackward.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>-",
+        ~command=Feature_Layout.Commands.decreaseVerticalSize.id,
+        ~condition=windowCommandCondition,
+      ),
       //      TODO: Does not work, blocked by bug in editor-input
       //      {
       //        key: "<C-W>+",
       //        command: Feature_Layout.Commands.increaseVerticalSize.id,
       //        condition: "!insertMode" |> WhenExpr.parse
       //      },
-      {
-        key: "<C-W><S-,>", // TODO: Does not work and should be `<`, but blocked by bugs in editor-input,
-        command: Feature_Layout.Commands.increaseHorizontalSize.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W><S-.>", // TODO: Does not work and should be `>`, but blocked by bugs in editor-input
-        command: Feature_Layout.Commands.decreaseHorizontalSize.id,
-        condition: windowCommandCondition,
-      },
-      {
-        key: "<C-W>=",
-        command: Feature_Layout.Commands.resetSizes.id,
-        condition: windowCommandCondition,
-      },
+      bind(
+        ~key="<C-W><S-,>", // TODO: Does not work and should be `<`, but blocked by bugs in editor-input,
+        ~command=Feature_Layout.Commands.increaseHorizontalSize.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><S-.>", // TODO: Does not work and should be `>`, but blocked by bugs in editor-input
+        ~command=Feature_Layout.Commands.decreaseHorizontalSize.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>=",
+        ~command=Feature_Layout.Commands.resetSizes.id,
+        ~condition=windowCommandCondition,
+      ),
       // TODO: Fails to parse
       // {
       //   key: "<C-W>_",
@@ -398,11 +398,11 @@ let defaultKeyBindings =
       //   command: Feature_Layout.Commands.maximizeHorizontal.id,
       //   condition: windowCommandCondition,
       // },
-      {
-        key: "<C-W>o",
-        command: Feature_Layout.Commands.toggleMaximize.id,
-        condition: windowCommandCondition,
-      },
+      bind(
+        ~key="<C-W>o",
+        ~command=Feature_Layout.Commands.toggleMaximize.id,
+        ~condition=windowCommandCondition,
+      ),
     ]
   @ Feature_SignatureHelp.Contributions.keybindings
   @ Component_VimWindows.Contributions.keybindings

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -408,13 +408,7 @@ let defaultKeyBindings =
   @ Component_VimWindows.Contributions.keybindings
   @ Component_VimList.Contributions.keybindings
   @ Component_VimTree.Contributions.keybindings
-  @ Feature_Input.Schema.[
-      remap(
-        ~fromKeys="<C-[>",
-        ~toKeys="<ESC>",
-        ~condition=WhenExpr.Value(True),
-      ),
-    ];
+  @ Feature_Vim.Contributions.keybindings;
 
 type windowDisplayMode =
   | Minimized


### PR DESCRIPTION
__Issue:__ As described in #2368, there were cases where we were not handling `Ctrl+[` as `<Escape>`.

__Fix:__ We should respect this same behavior - as @LeonT-A mentioned, this is often quicker & easier to press than reaching for `<Escape>`

This involves some refactoring, adjusting the input schema to handle bindings (key -> command), remaps (key -> key), and, eventually for #2870 , clearing commands too, but it means we'll be able to handle remaps more generally in JSON.