### PR TITLE
refactor(dependencies): update revery → f2da66e

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0956946879c45a0b35575b079e76cfb6",
+  "checksum": "e0c22dfe751847f306b38eb9bbbfef78",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#dd47c70@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#dd47c70",
+      "version": "github:revery-ui/revery#f2da66e",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#dd47c70" ]
+        "source": [ "github:revery-ui/revery#f2da66e" ]
       },
       "overrides": [],
       "dependencies": [
@@ -995,7 +995,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0956946879c45a0b35575b079e76cfb6",
+  "checksum": "e0c22dfe751847f306b38eb9bbbfef78",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#dd47c70@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#dd47c70",
+      "version": "github:revery-ui/revery#f2da66e",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#dd47c70" ]
+        "source": [ "github:revery-ui/revery#f2da66e" ]
       },
       "overrides": [],
       "dependencies": [
@@ -995,7 +995,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/integration_test/EditorFontValidTest.re
+++ b/integration_test/EditorFontValidTest.re
@@ -3,16 +3,16 @@ open Oni_IntegrationTestLib;
 
 let fontToUse =
   switch (Revery.Environment.os) {
-  | Revery.Environment.Windows => "Consolas"
-  | Revery.Environment.Mac => "Menlo"
-  | Revery.Environment.Linux => "Ubuntu Mono"
+  | Revery.Environment.Windows(_) => "Consolas"
+  | Revery.Environment.Mac(_) => "Menlo"
+  | Revery.Environment.Linux(_) => "Ubuntu Mono"
   | _ => "Courier"
   };
 
 // Try loading a different font
 let configuration = {|{ "editor.fontFamily": "|} ++ fontToUse ++ {|"}|};
 
-if (Revery.Environment.os !== Revery.Environment.Linux) {
+if (!Revery.Environment.isLinux) {
   // Skipping this test on Linux, because there is a known fontconfig memory leak we hit.
   // The `FcInit` function in fontconfig leaks, and calling `FcFini` to clean it up crashes.
   // Some related notes:

--- a/integration_test/QuickOpenEventuallyCompletesTest.re
+++ b/integration_test/QuickOpenEventuallyCompletesTest.re
@@ -8,7 +8,7 @@ runTest(~name="QuickOpen eventually completes", (dispatch, wait, runEffects) => 
 
   /* Switch to root directory */
   let (_: Vim.Context.t, _: list(Vim.Effect.t)) =
-    if (Revery.Environment.os == Revery.Environment.Mac) {
+    if (Revery.Environment.isMac) {
       // CI machines timeout with '/' - so we'll use home (which also reproduces the crash)
       Vim.command(
         "cd ~",

--- a/integration_test/TerminalConfigurationTest.re
+++ b/integration_test/TerminalConfigurationTest.re
@@ -18,17 +18,17 @@ let configuration =
 
 let expectedShellCmd =
   switch (Revery.Environment.os) {
-  | Windows => "win-shell"
-  | Mac => "osx-shell"
-  | Linux => "linux-shell"
+  | Windows(_) => "win-shell"
+  | Mac(_) => "osx-shell"
+  | Linux(_) => "linux-shell"
   | _ => failwith("Unsupported os")
   };
 
 let expectedShellArgs =
   switch (Revery.Environment.os) {
-  | Windows => ["win-arg"]
-  | Mac => ["osx-arg"]
-  | Linux => ["linux-arg"]
+  | Windows(_) => ["win-arg"]
+  | Mac(_) => ["osx-arg"]
+  | Linux(_) => ["linux-arg"]
   | _ => failwith("Unsupported os")
   };
 

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0956946879c45a0b35575b079e76cfb6",
+  "checksum": "e0c22dfe751847f306b38eb9bbbfef78",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#dd47c70@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#dd47c70",
+      "version": "github:revery-ui/revery#f2da66e",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#dd47c70" ]
+        "source": [ "github:revery-ui/revery#f2da66e" ]
       },
       "overrides": [],
       "dependencies": [
@@ -995,7 +995,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "revery": "revery-ui/revery#dd47c70",
+    "revery": "revery-ui/revery#f2da66e",
     "esy-skia": "revery-ui/esy-skia#91c98f6",
     "rench": "bryphe/rench#a976fe5",
     "isolinear": "revery-ui/isolinear#53fc4eb",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0956946879c45a0b35575b079e76cfb6",
+  "checksum": "e0c22dfe751847f306b38eb9bbbfef78",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#dd47c70@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#dd47c70",
+      "version": "github:revery-ui/revery#f2da66e",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#dd47c70" ]
+        "source": [ "github:revery-ui/revery#f2da66e" ]
       },
       "overrides": [],
       "dependencies": [
@@ -995,7 +995,7 @@
       "overrides": [ "release.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/src/Core/Filesystem.re
+++ b/src/Core/Filesystem.re
@@ -18,7 +18,7 @@ module Internal = {
   let getUserDataDirectoryExn = () =>
     Revery.(
       switch (Environment.os) {
-      | Environment.Windows =>
+      | Environment.Windows(_) =>
         Sys.getenv_opt("LOCALAPPDATA")
         |> OptionEx.flatMap(Fp.absoluteCurrentPlatform)
         |> Option.get
@@ -116,7 +116,7 @@ let mkdirp = path => {
 let getOniDirectory = dataDirectory =>
   Revery.(
     switch (Environment.os) {
-    | Environment.Windows => Fp.append(dataDirectory, "Oni2") |> return
+    | Environment.Windows(_) => Fp.append(dataDirectory, "Oni2") |> return
     | _ => Fp.At.(dataDirectory / ".config" / "oni2") |> return
     }
   );

--- a/src/Core/Setup.re
+++ b/src/Core/Setup.re
@@ -27,7 +27,7 @@ let default = () => {
   let execDir = Revery.Environment.executingDirectory;
 
   switch (Revery.Environment.os) {
-  | Revery.Environment.Windows => {
+  | Windows(_) => {
       nodePath: execDir ++ "node.exe",
       nodeScriptPath: execDir ++ "node",
       bundledExtensionsPath: execDir ++ "extensions",
@@ -35,7 +35,7 @@ let default = () => {
       rgPath: execDir ++ "rg.exe",
       rlsPath: execDir ++ "rls.exe",
     }
-  | Revery.Environment.Mac => {
+  | Mac(_) => {
       nodePath: execDir ++ "node",
       nodeScriptPath: execDir ++ "../Resources/node",
       bundledExtensionsPath: execDir ++ "../Resources/extensions",

--- a/src/Feature/AutoUpdate/Feature_AutoUpdate.re
+++ b/src/Feature/AutoUpdate/Feature_AutoUpdate.re
@@ -25,9 +25,9 @@ type outmsg =
 
 let platformStr =
   switch (Revery.Environment.os) {
-  | Mac => "macos"
-  | Linux => "linux"
-  | Windows => "windows"
+  | Mac(_) => "macos"
+  | Linux(_) => "linux"
+  | Windows(_) => "windows"
   | _ => ""
   };
 

--- a/src/Feature/MenuBar/Global.re
+++ b/src/Feature/MenuBar/Global.re
@@ -6,12 +6,10 @@ module OSX = {
     menu(~order=0, ~uniqueId="application", ~parent=None, "Application");
 };
 
-let isMac = Revery.Environment.os == Revery.Environment.Mac;
-
 let file = menu(~order=100, ~uniqueId="file", ~parent=None, "File");
 
 // The 'Application' menu on OSX
-let application = isMac ? OSX.application : file;
+let application = Revery.Environment.isMac ? OSX.application : file;
 
 let edit = menu(~order=200, ~uniqueId="edit", ~parent=None, "Edit");
 
@@ -89,7 +87,7 @@ module Items = {
   };
 };
 
-let menus = (isMac ? [OSX.application] : []) @ [file, edit, view, help];
+let menus = (Revery.Environment.isMac ? [OSX.application] : []) @ [file, edit, view, help];
 
 let groups = [
   group(~order=100, ~parent=file, Items.File.[newFile]),

--- a/src/Feature/MenuBar/Global.re
+++ b/src/Feature/MenuBar/Global.re
@@ -87,7 +87,9 @@ module Items = {
   };
 };
 
-let menus = (Revery.Environment.isMac ? [OSX.application] : []) @ [file, edit, view, help];
+let menus =
+  (Revery.Environment.isMac ? [OSX.application] : [])
+  @ [file, edit, view, help];
 
 let groups = [
   group(~order=100, ~parent=file, Items.File.[newFile]),

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -140,9 +140,9 @@ let update = (~config: Config.resolver, model: t, msg) => {
       switch (cmd) {
       | None =>
         switch (Revery.Environment.os) {
-        | Windows => Configuration.Shell.windows.get(config)
-        | Mac => Configuration.Shell.osx.get(config)
-        | Linux => Configuration.Shell.linux.get(config)
+        | Windows(_) => Configuration.Shell.windows.get(config)
+        | Mac(_) => Configuration.Shell.osx.get(config)
+        | Linux(_) => Configuration.Shell.linux.get(config)
         | _ => shellCmd
         }
       | Some(specifiedCommand) => specifiedCommand
@@ -150,9 +150,9 @@ let update = (~config: Config.resolver, model: t, msg) => {
 
     let arguments =
       switch (Revery.Environment.os) {
-      | Windows => Configuration.ShellArgs.windows.get(config)
-      | Mac => Configuration.ShellArgs.osx.get(config)
-      | Linux => Configuration.ShellArgs.linux.get(config)
+      | Windows(_) => Configuration.ShellArgs.windows.get(config)
+      | Mac(_) => Configuration.ShellArgs.osx.get(config)
+      | Linux(_) => Configuration.ShellArgs.linux.get(config)
       | _ => []
       };
 
@@ -160,14 +160,14 @@ let update = (~config: Config.resolver, model: t, msg) => {
       Exthost.ShellLaunchConfig.(
         switch (Revery.Environment.os) {
         // Windows - simply inherit from the running process
-        | Windows => Inherit
+        | Windows(_) => Inherit
 
         // Mac - inherit (we rely on the '-l' flag to pick up user config)
-        | Mac => Inherit
+        | Mac(_) => Inherit
 
         // For Linux, there's a few stray variables that may come in from the AppImage
         // for example - LD_LIBRARY_PATH in issue #2040. We need to clear those out.
-        | Linux =>
+        | Linux(_) =>
           switch (
             Sys.getenv_opt("ONI2_ORIG_PATH"),
             Sys.getenv_opt("ONI2_ORIG_LD_LIBRARY_PATH"),

--- a/src/Feature/TitleBar/Feature_TitleBar.re
+++ b/src/Feature/TitleBar/Feature_TitleBar.re
@@ -95,7 +95,7 @@ module Internal = {
 
   let getTitleDoubleClickBehavior = () => {
     switch (Revery.Environment.os) {
-    | Mac =>
+    | Mac(_) =>
       try({
         let ic =
           Unix.open_process_in(
@@ -507,7 +507,7 @@ module View = {
     let title =
       title(~activeBuffer, ~workspaceRoot, ~workspaceDirectory, ~config);
     switch (Revery.Environment.os) {
-    | Mac =>
+    | Mac(_) =>
       <Mac
         isFocused
         windowDisplayMode
@@ -519,7 +519,7 @@ module View = {
         registrationDispatch
         height
       />
-    | Windows =>
+    | Windows(_) =>
       <Windows
         menuBar
         isFocused
@@ -531,7 +531,7 @@ module View = {
         registrationDispatch
         registration
       />
-    | Linux => menuBar
+    | Linux(_) => menuBar
     | _ => React.empty
     };
   };

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -111,15 +111,9 @@ let other = {
   Schema.(
     fromList(
       State.[
-        bool("isLinux", _state =>
-          Revery.Environment.isLinux
-        ),
-        bool("isMac", _state =>
-          Revery.Environment.isMac
-        ),
-        bool("isWin", _state =>
-          Revery.Environment.isWindows
-        ),
+        bool("isLinux", _state => Revery.Environment.isLinux),
+        bool("isMac", _state => Revery.Environment.isMac),
+        bool("isWin", _state => Revery.Environment.isWindows),
         bool("sneakMode", state => Feature_Sneak.isActive(state.sneak)),
         bool("zenMode", state => state.zenMode),
       ],

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -112,13 +112,13 @@ let other = {
     fromList(
       State.[
         bool("isLinux", _state =>
-          Revery.Environment.os == Revery.Environment.Linux
+          Revery.Environment.isLinux
         ),
         bool("isMac", _state =>
-          Revery.Environment.os == Revery.Environment.Mac
+          Revery.Environment.isMac
         ),
         bool("isWin", _state =>
-          Revery.Environment.os == Revery.Environment.Windows
+          Revery.Environment.isWindows
         ),
         bool("sneakMode", state => Feature_Sneak.isActive(state.sneak)),
         bool("zenMode", state => state.zenMode),

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -164,7 +164,7 @@ let start = (window: option(Revery.Window.t), runEffects) => {
         // On Windows, we need to do some special handling here
         // Windows has this funky behavior where pressing AltGr registers as RAlt+LControl down - more info here:
         // https://devblogs.microsoft.com/oldnewthing/?p=40003
-        | Revery.Environment.Windows =>
+        | Windows(_) =>
           let altGr =
             altGr
             || Revery.Key.Keymod.isRightAltDown(keymod)

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -33,7 +33,7 @@ module Styles = {
         justifyContent(`Center),
         alignItems(`Stretch),
       ]);
-    if (Revery.Environment.os == Windows
+    if (Revery.Environment.isWindows
         && windowDisplayMode == State.Maximized) {
       style := [margin(6), ...style^];
     };
@@ -252,7 +252,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
     <Overlay>
       <Feature_Sneak.View.Overlay model={state.sneak} theme font />
     </Overlay>
-    {Revery.Environment.os == Windows
+    {Revery.Environment.isWindows
      && state.windowDisplayMode != State.Maximized
        ? <WindowResizers /> : React.empty}
   </View>;

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -33,8 +33,7 @@ module Styles = {
         justifyContent(`Center),
         alignItems(`Stretch),
       ]);
-    if (Revery.Environment.isWindows
-        && windowDisplayMode == State.Maximized) {
+    if (Revery.Environment.isWindows && windowDisplayMode == State.Maximized) {
       style := [margin(6), ...style^];
     };
     style^;
@@ -252,8 +251,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
     <Overlay>
       <Feature_Sneak.View.Overlay model={state.sneak} theme font />
     </Overlay>
-    {Revery.Environment.isWindows
-     && state.windowDisplayMode != State.Maximized
+    {Revery.Environment.isWindows && state.windowDisplayMode != State.Maximized
        ? <WindowResizers /> : React.empty}
   </View>;
 };

--- a/src/UI/VersionView.re
+++ b/src/UI/VersionView.re
@@ -81,15 +81,6 @@ module VersionView = {
   };
 };
 
-let osString =
-  Revery.Environment.os
-  |> (
-    fun
-    | Windows => "Windows"
-    | Mac => "OSX"
-    | _ => "Linux"
-  );
-
 let sdlVersionToString = ({major, minor, patch}: Sdl2.Version.t) => {
   Printf.sprintf("%d.%d.%d", major, minor, patch);
 };

--- a/src/UI/WelcomeView.re
+++ b/src/UI/WelcomeView.re
@@ -107,7 +107,7 @@ let animation =
 
 let cmdOrCtrl =
   switch (Revery.Environment.os) {
-  | Mac => "Cmd"
+  | Mac(_) => "Cmd"
   | _ => "Ctrl"
   };
 

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -172,13 +172,13 @@ switch (eff) {
 
     let decorated =
       switch (Revery.Environment.os) {
-      | Windows => false
+      | Windows(_) => false
       | _ => true
       };
 
     let icon =
       switch (Revery.Environment.os) {
-      | Mac =>
+      | Mac(_) =>
         switch (Sys.getenv_opt("ONI2_BUNDLED")) {
         | Some(_) => None
         | None => Some("logo.png")

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ee5895c143de4d63a6579e1e4e676917",
+  "checksum": "95e0211d973824d9d5e8c0db22f2aa10",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#dd47c70@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#dd47c70",
+      "version": "github:revery-ui/revery#f2da66e",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#dd47c70" ]
+        "source": [ "github:revery-ui/revery#f2da66e" ]
       },
       "overrides": [],
       "dependencies": [
@@ -995,7 +995,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#dd47c70@d41d8cd9",
+        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -88,7 +88,7 @@ describe("CLI Integration Tests", ({describe, _}) => {
     // On Linux Azure CI, this test fails when creating a window -
     // need to find a workaround to allow `SDL_CreateWindow` to succeed on CI machines.
     =>
-      if (Revery.Environment.os != Revery.Environment.Linux) {
+      if (!Revery.Environment.isLinux) {
         test("run ex commands with '+'", ({expect, _}) => {
           TestRunner.(
             {


### PR DESCRIPTION
This brings in all the OS versioning information from the recent revery PRs. I wanted to bring this in separate from #2876 since it requires a lot of changes to switch statements across the codebase.