### PR TITLE
chore(ci): Prepare `esy release` for new esy version

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -118,7 +118,7 @@ const updateIcon = (rcedit, exe, iconFile) => {
 }
 
 if (process.platform == "linux") {
-    const result = cp.spawnSync("esy", ["scripts/linux/package-linux.sh"], {
+    const result = cp.spawnSync("esy", ["bash", "-c", "scripts/linux/package-linux.sh"], {
         cwd: process.cwd(),
         env: process.env,
         stdio: "inherit",


### PR DESCRIPTION
Fix to remove dependency on shebang-shell-script behavior that will go away in next `esy`