### PR TITLE
fix(codelens): Only replace codelens in queried range

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -896,10 +896,6 @@ let setInlineElements = (~key, ~elements: list(inlineElement), editor) => {
 };
 
 let replaceInlineElements = (~key, ~startLine, ~stopLine, ~elements, editor) => {
-  // TODO
-  ignore(startLine);
-  ignore(stopLine);
-
   let elements': list(InlineElements.element) =
     elements
     |> List.map((inlineElement: inlineElement) =>
@@ -917,7 +913,13 @@ let replaceInlineElements = (~key, ~startLine, ~stopLine, ~elements, editor) => 
        {
          ...e,
          inlineElements:
-           InlineElements.set(~key, ~elements=elements', e.inlineElements),
+           InlineElements.replace(
+             ~startLine=Some(startLine),
+             ~stopLine=Some(stopLine),
+             ~key,
+             ~elements=elements',
+             e.inlineElements,
+           ),
        }
      );
 };


### PR DESCRIPTION
__Issue:__ When new codelens are provided, we remove all existing codelenses. However, we only query for a range of codelenses (in the visible view) - it doesn't make sense to remove codelenses outside of that range.

__Fix:__ Only replace codelenses within the range queried - ignore others. Fix up `InlineElements.replace` semantics.