### PR TITLE
fix(input/#2980): Bring back fix for #2972, and fix #2980

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -48,6 +48,7 @@
 - #2898 - Editor: Implement mouse selection (fixes #537)
 - #2959 - Completion: Implement `"editor.acceptSuggestionOnEnter"` configuration setting
 - #2956 - Layout: Fix extra editor when splitting with a file or terminal (fixes #2900, #2952)
+- #2977 - Input: Handle unicode characters in mappings (fixes #2972)
 
 ### Performance
 

--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -48,7 +48,7 @@
 - #2898 - Editor: Implement mouse selection (fixes #537)
 - #2959 - Completion: Implement `"editor.acceptSuggestionOnEnter"` configuration setting
 - #2956 - Layout: Fix extra editor when splitting with a file or terminal (fixes #2900, #2952)
-- #2977 - Input: Handle unicode characters in mappings (fixes #2972)
+- #2977, #2983 - Input: Handle unicode characters in mappings (fixes #2972, #2980)
 
 ### Performance
 

--- a/integration_test/AddRemoveSplitTest.re
+++ b/integration_test/AddRemoveSplitTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="AddRemoveSplitTest", (dispatch, wait, _runEffects) => {
+runTest(~name="AddRemoveSplitTest", ({dispatch, wait, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/ClipboardChangeTest.re
+++ b/integration_test/ClipboardChangeTest.re
@@ -2,7 +2,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 
 // Regression test for #2694
-runTest(~name="ClipboardChangeTest", (dispatch, wait, runEffects) => {
+runTest(~name="ClipboardChangeTest", ({dispatch, wait, runEffects, _}) => {
   wait(
     ~name="Set configuration to always yank to clipboard", (state: State.t) => {
     let configuration = state.configuration;

--- a/integration_test/ClipboardInsertModePasteEmptyTest.re
+++ b/integration_test/ClipboardInsertModePasteEmptyTest.re
@@ -8,7 +8,7 @@ module Log = (
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/ClipboardInsertModePasteMultiLineTest.re
+++ b/integration_test/ClipboardInsertModePasteMultiLineTest.re
@@ -8,7 +8,7 @@ module Log = (
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/ClipboardInsertModePasteSingleLineTest.re
+++ b/integration_test/ClipboardInsertModePasteSingleLineTest.re
@@ -8,7 +8,7 @@ module Log = (
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/ClipboardNormalModePasteTest.re
+++ b/integration_test/ClipboardNormalModePasteTest.re
@@ -17,7 +17,7 @@ module Log = (
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, input, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );
@@ -25,9 +25,10 @@ runTest(
   // '*' test case
   setClipboard(Some("abc\n"));
 
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "*"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("\"");
+  input("*");
+  input("P");
+
   runEffects();
 
   wait(~name="Mode switches to insert", (state: State.t) =>
@@ -43,9 +44,10 @@ runTest(
   // '*' multi-line test case
   setClipboard(Some("1\n2\n3\n"));
 
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "*"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("\"");
+  input("*");
+  input("P");
+
   runEffects();
 
   wait(~name="Multi-line paste works correctly", (state: State.t) =>
@@ -70,9 +72,9 @@ runTest(
   // '*' multi-line test case, windows style
   setClipboard(Some("4\r\n5\r\n6\r\n"));
 
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "*"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("\"");
+  input("*");
+  input("P");
   runEffects();
 
   wait(~name="Multi-line paste works correctly", (state: State.t) =>
@@ -96,9 +98,9 @@ runTest(
   // '+' test case
   setClipboard(Some("def\n"));
 
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "*"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("\"");
+  input("*");
+  input("P");
   runEffects();
 
   wait(~name="Mode switches to insert", (state: State.t) =>
@@ -113,17 +115,17 @@ runTest(
 
   // 'a' test case
   // yank current line - def - to 'a' register
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "a"}));
-  dispatch(KeyboardInput({isText: true, input: "y"}));
-  dispatch(KeyboardInput({isText: true, input: "y"}));
+  input("\"");
+  input("a");
+  input("y");
+  input("y");
   runEffects();
 
   setClipboard(Some("ghi\n"));
 
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "a"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("\"");
+  input("a");
+  input("P");
   runEffects();
 
   wait(~name="Mode switches to insert", (state: State.t) =>
@@ -157,10 +159,9 @@ runTest(
     runEffects();
     true;
   });
-
-  dispatch(KeyboardInput({isText: true, input: "y"}));
-  dispatch(KeyboardInput({isText: true, input: "y"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("y");
+  input("y");
+  input("P");
   runEffects();
 
   wait(
@@ -198,9 +199,9 @@ runTest(
     true;
   });
 
-  dispatch(KeyboardInput({isText: true, input: "y"}));
-  dispatch(KeyboardInput({isText: true, input: "y"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+  input("y");
+  input("y");
+  input("P");
   runEffects();
 
   wait(
@@ -218,9 +219,10 @@ runTest(
 
   // Single line case - should paste in front of previous text
   setClipboard(Some("mno"));
-  dispatch(KeyboardInput({isText: true, input: "\""}));
-  dispatch(KeyboardInput({isText: true, input: "*"}));
-  dispatch(KeyboardInput({isText: true, input: "P"}));
+
+  input("\"");
+  input("*");
+  input("P");
   runEffects();
 
   wait(~name="paste with single line, from clipboard", (state: State.t) =>

--- a/integration_test/ClipboardYankTest.re
+++ b/integration_test/ClipboardYankTest.re
@@ -14,7 +14,7 @@ let printOpt = sOpt =>
   | Some(v) => "Some(" ++ v ++ ")"
   };
 
-runTest(~name="ClipboardYankTest", (dispatch, wait, runEffects) => {
+runTest(~name="ClipboardYankTest", ({dispatch, wait, runEffects, _}) => {
   wait(
     ~name="Set configuration to always yank to clipboard", (state: State.t) => {
     let configuration = state.configuration;

--- a/integration_test/ClipboardxpTest.re
+++ b/integration_test/ClipboardxpTest.re
@@ -3,7 +3,7 @@ open Oni_Core.Utility;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="ClipboardyypTest", (dispatch, wait, runEffects) => {
+runTest(~name="ClipboardyypTest", ({dispatch, wait, runEffects, _}) => {
   wait(
     ~name="Set configuration to always yank to clipboard", (state: State.t) => {
     let configuration = state.configuration;

--- a/integration_test/ClipboardyypTest.re
+++ b/integration_test/ClipboardyypTest.re
@@ -3,7 +3,7 @@ open Oni_Core.Utility;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="ClipboardyypTest", (dispatch, wait, runEffects) => {
+runTest(~name="ClipboardyypTest", ({dispatch, wait, runEffects, _}) => {
   wait(
     ~name="Set configuration to always yank to clipboard", (state: State.t) => {
     let configuration = state.configuration;

--- a/integration_test/ConfigurationInvalidThemeTest.re
+++ b/integration_test/ConfigurationInvalidThemeTest.re
@@ -13,7 +13,7 @@ let configuration = {|
 runTest(
   ~configuration=Some(configuration),
   ~name="ConfigurationInvalidThemeTest (Regression test for #2985)",
-  (_dispatch, wait, _) => {
+  ({wait, _}) => {
     // We should get an error message referencing our very-invalid-theme..
     wait(~name="Wait for error message", (state: State.t) => {
       state.notifications

--- a/integration_test/ConfigurationPerFileTypeTest.re
+++ b/integration_test/ConfigurationPerFileTypeTest.re
@@ -21,7 +21,7 @@ let configuration = {|
 runTest(
   ~configuration=Some(configuration),
   ~name="ConfigurationPerFileType",
-  (dispatch, wait, _) => {
+  ({dispatch, wait, _}) => {
     wait(~name="Initial mode is normal", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
     );

--- a/integration_test/CopyActiveFilepathToClipboardTest.re
+++ b/integration_test/CopyActiveFilepathToClipboardTest.re
@@ -5,7 +5,7 @@ open Oni_IntegrationTestLib;
 runTest(
   ~name=
     "CopyActiveFilepathToClipboard writes the active buffer's file path to the clipboard",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
     setClipboard(Some("def"));
     dispatch(CopyActiveFilepathToClipboard);
     runEffects();

--- a/integration_test/EchoNotificationTest.re
+++ b/integration_test/EchoNotificationTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="EchoNotificationTest", (dispatch, wait, _runEffects) => {
+runTest(~name="EchoNotificationTest", ({dispatch, wait, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/EditorFontFromPathTest.re
+++ b/integration_test/EditorFontFromPathTest.re
@@ -14,7 +14,7 @@ let configuration = {|{ "editor.fontFamily": "|} ++ font ++ {|"}|};
 runTest(
   ~configuration=Some(configuration),
   ~name="EditorFontFromPath",
-  (_, wait, _) => {
+  ({wait, _}) => {
     wait(~name="Initial mode is normal", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
     );

--- a/integration_test/EditorFontValidTest.re
+++ b/integration_test/EditorFontValidTest.re
@@ -21,7 +21,7 @@ if (!Revery.Environment.isLinux) {
   runTest(
     ~configuration=Some(configuration),
     ~name="EditorFontValid",
-    (_, wait, _) => {
+    ({wait, _}) => {
       wait(~name="Initial mode is normal", (state: State.t) =>
         Selectors.mode(state) |> Vim.Mode.isNormal
       );

--- a/integration_test/EditorSplitFileTest.re
+++ b/integration_test/EditorSplitFileTest.re
@@ -3,7 +3,7 @@ open Oni_IntegrationTestLib;
 
 runTest(
   ~name="#2900: Splitting with a file should just show file",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/EditorUtf8Test.re
+++ b/integration_test/EditorUtf8Test.re
@@ -5,7 +5,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 open Feature_Editor;
 
-runTestWithInput(~name="EditorUtf8Test", (input, dispatch, wait, _) => {
+runTest(~name="EditorUtf8Test", ({input, dispatch, wait, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/ExCommandKeybindingNormTest.re
+++ b/integration_test/ExCommandKeybindingNormTest.re
@@ -1,6 +1,5 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
-open Actions;
 
 let keybindings =
   Some({|
@@ -12,21 +11,7 @@ let keybindings =
 runTest(
   ~keybindings,
   ~name="ExCommandKeybindingNormTest",
-  (dispatch, wait, _) => {
-    let input = key => {
-      let keyPress =
-        EditorInput.KeyPress.physicalKey(
-          ~key,
-          ~modifiers=EditorInput.Modifiers.none,
-        )
-        |> EditorInput.KeyCandidate.ofKeyPress;
-      let time = Revery.Time.now();
-
-      dispatch(KeyDown({key: keyPress, scancode: 1, time}));
-      //dispatch(TextInput(key));
-      dispatch(KeyUp({scancode: 1, time}));
-    };
-
+  ({dispatch, wait, input, _}) => {
     let testFile = getAssetPath("some-test-file.txt");
     dispatch(Actions.OpenFileByPath(testFile, None, None));
 
@@ -49,7 +34,7 @@ runTest(
     });
 
     // Press k, which is re-bound to 'norm! j'
-    input(EditorInput.Key.Character('k'));
+    input("k");
 
     // Verify cursor is at top of file
     wait(~name="Verify cursor moved down a line", (state: State.t) => {

--- a/integration_test/ExCommandKeybindingTest.re
+++ b/integration_test/ExCommandKeybindingTest.re
@@ -1,6 +1,5 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
-open Actions;
 
 let keybindings =
   Some(
@@ -14,21 +13,7 @@ let keybindings =
 runTest(
   ~keybindings,
   ~name="ExCommandKeybindingTest",
-  (dispatch, wait, _) => {
-    let input = key => {
-      let keyPress =
-        EditorInput.KeyPress.physicalKey(
-          ~key,
-          ~modifiers=EditorInput.Modifiers.none,
-        )
-        |> EditorInput.KeyCandidate.ofKeyPress;
-      let time = Revery.Time.now();
-
-      dispatch(KeyDown({key: keyPress, scancode: 1, time}));
-      //dispatch(TextInput(key));
-      dispatch(KeyUp({scancode: 1, time}));
-    };
-
+  ({wait, input, _}) => {
     wait(~name="Initial sanity check", (state: State.t) => {
       let splitCount =
         state.layout |> Feature_Layout.visibleEditors |> List.length;
@@ -36,8 +21,8 @@ runTest(
       splitCount == 1;
     });
 
-    input(EditorInput.Key.Character('k'));
-    input(EditorInput.Key.Character('k'));
+    input("k");
+    input("k");
 
     wait(~name="Wait for split to be created", (state: State.t) => {
       let splitCount =

--- a/integration_test/ExCommandKeybindingWithArgsTest.re
+++ b/integration_test/ExCommandKeybindingWithArgsTest.re
@@ -1,7 +1,6 @@
 open Oni_Core;
 open Oni_Model;
 open Oni_IntegrationTestLib;
-open Actions;
 
 let keybindings =
   Some(
@@ -15,21 +14,7 @@ let keybindings =
 runTest(
   ~keybindings,
   ~name="ExCommandKeybindingTest",
-  (dispatch, wait, _) => {
-    let input = key => {
-      let keyPress =
-        EditorInput.KeyPress.physicalKey(
-          ~key=EditorInput.Key.Character(key),
-          ~modifiers=EditorInput.Modifiers.none,
-        )
-        |> EditorInput.KeyCandidate.ofKeyPress;
-      let time = Revery.Time.now();
-
-      dispatch(KeyDown({key: keyPress, scancode: 1, time}));
-      //dispatch(TextInput(key));
-      dispatch(KeyUp({scancode: 1, time}));
-    };
-
+  ({dispatch, wait, input, _}) => {
     let testFile = getAssetPath("some-test-file.txt");
     dispatch(Actions.OpenFileByPath(testFile, None, None));
 
@@ -48,8 +33,8 @@ runTest(
       }
     );
 
-    input('k');
-    input('k');
+    input("k");
+    input("k");
 
     wait(~name="Wait for split to be created", (state: State.t) =>
       switch (Selectors.getActiveBuffer(state)) {

--- a/integration_test/ExtConfigurationChangedTest.re
+++ b/integration_test/ExtConfigurationChangedTest.re
@@ -6,8 +6,7 @@ open Oni_IntegrationTestLib;
 // - The 'oni-dev' extension gets activated
 // - That changes to configuration settings are properly propagated to extensions
 // - That extension messages are delivered as notifications Oni-side
-runTestWithInput(
-  ~name="ExtConfigurationChangedTest", (_input, dispatch, wait, _runEffects) => {
+runTest(~name="ExtConfigurationChangedTest", ({dispatch, wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/ExtHostBufferOpenTest.re
+++ b/integration_test/ExtHostBufferOpenTest.re
@@ -7,8 +7,7 @@ module TS = TextSynchronization;
 // - The 'oni-dev' extension gets activated
 // - When typing in an 'oni-dev' buffer, the buffer received by the extension host
 // is in sync with the buffer in the main process
-runTestWithInput(
-  ~name="ExtHostBufferOpen", (_input, dispatch, wait, _runEffects) => {
+runTest(~name="ExtHostBufferOpen", ({dispatch, wait, _}) => {
   wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
     Feature_Exthost.isInitialized(state.exthost)
   );

--- a/integration_test/ExtHostBufferUpdatesTest.re
+++ b/integration_test/ExtHostBufferUpdatesTest.re
@@ -8,8 +8,7 @@ module TS = TextSynchronization;
 // - The 'oni-dev' extension gets activated
 // - When typing in an 'oni-dev' buffer, the buffer received by the extension host
 // is in sync with the buffer in the main process
-runTestWithInput(
-  ~name="ExtHostBufferUpdates", (input, dispatch, wait, _runEffects) => {
+runTest(~name="ExtHostBufferUpdates", ({input, dispatch, wait, key, _}) => {
   wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
     Feature_Exthost.isInitialized(state.exthost)
   );
@@ -47,13 +46,13 @@ runTestWithInput(
   input("i");
 
   input("a");
-  input("<CR>");
+  key(EditorInput.Key.Return);
 
   input("b");
-  input("<CR>");
+  key(EditorInput.Key.Return);
 
   input("c");
-  input("<esc>");
+  key(EditorInput.Key.Escape);
 
   // TODO: Do we need to wait to ensure the buffer update gets sent?
   TS.validateTextIsSynchronized(

--- a/integration_test/ExtHostCompletionTest.re
+++ b/integration_test/ExtHostCompletionTest.re
@@ -5,8 +5,7 @@ open Oni_IntegrationTestLib;
 // This test validates:
 // - The 'oni-dev' extension gets activated
 // - When typing in an 'oni-dev' buffer, we get some completion results
-runTestWithInput(
-  ~name="ExtHostCompletionTest", (input, dispatch, wait, _runEffects) => {
+runTest(~name="ExtHostCompletionTest", ({input, dispatch, wait, _}) => {
   wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
     Feature_Exthost.isInitialized(state.exthost)
   );

--- a/integration_test/ExtHostDefinitionTest.re
+++ b/integration_test/ExtHostDefinitionTest.re
@@ -6,8 +6,7 @@ open Feature_Editor;
 // This test validates:
 // - The 'oni-dev' extension gets activated
 // - We get a definition response
-runTestWithInput(
-  ~name="ExtHostDefinitionTest", (input, dispatch, wait, _runEffects) => {
+runTest(~name="ExtHostDefinitionTest", ({input, dispatch, wait, key, _}) => {
   wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
     Feature_Exthost.isInitialized(state.exthost)
   );
@@ -48,9 +47,7 @@ runTestWithInput(
   input("b");
   input("c");
 
-  // Workaround a bug where cursor position is offset with <esc>
-  input("<esc>");
-  input("h");
+  key(EditorInput.Key.Escape);
 
   // Should get a definition
   wait(

--- a/integration_test/InputContextKeysTest.re
+++ b/integration_test/InputContextKeysTest.re
@@ -4,7 +4,7 @@ open WhenExpr;
 module Model = Oni_Model;
 module State = Model.State;
 
-runTest(~name="InputContextKeys", (dispatch, wait, _) => {
+runTest(~name="InputContextKeys", ({dispatch, wait, _}) => {
   // Wait until the extension is activated
   // Give some time for the exthost to start
   wait(

--- a/integration_test/InputIgnoreTest.re
+++ b/integration_test/InputIgnoreTest.re
@@ -5,7 +5,7 @@ open Oni_IntegrationTestLib;
 module Log = (val Log.withNamespace("IntegrationTest.inputIgnore"));
 
 // This test validates that certain keystrokes are ignored by our Vim layer
-runTest(~name="InputIgnore test", (dispatch, wait, runEffects) => {
+runTest(~name="InputIgnore test", ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/InputRemapMotionTest.re
+++ b/integration_test/InputRemapMotionTest.re
@@ -2,7 +2,9 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 open EditorCoreTypes;
 
-runTest(~name="InputRemapMotionTest (#2114)", (dispatch, wait, runEffects) => {
+runTest(
+  ~name="InputRemapMotionTest (#2114)",
+  ({dispatch, wait, runEffects, input, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );
@@ -39,22 +41,6 @@ runTest(~name="InputRemapMotionTest (#2114)", (dispatch, wait, runEffects) => {
   );
   runEffects();
 
-  let input = key => {
-    let modifiers = EditorInput.Modifiers.none;
-
-    let keyPress =
-      EditorInput.KeyPress.physicalKey(
-        ~key=EditorInput.Key.Character(key),
-        ~modifiers,
-      )
-      |> EditorInput.KeyCandidate.ofKeyPress;
-    let time = Revery.Time.now();
-
-    dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
-    dispatch(Model.Actions.KeyUp({scancode: 1, time}));
-    runEffects();
-  };
-
   let waitForCursorPosition = bytePosition => {
     wait(
       ~name="Verify cursor is at:" ++ BytePosition.show(bytePosition),
@@ -74,25 +60,25 @@ runTest(~name="InputRemapMotionTest (#2114)", (dispatch, wait, runEffects) => {
   );
 
   // Move down, jklm style
-  input('k');
+  input("k");
   waitForCursorPosition(
     BytePosition.{line: LineNumber.(zero + 1), byte: ByteIndex.zero},
   );
 
   // Move right, jklm style
-  input('m');
+  input("m");
   waitForCursorPosition(
     BytePosition.{line: LineNumber.(zero + 1), byte: ByteIndex.(zero + 1)},
   );
 
   // Move up, jklm style
-  input('l');
+  input("l");
   waitForCursorPosition(
     BytePosition.{line: LineNumber.(zero), byte: ByteIndex.(zero + 1)},
   );
 
   // Move left, jklm style
-  input('j');
+  input("j");
   waitForCursorPosition(
     BytePosition.{line: LineNumber.(zero), byte: ByteIndex.(zero)},
   );

--- a/integration_test/InsertModeTest.re
+++ b/integration_test/InsertModeTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="InsertMode test", (dispatch, wait, _) => {
+runTest(~name="InsertMode test", ({dispatch, wait, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/KeySequenceJJTest.re
+++ b/integration_test/KeySequenceJJTest.re
@@ -11,36 +11,19 @@ let keybindings =
 runTest(
   ~keybindings,
   ~name="KeySequenceJJTest",
-  (dispatch, wait, runEffects) => {
+  ({wait, input, _}) => {
     wait(~name="Initial mode is normal", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
     );
 
-    let input = key => {
-      let modifiers = EditorInput.Modifiers.none;
-
-      let keyPress =
-        EditorInput.KeyPress.physicalKey(
-          ~key=EditorInput.Key.Character(key),
-          ~modifiers,
-        )
-        |> EditorInput.KeyCandidate.ofKeyPress;
-      let time = Revery.Time.now();
-
-      dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
-      //dispatch(Model.Actions.TextInput(key));
-      dispatch(Model.Actions.KeyUp({scancode: 1, time}));
-      runEffects();
-    };
-
-    input('i');
+    input("i");
     wait(~name="Mode is now insert", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isInsert
     );
 
-    input('a');
-    input('j');
-    input('j');
+    input("a");
+    input("j");
+    input("j");
 
     wait(~name="Mode is back to normal", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
@@ -66,7 +49,7 @@ runTest(
 
     // #2601 - Make sure we're _actually_ in normal mode!
     // Type another 'j' to see...
-    input('j');
+    input("j");
 
     wait(
       ~name=

--- a/integration_test/KeybindingsInvalidJsonTest.re
+++ b/integration_test/KeybindingsInvalidJsonTest.re
@@ -8,7 +8,7 @@ invalid json
 runTest(
   ~keybindings,
   ~name="KeybindingsInvalidJson",
-  (_dispatch, wait, _) => {
+  ({wait, _}) => {
     wait(~name="Initial mode is normal", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
     );

--- a/integration_test/LanguageCssTest.re
+++ b/integration_test/LanguageCssTest.re
@@ -5,8 +5,7 @@ open Oni_IntegrationTestLib;
 // This test validates:
 // - The 'oni-dev' extension gets activated
 // - When typing in an 'oni-dev' buffer, we get some completion results
-runTestWithInput(
-  ~name="LanguageCssTest", (input, dispatch, wait, _runEffects) => {
+runTest(~name="LanguageCssTest", ({input, dispatch, wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/LanguageTypeScriptTest.re
+++ b/integration_test/LanguageTypeScriptTest.re
@@ -2,8 +2,7 @@ open Oni_Core;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTestWithInput(
-  ~name="LanguageTypeScriptTest", (input, dispatch, wait, _runEffects) => {
+runTest(~name="LanguageTypeScriptTest", ({input, dispatch, wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/LineEndingsCRLFTest.re
+++ b/integration_test/LineEndingsCRLFTest.re
@@ -3,7 +3,7 @@ open Oni_Core.Utility;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="LineEndingsCRLFTest", (dispatch, wait, _runEffects) => {
+runTest(~name="LineEndingsCRLFTest", ({dispatch, wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/LineEndingsLFTest.re
+++ b/integration_test/LineEndingsLFTest.re
@@ -3,7 +3,7 @@ open Oni_Core.Utility;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="LineEndingsLFTest", (dispatch, wait, _runEffects) => {
+runTest(~name="LineEndingsLFTest", ({dispatch, wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/QuickOpenEventuallyCompletesTest.re
+++ b/integration_test/QuickOpenEventuallyCompletesTest.re
@@ -1,7 +1,8 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="QuickOpen eventually completes", (dispatch, wait, runEffects) => {
+runTest(
+  ~name="QuickOpen eventually completes", ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/Regression1671Test.re
+++ b/integration_test/Regression1671Test.re
@@ -4,15 +4,15 @@ open Oni_IntegrationTestLib;
 
 // Validate that unsaved changes persist when switching buffers
 // Regression test for: https://github.com/onivim/oni2/issues/1671
-runTestWithInput(
+runTest(
   ~name="Regression1671 - Opening new buffer loses changes in previous buffer",
-  (input, _dispatch, wait, _runEffects) => {
+  ({input, wait, key, _}) => {
     wait(~name="Capture initial state", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
     );
 
     input(":e a-test-file");
-    input("<CR>");
+    key(EditorInput.Key.Return);
     input("iabc");
     //ignore(Vim.command("e a-test-file"): Vim.Context.t);
 
@@ -30,10 +30,10 @@ runTestWithInput(
       |> Option.value(~default=false)
     );
 
-    input("<ESC>");
+    key(EditorInput.Key.Escape);
     // Repro for 1671 - switch to a different file, and then back
     input(":e! another-test-file");
-    input("<CR>");
+    key(EditorInput.Key.Return);
 
     wait(~name="Buffer switched", (state: State.t) => {
       state
@@ -42,9 +42,9 @@ runTestWithInput(
       |> Option.value(~default=false)
     });
 
-    input("<ESC>");
+    key(EditorInput.Key.Escape);
     input(":e! a-test-file");
-    input("<CR>");
+    key(EditorInput.Key.Return);
 
     wait(~name="Buffer switched back", (state: State.t) => {
       state

--- a/integration_test/Regression2349EnewTest.re
+++ b/integration_test/Regression2349EnewTest.re
@@ -1,7 +1,8 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="Regression: Command line no completions", (dispatch, wait, _) => {
+runTest(
+  ~name="Regression: Command line no completions", ({dispatch, wait, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/RegressionCommandLineNoCompletionTest.re
+++ b/integration_test/RegressionCommandLineNoCompletionTest.re
@@ -1,7 +1,8 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="Regression: Command line no completions", (dispatch, wait, _) => {
+runTest(
+  ~name="Regression: Command line no completions", ({dispatch, wait, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/RegressionFileModifiedIndicationTest.re
+++ b/integration_test/RegressionFileModifiedIndicationTest.re
@@ -6,9 +6,9 @@ open Oni_IntegrationTestLib;
 // https://github.com/onivim/oni2/issues/600
 //
 // Verify some simple cases around the file modified flag
-runTestWithInput(
+runTest(
   ~name="RegressionFileModifiedIndication",
-  (input, dispatch, wait, runEffects) => {
+  ({input, dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/RegressionFontFallbackTest.re
+++ b/integration_test/RegressionFontFallbackTest.re
@@ -4,7 +4,7 @@ open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
 module LineNumber = EditorCoreTypes.LineNumber;
 
-runTestWithInput(~name="RegressionFontFallback", (input, dispatch, wait, _) => {
+runTest(~name="RegressionFontFallback", ({input, dispatch, wait, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/RegressionNonExistentDirectory.re
+++ b/integration_test/RegressionNonExistentDirectory.re
@@ -2,7 +2,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
 
-runTest(~name="RegressionVspEmpty", (_, wait, _) => {
+runTest(~name="RegressionVspEmpty", ({wait, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/RegressionVspEmptyExistingBufferTest.re
+++ b/integration_test/RegressionVspEmptyExistingBufferTest.re
@@ -2,7 +2,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
 
-runTest(~name="RegressionVspEmpty", (dispatch, wait, _) => {
+runTest(~name="RegressionVspEmpty", ({dispatch, wait, _}) => {
   let originalBuffer = ref(None);
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =

--- a/integration_test/RegressionVspEmptyInitialBufferTest.re
+++ b/integration_test/RegressionVspEmptyInitialBufferTest.re
@@ -11,7 +11,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
 
-runTest(~name="RegressionVspEmpty", (_, wait, _) => {
+runTest(~name="RegressionVspEmpty", ({wait, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/SCMGitTest.re
+++ b/integration_test/SCMGitTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="SCMGitTest", (_dispatch, wait, _runEffects) => {
+runTest(~name="SCMGitTest", ({wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/SearchShowClearHighlightsTest.re
+++ b/integration_test/SearchShowClearHighlightsTest.re
@@ -5,7 +5,7 @@ open Oni_Syntax;
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/SyntaxHighlightTextMateTest.re
+++ b/integration_test/SyntaxHighlightTextMateTest.re
@@ -3,7 +3,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 
 // Validate that textmate highlight runs
-runTest(~name="SyntaxHighlightTextMateTest", (dispatch, wait, _runEffects) => {
+runTest(~name="SyntaxHighlightTextMateTest", ({dispatch, wait, _}) => {
   wait(~name="Capture initial state", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/SyntaxHighlightTreesitterTest.re
+++ b/integration_test/SyntaxHighlightTreesitterTest.re
@@ -10,7 +10,7 @@ let configuration = Some({|
 runTest(
   ~configuration,
   ~name="SyntaxHighlightTreesitterTest",
-  (dispatch, wait, _runEffects) => {
+  ({dispatch, wait, _}) => {
     wait(~name="Capture initial state", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isNormal
     );

--- a/integration_test/TerminalConfigurationTest.re
+++ b/integration_test/TerminalConfigurationTest.re
@@ -35,7 +35,7 @@ let expectedShellArgs =
 runTest(
   ~configuration,
   ~name="TerminalConfigurationTest",
-  (dispatch, wait, _) => {
+  ({dispatch, wait, _}) => {
     // Wait until the extension is activated
     // Give some time for the exthost to start
     wait(

--- a/integration_test/TerminalSetPidTitleTest.re
+++ b/integration_test/TerminalSetPidTitleTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="TerminalSetPidTitle", (dispatch, wait, _) => {
+runTest(~name="TerminalSetPidTitle", ({dispatch, wait, _}) => {
   // Wait until the extension is activated
   // Give some time for the exthost to start
   wait(

--- a/integration_test/TypingBatchedTest.re
+++ b/integration_test/TypingBatchedTest.re
@@ -6,7 +6,7 @@ module Log = (val Log.withNamespace("IntegrationTest.TypingBatched"));
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/TypingUnbatchedTest.re
+++ b/integration_test/TypingUnbatchedTest.re
@@ -6,7 +6,7 @@ module Log = (val Log.withNamespace("IntegrationTest.TypingUnbatched"));
 
 runTest(
   ~name="InsertMode test - effects batched to runEffects",
-  (dispatch, wait, runEffects) => {
+  ({dispatch, wait, runEffects, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );

--- a/integration_test/VimScriptLocalFunctionTest.re
+++ b/integration_test/VimScriptLocalFunctionTest.re
@@ -1,7 +1,9 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="VimScriptLocalFunctionTest", (dispatch, wait, runEffects) => {
+runTest(
+  ~name="VimScriptLocalFunctionTest",
+  ({dispatch, wait, runEffects, input, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );
@@ -25,23 +27,7 @@ runTest(~name="VimScriptLocalFunctionTest", (dispatch, wait, runEffects) => {
   );
   runEffects();
 
-  let input = key => {
-    let modifiers = EditorInput.Modifiers.none;
-
-    let keyPress =
-      EditorInput.KeyPress.physicalKey(
-        ~key=EditorInput.Key.Character(key),
-        ~modifiers,
-      )
-      |> EditorInput.KeyCandidate.ofKeyPress;
-    let time = Revery.Time.now();
-
-    dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
-    dispatch(Model.Actions.KeyUp({scancode: 1, time}));
-    runEffects();
-  };
-
-  input('j');
+  input("j");
 
   wait(~name="plugin notification shows up", (state: State.t) => {
     let notifications = Feature_Notification.all(state.notifications);

--- a/integration_test/VimSimpleRemapTest.re
+++ b/integration_test/VimSimpleRemapTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="VimSimpleRemapTest", (dispatch, wait, runEffects) => {
+runTest(~name="VimSimpleRemapTest", ({dispatch, wait, runEffects, input, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );
@@ -12,30 +12,14 @@ runTest(~name="VimSimpleRemapTest", (dispatch, wait, runEffects) => {
   );
   runEffects();
 
-  let input = key => {
-    let modifiers = EditorInput.Modifiers.none;
-
-    let keyPress =
-      EditorInput.KeyPress.physicalKey(
-        ~key=EditorInput.Key.Character(key),
-        ~modifiers,
-      )
-      |> EditorInput.KeyCandidate.ofKeyPress;
-    let time = Revery.Time.now();
-
-    dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
-    dispatch(Model.Actions.KeyUp({scancode: 1, time}));
-    runEffects();
-  };
-
-  input('i');
+  input("i");
   wait(~name="Mode is now insert", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isInsert
   );
 
-  input('a');
-  input('j');
-  input('j');
+  input("a");
+  input("j");
+  input("j");
 
   wait(~name="Mode is back to normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
@@ -59,7 +43,7 @@ runTest(~name="VimSimpleRemapTest", (dispatch, wait, runEffects) => {
 
   // #2601 - Make sure we're _actually_ in normal mode!
   // Type another 'j' to see...
-  input('j');
+  input("j");
 
   wait(
     ~name=

--- a/integration_test/VimlRemapCmdlineTest.re
+++ b/integration_test/VimlRemapCmdlineTest.re
@@ -1,41 +1,25 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="Viml Remap ; -> :", (dispatch, wait, runEffects) => {
+runTest(~name="Viml Remap ö -> :", ({dispatch, wait, runEffects, input, _}) => {
   wait(~name="Initial mode is normal", (state: State.t) =>
     Selectors.mode(state) |> Vim.Mode.isNormal
   );
 
   dispatch(
-    VimExecuteCommand({allowAnimation: true, command: "nnoremap ; :"}),
+    VimExecuteCommand({allowAnimation: true, command: "nnoremap ö :"}),
   );
   runEffects();
 
-  let input = key => {
-    let modifiers = EditorInput.Modifiers.none;
-
-    let keyPress =
-      EditorInput.KeyPress.physicalKey(
-        ~key=EditorInput.Key.Character(key),
-        ~modifiers,
-      )
-      |> EditorInput.KeyCandidate.ofKeyPress;
-    let time = Revery.Time.now();
-
-    dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
-    dispatch(Model.Actions.KeyUp({scancode: 1, time}));
-    runEffects();
-  };
-
-  // Because of our remap, the ';' semicolon
+  // Because of our remap, the 'ö' character
   // is mapped to ':' - so sending it should open the command line.
-  input(';');
+  input("ö");
 
   wait(~name="Mode switches to command line", (state: State.t) => {
     Selectors.mode(state) == Vim.Mode.CommandLine
   });
 
-  input('e');
+  input("e");
 
   wait(~name="'e' key is entered", (state: State.t) =>
     switch (state.quickmenu) {
@@ -45,7 +29,7 @@ runTest(~name="Viml Remap ; -> :", (dispatch, wait, runEffects) => {
     }
   );
 
-  input('h');
+  input("h");
 
   wait(~name="'h' key is entered", (state: State.t) =>
     switch (state.quickmenu) {

--- a/integration_test/ZenModeSingleFileModeTest.re
+++ b/integration_test/ZenModeSingleFileModeTest.re
@@ -11,7 +11,7 @@ runTest(
   ~configuration=Some(configuration),
   ~filesToOpen=["some-random-file.txt"],
   ~name="ZenMode: Single-file mode works as expected",
-  (_dispatch, wait, _runEffects) => {
+  ({wait, _}) => {
     wait(~name="Wait for split to be created 1", (state: State.t) => {
       let splitCount =
         state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/ZenModeSplitTest.re
+++ b/integration_test/ZenModeSplitTest.re
@@ -1,7 +1,7 @@
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-runTest(~name="ZenModeSplitTest", (dispatch, wait, _) => {
+runTest(~name="ZenModeSplitTest", ({dispatch, wait, _}) => {
   dispatch(Actions.EnableZenMode);
 
   wait(~name="Wait until ZenMode is enabled", (state: State.t) =>

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -291,35 +291,31 @@ let runTest =
     };
   };
 
+  let key = (~modifiers=EditorInput.Modifiers.none, key) => {
+    let keyPress =
+      EditorInput.KeyPress.physicalKey(~key, ~modifiers)
+      |> EditorInput.KeyCandidate.ofKeyPress;
+    let time = Revery.Time.now();
+    dispatch(Model.Actions.KeyDown({key: keyPress, scancode: 1, time}));
+    dispatch(Model.Actions.KeyUp({scancode: 1, time}));
+    runEffects();
+  };
+
+  let input = (~modifiers=EditorInput.Modifiers.none, str) => {
+    str
+    |> Zed_utf8.explode
+    |> List.iter(uchar => {
+         key(~modifiers, EditorInput.Key.Character(uchar))
+       });
+  };
+
+  let ctx = {dispatch, wait: waitForState, runEffects, input, key};
+
   Log.info("--- Starting test: " ++ name);
-  test(dispatch, waitForState, runEffects);
+  test(ctx);
   Log.info("--- TEST COMPLETE: " ++ name);
 
   dispatch(Model.Actions.Quit(true));
-};
-
-let runTestWithInput =
-    (
-      ~configuration=?,
-      ~keybindings=?,
-      ~name,
-      ~onAfterDispatch=?,
-      f: testCallbackWithInput,
-    ) => {
-  runTest(
-    ~name,
-    ~configuration?,
-    ~keybindings?,
-    ~onAfterDispatch?,
-    (dispatch, wait, runEffects) => {
-      let input = key => {
-        dispatch(Model.Actions.KeyboardInput({isText: false, input: key}));
-        runEffects();
-      };
-
-      f(input, dispatch, wait, runEffects);
-    },
-  );
 };
 
 let runCommand = (~dispatch, command: Core.Command.t(_)) =>

--- a/integration_test/lib/Oni_IntegrationTestLib.rei
+++ b/integration_test/lib/Oni_IntegrationTestLib.rei
@@ -16,16 +16,6 @@ let runTest:
   ) =>
   unit;
 
-let runTestWithInput:
-  (
-    ~configuration: option(string)=?,
-    ~keybindings: option(string)=?,
-    ~name: string,
-    ~onAfterDispatch: Model.Actions.t => unit=?,
-    testCallbackWithInput
-  ) =>
-  unit;
-
 let setUserSettings: Core.Config.Settings.t => unit;
 let setClipboard: option(string) => unit;
 let getClipboard: unit => option(string);

--- a/integration_test/lib/Types.re
+++ b/integration_test/lib/Types.re
@@ -5,10 +5,17 @@ type runEffectsFunction = unit => unit;
 type waiter = Model.State.t => bool;
 type waitForState = (~name: string, ~timeout: float=?, waiter) => unit;
 
-type inputFunction = string => unit;
+type inputFunction = (~modifiers: EditorInput.Modifiers.t=?, string) => unit;
 
-type testCallback =
-  (dispatchFunction, waitForState, runEffectsFunction) => unit;
+type keyFunction =
+  (~modifiers: EditorInput.Modifiers.t=?, EditorInput.Key.t) => unit;
 
-type testCallbackWithInput =
-  (inputFunction, dispatchFunction, waitForState, runEffectsFunction) => unit;
+type testContext = {
+  dispatch: dispatchFunction,
+  wait: waitForState,
+  runEffects: runEffectsFunction,
+  input: inputFunction,
+  key: keyFunction,
+};
+
+type testCallback = testContext => unit;

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -57,16 +57,12 @@ module Internal = {
     | None => Log.info("No keymap for key.")
     };
 
-    let stringToKey = maybeString => {
-      maybeString
-      |> OptionEx.flatMap(str =>
-           if (String.length(str) != 1) {
-             None;
-           } else {
-             Some(str.[0]);
-           }
-         )
-      |> Option.map(char => EditorInput.Key.Character(char));
+    let stringToKey = (maybeString: string) => {
+      let maybeChar =
+        try(Some(ZedBundled.get(maybeString, 0))) {
+        | _exn => None
+        };
+      maybeChar |> Option.map(char => EditorInput.Key.Character(char));
     };
 
     maybeKeymap
@@ -87,13 +83,13 @@ module Internal = {
          let modifiers = {shift, control, alt, meta, altGr};
          let defaultCandidate =
            keymap.unmodified
-           |> stringToKey
+           |> OptionEx.flatMap(stringToKey)
            |> Option.map(key => physicalKey(~key, ~modifiers));
 
          let maybeShiftAltGrCandidate =
            if (shift && altGr) {
              keymap.withAltGraphShift
-             |> stringToKey
+             |> OptionEx.flatMap(stringToKey)
              |> Option.map(key =>
                   physicalKey(
                     ~key,
@@ -107,7 +103,7 @@ module Internal = {
          let maybeShiftCandidate =
            if (shift) {
              keymap.withShift
-             |> stringToKey
+             |> OptionEx.flatMap(stringToKey)
              |> Option.map(key =>
                   physicalKey(~key, ~modifiers={...modifiers, shift: false})
                 );
@@ -118,7 +114,7 @@ module Internal = {
          let maybeAltGrCandidate =
            if (altGr) {
              keymap.withAltGraph
-             |> stringToKey
+             |> OptionEx.flatMap(stringToKey)
              |> Option.map(key =>
                   physicalKey(~key, ~modifiers={...modifiers, altGr: false})
                 );

--- a/src/Input/Handler.re
+++ b/src/Input/Handler.re
@@ -14,7 +14,7 @@ module Internal = {
     EditorInput.Key.(
       {
         switch (key) {
-        | Character(char) => Some(String.make(1, char))
+        | Character(char) => Some(Zed_utf8.make(1, char))
         | Return => Some("CR")
         | Escape => Some("ESC")
         | Tab => Some("TAB")

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -1,6 +1,6 @@
 module Key: {
   type t =
-    | Character(char)
+    | Character(Uchar.t)
     | Function(int)
     | NumpadDigit(int)
     | Escape

--- a/src/editor-input/Key.re
+++ b/src/editor-input/Key.re
@@ -1,6 +1,8 @@
+open Oni_Core;
+
 [@deriving show]
 type t =
-  | Character(char)
+  | Character([@opaque] Uchar.t)
   | Function(int)
   | NumpadDigit(int)
   | Escape
@@ -31,7 +33,7 @@ type t =
 
 let toString =
   fun
-  | Character(c) => String.make(1, c)
+  | Character(c) => ZedBundled.make(1, c)
   | Function(digit) => Printf.sprintf("F%d", digit)
   | NumpadDigit(digit) => Printf.sprintf("Numpad%d", digit)
   | Escape => "Escape"

--- a/src/editor-input/Matcher.re
+++ b/src/editor-input/Matcher.re
@@ -24,6 +24,7 @@ let parse = (~explicitShiftKeyNeeded, str) => {
     | Matcher_internal.AllKeysReleased => Ok(AllKeysReleased)
     | Matcher_internal.Sequence(keys) =>
       keys
+      |> KeyPress.combineUnmatchedStrings
       |> List.map(KeyPress.ofInternal(~addShiftKeyToCapital))
       |> List.flatten
       |> Base.Result.all

--- a/src/editor-input/Matcher_internal.re
+++ b/src/editor-input/Matcher_internal.re
@@ -1,14 +1,17 @@
+[@deriving show]
 type modifier =
   | Control
   | Shift
   | Alt
   | Meta;
 
+[@deriving show]
 type keyPress =
   | UnmatchedString(string)
   | Physical(Key.t)
   | Special(SpecialKey.t);
 
+[@deriving show]
 type keyMatcher = (keyPress, list(modifier));
 
 type t =

--- a/src/editor-input/Matcher_lexer.mll
+++ b/src/editor-input/Matcher_lexer.mll
@@ -60,9 +60,9 @@
 	"numpad_multiply", BINDING(Physical(NumpadMultiply));
 	"leader", BINDING(Special(Leader));
 	"plug", BINDING(Special(Plug));
-	"lt", BINDING(Physical(Character('<')));
-	"gt", BINDING(Physical(Character('>')));
-	"plus", BINDING(Physical(Character('+')));
+	"lt", BINDING(Physical(Character(Uchar.of_char '<')));
+	"gt", BINDING(Physical(Character(Uchar.of_char '>')));
+	"plus", BINDING(Physical(Character(Uchar.of_char '+')));
 	]
 }
 
@@ -100,7 +100,7 @@ rule token = parse
 | ['f' 'F'] '1' (['0'-'9'] as m) { BINDING ( Physical (Function(int_of_string ("1" ^ (String.make 1 m))) ) ) }
 | white { token lexbuf }
 | binding as i
- { BINDING (Physical(Character (i))) }
+ { BINDING (Physical(Character (Uchar.of_char i))) }
 | '<' { LT }
 | '>' { GT }
 | eof { EOF }

--- a/test/Input/KeybindingsTests.re
+++ b/test/Input/KeybindingsTests.re
@@ -196,22 +196,22 @@ describe("Keybindings", ({describe, _}) => {
       let cases =
         EditorInput.[
           (
-            Key.Character('p'),
+            Key.Character(Uchar.of_char('p')),
             modifier(~control=true, ~shift=false, ~meta=false),
             "workbench.action.quickOpen",
           ),
           (
-            Key.Character('p'),
+            Key.Character(Uchar.of_char('p')),
             modifier(~control=false, ~shift=false, ~meta=true),
             "workbench.action.quickOpen",
           ),
           (
-            Key.Character('p'),
+            Key.Character(Uchar.of_char('p')),
             modifier(~control=true, ~shift=true, ~meta=false),
             "workbench.action.showCommands",
           ),
           (
-            Key.Character('p'),
+            Key.Character(Uchar.of_char('p')),
             modifier(~control=false, ~shift=true, ~meta=true),
             "workbench.action.showCommands",
           ),

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -3,17 +3,29 @@ open EditorInput;
 
 let aKeyScancode = 101;
 let aKeyNoModifiers =
-  KeyPress.physicalKey(~key=Key.Character('a'), ~modifiers=Modifiers.none);
+  KeyPress.physicalKey(
+    ~key=Key.Character(Uchar.of_char('a')),
+    ~modifiers=Modifiers.none,
+  );
 
 let bKeyScancode = 102;
 
 let bKeyNoModifiers =
-  KeyPress.physicalKey(~key=Key.Character('b'), ~modifiers=Modifiers.none);
+  KeyPress.physicalKey(
+    ~key=Key.Character(Uchar.of_char('b')),
+    ~modifiers=Modifiers.none,
+  );
 
 let cKeyScancode = 103;
 
 let cKeyNoModifiers =
-  KeyPress.physicalKey(~key=Key.Character('c'), ~modifiers=Modifiers.none);
+  KeyPress.physicalKey(
+    ~key=Key.Character(Uchar.of_char('c')),
+    ~modifiers=Modifiers.none,
+  );
+
+let ucharNoModifiers = uchar =>
+  KeyPress.physicalKey(~key=Key.Character(uchar), ~modifiers=Modifiers.none);
 
 let leaderKey = KeyPress.specialKey(SpecialKey.Leader);
 let plugKey = KeyPress.specialKey(SpecialKey.Plug);
@@ -102,7 +114,10 @@ describe("EditorInput", ({describe, _}) => {
 
     test("leader key defined as a", ({expect, _}) => {
       let physicalKey =
-        PhysicalKey.{key: Key.Character('a'), modifiers: Modifiers.none};
+        PhysicalKey.{
+          key: Key.Character(Uchar.of_char('a')),
+          modifiers: Modifiers.none,
+        };
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(Sequence([leaderKey]), _ => true, "commandA");
@@ -144,7 +159,10 @@ describe("EditorInput", ({describe, _}) => {
 
     test("leader key defined as a", ({expect, _}) => {
       let physicalKey =
-        PhysicalKey.{key: Key.Character('a'), modifiers: Modifiers.none};
+        PhysicalKey.{
+          key: Key.Character(Uchar.of_char('a')),
+          modifiers: Modifiers.none,
+        };
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(Sequence([leaderKey]), _ => true, "commandA");
@@ -615,6 +633,70 @@ describe("EditorInput", ({describe, _}) => {
           Unhandled({
             key: candidate(aKeyNoModifiers),
             isProducedByRemap: false,
+          }),
+        ],
+      );
+    });
+  });
+  describe("utf8", ({test, _}) => {
+    let uc252 = Zed_utf8.get("ü", 0);
+    let sc252 = 252;
+
+    let uc246 = Zed_utf8.get("ö", 0);
+
+    test("map utf8 -> ascii", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             ~allowRecursive=false,
+             Sequence([ucharNoModifiers(uc252)]),
+             _ => true,
+             [aKeyNoModifiers],
+           );
+
+      let (_bindings, effects) =
+        Input.keyDown(
+          ~context=true,
+          ~scancode=sc252,
+          ~key=candidate(ucharNoModifiers(uc252)),
+          bindings,
+        );
+
+      expect.equal(
+        effects,
+        [
+          Unhandled({
+            key: candidate(aKeyNoModifiers),
+            isProducedByRemap: true,
+          }),
+        ],
+      );
+    });
+
+    test("map ascii -> utf8", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             ~allowRecursive=false,
+             Sequence([aKeyNoModifiers]),
+             _ => true,
+             [ucharNoModifiers(uc246)],
+           );
+
+      let (_bindings, effects) =
+        Input.keyDown(
+          ~context=true,
+          ~scancode=aKeyScancode,
+          ~key=candidate(aKeyNoModifiers),
+          bindings,
+        );
+
+      expect.equal(
+        effects,
+        [
+          Unhandled({
+            key: candidate(ucharNoModifiers(uc246)),
+            isProducedByRemap: true,
           }),
         ],
       );

--- a/test/editor-input/MatcherTest.re
+++ b/test/editor-input/MatcherTest.re
@@ -23,21 +23,22 @@ describe("Matcher", ({describe, _}) => {
       // https://code.visualstudio.com/docs/getstarted/keybindings#_accepted-keys
       let cases = [
         // TODO: Add production cases here
-        ("a", keyPress(Key.Character('a'))),
-        ("A", keyPress(Key.Character('a'))), // Because implicit shift is false
-        ("0", keyPress(Key.Character('0'))),
-        ("9", keyPress(Key.Character('9'))),
-        ("`", keyPress(Key.Character('`'))),
-        ("-", keyPress(Key.Character('-'))),
-        ("=", keyPress(Key.Character('='))),
-        ("[", keyPress(Key.Character('['))),
-        ("]", keyPress(Key.Character(']'))),
-        ("\\", keyPress(Key.Character('\\'))),
-        (";", keyPress(Key.Character(';'))),
-        ("'", keyPress(Key.Character('\''))),
-        (",", keyPress(Key.Character(','))),
-        (".", keyPress(Key.Character('.'))),
-        ("/", keyPress(Key.Character('/'))),
+        ("a", keyPress(Key.Character(Uchar.of_char('a')))),
+        ("A", keyPress(Key.Character(Uchar.of_char('a')))), // Because implicit shift is false
+        ("0", keyPress(Key.Character(Uchar.of_char('0')))),
+        ("9", keyPress(Key.Character(Uchar.of_char('9')))),
+        ("`", keyPress(Key.Character(Uchar.of_char('`')))),
+        ("-", keyPress(Key.Character(Uchar.of_char('-')))),
+        ("=", keyPress(Key.Character(Uchar.of_char('=')))),
+        ("[", keyPress(Key.Character(Uchar.of_char('[')))),
+        ("]", keyPress(Key.Character(Uchar.of_char(']')))),
+        ("\\", keyPress(Key.Character(Uchar.of_char('\\')))),
+        (";", keyPress(Key.Character(Uchar.of_char(';')))),
+        ("'", keyPress(Key.Character(Uchar.of_char('\'')))),
+        (",", keyPress(Key.Character(Uchar.of_char(',')))),
+        (".", keyPress(Key.Character(Uchar.of_char('.')))),
+        ("/", keyPress(Key.Character(Uchar.of_char('/')))),
+        ("ö", keyPress(Key.Character(Uchar.of_int(246)))),
         ("tab", keyPress(Key.Tab)),
         ("ESC", keyPress(Key.Escape)),
         ("up", keyPress(Key.Up)),
@@ -78,10 +79,10 @@ describe("Matcher", ({describe, _}) => {
         ("<leader>", specialKey(SpecialKey.Leader)),
         ("<Leader>", specialKey(SpecialKey.Leader)),
         // Non-direct production keys - start of cases for #2114 / #2883
-        (":", keyPress(Key.Character(':'))),
-        ("~", keyPress(Key.Character('~'))),
-        ("_", keyPress(Key.Character('_'))),
-        ("+", keyPress(Key.Character('+'))),
+        (":", keyPress(Key.Character(Uchar.of_char(':')))),
+        ("~", keyPress(Key.Character(Uchar.of_char('~')))),
+        ("_", keyPress(Key.Character(Uchar.of_char('_')))),
+        ("+", keyPress(Key.Character(Uchar.of_char('+')))),
       ];
 
       let runCase = case => {
@@ -96,10 +97,16 @@ describe("Matcher", ({describe, _}) => {
     });
     test("simple parsing", ({expect, _}) => {
       let result = defaultParse("a");
-      expect.equal(result, Ok(Sequence([keyPress(Key.Character('a'))])));
+      expect.equal(
+        result,
+        Ok(Sequence([keyPress(Key.Character(Uchar.of_char('a')))])),
+      );
 
       let result = defaultParse("b");
-      expect.equal(result, Ok(Sequence([keyPress(Key.Character('b'))])));
+      expect.equal(
+        result,
+        Ok(Sequence([keyPress(Key.Character(Uchar.of_char('b')))])),
+      );
 
       let result = defaultParse("esc");
       expect.equal(result, Ok(Sequence([keyPress(Key.Escape)])));
@@ -110,14 +117,20 @@ describe("Matcher", ({describe, _}) => {
     });
     test("vim bindings", ({expect, _}) => {
       let result = defaultParse("<a>");
-      expect.equal(result, Ok(Sequence([keyPress(Key.Character('a'))])));
+      expect.equal(
+        result,
+        Ok(Sequence([keyPress(Key.Character(Uchar.of_char('a')))])),
+      );
 
       let result = defaultParse("<c-a>");
       expect.equal(
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersControl, Key.Character('a')),
+            keyPress(
+              ~modifiers=modifiersControl,
+              Key.Character(Uchar.of_char('a')),
+            ),
           ]),
         ),
       );
@@ -127,7 +140,10 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersShift, Key.Character('a')),
+            keyPress(
+              ~modifiers=modifiersShift,
+              Key.Character(Uchar.of_char('a')),
+            ),
           ]),
         ),
       );
@@ -146,7 +162,10 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersControl, Key.Character('a')),
+            keyPress(
+              ~modifiers=modifiersControl,
+              Key.Character(Uchar.of_char('a')),
+            ),
           ]),
         ),
       );
@@ -156,7 +175,10 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersControl, Key.Character('a')),
+            keyPress(
+              ~modifiers=modifiersControl,
+              Key.Character(Uchar.of_char('a')),
+            ),
           ]),
         ),
       );
@@ -167,8 +189,8 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(Key.Character('a')),
-            keyPress(Key.Character('b')),
+            keyPress(Key.Character(Uchar.of_char('a'))),
+            keyPress(Key.Character(Uchar.of_char('b'))),
           ]),
         ),
       );
@@ -178,8 +200,8 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(Key.Character('a')),
-            keyPress(Key.Character('b')),
+            keyPress(Key.Character(Uchar.of_char('a'))),
+            keyPress(Key.Character(Uchar.of_char('b'))),
           ]),
         ),
       );
@@ -189,8 +211,8 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(Key.Character('a')),
-            keyPress(Key.Character('b')),
+            keyPress(Key.Character(Uchar.of_char('a'))),
+            keyPress(Key.Character(Uchar.of_char('b'))),
           ]),
         ),
       );
@@ -199,8 +221,8 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(Key.Character('a')),
-            keyPress(Key.Character('b')),
+            keyPress(Key.Character(Uchar.of_char('a'))),
+            keyPress(Key.Character(Uchar.of_char('b'))),
           ]),
         ),
       );
@@ -210,8 +232,14 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersControl, Key.Character('a')),
-            keyPress(~modifiers=modifiersControl, Key.Character('b')),
+            keyPress(
+              ~modifiers=modifiersControl,
+              Key.Character(Uchar.of_char('a')),
+            ),
+            keyPress(
+              ~modifiers=modifiersControl,
+              Key.Character(Uchar.of_char('b')),
+            ),
           ]),
         ),
       );
@@ -222,7 +250,10 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersShift, Key.Character('a')),
+            keyPress(
+              ~modifiers=modifiersShift,
+              Key.Character(Uchar.of_char('a')),
+            ),
           ]),
         ),
       );
@@ -232,8 +263,11 @@ describe("Matcher", ({describe, _}) => {
         result,
         Ok(
           Sequence([
-            keyPress(~modifiers=modifiersShift, Key.Character('a')),
-            keyPress(Key.Character('b')),
+            keyPress(
+              ~modifiers=modifiersShift,
+              Key.Character(Uchar.of_char('a')),
+            ),
+            keyPress(Key.Character(Uchar.of_char('b'))),
           ]),
         ),
       );

--- a/test/editor-input/MatcherTest.re
+++ b/test/editor-input/MatcherTest.re
@@ -272,6 +272,21 @@ describe("Matcher", ({describe, _}) => {
         ),
       );
     });
+    test("#2980 - separate modifier keys", ({expect, _}) => {
+      let result = defaultParse("<c-w>r");
+      expect.equal(
+        result,
+        Ok(
+          Sequence([
+            keyPress(
+              ~modifiers=modifiersControl,
+              Key.Character(Uchar.of_char('w')),
+            ),
+            keyPress(Key.Character(Uchar.of_char('r'))),
+          ]),
+        ),
+      );
+    })
     //    test("keyup", ({expect, _}) => {
     //      let result = defaultParse("!a");
     //      expect.equal(

--- a/test/editor-input/MatcherTest.re
+++ b/test/editor-input/MatcherTest.re
@@ -286,7 +286,7 @@ describe("Matcher", ({describe, _}) => {
           ]),
         ),
       );
-    })
+    });
     //    test("keyup", ({expect, _}) => {
     //      let result = defaultParse("!a");
     //      expect.equal(


### PR DESCRIPTION
__Issue:__ #2977 introduced a regression where the `w` key wasn't working as it should - it would do nothing, and then potentially move on a subsequent key press.

__Defect:__ The new coalesce-input-binding behavior in #2977 introduced a bug - for a binding like `Control+w`, `r` (rotate window) - it would only take the modifiers from the _last_ binding item. This meant that binding would get persisted internally as `w`, `r` - so a bunch of window bindings that should've been `Control+` bindings were now engaged with just pressing `w`. Subsequent key presses would potentially either run a window command (ie, `w` + `j`) would move down a window, or run the `w` if there wasn't a relevant binding.

__Fix:__ Only coalesce character strings if they have equivalent modifiers. We were missing a test case for this in our corpus, so add a test case to avoid a regression like this in the future.

Fixes #2972 
Fixes #2980 