### PR TITLE
fix(theme/#2985): Fallback to default theme when invalid theme is specified

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -50,6 +50,7 @@
 - #2898 - Editor: Implement mouse selection (fixes #537)
 - #2959 - Completion: Implement `"editor.acceptSuggestionOnEnter"` configuration setting
 - #2956 - Layout: Fix extra editor when splitting with a file or terminal (fixes #2900, #2952)
+- #2986 - Theme: Fallback to default theme if invalid theme is specified
 
 ### Performance
 

--- a/integration_test/ConfigurationInvalidThemeTest.re
+++ b/integration_test/ConfigurationInvalidThemeTest.re
@@ -1,0 +1,44 @@
+open Oni_Core;
+open Utility;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+module Buffer = Oni_Core.Buffer;
+
+let configuration = {|
+{
+    "workbench.colorTheme": "very-invalid-theme",
+}
+|};
+
+runTest(
+  ~configuration=Some(configuration),
+  ~name="ConfigurationInvalidThemeTest",
+  (dispatch, wait, _) => {
+    wait(~name="Initial mode is normal", (state: State.t) =>
+      Selectors.mode(state) |> Vim.Mode.isNormal
+    );
+
+    // We should get an error message referencing our very-invalid-theme..
+    wait(~name="Wait for error message", (state: State.t) => {
+      state.notifications
+      |> Feature_Notification.all
+      |> List.exists(notification => {
+        Feature_Notification.({
+        notification.kind == Error && StringEx.contains("very-invalid-theme", notification.message)
+        })
+      })
+    });
+
+    // But, we should revert to our default laserwave-italic theme. Check one of the colors...
+    wait(~name="Wait for error message", (state: State.t) => {
+      let colors = state.colorTheme
+      |> Feature_Theme.colors;
+
+      let editorBackgroundColor = Feature_Theme.Colors.Editor.background.from(colors);
+
+      let expectedColor = Revery.Color.hex("#27212e");
+      expectedColor == editorBackgroundColor
+    });
+
+  },
+);

--- a/integration_test/ConfigurationInvalidThemeTest.re
+++ b/integration_test/ConfigurationInvalidThemeTest.re
@@ -12,33 +12,34 @@ let configuration = {|
 
 runTest(
   ~configuration=Some(configuration),
-  ~name="ConfigurationInvalidThemeTest",
-  (dispatch, wait, _) => {
-    wait(~name="Initial mode is normal", (state: State.t) =>
-      Selectors.mode(state) |> Vim.Mode.isNormal
-    );
-
+  ~name="ConfigurationInvalidThemeTest (Regression test for #2985)",
+  (_dispatch, wait, _) => {
     // We should get an error message referencing our very-invalid-theme..
     wait(~name="Wait for error message", (state: State.t) => {
       state.notifications
       |> Feature_Notification.all
       |> List.exists(notification => {
-        Feature_Notification.({
-        notification.kind == Error && StringEx.contains("very-invalid-theme", notification.message)
-        })
-      })
+           Feature_Notification.(
+             {
+               notification.kind == Error
+               && StringEx.contains(
+                    "very-invalid-theme",
+                    notification.message,
+                  );
+             }
+           )
+         })
     });
 
     // But, we should revert to our default laserwave-italic theme. Check one of the colors...
     wait(~name="Wait for error message", (state: State.t) => {
-      let colors = state.colorTheme
-      |> Feature_Theme.colors;
+      let colors = state.colorTheme |> Feature_Theme.colors;
 
-      let editorBackgroundColor = Feature_Theme.Colors.Editor.background.from(colors);
+      let editorBackgroundColor =
+        Feature_Theme.Colors.Editor.background.from(colors);
 
       let expectedColor = Revery.Color.hex("#27212e");
-      expectedColor == editorBackgroundColor
+      expectedColor == editorBackgroundColor;
     });
-
   },
 );

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -3,19 +3,19 @@
    ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
    ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
    ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
-   ConfigurationInvalidThemeTest
-   ConfigurationPerFileTypeTest EditorFontFromPathTest EditorFontValidTest
-   EditorSplitFileTest EditorUtf8Test ExCommandKeybindingTest
-   ExCommandKeybindingWithArgsTest ExCommandKeybindingNormTest
-   ExtConfigurationChangedTest ExtHostBufferOpenTest ExtHostBufferUpdatesTest
-   ExtHostCompletionTest ExtHostDefinitionTest FileWatcherTest
-   KeybindingsInvalidJsonTest KeySequenceJJTest InputIgnoreTest
-   InputContextKeysTest InputRemapMotionTest LanguageCssTest
-   LanguageTypeScriptTest LineEndingsLFTest LineEndingsCRLFTest
-   QuickOpenEventuallyCompletesTest SearchShowClearHighlightsTest
-   SyntaxServer SyntaxServerCloseTest SyntaxServerMessageExceptionTest
-   SyntaxServerParentPidTest SyntaxServerParentPidCorrectTest
-   SyntaxServerReadExceptionTest Regression1671Test Regression2349EnewTest
+   ConfigurationInvalidThemeTest ConfigurationPerFileTypeTest
+   EditorFontFromPathTest EditorFontValidTest EditorSplitFileTest
+   EditorUtf8Test ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
+   ExCommandKeybindingNormTest ExtConfigurationChangedTest
+   ExtHostBufferOpenTest ExtHostBufferUpdatesTest ExtHostCompletionTest
+   ExtHostDefinitionTest FileWatcherTest KeybindingsInvalidJsonTest
+   KeySequenceJJTest InputIgnoreTest InputContextKeysTest
+   InputRemapMotionTest LanguageCssTest LanguageTypeScriptTest
+   LineEndingsLFTest LineEndingsCRLFTest QuickOpenEventuallyCompletesTest
+   SearchShowClearHighlightsTest SyntaxServer SyntaxServerCloseTest
+   SyntaxServerMessageExceptionTest SyntaxServerParentPidTest
+   SyntaxServerParentPidCorrectTest SyntaxServerReadExceptionTest
+   Regression1671Test Regression2349EnewTest
    RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
    RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
    RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
@@ -34,14 +34,14 @@
    ClipboardInsertModePasteSingleLineTest.exe
    ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
    ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
-   ConfigurationInvalidThemeTest.exe
-   ConfigurationPerFileTypeTest.exe CopyActiveFilepathToClipboardTest.exe
-   EchoNotificationTest.exe EditorFontFromPathTest.exe
-   EditorFontValidTest.exe EditorSplitFileTest.exe EditorUtf8Test.exe
-   ExCommandKeybindingTest.exe ExCommandKeybindingNormTest.exe
-   ExCommandKeybindingWithArgsTest.exe ExtConfigurationChangedTest.exe
-   ExtHostBufferOpenTest.exe ExtHostBufferUpdatesTest.exe
-   ExtHostCompletionTest.exe ExtHostDefinitionTest.exe FileWatcherTest.exe
+   ConfigurationInvalidThemeTest.exe ConfigurationPerFileTypeTest.exe
+   CopyActiveFilepathToClipboardTest.exe EchoNotificationTest.exe
+   EditorFontFromPathTest.exe EditorFontValidTest.exe EditorSplitFileTest.exe
+   EditorUtf8Test.exe ExCommandKeybindingTest.exe
+   ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
+   ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
+   ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
+   ExtHostDefinitionTest.exe FileWatcherTest.exe
    KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
    InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
    LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -3,6 +3,7 @@
    ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
    ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
    ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
+   ConfigurationInvalidThemeTest
    ConfigurationPerFileTypeTest EditorFontFromPathTest EditorFontValidTest
    EditorSplitFileTest EditorUtf8Test ExCommandKeybindingTest
    ExCommandKeybindingWithArgsTest ExCommandKeybindingNormTest
@@ -33,6 +34,7 @@
    ClipboardInsertModePasteSingleLineTest.exe
    ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
    ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
+   ConfigurationInvalidThemeTest.exe
    ConfigurationPerFileTypeTest.exe CopyActiveFilepathToClipboardTest.exe
    EchoNotificationTest.exe EditorFontFromPathTest.exe
    EditorFontValidTest.exe EditorSplitFileTest.exe EditorUtf8Test.exe

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -68,7 +68,7 @@ let default = {
   terminalIntegratedFontWeight: Revery.Font.Weight.Normal,
   terminalIntegratedFontSmoothing: Default,
   workbenchActivityBarVisible: true,
-  workbenchColorTheme: "LaserWave Italic",
+  workbenchColorTheme: Constants.defaultTheme,
   workbenchEditorShowTabs: true,
   workbenchEditorEnablePreview: true,
   workbenchStatusBarVisible: true,

--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -44,6 +44,8 @@ let defaultFontFamily =
   });
 let defaultTerminalFontSize = 12.;
 
