### PR TITLE
fix(editor): Correct diff marker rendering in presence of codelens

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -16,6 +16,7 @@
 - #2871 - Vim: Fix `ctrl+o` behavior in insert mode (fixes #2425)
 - #2854 - Extensions: Signature Help - fix overlay staying open in normal mode
 - #2877 - Vim: Remove conflicting `ctrl+b` binding on Windows / Linux (fixes #2870)
+- #2879 - Editor: Correct diff marker rendering in presence of codelens
 
 ### Performance
 

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -108,33 +108,26 @@ let renderMarker =
 
 let render =
     (
-      ~editor,
+      ~context: Draw.context,
       ~scrollY,
       ~rowHeight,
       ~x,
-      ~height,
       ~width,
-      ~count,
       ~canvasContext,
       ~colors,
       markers,
     ) =>
-  ImmediateList.render(
-    ~scrollY,
-    ~rowHeight,
-    ~height,
-    ~count,
-    ~render=
-      (i, _y) => {
+  Draw.renderImmediate(
+    ~context,
+      (i, y) => {
         let bufferLine =
-          Editor.viewLineToBufferLine(i, editor)
+          Editor.viewLineToBufferLine(i, context.editor)
           |> EditorCoreTypes.LineNumber.toZeroBased;
 
-        let y = Editor.viewLineToPixelY(i, editor);
         if (markers[bufferLine] != Unmodified) {
           renderMarker(
             ~x,
-            ~y=y -. scrollY,
+            ~y,
             ~rowHeight,
             ~width,
             ~canvasContext,
@@ -143,7 +136,6 @@ let render =
           );
         };
       },
-    (),
   );
 
 let renderMinimap =
@@ -184,3 +176,4 @@ let renderMinimap =
       },
     (),
   );
+

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -109,7 +109,6 @@ let renderMarker =
 let render =
     (
       ~context: Draw.context,
-      ~scrollY,
       ~rowHeight,
       ~x,
       ~width,
@@ -119,23 +118,23 @@ let render =
     ) =>
   Draw.renderImmediate(
     ~context,
-      (i, y) => {
-        let bufferLine =
-          Editor.viewLineToBufferLine(i, context.editor)
-          |> EditorCoreTypes.LineNumber.toZeroBased;
+    (i, y) => {
+      let bufferLine =
+        Editor.viewLineToBufferLine(i, context.editor)
+        |> EditorCoreTypes.LineNumber.toZeroBased;
 
-        if (markers[bufferLine] != Unmodified) {
-          renderMarker(
-            ~x,
-            ~y,
-            ~rowHeight,
-            ~width,
-            ~canvasContext,
-            ~colors,
-            markers[bufferLine],
-          );
-        };
-      },
+      if (markers[bufferLine] != Unmodified) {
+        renderMarker(
+          ~x,
+          ~y,
+          ~rowHeight,
+          ~width,
+          ~canvasContext,
+          ~colors,
+          markers[bufferLine],
+        );
+      };
+    },
   );
 
 let renderMinimap =
@@ -176,4 +175,3 @@ let renderMinimap =
       },
     (),
   );
-

--- a/src/Feature/Editor/EditorDiffMarkers.rei
+++ b/src/Feature/Editor/EditorDiffMarkers.rei
@@ -14,13 +14,11 @@ let generate: (~scm: Feature_SCM.model, Buffer.t) => option(t);
 
 let render:
   (
-    ~editor: Editor.t,
+    ~context: Draw.context,
     ~scrollY: float,
     ~rowHeight: float,
     ~x: float,
-    ~height: float,
     ~width: float,
-    ~count: int,
     ~canvasContext: Revery.Draw.CanvasContext.t,
     ~colors: Colors.t,
     t

--- a/src/Feature/Editor/EditorDiffMarkers.rei
+++ b/src/Feature/Editor/EditorDiffMarkers.rei
@@ -15,7 +15,6 @@ let generate: (~scm: Feature_SCM.model, Buffer.t) => option(t);
 let render:
   (
     ~context: Draw.context,
-    ~scrollY: float,
     ~rowHeight: float,
     ~x: float,
     ~width: float,

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -117,7 +117,6 @@ let render =
       ~height,
       ~colors,
       ~editorFont: Service_Font.font,
-      ~count,
       ~cursorLine,
       ~diffMarkers,
       canvasContext,
@@ -140,7 +139,6 @@ let render =
   Option.iter(
     EditorDiffMarkers.render(
       ~context,
-      ~scrollY=Editor.scrollY(editor),
       ~rowHeight=Editor.lineHeightInPixels(editor),
       ~x=lineNumberWidth,
       ~width=Constants.diffMarkerWidth,

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -198,7 +198,6 @@ let make =
       ~height,
       ~colors,
       ~editorFont,
-      ~count,
       ~cursorLine,
       ~diffMarkers,
     );

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -139,13 +139,11 @@ let render =
 
   Option.iter(
     EditorDiffMarkers.render(
-      ~editor,
+      ~context,
       ~scrollY=Editor.scrollY(editor),
       ~rowHeight=Editor.lineHeightInPixels(editor),
       ~x=lineNumberWidth,
-      ~height=float(height),
       ~width=Constants.diffMarkerWidth,
-      ~count,
       ~canvasContext,
       ~colors,
     ),


### PR DESCRIPTION
__Issue:__ The diff markers would not always render in the presence of codelens / inline elements

__Defect:__ The diff marker rendering was using a naive approach to calculate the current view `y` position - just based on the `scrollY` and the `rowHeight`. This worked fine without codelens, since the line height would never be variable - but in the presence of variable-height lines, this logic doesn't work anymore.

__Fix:__ Switch to using `Draw.renderImmediate` which handles this correctly.