### PR TITLE
perf(language-features): Debounce high-frequency subscriptions

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -35,6 +35,7 @@
 
 - #2852,#2864 - Performance: Batch editor / codelens animations
 - #2901 - Bundle Size: Remove unused Selawik and Inconsolata fonts
+- #2932 - Language Features: Debounce high-frequency subscriptions
 
 ### Documentation
 

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -392,10 +392,21 @@ let configurationChanged = (~config, model) => {
     ),
 };
 
-let cursorMoved = (~previous, ~current, model) => {
+let cursorMoved = (~maybeBuffer, ~previous, ~current, model) => {
   let completion =
     Completion.cursorMoved(~previous, ~current, model.completion);
-  {...model, completion};
+
+  let documentHighlights =
+    maybeBuffer
+    |> Option.map(buffer =>
+         DocumentHighlights.cursorMoved(
+           ~buffer,
+           ~cursor=current,
+           model.documentHighlights,
+         )
+       )
+    |> Option.value(~default=model.documentHighlights);
+  {...model, completion, documentHighlights};
 };
 
 let startInsertMode = model => {
@@ -631,6 +642,7 @@ let sub =
 
   let documentHighlightsSub =
     OldHighlights.sub(
+      ~isInsertMode,
       ~config,
       ~buffer=activeBuffer,
       ~location=activePosition,

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -108,7 +108,12 @@ let bufferUpdated:
 let configurationChanged: (~config: Config.resolver, model) => model;
 
 let cursorMoved:
-  (~previous: CharacterPosition.t, ~current: CharacterPosition.t, model) =>
+  (
+    ~maybeBuffer: option(Oni_Core.Buffer.t),
+    ~previous: CharacterPosition.t,
+    ~current: CharacterPosition.t,
+    model
+  ) =>
   model;
 let startInsertMode: model => model;
 let stopInsertMode: model => model;

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -223,6 +223,7 @@ module Internal = {
     let languageSupport =
       if (prevCursor != newCursor) {
         Feature_LanguageSupport.cursorMoved(
+          ~maybeBuffer,
           ~previous=prevCursor,
           ~current=newCursor,
           state.languageSupport,


### PR DESCRIPTION
__Issue:__ We were calling several language feature extension host APIs on every cursor move, or on every insert.

The APIs being called were:
1) `$provideDocumentHighlights` - called on every cursor move
2) `$provideDefinition` - called on every cursor move
3) `$provideDocumentSymbols` - called on every edit

This is problematic when holding a key or typing fast - calling an extension host API isn't cheap, so we should debounce and wait to call when the cursor / input is settled.

__Todo:__
- [x] For document highlights & definition, if the cursor moves out of range, clear the highlight / definition - this helps improve perceived performance even with the debounce