### PR TITLE
fix(ux/#2953): Extensions - remove hardcoded button colors

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,6 +37,7 @@
 - #2942 - TextMate: Fix infinite loop with vala grammar (fixes #2933)
 - #2937 - Editor: Fix bugs around horizontal scrolling (fixes #1544, #2914)
 - #2946 - SCM: Fix StackOverflow when retrieving original content for large files
+- #2955 - UX: Fix hardcoded theme colors in extensions list/details
 
 ### Performance
 

--- a/src/Feature/Extensions/DetailsView.re
+++ b/src/Feature/Extensions/DetailsView.re
@@ -73,14 +73,16 @@ module Rating = {
   };
 };
 
-let installButton = (~font, ~extensionId, ~dispatch, ()) => {
+let installButton = (~theme, ~font, ~extensionId, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.background.from(theme);
+  let color = Colors.Button.foreground.from(theme);
   <View style=Styles.headerButton>
     <ItemView.ActionButton
       font
       title="Install"
       extensionId
-      backgroundColor=Revery.Colors.green
-      color=Revery.Colors.white
+      backgroundColor
+      color
       onAction={() =>
         dispatch(Model.InstallExtensionClicked({extensionId: extensionId}))
       }
@@ -88,14 +90,16 @@ let installButton = (~font, ~extensionId, ~dispatch, ()) => {
   </View>;
 };
 
-let uninstallButton = (~font, ~extensionId, ~dispatch, ()) => {
+let uninstallButton = (~theme, ~font, ~extensionId, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.background.from(theme);
+  let color = Colors.Button.foreground.from(theme);
   <View style=Styles.headerButton>
     <ItemView.ActionButton
       font
       title="Uninstall"
       extensionId
-      backgroundColor=Revery.Colors.green
-      color=Revery.Colors.white
+      backgroundColor
+      color
       onAction={() =>
         dispatch(Model.UninstallExtensionClicked({extensionId: extensionId}))
       }
@@ -103,14 +107,16 @@ let uninstallButton = (~font, ~extensionId, ~dispatch, ()) => {
   </View>;
 };
 
-let updateButton = (~font, ~extensionId, ~dispatch, ()) => {
+let updateButton = (~theme, ~font, ~extensionId, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.secondaryBackground.from(theme);
+  let color = Colors.Button.secondaryForeground.from(theme);
   <View style=Styles.headerButton>
     <ItemView.ActionButton
       font
       title="Update"
       extensionId
-      backgroundColor=Revery.Colors.green
-      color=Revery.Colors.white
+      backgroundColor
+      color
       onAction={() =>
         dispatch(Model.UpdateExtensionClicked({extensionId: extensionId}))
       }
@@ -118,14 +124,16 @@ let updateButton = (~font, ~extensionId, ~dispatch, ()) => {
   </View>;
 };
 
-let setThemeButton = (~font, ~extensionId, ~dispatch, ()) => {
+let setThemeButton = (~theme, ~font, ~extensionId, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.secondaryBackground.from(theme);
+  let color = Colors.Button.secondaryForeground.from(theme);
   <View style=Styles.headerButton>
     <ItemView.ActionButton
       font
       title="Set Theme"
       extensionId
-      backgroundColor=Revery.Colors.green
-      color=Revery.Colors.white
+      backgroundColor
+      color
       onAction={() =>
         dispatch(Model.SetThemeClicked({extensionId: extensionId}))
       }
@@ -161,17 +169,17 @@ let header =
   let buttons =
     switch (isInstalled, hasThemes) {
     | (true, true) => [
-        <setThemeButton font extensionId dispatch />,
-        <uninstallButton font extensionId dispatch />,
+        <setThemeButton theme font extensionId dispatch />,
+        <uninstallButton theme font extensionId dispatch />,
       ]
-    | (true, false) => [<uninstallButton font extensionId dispatch />]
-    | _ => [<installButton font extensionId dispatch />]
+    | (true, false) => [<uninstallButton theme font extensionId dispatch />]
+    | _ => [<installButton theme font extensionId dispatch />]
     };
 
   // Tack on an update button, if available...
   let buttons' =
     if (isInstalled && Model.isUpdateAvailable(~extensionId, model)) {
-      [<updateButton font extensionId dispatch />, ...buttons];
+      [<updateButton theme font extensionId dispatch />, ...buttons];
     } else {
       buttons;
     };

--- a/src/Feature/Extensions/ListView.re
+++ b/src/Feature/Extensions/ListView.re
@@ -46,60 +46,70 @@ let reduce = (msg, model) =>
   | WidthChanged(width) => {...model, width}
   };
 
-let installButton = (~font, ~extensionId, ~dispatch, ()) => {
+let installButton = (~theme, ~font, ~extensionId, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.background.from(theme);
+  let color = Colors.Button.foreground.from(theme);
   <ItemView.ActionButton
     font
     title="Install"
-    backgroundColor=Revery.Colors.green
-    color=Revery.Colors.white
+    backgroundColor
+    color
     onAction={() =>
       dispatch(Model.InstallExtensionClicked({extensionId: extensionId}))
     }
   />;
 };
 
-let uninstallButton = (~font, ~extensionId, ~dispatch, ()) => {
+let uninstallButton = (~theme, ~font, ~extensionId, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.background.from(theme);
+  let color = Colors.Button.foreground.from(theme);
   <ItemView.ActionButton
     extensionId
     font
     title="Uninstall"
-    backgroundColor=Revery.Colors.red
-    color=Revery.Colors.white
+    backgroundColor
+    color
     onAction={() =>
       dispatch(Model.UninstallExtensionClicked({extensionId: extensionId}))
     }
   />;
 };
 
-let progressButton = (~extensionId, ~font, ~title, ()) => {
+let progressButton = (~theme, ~extensionId, ~font, ~title, ()) => {
+  let backgroundColor = Colors.Button.secondaryBackground.from(theme);
+  let color = Colors.Button.secondaryForeground.from(theme);
   <ItemView.ActionButton
     extensionId
     font
     title
-    backgroundColor=Revery.Colors.blue
-    color=Revery.Colors.white
+    backgroundColor
+    color
     onAction={() => ()}
   />;
 };
 
-let installedButton = (~extensionId, ~font, ()) => {
+let installedButton = (~theme, ~extensionId, ~font, ()) => {
+  let backgroundColor = Colors.Button.background.from(theme);
+  let color = Colors.Button.foreground.from(theme);
   <ItemView.ActionButton
     extensionId
     font
     title="Installed"
-    backgroundColor=Revery.Colors.blue
-    color=Revery.Colors.white
+    backgroundColor
+    color
     onAction={() => ()}
   />;
 };
 
-let updateButton = (~extensionId, ~font, ~dispatch, ()) => {
+let updateButton = (~theme, ~extensionId, ~font, ~dispatch, ()) => {
+  let backgroundColor = Colors.Button.secondaryBackground.from(theme);
+  let color = Colors.Button.secondaryForeground.from(theme);
   <ItemView.ActionButton
     extensionId
     font
     title="Update"
-    backgroundColor=Revery.Colors.blue
-    color=Revery.Colors.white
+    backgroundColor
+    color
     onAction={() =>
       dispatch(Model.UpdateExtensionClicked({extensionId: extensionId}))
     }
@@ -167,13 +177,13 @@ let%component make =
     let isRestartRequired = Model.isRestartRequired(~extensionId, model);
     let actionButton =
       if (Model.isInstalling(~extensionId, model)) {
-        <progressButton extensionId title="Updating" font />;
+        <progressButton theme extensionId title="Updating" font />;
       } else if (Model.isUninstalling(~extensionId=id, model)) {
-        <progressButton extensionId font title="Uninstalling" />;
+        <progressButton theme extensionId font title="Uninstalling" />;
       } else if (Model.isUpdateAvailable(~extensionId=id, model)) {
-        <updateButton font extensionId dispatch />;
+        <updateButton theme font extensionId dispatch />;
       } else {
-        <uninstallButton font extensionId dispatch />;
+        <uninstallButton theme font extensionId dispatch />;
       };
 
     <ItemView
@@ -258,16 +268,16 @@ let%component make =
             let actionButton =
               if (Model.isInstalled(~extensionId, model)) {
                 if (Model.isInstalling(~extensionId, model)) {
-                  <progressButton extensionId title="Updating" font />;
+                  <progressButton theme extensionId title="Updating" font />;
                 } else if (Model.canUpdate(~extensionId, ~maybeVersion, model)) {
-                  <updateButton extensionId font dispatch />;
+                  <updateButton theme extensionId font dispatch />;
                 } else {
-                  <installedButton extensionId font />;
+                  <installedButton theme extensionId font />;
                 };
               } else {
                 Model.isInstalling(~extensionId, model)
-                  ? <progressButton extensionId title="Installing" font />
-                  : <installButton extensionId dispatch font extensionId />;
+                  ? <progressButton theme extensionId title="Installing" font />
+                  : <installButton theme extensionId dispatch font extensionId />;
               };
 
             <ItemView

--- a/src/Feature/Extensions/ListView.re
+++ b/src/Feature/Extensions/ListView.re
@@ -276,8 +276,19 @@ let%component make =
                 };
               } else {
                 Model.isInstalling(~extensionId, model)
-                  ? <progressButton theme extensionId title="Installing" font />
-                  : <installButton theme extensionId dispatch font extensionId />;
+                  ? <progressButton
+                      theme
+                      extensionId
+                      title="Installing"
+                      font
+                    />
+                  : <installButton
+                      theme
+                      extensionId
+                      dispatch
+                      font
+                      extensionId
+                    />;
               };
 
             <ItemView

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -128,10 +128,21 @@ module Button = {
   let secondaryHoverBackground =
     define(
       "button.secondaryHoverBackground",
-      {dark: ref(secondaryBackground), light: ref(secondaryBackground), hc: unspecified},
+      {
+        dark: ref(secondaryBackground),
+        light: ref(secondaryBackground),
+        hc: unspecified,
+      },
     );
 
-  let defaults = [background, foreground, hoverBackground, secondaryForeground, secondaryBackground, secondaryHoverBackground];
+  let defaults = [
+    background,
+    foreground,
+    hoverBackground,
+    secondaryForeground,
+    secondaryBackground,
+    secondaryHoverBackground,
+  ];
 };
 
 module Dropdown = {

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -113,7 +113,25 @@ module Button = {
       {dark: ref(background), light: ref(background), hc: unspecified},
     );
 
-  let defaults = [background, foreground, hoverBackground];
+  let secondaryForeground =
+    define(
+      "button.secondaryForeground",
+      {dark: hex("#FFF"), light: hex("#FFF"), hc: hex("#FFF")},
+    );
+
+  let secondaryBackground =
+    define(
+      "button.secondaryBackground",
+      {dark: hex("#0E639C"), light: hex("#007ACC"), hc: unspecified},
+    );
+
+  let secondaryHoverBackground =
+    define(
+      "button.secondaryHoverBackground",
+      {dark: ref(secondaryBackground), light: ref(secondaryBackground), hc: unspecified},
+    );
+
+  let defaults = [background, foreground, hoverBackground, secondaryForeground, secondaryBackground, secondaryHoverBackground];
 };
 
 module Dropdown = {


### PR DESCRIPTION
__Issue:__ Some of the colors for buttons in the extensions list / details page were hardcoded

__Fix:__ Use theme colors - thanks for catching this @zbaylin 

Related #2953 