### PR TITLE
fix(dependency): esy-skia -> 91c98f6

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08a844c7cc3444a3bef9a65e24029a49",
+  "checksum": "0956946879c45a0b35575b079e76cfb6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -141,7 +141,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@github:bryphe/flex#5e19b05@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9", "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
@@ -675,13 +675,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#60e0260",
+      "version": "github:revery-ui/esy-skia#91c98f6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#60e0260" ]
+        "source": [ "github:revery-ui/esy-skia#91c98f6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1004,7 +1004,7 @@
         "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.83@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",
         "esy-oniguruma@github:onivim/esy-oniguruma#4698ce4@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08a844c7cc3444a3bef9a65e24029a49",
+  "checksum": "0956946879c45a0b35575b079e76cfb6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -141,7 +141,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@github:bryphe/flex#5e19b05@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9", "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
@@ -675,13 +675,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#60e0260",
+      "version": "github:revery-ui/esy-skia#91c98f6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#60e0260" ]
+        "source": [ "github:revery-ui/esy-skia#91c98f6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1003,7 +1003,7 @@
         "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.83@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",
         "esy-oniguruma@github:onivim/esy-oniguruma#4698ce4@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08a844c7cc3444a3bef9a65e24029a49",
+  "checksum": "0956946879c45a0b35575b079e76cfb6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -141,7 +141,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@github:bryphe/flex#5e19b05@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9", "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
@@ -675,13 +675,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#60e0260",
+      "version": "github:revery-ui/esy-skia#91c98f6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#60e0260" ]
+        "source": [ "github:revery-ui/esy-skia#91c98f6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1003,7 +1003,7 @@
         "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.83@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",
         "esy-oniguruma@github:onivim/esy-oniguruma#4698ce4@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
   },
   "resolutions": {
     "revery": "revery-ui/revery#dd47c70",
-    "esy-skia": "revery-ui/esy-skia#60e0260",
+    "esy-skia": "revery-ui/esy-skia#91c98f6",
     "rench": "bryphe/rench#a976fe5",
     "isolinear": "revery-ui/isolinear#53fc4eb",
     "revery-terminal": "revery-ui/revery-terminal#a9cb168",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4da271e243033585be0d294b6c31fd01",
+  "checksum": "0956946879c45a0b35575b079e76cfb6",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -141,7 +141,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@github:bryphe/flex#5e19b05@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9", "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
@@ -675,13 +675,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#8b753be",
+      "version": "github:revery-ui/esy-skia#91c98f6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#8b753be" ]
+        "source": [ "github:revery-ui/esy-skia#91c98f6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1003,7 +1003,7 @@
         "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.83@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",
         "esy-oniguruma@github:onivim/esy-oniguruma#4698ce4@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08a844c7cc3444a3bef9a65e24029a49",
+  "checksum": "4da271e243033585be0d294b6c31fd01",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -141,7 +141,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@github:bryphe/flex#5e19b05@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9", "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
@@ -675,13 +675,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#60e0260",
+      "version": "github:revery-ui/esy-skia#8b753be",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#60e0260" ]
+        "source": [ "github:revery-ui/esy-skia#8b753be" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1003,7 +1003,7 @@
         "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.83@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#8b753be@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",
         "esy-oniguruma@github:onivim/esy-oniguruma#4698ce4@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bfe6f9e2e2eade013cac087978c499a3",
+  "checksum": "ee5895c143de4d63a6579e1e4e676917",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -141,7 +141,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@github:bryphe/flex#5e19b05@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9", "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
@@ -675,13 +675,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9": {
-      "id": "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+    "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9": {
+      "id": "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
       "name": "esy-skia",
-      "version": "github:revery-ui/esy-skia#60e0260",
+      "version": "github:revery-ui/esy-skia#91c98f6",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/esy-skia#60e0260" ]
+        "source": [ "github:revery-ui/esy-skia#91c98f6" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1003,7 +1003,7 @@
         "ocaml@4.10.0@d41d8cd9", "libvim@8.10869.83@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
-        "esy-skia@github:revery-ui/esy-skia#60e0260@d41d8cd9",
+        "esy-skia@github:revery-ui/esy-skia#91c98f6@d41d8cd9",
         "esy-sdl2@2.0.10008@d41d8cd9",
         "esy-oniguruma@github:onivim/esy-oniguruma#4698ce4@d41d8cd9",
         "esy-macdylibbundler@0.4.5@d41d8cd9",


### PR DESCRIPTION
Brings in fixes to esy-skia that allows it to build with clang 10.2 on Arch Linux.