### PR TITLE
fix(vim/#2882): Fix count behavior for L/H jumps

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -18,6 +18,7 @@
 - #2877 - Vim: Remove conflicting `ctrl+b` binding on Windows / Linux (fixes #2870)
 - #2878 - Input: Treat `Ctrl+[` as `Escape` everywhere
 - #2879 - Editor: Correct diff marker rendering in presence of codelens
+- #2891 - Vim: Fix count behavior for L/H jumps (fixes #2882)
 
 ### Performance
 

--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -66,3 +66,23 @@ __Pass:__
 - [ ] Win
 - [ ] OSX
 - [ ] Linux
+
+# 4. Editing
+
+## 4.1 Verify H/L/M behavior on editor surface
+
+- Launch Onivim in oni2 directory
+- Open `README.md`
+- Set line wrap (`:set wrap`)
+- In normal mode, verify `H` goes to top buffer line
+- In normal mode, verify `L` goes to bottom buffer line
+- In normal mode, verify `M` goes to middle buffer line
+- In normal mode, verify `3H` goes to third buffer line 
+- In normal mode, verify `4L` goes to fourth-from-bottom buffer line
+- In normal mode, verify `1000H` goes to the same position as `L`
+- In normal mode, verify `1000L` goes to the same position as `H`
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -162,25 +162,21 @@ let current = (state: State.t) => {
     |> Array.of_list;
   };
 
-  let viewLineMotion = (~motion, ~count as _, ~startLine as _) => {
+  let viewLineMotion = (~motion, ~count, ~startLine as _) => {
+    open EditorCoreTypes;
+    let topLine =
+      editor |> Editor.getTopVisibleBufferLine |> LineNumber.toZeroBased;
+    let bottomLine =
+      (editor |> Editor.getBottomVisibleBufferLine |> LineNumber.toZeroBased)
+      - 1;
+    let normalizedCount = max(count - 1, 0);
     switch (motion) {
-    | Vim.ViewLineMotion.MotionH => Editor.getTopVisibleBufferLine(editor)
+    | Vim.ViewLineMotion.MotionH =>
+      LineNumber.ofZeroBased(min(topLine + normalizedCount, bottomLine))
     | Vim.ViewLineMotion.MotionM =>
-      EditorCoreTypes.(
-        {
-          let topLine =
-            editor |> Editor.getTopVisibleBufferLine |> LineNumber.toZeroBased;
-          let bottomLine =
-            editor
-            |> Editor.getBottomVisibleBufferLine
-            |> LineNumber.toZeroBased;
-          LineNumber.ofZeroBased(topLine + (bottomLine - topLine) / 2);
-        }
-      )
+      LineNumber.ofZeroBased(topLine + (bottomLine - topLine) / 2)
     | Vim.ViewLineMotion.MotionL =>
-      EditorCoreTypes.LineNumber.(
-        Editor.getBottomVisibleBufferLine(editor) - 1
-      )
+      LineNumber.ofZeroBased(max(bottomLine - normalizedCount, topLine))
     };
   };
 


### PR DESCRIPTION
__Issue:__ Using a count for `L` or `H` (screen-space linewise jump) had no effect

__Defect:__ We were ignoring the `count` parameter

__Fix:__ Handle the `count` parameter, offsetting from the top/bottom of the screen, and limiting to the bounds of the screen.

Fixes #2882 