### PR TITLE
fix(input/#2935): <space> key not recognized as leader

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,5 +1,4 @@
-### Features
-
+### Features 
 - #2866 - Extensions: Show ratings / download count in details view (fixes #2866)
 - #2889 - Extensions: Include HTML, JSON, PHP, and Markdown language servers
 - #2849 - UX: Initial menu bar on Windows / Linux (fixes #1255)
@@ -31,6 +30,7 @@
 - #2628 - Input: Right arrow key treated as PageUp
 - #2929 - Input: Fix intermittent crash when scrolling with the mouse (fixes #2919)
 - #2927 - Input: Windows - fix crash in entering Unicode character (fixes #2926)
+- #2941 - Input: Fix handling of `<space>` as leader key (fixes #2935)
 
 ### Performance
 

--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -142,3 +142,20 @@ __Pass:__
 - [ ] Win
 - [ ] OSX
 - [ ] Linux
+
+## 7.2 Leader Key
+
+Regression test for #2935
+
+Prerequisite:
+- Set `vim.leader` to `"<space>"` in configuration
+- Add keybinding `{ "key": "<leader>p", "command": "workbench.action.quickOpen", "when": "!insertMode && editorTextFocus" }`
+
+- Run Onivim 2
+- Press `<space>` and then `p` in editor surface
+- Verify quick open shows
+
+__Pass:__
+- [ ] Windows
+- [ ] OSX
+- [ ] LInux

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -14,6 +14,7 @@ module Internal = {
       | v when v == 9 /*Revery.Key.Keycode.tab*/ => Some(Key.Tab)
       | v when v == Revery.Key.Keycode.backspace => Some(Key.Backspace)
       | v when v == Revery.Key.Keycode.delete => Some(Key.Delete)
+      | v when v == Revery.Key.Keycode.space => Some(Key.Space)
       | v when v == 1073741897 => Some(Key.Insert)
       | v when v == 1073741898 => Some(Key.Home)
       | v when v == 1073741899 => Some(Key.PageUp)


### PR DESCRIPTION
__Issue:__ If `<space>` is specified as the leader key, it won't be recognized in `<leader>` bindings.

__Defect:__ When `<space>` is parsed, it is recognized as `Key.Space`. However, when the space key is pressed, it was associated with `Key.Character(' ')` - so when we went to match the pressed key against bindings with leader key, they wouldn't match.

__Fix:__ Associate the pressed input key with `Key.Space` instead of `Key.Character`

__TODO:__
- [x] Validate on OSX
- [x] Validate on Windows
- [x] Validate on Linux