### PR TITLE
fix(input/#2114): Handle `nnoremap` correctly

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #2905 - CLI: HealthCheck - Re-enable output logging
 - #2907 - Editor: Add configuration for document highlights and use proper theme color
 - #2902 - Input: Fix remaps for characters w/o scancode (fixes #2883)
+- #2908 - Input: Fix no-recursive remap behavior (fixes #2114)
 
 ### Performance
 

--- a/integration_test/InputRemapMotionTest.re
+++ b/integration_test/InputRemapMotionTest.re
@@ -1,0 +1,98 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+open EditorCoreTypes;
+
+runTest(~name="InputRemapMotionTest (#2114)", (dispatch, wait, runEffects) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    Selectors.mode(state) |> Vim.Mode.isNormal
+  );
+
+  let testFile = getAssetPath("some-test-file.txt");
+  // Open an erroneous CSS file - verify we get some diagnostics
+  dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+  wait(~name="buffer load", (state: State.t) => {
+    switch (Selectors.getActiveBuffer(state)) {
+    | Some(buffer) => Oni_Core.Buffer.getNumberOfLines(buffer) > 2
+    | None => false
+    }
+  });
+
+  // #2114 - remap hjkl -> jklm
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "nnoremap j h "}),
+  );
+  runEffects();
+
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "nnoremap l k "}),
+  );
+  runEffects();
+
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "nnoremap m l "}),
+  );
+  runEffects();
+
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "nnoremap k j "}),
+  );
+  runEffects();
+
+  let input = key => {
+    let modifiers = EditorInput.Modifiers.none;
+
+    let keyPress: EditorInput.KeyPress.t =
+      EditorInput.KeyPress.physicalKey(
+        ~key=EditorInput.Key.Character(key),
+        ~modifiers,
+      );
+    let time = Revery.Time.now();
+
+    dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
+    dispatch(Model.Actions.KeyUp({key: keyPress, scancode: 1, time}));
+    runEffects();
+  };
+
+  let waitForCursorPosition = bytePosition => {
+    wait(
+      ~name="Verify cursor is at:" ++ BytePosition.show(bytePosition),
+      (state: State.t) => {
+        let cursorPosition =
+          state.layout
+          |> Feature_Layout.activeEditor
+          |> Feature_Editor.Editor.getPrimaryCursorByte;
+
+        cursorPosition == bytePosition;
+      },
+    );
+  };
+
+  waitForCursorPosition(
+    BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+  );
+
+  // Move down, jklm style
+  input('k');
+  waitForCursorPosition(
+    BytePosition.{line: LineNumber.(zero + 1), byte: ByteIndex.zero},
+  );
+
+  // Move right, jklm style
+  input('m');
+  waitForCursorPosition(
+    BytePosition.{line: LineNumber.(zero + 1), byte: ByteIndex.(zero + 1)},
+  );
+
+  // Move up, jklm style
+  input('l');
+  waitForCursorPosition(
+    BytePosition.{line: LineNumber.(zero), byte: ByteIndex.(zero + 1)},
+  );
+
+  // Move left, jklm style
+  input('j');
+  waitForCursorPosition(
+    BytePosition.{line: LineNumber.(zero), byte: ByteIndex.(zero)},
+  );
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -8,12 +8,13 @@
    ExCommandKeybindingNormTest ExtConfigurationChangedTest
    ExtHostBufferOpenTest ExtHostBufferUpdatesTest ExtHostCompletionTest
    ExtHostDefinitionTest FileWatcherTest KeybindingsInvalidJsonTest
-   KeySequenceJJTest InputIgnoreTest InputContextKeysTest LanguageCssTest
-   LanguageTypeScriptTest LineEndingsLFTest LineEndingsCRLFTest
-   QuickOpenEventuallyCompletesTest SearchShowClearHighlightsTest
-   SyntaxServer SyntaxServerCloseTest SyntaxServerMessageExceptionTest
-   SyntaxServerParentPidTest SyntaxServerParentPidCorrectTest
-   SyntaxServerReadExceptionTest Regression1671Test Regression2349EnewTest
+   KeySequenceJJTest InputIgnoreTest InputContextKeysTest
+   InputRemapMotionTest LanguageCssTest LanguageTypeScriptTest
+   LineEndingsLFTest LineEndingsCRLFTest QuickOpenEventuallyCompletesTest
+   SearchShowClearHighlightsTest SyntaxServer SyntaxServerCloseTest
+   SyntaxServerMessageExceptionTest SyntaxServerParentPidTest
+   SyntaxServerParentPidCorrectTest SyntaxServerReadExceptionTest
+   Regression1671Test Regression2349EnewTest
    RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
    RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
    RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