+let defaultTheme = "LaserWave Italic";
+
 let syntaxEagerMaxLines = 500;
 let syntaxEagerMaxLineLength = 1000;
 let syntaxEagerBudget = 0.25; /* 250 milliseconds */

--- a/src/Store/ThemeStoreConnector.re
+++ b/src/Store/ThemeStoreConnector.re
@@ -78,7 +78,6 @@ let start = () => {
     });
 
   let loadThemeByIdEffect = (~extensions, themeId) => {
-    prerr_endline("Load theme by id: " ++ themeId);
     Log.infof(m => m("Loading theme by id: %s", themeId));
     let maybeTheme = Feature_Extensions.themeById(~id=themeId, extensions);
 

--- a/src/Store/ThemeStoreConnector.re
+++ b/src/Store/ThemeStoreConnector.re
@@ -78,18 +78,37 @@ let start = () => {
     });
 
   let loadThemeByIdEffect = (~extensions, themeId) => {
+    prerr_endline("Load theme by id: " ++ themeId);
     Log.infof(m => m("Loading theme by id: %s", themeId));
-    let themeInfo = Feature_Extensions.themeById(~id=themeId, extensions);
+    let maybeTheme = Feature_Extensions.themeById(~id=themeId, extensions);
 
-    switch (themeInfo) {
-    | Some({uiTheme, path, _}) => loadThemeByPathEffect(uiTheme, path)
-    | None =>
-      Feature_Notification.Effects.create(
-        ~kind=Error,
-        "Unable to find theme: " ++ themeId,
-      )
-      |> Isolinear.Effect.map(msg => Actions.Notification(msg))
-    };
+    let errorEffect =
+      switch (maybeTheme) {
+      | Some(_) => Isolinear.Effect.none
+      | None =>
+        Feature_Notification.Effects.create(
+          ~kind=Error,
+          "Unable to find theme: " ++ themeId,
+        )
+        |> Isolinear.Effect.map(msg => Actions.Notification(msg))
+      };
+
+    let loadThemeEffect =
+      maybeTheme
+      |> Utility.OptionEx.or_lazy(() => {
+           // If we were unable to load, fall back to the default
+           Feature_Extensions.themeById(
+             ~id=Constants.defaultTheme,
+             extensions,
+           )
+         })
+      |> Option.map(
+           ({uiTheme, path, _}: Exthost.Extension.Contributions.Theme.t) =>
+           loadThemeByPathEffect(uiTheme, path)
+         )
+      |> Option.value(~default=Isolinear.Effect.none);
+
+    [errorEffect, loadThemeEffect] |> Isolinear.Effect.batch;
   };
 
   let persistThemeEffect = name =>


### PR DESCRIPTION
__Issue:__ If an invalid theme is specified, there is no syntax highlighting

__Defect:__ If we fail to load/find a theme, we show an error message, but don't bother loading our default theme - this means that we get no theme colors for tokens, and fallback to just the editor background / foreground color.

__Fix:__ If we can't find a specified theme, load our default LaserWave Italic theme.

Related to #2985 , and fixes one manifestation of it, but there may still be another underlying issue.