### PR TITLE
fix(editor): Fix isPressed edge condition for auto-scroll

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -41,7 +41,7 @@
 - #2954 - Markdown: explicitly set code block font size (fixes #2953)
 - #2950 - Input: Fix binding to `+` key (fixes #2293)
 - #2955 - UX: Fix hardcoded theme colors in extensions list/details
-- #2898 - Editor: Implement mouse selection (fixes #537)
+- #2898, #2966 - Editor: Implement mouse selection (fixes #537)
 
 ### Performance
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1862,33 +1862,39 @@ let update = (msg, editor) => {
   };
 };
 
-let isMousePressedNearTop = ({lastMouseScreenPosition, _}) => {
-  lastMouseScreenPosition
+let isMousePressedNearTop = ({isMouseDown, lastMouseScreenPosition, _}) => {
+  isMouseDown
+  && lastMouseScreenPosition
   |> Option.map(({y, _}: PixelPosition.t) => {
        int_of_float(y) < Constants.mouseAutoScrollBorder
      })
   |> Option.value(~default=false);
 };
 
-let isMousePressedNearBottom = ({lastMouseScreenPosition, pixelHeight, _}) => {
-  lastMouseScreenPosition
+let isMousePressedNearBottom =
+    ({isMouseDown, lastMouseScreenPosition, pixelHeight, _}) => {
+  isMouseDown
+  && lastMouseScreenPosition
   |> Option.map(({y, _}: PixelPosition.t) => {
        int_of_float(y) > pixelHeight - Constants.mouseAutoScrollBorder
      })
   |> Option.value(~default=false);
 };
 
-let isMousePressedNearLeftEdge = ({lastMouseScreenPosition, _}) => {
-  lastMouseScreenPosition
+let isMousePressedNearLeftEdge = ({isMouseDown, lastMouseScreenPosition, _}) => {
+  isMouseDown
+  && lastMouseScreenPosition
   |> Option.map(({x, _}: PixelPosition.t) => {
        int_of_float(x) < Constants.mouseAutoScrollBorder
      })
   |> Option.value(~default=false);
 };
 
-let isMousePressedNearRightEdge = ({lastMouseScreenPosition, _} as editor) => {
+let isMousePressedNearRightEdge =
+    ({isMouseDown, lastMouseScreenPosition, _} as editor) => {
   let {bufferWidthInPixels, _}: EditorLayout.t = getLayout(editor);
-  lastMouseScreenPosition
+  isMouseDown
+  && lastMouseScreenPosition
   |> Option.map(({x, _}: PixelPosition.t) => {
        x > bufferWidthInPixels -. float(Constants.mouseAutoScrollBorder)
      })


### PR DESCRIPTION
__Issue:__ On a trackpad, simply moving the trackpad to the edge of the editor would auto-scroll

__Defect:__ The `isPressed*` conditions were missing checking if the mouse is down

__Fix:__ Add mouse down check

Related #2898 