### PR TITLE
chore(ci): Remove health-check output logging on Windows build

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -25,8 +25,8 @@ steps:
     displayName: "esy x Oni2 --help"
   - script: esy x Oni2 -f --version
     displayName: "esy x Oni2_editor -f --version"
-  - script: esy x Oni2 --checkhealth 
-    displayName: "esy x Oni2 --checkhealth"
+  - script: esy x Oni2 -f --silent --checkhealth 
+    displayName: "esy x Oni2 -f --silent --checkhealth"
   - script: 'esy @release install'
     displayName: 'Release: install'
   - script: 'esy @release build'

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -25,8 +25,8 @@ steps:
     displayName: "esy x Oni2 --help"
   - script: esy x Oni2 -f --version
     displayName: "esy x Oni2_editor -f --version"
-  - script: esy x Oni2 -f --checkhealth 
-    displayName: "esy x Oni2 -f --checkhealth"
+  - script: esy x Oni2 --checkhealth 
+    displayName: "esy x Oni2 --checkhealth"
   - script: 'esy @release install'
     displayName: 'Release: install'
   - script: 'esy @release build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ jobs:
     displayName: 'Check esy root path'
   - script: ls $(ESY__CACHE_INSTALL_PATH)
     displayName: 'Check esy cache install path after build'
-  - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --checkhealth
+  - script: _release/Onivim2.AppDir/usr/bin/Oni2 -f --no-log-colors --checkhealth
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-linux.yml
   - template: .ci/publish-build-cache.yml
@@ -149,7 +149,7 @@ jobs:
   - template: .ci/run-integration-tests.yml
     parameters:
       platform: darwin
-  - script: _release/Onivim2.App/Contents/MacOS/Oni2 -f --checkhealth
+  - script: _release/Onivim2.App/Contents/MacOS/Oni2 -f --no-log-colors --checkhealth
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-osx.yml
   - template: .ci/publish-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,9 +182,6 @@ jobs:
   - script: dir
     workingDirectory: _release/win32
     displayName: 'check directory contents'
-  - script: Oni2.exe -f --silent --checkhealth
-    workingDirectory: _release/win32
-    displayName: 'Release: --checkhealth'
   - template: .ci/publish-win.yml
   - template: .ci/publish-build-cache.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ jobs:
   - script: dir
     workingDirectory: _release/win32
     displayName: 'check directory contents'
-  - script: Oni2.exe --checkhealth
+  - script: Oni2.exe -f --silent --checkhealth
     workingDirectory: _release/win32
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-win.yml
@@ -343,5 +343,5 @@ jobs:
   # but we need to check from the command prompt, too via %PATH% - for #872
   - script: |
       set PATH=%PATH%;D:/a/1/s/Onivim2
-      Oni2.exe -f --no-log-colors --checkhealth
-    displayName: "Oni2.exe -f --no-log-colors --checkhealth (run installed)"
+      Oni2.exe -f --silent --checkhealth
+    displayName: "Oni2.exe -f --silent --checkhealth (run installed)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ jobs:
   - script: dir
     workingDirectory: _release/win32
     displayName: 'check directory contents'
-  - script: Oni2.exe -f --no-log-colors --checkhealth
+  - script: Oni2.exe --checkhealth
     workingDirectory: _release/win32
     displayName: 'Release: --checkhealth'
   - template: .ci/publish-win.yml

--- a/scripts/windows/validate-release.ps1
+++ b/scripts/windows/validate-release.ps1
@@ -12,7 +12,7 @@ Expand-Archive -Path $env:SYSTEM_ARTIFACTSDIRECTORY/Release_Windows/Onivim2-$SHO
 ls _unpacked
 $env:ONI2_DEBUG=1
 Write-Host "Running health-check on zip build..."
-./_unpacked/win32/Oni2.exe --checkhealth
+./_unpacked/win32/Oni2.exe -f --silent --checkhealth
 
 Write-Host "** Validating .exe installer **"
 rm -r _unpacked
@@ -33,4 +33,4 @@ ls D:/a/1/s
 ls D:/a/1/s/Onivim2
 
 Write-Host "Running health-check on installed build..."
-D:/a/1/s/Onivim2/Oni2.exe --checkhealth
+D:/a/1/s/Onivim2/Oni2.exe -f --silent --checkhealth

--- a/scripts/windows/validate-release.ps1
+++ b/scripts/windows/validate-release.ps1
@@ -12,7 +12,7 @@ Expand-Archive -Path $env:SYSTEM_ARTIFACTSDIRECTORY/Release_Windows/Onivim2-$SHO
 ls _unpacked
 $env:ONI2_DEBUG=1
 Write-Host "Running health-check on zip build..."
-./_unpacked/win32/Oni2.exe -f --no-log-colors --checkhealth
+./_unpacked/win32/Oni2.exe --checkhealth
 
 Write-Host "** Validating .exe installer **"
 rm -r _unpacked
@@ -33,4 +33,4 @@ ls D:/a/1/s
 ls D:/a/1/s/Onivim2
 
 Write-Host "Running health-check on installed build..."
-D:/a/1/s/Onivim2/Oni2.exe -f --no-log-colors --checkhealth
+D:/a/1/s/Onivim2/Oni2.exe --checkhealth


### PR DESCRIPTION
Getting intermittent hangs during the health-check - check if it is due to logging, or another issue.