### PR TITLE
fix(components): remove overscroll in `VimList`

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -33,6 +33,7 @@
 - #2927 - Input: Windows - fix crash in entering Unicode character (fixes #2926)
 - #2938 - Input: OSX - Modifier keys not working on Romaji keyboard (fixes #2924)
 - #2941 - Input: Fix handling of `<space>` as leader key (fixes #2935)
+- #2944 - Components: Remove overscroll in `VimList`
 
 ### Performance
 

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -258,6 +258,7 @@ let scrollSelectedToBottom = model => {
 let scrollSelectedToCenter = model => {
   model
   |> setScrollY(
+       ~allowOverscroll=true,
        ~scrollY=
          float(
            model.selected

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -190,13 +190,19 @@ let set = (~searchText=?, items, model) => {
   {...model, searchContext, items} |> setSelected(~selected=model.selected);
 };
 
-let setScrollY = (~scrollY, model) => {
-  let visibleCount =
-    max(
-      0,
-      Array.length(model.items) - model.viewportHeight / model.rowHeight,
-    );
-  let maxScroll = float(visibleCount * model.rowHeight);
+let setScrollY = (~allowOverscroll=false, ~scrollY, model) => {
+  let maxScroll =
+    if (allowOverscroll) {
+      let minusOneCount = max(0, Array.length(model.items) - 1);
+      float(minusOneCount * model.rowHeight);
+    } else {
+      let visibleCount =
+        max(
+          0,
+          Array.length(model.items) - model.viewportHeight / model.rowHeight,
+        );
+      float(visibleCount * model.rowHeight);
+    };
   let minScroll = 0.;
 
   let newScrollY = FloatEx.clamp(scrollY, ~hi=maxScroll, ~lo=minScroll);
@@ -226,7 +232,10 @@ let setScrollAlignment = (~maybeAlignment, model) => {
 
 let scrollSelectedToTop = model => {
   model
-  |> setScrollY(~scrollY=float(model.selected * model.rowHeight))
+  |> setScrollY(
+       ~allowOverscroll=true,
+       ~scrollY=float(model.selected * model.rowHeight),
+     )
   |> setScrollAlignment(~maybeAlignment=Some(`Top))
   |> enableScrollAnimation;
 };
@@ -234,6 +243,7 @@ let scrollSelectedToTop = model => {
 let scrollSelectedToBottom = model => {
   model
   |> setScrollY(
+       ~allowOverscroll=true,
        ~scrollY=
          float(
            model.selected

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -191,9 +191,12 @@ let set = (~searchText=?, items, model) => {
 };
 
 let setScrollY = (~scrollY, model) => {
-  // Allow for overscroll such that the very last item is visible
-  let countMinusOne = max(0, Array.length(model.items) - 1);
-  let maxScroll = float(countMinusOne * model.rowHeight);
+  let visibleCount =
+    max(
+      0,
+      Array.length(model.items) - model.viewportHeight / model.rowHeight,
+    );
+  let maxScroll = float(visibleCount * model.rowHeight);
   let minScroll = 0.;
 
   let newScrollY = FloatEx.clamp(scrollY, ~hi=maxScroll, ~lo=minScroll);


### PR DESCRIPTION
I'm actually not sure if there are historical reasons that we allow overscroll up to 1 element, but if not, I find it slightly annoying sometimes when I scroll with the mousewheel and get something like this (especially considering the displayed scroll bar doesn't allow the same and disappears):
![image](https://user-images.githubusercontent.com/4527949/103798238-6a21c500-5017-11eb-9d4d-d9c1b53ad0a1.png)

This is just a simple math change so that we bound the scroll to remove overscroll.