### PR TITLE
fix(input/#2963): Fix 'm-' modifier behavior

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -52,6 +52,7 @@
 - #2956 - Layout: Fix extra editor when splitting with a file or terminal (fixes #2900, #2952)
 - #2986 - Theme: Fallback to default theme if invalid theme is specified
 - #2977, #2983 - Input: Handle unicode characters in mappings (fixes #2972, #2980)
+- #2978 - Input: Fix `m-` modifier behavior (fixes #2963)
 
 ### Performance
 

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -6,11 +6,7 @@ module Log = (val Log.withNamespace("Oni2.Feature.Input"));
 module ReveryKeyConverter = ReveryKeyConverter;
 
 let keyPressToString = key => {
-  key
-  |> EditorInput.KeyPress.toString(
-       ~meta="Meta",
-       ~keyToString=EditorInput.Key.toString,
-     );
+  key |> EditorInput.KeyPress.toString(~keyToString=EditorInput.Key.toString);
 };
 
 let keyCandidateToString = keyCandidate => {

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -44,7 +44,7 @@ module Internal = {
   };
 
   let tryToGetCharacterFromKey =
-      (~shift, ~control, ~alt, ~meta, ~altGr, ~scancode) => {
+      (~shift, ~control, ~alt, ~super, ~altGr, ~scancode) => {
     let keyboard = Oni2_KeyboardLayout.Keymap.getCurrent();
     let maybeKeymap =
       Oni2_KeyboardLayout.Keymap.entryOfScancode(keyboard, scancode);
@@ -80,7 +80,7 @@ module Internal = {
          open KeyPress;
          open Modifiers;
 
-         let modifiers = {shift, control, alt, meta, altGr};
+         let modifiers = {shift, control, alt, super, altGr};
          let defaultCandidate =
            keymap.unmodified
            |> OptionEx.flatMap(stringToKey)
@@ -151,7 +151,7 @@ let reveryKeyToKeyPress =
     let shift = Revery.Key.Keymod.isShiftDown(keymod);
     let control = Revery.Key.Keymod.isControlDown(keymod);
     let alt = Revery.Key.Keymod.isAltDown(keymod);
-    let meta = Revery.Key.Keymod.isGuiDown(keymod);
+    let super = Revery.Key.Keymod.isGuiDown(keymod);
     let altGr = Revery.Key.Keymod.isAltGrKeyDown(keymod);
 
     let (altGr, control, alt) =
@@ -170,7 +170,7 @@ let reveryKeyToKeyPress =
         (altGr, ctrlKey, altKey);
       | _ => (altGr, control, alt)
       };
-    let modifiers = EditorInput.Modifiers.{shift, control, alt, meta, altGr};
+    let modifiers = EditorInput.Modifiers.{shift, control, alt, super, altGr};
 
     keycode
     |> Internal.tryToGetSpecialKey
@@ -182,7 +182,7 @@ let reveryKeyToKeyPress =
            ~shift,
            ~control,
            ~alt,
-           ~meta,
+           ~super,
            ~altGr,
            ~scancode,
          )

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -14,7 +14,7 @@ module Internal = {
          )
       |> List.filter_map(EditorInput.KeyPress.toPhysicalKey)
       |> List.filter(({modifiers, _}: EditorInput.PhysicalKey.t) => {
-           modifiers.meta
+           modifiers.super
          })
       |> (
         l =>

--- a/src/Input/Handler.re
+++ b/src/Input/Handler.re
@@ -110,7 +110,7 @@ let keyPressToCommand = (~force, ~isTextInputActive, key) => {
        let shiftKey = modifiers.shift;
        let altKey = modifiers.alt;
        let ctrlKey = modifiers.control;
-       let superKey = modifiers.meta;
+       let superKey = modifiers.super;
 
        if (altGr && isTextInputActive) {
          None;

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -39,7 +39,7 @@ module Modifiers: {
     alt: bool,
     altGr: bool,
     shift: bool,
-    meta: bool,
+    super: bool,
   };
 
   let none: t;
@@ -76,8 +76,8 @@ module KeyPress: {
     | SpecialKey(SpecialKey.t);
 
   let toString:
-    // The name of the 'meta' key. Defaults to "Meta".
-    (~meta: string=?, ~keyToString: Key.t => string=?, t) => string;
+    // The name of the 'super' key. Defaults to "Super".
+    (~super: string=?, ~keyToString: Key.t => string=?, t) => string;
 
   let physicalKey: (~key: Key.t, ~modifiers: Modifiers.t) => t;
 

--- a/src/editor-input/KeyPress.re
+++ b/src/editor-input/KeyPress.re
@@ -128,7 +128,15 @@ let parse = (~explicitShiftKeyNeeded, str) => {
   str |> Lexing.from_string |> parse |> flatMap(finish);
 };
 
-let toString = (~meta="Meta", ~keyToString=Key.toString, key) => {
+let defaultSuper =
+  switch (Revery.Environment.os) {
+  | Mac(_) => "Cmd"
+  | Windows(_) => "Win"
+  | Linux(_) => "Meta"
+  | _ => "Super"
+  };
+
+let toString = (~super=defaultSuper, ~keyToString=Key.toString, key) => {
   switch (key) {
   | SpecialKey(special) =>
     Printf.sprintf("Special(%s)", SpecialKey.show(special))
@@ -141,15 +149,15 @@ let toString = (~meta="Meta", ~keyToString=Key.toString, key) => {
     let onlyShiftPressed =
       modifiers.shift
       && !modifiers.control
-      && !modifiers.meta
+      && !modifiers.super
       && !modifiers.alt;
 
     let keyString =
       String.length(keyString) == 1 && !onlyShiftPressed
         ? String.lowercase_ascii(keyString) : keyString;
 
-    if (modifiers.meta) {
-      Buffer.add_string(buffer, meta ++ separator);
+    if (modifiers.super) {
+      Buffer.add_string(buffer, super ++ separator);
     };
 
     if (modifiers.control) {
@@ -162,7 +170,7 @@ let toString = (~meta="Meta", ~keyToString=Key.toString, key) => {
       Buffer.add_string(buffer, "Alt" ++ separator);
     };
 
-    if ((modifiers.meta || modifiers.control || modifiers.alt)
+    if ((modifiers.super || modifiers.control || modifiers.alt)
         && modifiers.shift) {
       Buffer.add_string(buffer, "Shift" ++ separator);
     };

--- a/src/editor-input/Matcher_internal.re
+++ b/src/editor-input/Matcher_internal.re
@@ -3,7 +3,7 @@ type modifier =
   | Control
   | Shift
   | Alt
-  | Meta;
+  | Super;
 
 [@deriving show]
 type keyPress =
@@ -28,7 +28,7 @@ module Helpers = {
       | [Control, ...tail] => loop(Modifiers.{...mods, control: true}, tail)
       | [Shift, ...tail] => loop(Modifiers.{...mods, shift: true}, tail)
       | [Alt, ...tail] => loop(Modifiers.{...mods, alt: true}, tail)
-      | [Meta, ...tail] => loop(Modifiers.{...mods, meta: true}, tail)
+      | [Super, ...tail] => loop(Modifiers.{...mods, super: true}, tail)
       };
 
     loop(Modifiers.none, modList);

--- a/src/editor-input/Matcher_lexer.mll
+++ b/src/editor-input/Matcher_lexer.mll
@@ -16,13 +16,16 @@
 	"c-", MODIFIER (Control);
 	"s-", MODIFIER (Shift);
 	"a-", MODIFIER (Alt);
-	"d-", MODIFIER (Meta);
+	(* For Vim-style keybindings, a- and m- are equivalent modifiers *)
+	"m-", MODIFIER (Alt);
+	"d-", MODIFIER (Super);
 	"ctrl+", MODIFIER (Control);
 	"shift+", MODIFIER (Shift);
 	"alt+", MODIFIER (Alt);
-	"meta+", MODIFIER (Meta);
-	"win+", MODIFIER (Meta);
-	"cmd+", MODIFIER (Meta);
+	(* For Code-style bindings, meta+ refers to the 'super' key on Linux *)
+	"meta+", MODIFIER (Super);
+	"win+", MODIFIER (Super);
+	"cmd+", MODIFIER (Super);
 	]
 
 	let _ = List.iter(fun (name, keyword) ->

--- a/src/editor-input/Modifiers.re
+++ b/src/editor-input/Modifiers.re
@@ -4,7 +4,7 @@ type t = {
   alt: bool,
   altGr: bool,
   shift: bool,
-  meta: bool,
+  super: bool,
 };
 
 let none = {
@@ -12,7 +12,7 @@ let none = {
   alt: false,
   altGr: false,
   shift: false,
-  meta: false,
+  super: false,
 };
 
 let equals = (mod1, mod2) => {
@@ -20,5 +20,5 @@ let equals = (mod1, mod2) => {
   && mod1.alt == mod2.alt
   && mod1.altGr == mod2.altGr
   && mod1.shift == mod2.shift
-  && mod1.meta == mod2.meta;
+  && mod1.super == mod2.super;
 };

--- a/test/Input/KeybindingsTests.re
+++ b/test/Input/KeybindingsTests.re
@@ -186,33 +186,33 @@ describe("Keybindings", ({describe, _}) => {
            });
       };
 
-      let modifier = (~control, ~shift, ~meta) => {
+      let modifier = (~control, ~shift, ~super) => {
         ...EditorInput.Modifiers.none,
         control,
         shift,
-        meta,
+        super,
       };
 
       let cases =
         EditorInput.[
           (
             Key.Character(Uchar.of_char('p')),
-            modifier(~control=true, ~shift=false, ~meta=false),
+            modifier(~control=true, ~shift=false, ~super=false),
             "workbench.action.quickOpen",
           ),
           (
             Key.Character(Uchar.of_char('p')),
-            modifier(~control=false, ~shift=false, ~meta=true),
+            modifier(~control=false, ~shift=false, ~super=true),
             "workbench.action.quickOpen",
           ),
           (
             Key.Character(Uchar.of_char('p')),
-            modifier(~control=true, ~shift=true, ~meta=false),
+            modifier(~control=true, ~shift=true, ~super=false),
             "workbench.action.showCommands",
           ),
           (
             Key.Character(Uchar.of_char('p')),
-            modifier(~control=false, ~shift=true, ~meta=true),
+            modifier(~control=false, ~shift=true, ~super=true),
             "workbench.action.showCommands",
           ),
         ];


### PR DESCRIPTION
__Issue:__ As described in #2963 - Onivim was not handling the `M-` modifier correctly (according to the Vim docs, it should be handled like `A-`).

__Defect:__ We weren't parsing the `M-` modifier. In addition, the `meta` modifier used internally was ambiguous - the challenge is that `meta` means different things in the 'Vim' vs the 'Code' world - in Vim, it's used like `A-`, whereas in Code, it's used to reference the _super_ key in Linux.

__Fix:__ Handle the `M-` modifier in the same way as the `A-` modifier. Update references from `meta` to `super` to disambiguate.