### PR TITLE
fix(scm): StackOverflow on large diff

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -36,6 +36,7 @@
 - #2944 - Components: Remove overscroll in `VimList`
 - #2942 - TextMate: Fix infinite loop with vala grammar (fixes #2933)
 - #2937 - Editor: Fix bugs around horizontal scrolling (fixes #1544, #2914)
+- #2946 - SCM: Fix StackOverflow when retrieving original content for large files
 
 ### Performance
 

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -278,58 +278,73 @@ let extractSnippet = (~maxLength, ~charStart, ~charEnd, text) => {
   };
 };
 
-let removeWindowsNewLines = s =>
-  List.init(String.length(s), String.get(s))
-  |> List.filter(c => c != '\r')
-  |> List.map(c => String.make(1, c))
-  |> String.concat("");
+let removeWindowsNewLines = str => {
+  let len = String.length(str);
+  let filteredString = Bytes.of_string(str);
 
-let%test_module "removeWindowsNewLines" = (module {
-  let%test "empty" = {
-    removeWindowsNewLines("") == ""
+  let destIdx = ref(0);
+  for (srcIdx in 0 to len - 1) {
+    if (str.[srcIdx] != '\r') {
+      Bytes.set(filteredString, destIdx^, str.[srcIdx]);
+      incr(destIdx);
+    };
   };
-  let%test "just \r" = {
-    removeWindowsNewLines("\r") == "";
-  };
-  let%test "part of a newline" = {
-    removeWindowsNewLines("a\r\nb")== "a\nb";
-  }
 
-  let%test "very large string" = {
-    let size = 100 * 1024 * 1024;
-    let str = String.make(size, 'a')
-    removeWindowsNewLines(str) == "";
-  }
-});
+  let destLen = destIdx^;
+  Bytes.sub(filteredString, 0, destLen) |> Bytes.to_string;
+};
+
+let%test_module "removeWindowsNewLines" =
+  (module
+   {
+     let%test "empty" = {
+       removeWindowsNewLines("") == "";
+     };
+     let%test "just CR" = {
+       removeWindowsNewLines("\r") == "";
+     };
+     let%test "CR as part of a newline" = {
+       removeWindowsNewLines("a\r\nb") == "a\nb";
+     };
+
+     let%test "very large string, without CR" = {
+       let size = 100 * 1024 * 1024;
+       let str = String.make(size, 'a');
+       removeWindowsNewLines(str) == str;
+     };
+
+     let%test "very large string, with CR" = {
+       let size = 100 * 1024 * 1024;
+       let str = String.make(size, '\r');
+       removeWindowsNewLines(str) == "";
+     };
+   });
 
 let splitNewLines = s => s |> String.split_on_char('\n') |> Array.of_list;
 
-let%test_module "splitNewLines" = (module {
-  let%test "empty" = {
-    splitNewLines("") == [|""|];
-  };
-  let%test "single line" = {
-    splitNewLines("abc") == [|"abc"|];
-  };
-  let%test "multiple lines, LF" = {
-    splitNewLines("abc\ndef") == [|"abc", "def"|];
-  }
+let%test_module "splitNewLines" =
+  (module
+   {
+     let%test "empty" = {
+       splitNewLines("") == [|""|];
+     };
+     let%test "single line" = {
+       splitNewLines("abc") == [|"abc"|];
+     };
+     let%test "multiple lines, LF" = {
+       splitNewLines("abc\ndef") == [|"abc", "def"|];
+     };
 
-  let%test "multiple lines, ending with newline, LF" = {
-    splitNewLines("abc\ndef\n") == [|"abc", "def", ""|];
-  }
+     let%test "multiple lines, ending with newline, LF" = {
+       splitNewLines("abc\ndef\n") == [|"abc", "def", ""|];
+     };
 
-  // TODO:
-  // let%test "multiple lines, ending with newline, CRLF" = {
-  //   splitNewLines("abc\r\ndef\r\n") == [|"abc", "def", ""|];
-  // }
-
-  let%test "very large string, LF" = {
-    let size = 100 * 1024 * 1024;
-    let str = String.make(size, '\n')
-    splitNewLines(str) == Array.make(size + 1, "");
-  }
-});
+     let%test "very large string, LF" = {
+       let size = 100 * 1024 * 1024;
+       let str = String.make(size, '\n');
+       splitNewLines(str) == Array.make(size + 1, "");
+     };
+   });
 
 let removeTrailingNewLine = s => {
   let len = String.length(s);

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -308,13 +308,13 @@ let%test_module "removeWindowsNewLines" =
      };
 
      let%test "very large string, without CR" = {
-       let size = 100 * 1024 * 1024;
+       let size = 10 * 1024 * 1024;
        let str = String.make(size, 'a');
        removeWindowsNewLines(str) == str;
      };
 
      let%test "very large string, with CR" = {
-       let size = 100 * 1024 * 1024;
+       let size = 10 * 1024 * 1024;
        let str = String.make(size, '\r');
        removeWindowsNewLines(str) == "";
      };
@@ -340,7 +340,7 @@ let%test_module "splitNewLines" =
      };
 
      let%test "very large string, LF" = {
-       let size = 100 * 1024 * 1024;
+       let size = 10 * 1024 * 1024;
        let str = String.make(size, '\n');
        splitNewLines(str) == Array.make(size + 1, "");
      };

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -284,7 +284,52 @@ let removeWindowsNewLines = s =>
   |> List.map(c => String.make(1, c))
   |> String.concat("");
 
