### PR TITLE
chore(ci): Increase timeout for master builds on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,7 @@ jobs:
   - template: .ci/publish-build-cache.yml
 
 - job: Windows
-  timeoutInMinutes: 150
+  timeoutInMinutes: 180
   displayName: "Windows - Build & Package"
   pool:
     vmImage: 'vs2017-win2016'


### PR DESCRIPTION
 `master` (uncached) builds are failing on Windows due to timeout. The timeout is not due to a hang - the build-the-world compilation is taking that long on Windows. Bump timeout to get master green again-