### PR TITLE
feat(osx): Native application menu

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -5,6 +5,7 @@
 - #2849 - UX: Initial menu bar on Windows / Linux (fixes #1255)
 - #2596 - Editor: File preview when clicking on files (thanks @fanantoxa!)
 - #2755 - Editor: Implement customizable font-weight (fixes #1573, thanks @marcagba!)
+- #2969 - UX: Menu bar integration on OSX
 
 ### Bug Fixes
 

--- a/src/Core/MenuBar.re
+++ b/src/Core/MenuBar.re
@@ -172,6 +172,8 @@ module Menu = {
 
 let build = (~contextKeys as _, ~commands as _, menu) => {schema: menu};
 
+let schema = ({schema, _}) => schema;
+
 let top = schema => {
   Schema.(
     {

--- a/src/Core/MenuBar.rei
+++ b/src/Core/MenuBar.rei
@@ -60,5 +60,7 @@ let build:
   ) =>
   builtMenu;
 
+let schema: builtMenu => Schema.t;
+
 // [top(builtMenu)] returns the top-level menu items for [builtMenu]
 let top: Schema.t => list(Menu.t);

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -512,4 +512,23 @@ module Contributions = {
     ];
 
   let commands = Commands.[detectIndentation] |> Command.Lookup.fromList;
+
+  let keybindings =
+    Feature_Input.Schema.[
+      bind(
+        ~key="<D-N>",
+        ~command=":enew",
+        ~condition="isMac" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-S>",
+        ~command=":w!",
+        ~condition="isMac" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<D-S-S>",
+        ~command=":wa!",
+        ~condition="isMac" |> WhenExpr.parse,
+      ),
+    ];
 };

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -128,4 +128,5 @@ module Effects: {
 module Contributions: {
   let commands: Command.Lookup.t(msg);
   let configuration: list(Config.Schema.spec);
+  let keybindings: list(Feature_Input.Schema.keybinding);
 };

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -372,13 +372,7 @@ let commandToAvailableBindings = (~command, ~config, ~context, model) => {
   if (String.length(command) <= 0) {
     [];
   } else {
-    let firstChar = command.[0];
-    let execute =
-      if (firstChar == ':') {
-        VimExCommand(String.sub(command, 1, String.length(command) - 1));
-      } else {
-        NamedCommand(command);
-      };
+    let execute = NamedCommand(command);
 
     allCandidates
     |> List.filter_map(((matcher: EditorInput.Matcher.t, ex: execute)) =>

--- a/src/Feature/MenuBar/Feature_MenuBar.re
+++ b/src/Feature/MenuBar/Feature_MenuBar.re
@@ -59,7 +59,7 @@ type msg =
   | MouseOver({uniqueId: string})
   | MouseOut({uniqueId: string})
   | ContextMenu(Component_ContextMenu.msg(string))
-  | Noop;
+  | NativeMenu({command: string});
 
 type session = {
   activePath: string,
@@ -142,6 +142,9 @@ let update = (~contextKeys, ~commands, msg, model) => {
         model;
       };
     (model', Nothing);
+
+  | NativeMenu({command}) =>
+    (model, ExecuteCommand({command: command}))
 
   | ContextMenu(contextMenuMsg) =>
     let (activeSession', eff) =
@@ -383,7 +386,7 @@ module View = {
 
 let sub = (~contextKeys, ~commands, model) => {
   let builtMenu = MenuBar.build(~contextKeys, ~commands, model.menuSchema);
-  NativeMenu.sub(~toMsg=_ => Noop, ~builtMenu);
+  NativeMenu.sub(~toMsg=command => NativeMenu({command: command}), ~builtMenu);
 };
 
 // CONTRIBUTIONS

--- a/src/Feature/MenuBar/Feature_MenuBar.re
+++ b/src/Feature/MenuBar/Feature_MenuBar.re
@@ -58,7 +58,8 @@ type msg =
   | MouseClicked({uniqueId: string})
   | MouseOver({uniqueId: string})
   | MouseOut({uniqueId: string})
-  | ContextMenu(Component_ContextMenu.msg(string));
+  | ContextMenu(Component_ContextMenu.msg(string))
+  | Noop;
 
 type session = {
   activePath: string,
@@ -376,6 +377,13 @@ module View = {
 
     <View style={Styles.container(bgColor)}> menuItems </View>;
   };
+};
+
+// SUBSCRIPTIOn
+
+let sub = (~contextKeys, ~commands, model) => {
+  let builtMenu = MenuBar.build(~contextKeys, ~commands, model.menuSchema);
+  NativeMenu.sub(~toMsg=_ => Noop, ~builtMenu);
 };
 
 // CONTRIBUTIONS

--- a/src/Feature/MenuBar/Feature_MenuBar.re
+++ b/src/Feature/MenuBar/Feature_MenuBar.re
@@ -383,9 +383,12 @@ module View = {
 
 // SUBSCRIPTIOn
 
-let sub = (~contextKeys, ~commands, model) => {
+let sub = (~config, ~contextKeys, ~commands, ~input, model) => {
   let builtMenu = MenuBar.build(~contextKeys, ~commands, model.menuSchema);
   NativeMenu.sub(
+    ~config,
+    ~context=contextKeys,
+    ~input,
     ~toMsg=command => NativeMenu({command: command}),
     ~builtMenu,
   );

--- a/src/Feature/MenuBar/Feature_MenuBar.re
+++ b/src/Feature/MenuBar/Feature_MenuBar.re
@@ -143,8 +143,7 @@ let update = (~contextKeys, ~commands, msg, model) => {
       };
     (model', Nothing);
 
-  | NativeMenu({command}) =>
-    (model, ExecuteCommand({command: command}))
+  | NativeMenu({command}) => (model, ExecuteCommand({command: command}))
 
   | ContextMenu(contextMenuMsg) =>
     let (activeSession', eff) =
@@ -386,7 +385,10 @@ module View = {
 
 let sub = (~contextKeys, ~commands, model) => {
   let builtMenu = MenuBar.build(~contextKeys, ~commands, model.menuSchema);
-  NativeMenu.sub(~toMsg=command => NativeMenu({command: command}), ~builtMenu);
+  NativeMenu.sub(
+    ~toMsg=command => NativeMenu({command: command}),
+    ~builtMenu,
+  );
 };
 
 // CONTRIBUTIONS

--- a/src/Feature/MenuBar/Feature_MenuBar.rei
+++ b/src/Feature/MenuBar/Feature_MenuBar.rei
@@ -22,6 +22,16 @@ let update:
   ) =>
   (model, outmsg);
 
+// SUBSCRIPTION
+
+let sub:
+  (
+    ~contextKeys: WhenExpr.ContextKeys.t,
+    ~commands: Command.Lookup.t(_),
+    model
+  ) =>
+  Isolinear.Sub.t(msg);
+
 module Global = Global;
 
 module View: {

--- a/src/Feature/MenuBar/Feature_MenuBar.rei
+++ b/src/Feature/MenuBar/Feature_MenuBar.rei
@@ -26,8 +26,10 @@ let update:
 
 let sub:
   (
+    ~config: Config.resolver,
     ~contextKeys: WhenExpr.ContextKeys.t,
     ~commands: Command.Lookup.t(_),
+    ~input: Feature_Input.model,
     model
   ) =>
   Isolinear.Sub.t(msg);

--- a/src/Feature/MenuBar/Global.re
+++ b/src/Feature/MenuBar/Global.re
@@ -94,7 +94,7 @@ let menus =
 let groups = [
   group(~order=100, ~parent=file, Items.File.[newFile]),
   group(~order=200, ~parent=file, Items.File.[saveFile, saveAll]),
-  group(~order=300, ~parent=file, Items.File.Preferences.[submenu]),
+  group(~order=300, ~parent=application, Items.File.Preferences.[submenu]),
   group(~order=999, ~parent=file, Items.File.[quit]),
   group(
     ~order=100,

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -12,7 +12,7 @@ module Sub = {
       let name = "Feature_Menu.nativeOSX";
       let id = (_: params) => "";
 
-      let init = (~params, ~dispatch as _) => {
+      let init = (~params, ~dispatch) => {
         module NativeMenu = Revery.Native.Menu;
         let menuBar = NativeMenu.getMenuBarHandle();
 
@@ -29,6 +29,15 @@ module Sub = {
                  buildGroup(nativeMenu, MenuBar.Item.submenu(item));
                } else {
                  ();
+                 let command = MenuBar.Item.command(item);
+                 let keyEquivalent = Revery.Native.Menu.KeyEquivalent.ofString("");
+                 let nativeMenuItem = Revery.Native.Menu.Item.create(
+                   ~title,
+                   ~onClick={() => {
+                    dispatch(command);
+                   }},
+                   ~keyEquivalent, ());
+                  Revery.Native.Menu.addItem(parent, nativeMenuItem);
                };
              });
         }

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -30,23 +30,32 @@ module Sub = {
                } else {
                  ();
                  let command = MenuBar.Item.command(item);
-                 let keyEquivalent = Revery.Native.Menu.KeyEquivalent.ofString("");
-                 let nativeMenuItem = Revery.Native.Menu.Item.create(
-                   ~title,
-                   ~onClick={() => {
-                    dispatch(command);
-                   }},
-                   ~keyEquivalent, ());
-                  Revery.Native.Menu.addItem(parent, nativeMenuItem);
+                 let keyEquivalent =
+                   Revery.Native.Menu.KeyEquivalent.ofString("");
+                 let nativeMenuItem =
+                   Revery.Native.Menu.Item.create(
+                     ~title,
+                     ~onClick=() => {dispatch(command)},
+                     ~keyEquivalent,
+                     (),
+                   );
+                 Revery.Native.Menu.addItem(parent, nativeMenuItem);
                };
              });
         }
         and buildGroup =
             (parent: NativeMenu.t, groups: list(MenuBar.Group.t)) => {
+          let len = List.length(groups);
           groups
-          |> List.iter(group => {
+          |> List.iteri((idx, group) => {
+               let isLast = idx == len - 1;
                let items = MenuBar.Group.items(group);
                buildItem(parent, items);
+
+               if (!isLast) {
+                 let separator = Revery.Native.Menu.Item.createSeparator();
+                 Revery.Native.Menu.addItem(parent, separator);
+               };
              });
         };
         topItems

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -1,0 +1,41 @@
+open Oni_Core;
+
+module Sub = {
+  type menuParams = {builtMenu: MenuBar.builtMenu};
+
+  module OSXMenuSub =
+    Isolinear.Sub.Make({
+      type nonrec msg = string;
+      type nonrec params = menuParams;
+      type state = unit;
+
+      let name = "Feature_Menu.nativeOSX";
+      let id = (_: params) => "";
+
+      let init = (~params as _, ~dispatch as _) => {
+        open Revery.Native;
+        let menuBar = Menu.getMenuBarHandle();
+
+        let menu1 = Menu.create("Test 1");
+        Menu.addSubmenu(~parent=menuBar, ~child=menu1);
+        ();
+      };
+
+      let update = (~params as _, ~state, ~dispatch as _) => {
+        state;
+      };
+
+      let dispose = (~params as _, ~state as _) => {
+        ();
+      };
+    });
+
+  let menu = (~builtMenu: MenuBar.builtMenu, ~toMsg) =>
+    if (Revery.Environment.isMac) {
+      OSXMenuSub.create({builtMenu: builtMenu}) |> Isolinear.Sub.map(toMsg);
+    } else {
+      Isolinear.Sub.none;
+    };
+};
+
+let sub = Sub.menu;

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -111,11 +111,25 @@ module Sub = {
              });
         };
         topItems
+        |> List.rev
         |> List.iter(item => {
              let title = MenuBar.Menu.title(item);
              let nativeMenu = NativeMenu.create(title);
-             let () =
-               NativeMenu.addSubmenu(~parent=menuBar, ~child=nativeMenu);
+
+             if (MenuBar.Menu.uniqueId(item) == "help") {
+               // Always add 'Help' last...
+               NativeMenu.addSubmenu(
+                 ~parent=menuBar,
+                 ~child=nativeMenu,
+               );
+             } else {
+               // But other menu items - add before the existing 'Window' menu item
+               NativeMenu.insertSubmenuAt(
+                 ~idx=1,
+                 ~parent=menuBar,
+                 ~child=nativeMenu,
+               );
+             };
              buildGroup(
                nativeMenu,
                MenuBar.Menu.contents(item, params.builtMenu),

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -134,16 +134,17 @@ module Sub = {
     });
 
   let menu =
-      (
-        ~config as _,
-        ~context as _,
-        ~input,
-        ~builtMenu: MenuBar.builtMenu,
-        ~toMsg,
-      ) =>
+      (~config, ~context, ~input, ~builtMenu: MenuBar.builtMenu, ~toMsg) =>
     if (Revery.Environment.isMac) {
       let getKeyEquivalent = command => {
-        None;
+        let bindings =
+          Feature_Input.commandToAvailableBindings(
+            ~config,
+            ~context,
+            ~command,
+            input,
+          );
+        Internal.keyBindingsToKeyEquivalent(bindings);
       };
       OSXMenuSub.create({getKeyEquivalent, builtMenu})
       |> Isolinear.Sub.map(toMsg);

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -1,7 +1,10 @@
 open Oni_Core;
 
 module Sub = {
-  type menuParams = {builtMenu: MenuBar.builtMenu};
+  type menuParams = {
+    builtMenu: MenuBar.builtMenu,
+    getKeyEquivalent: string => option(Revery.Native.Menu.KeyEquivalent.t),
+  };
 
   module OSXMenuSub =
     Isolinear.Sub.Make({
@@ -31,7 +34,12 @@ module Sub = {
                  ();
                  let command = MenuBar.Item.command(item);
                  let keyEquivalent =
-                   Revery.Native.Menu.KeyEquivalent.ofString("");
+                   params.getKeyEquivalent(command)
+                   |> Option.value(
+                        ~default=
+                          Revery.Native.Menu.KeyEquivalent.ofString(""),
+                      );
+
                  let nativeMenuItem =
                    Revery.Native.Menu.Item.create(
                      ~title,
@@ -81,9 +89,20 @@ module Sub = {
       };
     });
 
-  let menu = (~builtMenu: MenuBar.builtMenu, ~toMsg) =>
+  let menu =
+      (
+        ~config as _,
+        ~context as _,
+        ~input,
+        ~builtMenu: MenuBar.builtMenu,
+        ~toMsg,
+      ) =>
     if (Revery.Environment.isMac) {
-      OSXMenuSub.create({builtMenu: builtMenu}) |> Isolinear.Sub.map(toMsg);
+      let getKeyEquivalent = command => {
+        None;
+      };
+      OSXMenuSub.create({getKeyEquivalent, builtMenu})
+      |> Isolinear.Sub.map(toMsg);
     } else {
       Isolinear.Sub.none;
     };

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -1,5 +1,49 @@
 open Oni_Core;
 
+module Internal = {
+  let keyBindingsToKeyEquivalent:
+    list(list(EditorInput.KeyPress.t)) =>
+    option(Revery.Native.Menu.KeyEquivalent.t) =
+    candidates => {
+      candidates
+      // Filter to single key press
+      |> List.filter_map(
+           fun
+           | [hd] => Some(hd)
+           | _ => None,
+         )
+      |> List.filter_map(EditorInput.KeyPress.toPhysicalKey)
+      |> List.filter(({modifiers, _}: EditorInput.PhysicalKey.t) => {
+           modifiers.meta
+         })
+      |> (
+        l =>
+          List.nth_opt(l, 0)
+          |> Option.map(({modifiers, key}: EditorInput.PhysicalKey.t) => {
+               open Revery.Native.Menu;
+               let key =
+                 KeyEquivalent.ofString(EditorInput.Key.toString(key));
+
+               let key =
+                 if (modifiers.shift) {
+                   KeyEquivalent.enableShift(key);
+                 } else {
+                   key;
+                 };
+
+               let key =
+                 if (modifiers.alt) {
+                   KeyEquivalent.enableAlt(key);
+                 } else {
+                   key;
+                 };
+
+               key;
+             })
+      );
+    };
+};
+
 module Sub = {
   type menuParams = {
     builtMenu: MenuBar.builtMenu,

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -137,6 +137,7 @@ let defaultKeyBindings =
     ]
   @ Feature_Registers.Contributions.keybindings
   @ Feature_LanguageSupport.Contributions.keybindings
+  @ Feature_Buffers.Contributions.keybindings
   @ Feature_Input.Schema.[
       bind(
         ~key="<CR>",

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -207,6 +207,13 @@ let start =
 
   let subscriptions = (state: Model.State.t) => {
     let config = Model.Selectors.configResolver(state);
+    let contextKeys = Model.ContextKeys.all(state);
+    let commands = Model.CommandManager.current(state);
+
+    let menuBarSub =
+      Feature_MenuBar.sub(~contextKeys, ~commands, state.menuBar)
+      |> Isolinear.Sub.map(msg => Model.Actions.MenuBar(msg));
+
     let visibleBuffersAndRanges =
       state |> Model.EditorVisibleRanges.getVisibleBuffersAndRanges;
     let activeEditor = state.layout |> Feature_Layout.activeEditor;
@@ -449,6 +456,7 @@ let start =
       |> Isolinear.Sub.map(msg => Model.Actions.Notification(msg));
 
     [
+      menuBarSub,
       extHostSubscription,
       languageSupportSub,
       syntaxSubscription,

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -211,7 +211,13 @@ let start =
     let commands = Model.CommandManager.current(state);
 
     let menuBarSub =
-      Feature_MenuBar.sub(~contextKeys, ~commands, state.menuBar)
+      Feature_MenuBar.sub(
+        ~config,
+        ~contextKeys,
+        ~commands,
+        ~input=state.input,
+        state.menuBar,
+      )
       |> Isolinear.Sub.map(msg => Model.Actions.MenuBar(msg));
 
     let visibleBuffersAndRanges =


### PR DESCRIPTION
WIP work to integrate the `MenuBar` / `Feature_MenuBar` with the work @zbaylin did to expose an API for it in Revery: https://github.com/revery-ui/revery/pull/1024

__Todo:__
- [x] Convert our key matchers to `KeyEquivalent.t` to show proper shortcut keys
- [x] Add 'separator' element
- [x] Fix `New File` shortcut (Command+n)
- [x] Fix `Save` shortcut (Command+s)
- [x] Fix `Save all` shortcut (Command+shift+s)
- [x] Fix ordering of top-level elements (merge with existing Application / Help)
- [x] Move preferences into Application menu, replace current 'Preferences'

__Next steps:__
- Handle `enabled` across menu items
- Handle `visible` across menu items
- Allow toggle-able menu items