+let%test_module "removeWindowsNewLines" = (module {
+  let%test "empty" = {
+    removeWindowsNewLines("") == ""
+  };
+  let%test "just \r" = {
+    removeWindowsNewLines("\r") == "";
+  };
+  let%test "part of a newline" = {
+    removeWindowsNewLines("a\r\nb")== "a\nb";
+  }
+
+  let%test "very large string" = {
+    let size = 100 * 1024 * 1024;
+    let str = String.make(size, 'a')
+    removeWindowsNewLines(str) == "";
+  }
+});
+
 let splitNewLines = s => s |> String.split_on_char('\n') |> Array.of_list;
+
+let%test_module "splitNewLines" = (module {
+  let%test "empty" = {
+    splitNewLines("") == [|""|];
+  };
+  let%test "single line" = {
+    splitNewLines("abc") == [|"abc"|];
+  };
+  let%test "multiple lines, LF" = {
+    splitNewLines("abc\ndef") == [|"abc", "def"|];
+  }
+
+  let%test "multiple lines, ending with newline, LF" = {
+    splitNewLines("abc\ndef\n") == [|"abc", "def", ""|];
+  }
+
+  // TODO:
+  // let%test "multiple lines, ending with newline, CRLF" = {
+  //   splitNewLines("abc\r\ndef\r\n") == [|"abc", "def", ""|];
+  // }
+
+  let%test "very large string, LF" = {
+    let size = 100 * 1024 * 1024;
+    let str = String.make(size, '\n')
+    splitNewLines(str) == Array.make(size + 1, "");
+  }
+});
 
 let removeTrailingNewLine = s => {
   let len = String.length(s);


### PR DESCRIPTION
__Issue:__ When a large file is loaded, and we get the 'original content' (via a diff provider) - large files could cause a stack overflow. The file doesn't need to be too large - this could be reproduced by trying to open the `large-c-file.c` in the integration_test folder in this repo.

__Defect:__ In migrating to the virtual file system in #2868 - we use a new strategy for loading the original content. This relied on using `StringEx.removeWindowsNewLines`, which was very inefficient, and could cause a stack overflow for very large content.

__Fix:__ Add test cases to cover existing functionality; improve performance by moving to a more efficient (less allocating) and stack friendly algorithm.