### PR TITLE
fix(markdown/#2953): explicitly set code block font size in Markdown

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,6 +37,7 @@
 - #2942 - TextMate: Fix infinite loop with vala grammar (fixes #2933)
 - #2937 - Editor: Fix bugs around horizontal scrolling (fixes #1544, #2914)
 - #2946 - SCM: Fix StackOverflow when retrieving original content for large files
+- #2954 - Markdown: explicitly set code block font size (fixes #2953)
 
 ### Performance
 

--- a/src/Components/RemoteMarkdown.re
+++ b/src/Components/RemoteMarkdown.re
@@ -34,6 +34,7 @@ let make =
              codeFontFamily
              headerMargin=16
              baseFontSize=12.
+             codeBlockFontSize=12.
            />
          | FileContentsDownloader.DownloadFailed({errorMsg}) =>
            <Text text=errorMsg />


### PR DESCRIPTION
For some reason, explicitly setting the code block font size fixes the code block issue in extension descriptions.

This should just be a temporary fix until I can figure out *why* this is happening, but it works well for now.

Fixes #2953