### PR TITLE
fix(osx): Crash in open file / folder dialog with virtual keyboard layout

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08b2162d5479db000940eb0e61e157b5",
+  "checksum": "585b029df9082588f0e0dc5e6e05ebcd",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f48f6d@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+    "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f48f6d",
+      "version": "github:revery-ui/revery#f9bbf3f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f48f6d" ]
+        "source": [ "github:revery-ui/revery#f9bbf3f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08b2162d5479db000940eb0e61e157b5",
+  "checksum": "585b029df9082588f0e0dc5e6e05ebcd",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f48f6d@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+    "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f48f6d",
+      "version": "github:revery-ui/revery#f9bbf3f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f48f6d" ]
+        "source": [ "github:revery-ui/revery#f9bbf3f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08b2162d5479db000940eb0e61e157b5",
+  "checksum": "585b029df9082588f0e0dc5e6e05ebcd",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f48f6d@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+    "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f48f6d",
+      "version": "github:revery-ui/revery#f9bbf3f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f48f6d" ]
+        "source": [ "github:revery-ui/revery#f9bbf3f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "revery": "revery-ui/revery#3f48f6d",
+    "revery": "revery-ui/revery#f9bbf3f",
     "esy-skia": "revery-ui/esy-skia#91c98f6",
     "rench": "bryphe/rench#a976fe5",
     "isolinear": "revery-ui/isolinear#53fc4eb",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08b2162d5479db000940eb0e61e157b5",
+  "checksum": "585b029df9082588f0e0dc5e6e05ebcd",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f48f6d@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+    "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f48f6d",
+      "version": "github:revery-ui/revery#f9bbf3f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f48f6d" ]
+        "source": [ "github:revery-ui/revery#f9bbf3f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "release.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/src/oni2-keyboard-layout/stubs/keyboard-layout-mac.c
+++ b/src/oni2-keyboard-layout/stubs/keyboard-layout-mac.c
@@ -75,14 +75,30 @@ static void notificationHandler(
 CAMLprim value oni2_KeyboardLayoutInit() {
   CAMLparam0();
 
-  CFNotificationCenterAddObserver(
-    CFNotificationCenterGetDistributedCenter(),
-    NULL,
-    notificationHandler,
-    kTISNotifySelectedKeyboardInputSourceChanged,
-    NULL,
-    CFNotificationSuspensionBehaviorDeliverImmediately
-  );
+  // TODO:
+
+  // This callback can get called in unexpected scenarios,
+  // like when the open file dialog is opened. 
+
+  // This means that we hit the same issue we had with the resize -
+  // we could get a callback on a thread that already has the
+  // ocaml runtime locked (or not), which can cause a crash.
+
+  // Until we have a robust way to ensure the state of the runtime,
+  // it makes sense to disable this to avoid a crash.
+
+  // The downside is that the callbacks for keyboard layout changing
+  // won't work as expected... but today we're querying each key press,
+  // anyway.
+
+  // CFNotificationCenterAddObserver(
+  //   CFNotificationCenterGetDistributedCenter(),
+  //   NULL,
+  //   notificationHandler,
+  //   kTISNotifySelectedKeyboardInputSourceChanged,
+  //   NULL,
+  //   CFNotificationSuspensionBehaviorDrop
+  // );
 
   CAMLreturn(Val_unit);
 }

--- a/src/oni2-keyboard-layout/stubs/keyboard-layout-mac.c
+++ b/src/oni2-keyboard-layout/stubs/keyboard-layout-mac.c
@@ -75,30 +75,14 @@ static void notificationHandler(
 CAMLprim value oni2_KeyboardLayoutInit() {
   CAMLparam0();
 
-  // TODO:
-
-  // This callback can get called in unexpected scenarios,
-  // like when the open file dialog is opened. 
-
-  // This means that we hit the same issue we had with the resize -
-  // we could get a callback on a thread that already has the
-  // ocaml runtime locked (or not), which can cause a crash.
-
-  // Until we have a robust way to ensure the state of the runtime,
-  // it makes sense to disable this to avoid a crash.
-
-  // The downside is that the callbacks for keyboard layout changing
-  // won't work as expected... but today we're querying each key press,
-  // anyway.
-
-  // CFNotificationCenterAddObserver(
-  //   CFNotificationCenterGetDistributedCenter(),
-  //   NULL,
-  //   notificationHandler,
-  //   kTISNotifySelectedKeyboardInputSourceChanged,
-  //   NULL,
-  //   CFNotificationSuspensionBehaviorDrop
-  // );
+  CFNotificationCenterAddObserver(
+    CFNotificationCenterGetDistributedCenter(),
+    NULL,
+    notificationHandler,
+    kTISNotifySelectedKeyboardInputSourceChanged,
+    NULL,
+    CFNotificationSuspensionBehaviorDeliverImmediately
+  );
 
   CAMLreturn(Val_unit);
 }

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "38dbb28b5daa182cadae7b4baca16327",
+  "checksum": "43cbafe3a6caaf7a393f990f02593442",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#3f48f6d@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+    "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#3f48f6d",
+      "version": "github:revery-ui/revery#f9bbf3f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#3f48f6d" ]
+        "source": [ "github:revery-ui/revery#f9bbf3f" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#3f48f6d@d41d8cd9",
+        "revery@github:revery-ui/revery#f9bbf3f@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",


### PR DESCRIPTION
__Issue:__ On OSX, if the keyboard layout is set to a virtual layout, or in a configuration that would cause it to change when an open dialog is brought up, the application could crash. I can reproduce reliably setting the keyboard layout to `Romaji`, and then trying to open a folder.

__Defect:__ When the dialog is opened in this configuration, a `kTISNotifySelectedKeyboardInputSourceChanged` notification is produced, which calls into our `notificationHandler`. The `notificationHandler` expects the OCaml runtime to _not_ be active, and tries to acquire it - however, in this case, it actually is acquired.

Callstack is:
```
Heaviest stack for the main thread of the target process:
  41  camlRevery_Native__Dialog__openFiles_inner_115 + 90 (Oni2_editor.exe + 4050506) [0x10b050e4a]
  41  revery_alertOpenFiles_native + 773 (dialog.c:113,16 in Oni2_editor.exe + 7643029) [0x10b3bdf95]
  41  revery_open_files_cocoa + 576 (dialog_cocoa.c:76,24 in Oni2_editor.exe + 7644208) [0x10b3be430]
  41  -[NSSavePanel runModal] + 145 (AppKit + 10723623) [0x7fff37296127]
  41  -[NSApplication runModalForWindow:] + 128 (AppKit + 3408809) [0x7fff36b9c3a9]
  41  _NSTryRunModal + 100 (AppKit + 3409092) [0x7fff36b9c4c4]
  41  __35-[NSApplication runModalForWindow:]_block_invoke + 70 (AppKit + 3410994) [0x7fff36b9cc32]
  41  __35-[NSApplication runModalForWindow:]_block_invoke_2 + 64 (AppKit + 3411077) [0x7fff36b9cc85]
  41  -[NSApplication _doModalLoop:peek:] + 315 (AppKit + 3415794) [0x7fff36b9def2]
  41  -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352 (AppKit + 260224) [0x7fff3689b880]
  41  _DPSNextEvent + 883 (AppKit + 266297) [0x7fff3689d039]
  41  _BlockUntilNextEventMatchingListInModeWithFilter + 64 (HIToolbox + 193913) [0x7fff38257579]
  41  ReceiveNextEventCommon + 584 (HIToolbox + 194517) [0x7fff382577d5]
  41  RunCurrentEventLoopInMode + 292 (HIToolbox + 195261) [0x7fff38257abd]
  41  CFRunLoopRunSpecific + 462 (CoreFoundation + 532030) [0x7fff3962ae3e]
  41  __CFRunLoopRun + 2028 (CoreFoundation + 535687) [0x7fff3962bc87]
  41  __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9 (CoreFoundation + 798337) [0x7fff3966be81]
  41  _dispatch_main_queue_callback_4CF + 936 (libdispatch.dylib + 56491) [0x7fff73647cab]
  41  _dispatch_client_callout + 8 (libdispatch.dylib + 9816) [0x7fff7363c658]
  41  _dispatch_call_block_and_release + 12 (libdispatch.dylib + 5828) [0x7fff7363b6c4]
  41  ___CFXRegistrationPost1_block_invoke + 63 (CoreFoundation + 497571) [0x7fff396227a3]
  41  __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12 (CoreFoundation + 497679) [0x7fff3962280f]
  41  notificationHandler + 144 (keyboard-layout-mac.c:65,3 in Oni2_editor.exe + 6995216) [0x10b31fd10]
  41  caml_leave_blocking_section + 19 (signals.c:186,3 in Oni2_editor.exe + 15917123) [0x10bba2043]
  41  caml_thread_leave_blocking_section + 65 (Oni2_editor.exe + 15853345) [0x10bb92721]
  41  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff737d9882]
 *41  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f82cc7922]
 ```

__Fix:__ To address the crash, I'm turning off the notification for this - AFAIK, we don't currently use the layout change events, so this should be a safe fix.

However, a more robust fix might be to always unregister the runtime around the `runModal` call when open the file picker dialog - wrapping this: https://github.com/revery-ui/revery/blob/3f48f6d3444aec8f8c7e810938f2a5d03baf5693/src/Native/dialog_cocoa.c#L76 with release runtime / acquire runtime.

__Todo:__
- [x] Try out the more robust release / acquire fix