@@ -40,8 +41,8 @@
    ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
    ExtHostDefinitionTest.exe FileWatcherTest.exe
    KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
-   InputContextKeysTest.exe LanguageCssTest.exe LanguageTypeScriptTest.exe
-   LineEndingsCRLFTest.exe LineEndingsLFTest.exe
+   InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
+   LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
    QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
    Regression2349EnewTest.exe RegressionCommandLineNoCompletionTest.exe
    RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -476,7 +476,7 @@ module Internal = {
 
                | ResolvedRemap({allowRecursive, matcher, condition, toKeys}) =>
                  InputStateMachine.addMapping(
-                   allowRecursive,
+                   ~allowRecursive,
                    matcher,
                    condition,
                    toKeys,

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -238,7 +238,13 @@ let initial = keybindings => {
 
            | Ok(ResolvedRemap({allowRecursive, matcher, condition, toKeys})) =>
              let (ism, _bindingId) =
-               InputStateMachine.addMapping(~allowRecursive, matcher, condition, toKeys, ism);
+               InputStateMachine.addMapping(
+                 ~allowRecursive,
+                 matcher,
+                 condition,
+                 toKeys,
+                 ism,
+               );
              ism;
            }
          },
@@ -469,7 +475,13 @@ module Internal = {
                  )
 
                | ResolvedRemap({allowRecursive, matcher, condition, toKeys}) =>
-                 InputStateMachine.addMapping(allowRecursive, matcher, condition, toKeys, ism)
+                 InputStateMachine.addMapping(
+                   allowRecursive,
+                   matcher,
+                   condition,
+                   toKeys,
+                   ism,
+                 )
                };
              (ism', [bindingId, ...bindings]);
            },

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -96,6 +96,7 @@ module Schema = {
         condition: WhenExpr.t,
       })
     | Remap({
+        allowRecursive: bool,
         fromKeys: string,
         toKeys: string,
         condition: WhenExpr.t,
@@ -108,6 +109,7 @@ module Schema = {
         condition: WhenExpr.ContextKeys.t => bool,
       })
     | ResolvedRemap({
+        allowRecursive: bool,
         matcher: EditorInput.Matcher.t,
         toKeys: list(EditorInput.KeyPress.t),
         condition: WhenExpr.ContextKeys.t => bool,
@@ -125,8 +127,8 @@ module Schema = {
 
   let clear = (~key as _) => failwith("Not implemented");
 
-  let remap = (~fromKeys, ~toKeys, ~condition) =>
-    Remap({fromKeys, toKeys, condition});
+  let remap = (~allowRecursive, ~fromKeys, ~toKeys, ~condition) =>
+    Remap({allowRecursive, fromKeys, toKeys, condition});
 
   let resolve = keybinding => {
     let evaluateCondition = (whenExpr, contextKeys) => {
@@ -149,7 +151,7 @@ module Schema = {
            })
          });
 
-    | Remap({fromKeys, condition, toKeys}) =>
+    | Remap({allowRecursive, fromKeys, condition, toKeys}) =>
       let evaluateCondition = (whenExpr, contextKeys) => {
         WhenExpr.evaluate(
           whenExpr,
@@ -166,6 +168,7 @@ module Schema = {
       ResultEx.map2(
         (matcher, toKeys) => {
           ResolvedRemap({
+            allowRecursive,
             matcher,
             condition: evaluateCondition(condition),
             toKeys,
@@ -233,9 +236,9 @@ let initial = keybindings => {
                InputStateMachine.addBinding(matcher, condition, command, ism);
              ism;
 
-           | Ok(ResolvedRemap({matcher, condition, toKeys})) =>
+           | Ok(ResolvedRemap({allowRecursive, matcher, condition, toKeys})) =>
              let (ism, _bindingId) =
-               InputStateMachine.addMapping(matcher, condition, toKeys, ism);
+               InputStateMachine.addMapping(~allowRecursive, matcher, condition, toKeys, ism);
              ism;
            }
          },
@@ -390,6 +393,7 @@ let addKeyBinding = (~binding, {inputStateMachine, _} as model) => {
     | ResolvedRemap(remap) =>
       let (inputStateMachine', uniqueId) =
         InputStateMachine.addMapping(
+          ~allowRecursive=remap.allowRecursive,
           remap.matcher,
           remap.condition,
           remap.toKeys,
@@ -464,8 +468,8 @@ module Internal = {
                    ism,
                  )
 
-               | ResolvedRemap({matcher, condition, toKeys}) =>
-                 InputStateMachine.addMapping(matcher, condition, toKeys, ism)
+               | ResolvedRemap({allowRecursive, matcher, condition, toKeys}) =>
+                 InputStateMachine.addMapping(allowRecursive, matcher, condition, toKeys, ism)
                };
              (ism', [bindingId, ...bindings]);
            },
@@ -510,6 +514,7 @@ let update = (msg, model) => {
             (matcher, keys) => {
               let (inputStateMachine', _mappingId) =
                 InputStateMachine.addMapping(
+                  ~allowRecursive=mapping.recursive,
                   matcher,
                   Internal.vimMapModeToWhenExpr(mapping.mode),
                   keys,

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -30,7 +30,13 @@ module Schema: {
 
   // Remap a key -> to another key
   let remap:
-    (~allowRecursive: bool, ~fromKeys: string, ~toKeys: string, ~condition: WhenExpr.t) => keybinding;
+    (
+      ~allowRecursive: bool,
+      ~fromKeys: string,
+      ~toKeys: string,
+      ~condition: WhenExpr.t
+    ) =>
+    keybinding;
 
   let mapCommand: (~f: string => string, keybinding) => keybinding;
 

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -30,7 +30,7 @@ module Schema: {
 
   // Remap a key -> to another key
   let remap:
-    (~fromKeys: string, ~toKeys: string, ~condition: WhenExpr.t) => keybinding;
+    (~allowRecursive: bool, ~fromKeys: string, ~toKeys: string, ~condition: WhenExpr.t) => keybinding;
 
   let mapCommand: (~f: string => string, keybinding) => keybinding;
 

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -152,6 +152,7 @@ module Keybindings = {
   open Feature_Input.Schema;
   let controlSquareBracketRemap =
     remap(
+      ~allowRecursive=true,
       ~fromKeys="<C-[>",
       ~toKeys="<ESC>",
       ~condition=WhenExpr.Value(True),

--- a/src/editor-input/EditorInput.re
+++ b/src/editor-input/EditorInput.re
@@ -21,7 +21,14 @@ module type Input = {
 
   let addBinding: (Matcher.t, context => bool, command, t) => (t, uniqueId);
   let addMapping:
-    (~allowRecursive: bool, Matcher.t, context => bool, list(KeyPress.t), t) => (t, uniqueId);
+    (
+      ~allowRecursive: bool,
+      Matcher.t,
+      context => bool,
+      list(KeyPress.t),
+      t
+    ) =>
+    (t, uniqueId);
 
   let disable: t => t;
   let enable: t => t;
@@ -109,7 +116,10 @@ module Make = (Config: {
 
   type action =
     | Dispatch(command)
-    | Remap({ allowRecursive: bool, keys: list(KeyPress.t) });
+    | Remap({
+        allowRecursive: bool,
+        keys: list(KeyPress.t),
+      });
 
   type matchState =
     | Matched
@@ -262,7 +272,12 @@ module Make = (Config: {
     let {bindings, _} = keyBindings;
     let id = UniqueId.get();
     let bindings = [
-      {id, matcher: Unmatched(matcher), action: Remap({ allowRecursive, keys }), enabled},
+      {
+        id,
+        matcher: Unmatched(matcher),
+        action: Remap({allowRecursive, keys}),
+        enabled,
+      },
       ...bindings,
     ];
 

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -123,7 +123,7 @@ module type Input = {
   let addBinding: (Matcher.t, context => bool, command, t) => (t, uniqueId);
 
   let addMapping:
-    (Matcher.t, context => bool, list(KeyPress.t), t) => (t, uniqueId);
+    (~allowRecursive: bool, Matcher.t, context => bool, list(KeyPress.t), t) => (t, uniqueId);
 
   // Turn off all bindings, as if no bindings are defined
   let disable: t => t;

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -123,7 +123,14 @@ module type Input = {
   let addBinding: (Matcher.t, context => bool, command, t) => (t, uniqueId);
 
   let addMapping:
-    (~allowRecursive: bool, Matcher.t, context => bool, list(KeyPress.t), t) => (t, uniqueId);
+    (
+      ~allowRecursive: bool,
+      Matcher.t,
+      context => bool,
+      list(KeyPress.t),
+      t
+    ) =>
+    (t, uniqueId);
 
   // Turn off all bindings, as if no bindings are defined
   let disable: t => t;

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -582,6 +582,37 @@ describe("EditorInput", ({describe, _}) => {
     });
   });
   describe("remapping", ({test, _}) => {
+    test("no-recursive mapping", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             ~allowRecursive=false,
+             Sequence([aKeyNoModifiers]),
+             _ => true,
+             [bKeyNoModifiers],
+           );
+
+        let (bindings, _id) = bindings
+        |> Input.addMapping(
+             ~allowRecursive=false,
+             Sequence([bKeyNoModifiers]),
+             _ => true,
+             [cKeyNoModifiers],
+           );
+        let (_bindings, effects) =
+          Input.keyDown(
+            ~context=true,
+            ~scancode=aKeyScancode,
+            ~key=aKeyNoModifiers,
+            bindings,
+          );
+
+        expect.equal(
+          effects,
+          [Unhandled({key: bKeyNoModifiers, isProducedByRemap: true})],
+        );
+    });
+
     test("unhandled, single key remap", ({expect, _}) => {
       let (bindings, _id) =
         Input.empty

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -40,6 +40,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([bKeyNoModifiers]),
              _ => true,
              [plugKey, aKeyNoModifiers],
@@ -70,6 +71,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([bKeyNoModifiers]),
              _ => true,
              [leaderKey],
@@ -584,6 +586,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([aKeyNoModifiers]),
              _ => true,
              [bKeyNoModifiers],
@@ -607,6 +610,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([aKeyNoModifiers]),
              _ => true,
              [bKeyNoModifiers],
@@ -615,6 +619,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([bKeyNoModifiers]),
              _ => true,
              [cKeyNoModifiers],
@@ -638,6 +643,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([aKeyNoModifiers]),
              _ => true,
              [aKeyNoModifiers],
@@ -664,6 +670,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([aKeyNoModifiers, bKeyNoModifiers]),
              _ => true,
              [cKeyNoModifiers],
@@ -694,6 +701,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=false,
              Sequence([aKeyNoModifiers]),
              _ => true,
              [bKeyNoModifiers, cKeyNoModifiers],
@@ -719,6 +727,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([aKeyNoModifiers]),
              _ => true,
              [bKeyNoModifiers],
@@ -745,6 +754,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
+             ~allowRecursive=true,
              Sequence([aKeyNoModifiers]),
              _ => true,
              [bKeyNoModifiers, cKeyNoModifiers],

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -592,25 +592,26 @@ describe("EditorInput", ({describe, _}) => {
              [bKeyNoModifiers],
            );
 
-        let (bindings, _id) = bindings
+      let (bindings, _id) =
+        bindings
         |> Input.addMapping(
              ~allowRecursive=false,
              Sequence([bKeyNoModifiers]),
              _ => true,
              [cKeyNoModifiers],
            );
-        let (_bindings, effects) =
-          Input.keyDown(
-            ~context=true,
-            ~scancode=aKeyScancode,
-            ~key=aKeyNoModifiers,
-            bindings,
-          );
-
-        expect.equal(
-          effects,
-          [Unhandled({key: bKeyNoModifiers, isProducedByRemap: true})],
+      let (_bindings, effects) =
+        Input.keyDown(
+          ~context=true,
+          ~scancode=aKeyScancode,
+          ~key=aKeyNoModifiers,
+          bindings,
         );
+
+      expect.equal(
+        effects,
+        [Unhandled({key: bKeyNoModifiers, isProducedByRemap: true})],
+      );
     });
 
     test("unhandled, single key remap", ({expect, _}) => {


### PR DESCRIPTION
__Issue:__ All of our bindings, whether defined by `nmap` or `nnoremap`, were allowing recursive definitions. This breaks the case in #2114, where the remaps would bounce back and forth until they hit our recursion limit.

__Defect:__ We weren't gating recursive remaps, aside from the recursion limit.

__Fix:__ Define and handle no-recursive remaps correctly.

__Todo:__
- [x] Update existing test cases to pick up new API
- [x] Add test cases to validate non-recursive maps
- [x] Get tests green
- [x] Add integration test covering #2114 
- [x] Update CHANGES
- [x] Rebase on #2883 when merged

Fixes #2114

Depends on #2883 

Related #1551 