### PR TITLE
fix(input/#2926): Part 2 - Right arrow key treated as PageUp

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -27,6 +27,7 @@
 - #2907 - Editor: Add configuration for document highlights and use proper theme color
 - #2902 - Input: Fix remaps for characters w/o scancode (fixes #2883)
 - #2908 - Input: Fix no-recursive remap behavior (fixes #2114)
+- #2628 - Input: Right arrow key treated as PageUp
 
 ### Performance
 

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -19,7 +19,7 @@ module Internal = {
       | v when v == 1073741899 => Some(Key.PageUp)
       | v when v == 1073741901 => Some(Key.End)
       | v when v == 1073741902 => Some(Key.PageDown)
-      | v when v == 1073741903 => Some(Key.PageUp)
+      | v when v == 1073741903 => Some(Key.Right)
       | v when v == 1073741904 => Some(Key.Left)
       | v when v == 1073741905 => Some(Key.Down)
       | v when v == 1073741906 => Some(Key.Up)


### PR DESCRIPTION
__Issue:__ Right arrow key is being treated as page-up

__Defect:__ An incorrect conversion snuck in #2902 

__Fix:__ Fix the keycode -> key mapping for right arrow key

Related #2926 