### PR TITLE
In linux package build script, rm -f file on cleanup

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -33,3 +33,4 @@
 - #2886 - Extensions: Upgrade vscode-exthost -> 1.51.0
 - #2887 - Build: Remove hardcoded extension host version; pull from package
 - #2888 - Extensions: Upgrade vscode-exthost -> 1.52.1
+- #2894 - Build: Linux - Fix permission problem removing setup.json (thanks @marcinkoziej!)

--- a/scripts/linux/package-linux.sh
+++ b/scripts/linux/package-linux.sh
@@ -40,7 +40,7 @@ cp -r extensions/ _release/Onivim2.AppDir/usr/bin
 cp -r node/ _release/Onivim2.AppDir/usr/share
 # cp -r src/textmate_service/ _release/Onivim2.AppDir/usr/bin
 
-rm _release/Onivim2.AppDir/usr/bin/setup.json
+rm -f _release/Onivim2.AppDir/usr/bin/setup.json
 
 ARCH=x86_64 _staging/appimagetool-x86_64.AppImage _release/Onivim2.AppDir _release/Onivim2-x86_64.AppImage
 


### PR DESCRIPTION
Package building problem on Ubuntu Linux Focal 20.04: 
Permission problem removing `_release/Onivim2.AppDir/usr/bin/setup.json`.
I have add force option to make it work.