### PR TITLE
refactor(dependency): vscode-exthost -> 1.51.0

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -29,4 +29,5 @@
 ### Infrastructure / Refactoring
 
 - #2853 - Input: Add APIs for querying contextually available bindings and consumed keys
+- #2886 - Extensions: Upgrade vscode-exthost -> 1.51.0
 

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onivim/vscode-exthost": "1.50.1000",
+    "@onivim/vscode-exthost": "1.51.0",
     "follow-redirects": "1.13.0",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@onivim/vscode-exthost@1.50.1000":
-  version "1.50.1000"
-  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.50.1000.tgz#4b883e6668020f0fa71ca611df46bdb313ec46c3"
-  integrity sha512-ud7CLJ179ypSzD2TPPWBI8wtLbj1KeCexDbjkmTlkRZb1iov1sqhql+bBt1TQwNF3m9H7qTLYGwpqtEjeE7bPw==
+"@onivim/vscode-exthost@1.51.0":
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.51.0.tgz#539e440cda74aaef47b3f215139f2350f39bf609"
+  integrity sha512-ay1WFryuFDfTY8RE7H0pQCpb5su4YHLPG+/83dGfFfj7zt44BqSmhOSE3ui5M9CLSxNkz3KA44i3qGN4sV/Txg==
   dependencies:
     graceful-fs "4.2.3"
     iconv-lite-umd "0.6.8"

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -258,7 +258,7 @@ let create =
 
   let initData =
     InitData.create(
-      ~version="1.50.1", // TODO: How to keep in sync with bundled version?
+      ~version="1.51.0", // TODO: How to keep in sync with bundled version?
       ~parentPid,
       ~logsLocation,
       ~logFile,


### PR DESCRIPTION
Upgrade extension host to 1.51.0

Related #1058 

> NOTE: If building from source, make sure to run `node install-node-deps.js` after picking up this change.