### PR TITLE
fix(input/#2919): Windows - Intermittent crash on mouse scroll

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -29,6 +29,7 @@
 - #2908 - Input: Fix no-recursive remap behavior (fixes #2114)
 - #2917 - Extensions: CodeLens - fix extraneous animation with multiple providers
 - #2628 - Input: Right arrow key treated as PageUp
+- #2929 - Input: Fix intermittent crash when scrolling with the mouse (fixes #2919)
 
 ### Performance
 

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7881c97bad0f1edfdb02d158812549f3",
+  "checksum": "ff568f16a842aa3d96e77e47302f2228",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+    "revery@github:revery-ui/revery#931f3d0@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f2da66e",
+      "version": "github:revery-ui/revery#931f3d0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f2da66e" ]
+        "source": [ "github:revery-ui/revery#931f3d0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7881c97bad0f1edfdb02d158812549f3",
+  "checksum": "ff568f16a842aa3d96e77e47302f2228",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+    "revery@github:revery-ui/revery#931f3d0@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f2da66e",
+      "version": "github:revery-ui/revery#931f3d0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f2da66e" ]
+        "source": [ "github:revery-ui/revery#931f3d0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7881c97bad0f1edfdb02d158812549f3",
+  "checksum": "ff568f16a842aa3d96e77e47302f2228",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+    "revery@github:revery-ui/revery#931f3d0@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f2da66e",
+      "version": "github:revery-ui/revery#931f3d0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f2da66e" ]
+        "source": [ "github:revery-ui/revery#931f3d0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "revery": "revery-ui/revery#f2da66e",
+    "revery": "revery-ui/revery#931f3d0",
     "esy-skia": "revery-ui/esy-skia#91c98f6",
     "rench": "bryphe/rench#a976fe5",
     "isolinear": "revery-ui/isolinear#53fc4eb",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7881c97bad0f1edfdb02d158812549f3",
+  "checksum": "ff568f16a842aa3d96e77e47302f2228",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+    "revery@github:revery-ui/revery#931f3d0@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f2da66e",
+      "version": "github:revery-ui/revery#931f3d0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f2da66e" ]
+        "source": [ "github:revery-ui/revery#931f3d0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "release.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9452b4c13b219f17db0d4f9acb22c2cb",
+  "checksum": "595f91a8f34977d6601370874bc99691",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#f2da66e@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+    "revery@github:revery-ui/revery#931f3d0@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#f2da66e",
+      "version": "github:revery-ui/revery#931f3d0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#f2da66e" ]
+        "source": [ "github:revery-ui/revery#931f3d0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#f2da66e@d41d8cd9",
+        "revery@github:revery-ui/revery#931f3d0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",


### PR DESCRIPTION
This picks up https://github.com/revery-ui/revery/pull/1037 , which is the fixes the root issue of #2919  . We were not properly integrating the sdl2 hit test callback with the OCaml garbage collector, which could cause an intermittent crash on mouse gestures that engage the hit test callback.