### PR TITLE
fix(osx): Don't trigger menu command if from key press

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -55,6 +55,7 @@
 - #2984 - Editor: Fix extraneous clones of editor on Control+Tab (fixes #2988)
 - #2978 - Input: Fix `m-` modifier behavior (fixes #2963)
 - #2990 - Signature Help: Fix blocking `esc` key press back to normal mode
+- #2991 - OSX: Fix shortcut keys double-triggering events
 
 ### Performance
 

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "964e04d93a0daf963894ac7b1bf04cff",
+  "checksum": "1a150dab488cd4565363c1ab83fed405",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#8497f52@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+    "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#8497f52",
+      "version": "github:revery-ui/revery#0c3be5dd",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#8497f52" ]
+        "source": [ "github:revery-ui/revery#0c3be5dd" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "bench.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "reperf@1.5.0@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "964e04d93a0daf963894ac7b1bf04cff",
+  "checksum": "1a150dab488cd4565363c1ab83fed405",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#8497f52@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+    "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#8497f52",
+      "version": "github:revery-ui/revery#0c3be5dd",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#8497f52" ]
+        "source": [ "github:revery-ui/revery#0c3be5dd" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "964e04d93a0daf963894ac7b1bf04cff",
+  "checksum": "1a150dab488cd4565363c1ab83fed405",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#8497f52@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+    "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#8497f52",
+      "version": "github:revery-ui/revery#0c3be5dd",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#8497f52" ]
+        "source": [ "github:revery-ui/revery#0c3be5dd" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "integrationtest.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "revery-terminal": "*"
   },
   "resolutions": {
-    "revery": "revery-ui/revery#8497f52",
+    "revery": "revery-ui/revery#0c3be5dd",
     "esy-skia": "revery-ui/esy-skia#91c98f6",
     "rench": "bryphe/rench#a976fe5",
     "isolinear": "revery-ui/isolinear#53fc4eb",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "964e04d93a0daf963894ac7b1bf04cff",
+  "checksum": "1a150dab488cd4565363c1ab83fed405",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#8497f52@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+    "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#8497f52",
+      "version": "github:revery-ui/revery#0c3be5dd",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#8497f52" ]
+        "source": [ "github:revery-ui/revery#0c3be5dd" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "release.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",

--- a/src/Feature/MenuBar/NativeMenu.re
+++ b/src/Feature/MenuBar/NativeMenu.re
@@ -87,7 +87,11 @@ module Sub = {
                  let nativeMenuItem =
                    Revery.Native.Menu.Item.create(
                      ~title,
-                     ~onClick=() => {dispatch(command)},
+                     ~onClick=
+                       (~fromKeyPress, ()) =>
+                         if (!fromKeyPress) {
+                           dispatch(command);
+                         },
                      ~keyEquivalent,
                      (),
                    );
@@ -121,7 +125,11 @@ module Sub = {
                  let nativeMenuItem =
                    Revery.Native.Menu.Item.create(
                      ~title,
-                     ~onClick=() => {dispatch(command)},
+                     ~onClick=
+                       (~fromKeyPress, ()) =>
+                         if (!fromKeyPress) {
+                           dispatch(command);
+                         },
                      ~keyEquivalent,
                      (),
                    );

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "821278cd65da008145ab6cce66e11e50",
+  "checksum": "5ad923d3038bcd4718b1872d244be5e0",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -118,7 +118,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
         "@revery/esy-libvterm@1.0.3@d41d8cd9",
@@ -126,13 +126,13 @@
       ],
       "devDependencies": []
     },
-    "revery@github:revery-ui/revery#8497f52@d41d8cd9": {
-      "id": "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+    "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9": {
+      "id": "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
       "name": "revery",
-      "version": "github:revery-ui/revery#8497f52",
+      "version": "github:revery-ui/revery#0c3be5dd",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/revery#8497f52" ]
+        "source": [ "github:revery-ui/revery#0c3be5dd" ]
       },
       "overrides": [],
       "dependencies": [
@@ -996,7 +996,7 @@
       "overrides": [ "test.json" ],
       "dependencies": [
         "revery-terminal@github:revery-ui/revery-terminal#a9cb168@d41d8cd9",
-        "revery@github:revery-ui/revery#8497f52@d41d8cd9",
+        "revery@github:revery-ui/revery#0c3be5dd@d41d8cd9",
         "rench@github:bryphe/rench#a976fe5@d41d8cd9",
         "refmterr@3.3.2@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",


### PR DESCRIPTION
__Issue:__ Some shortcut keys (shortcuts used by the native-menu introduced in #2969 ) would be triggered twice. This is problematic, because some of the commands have 'toggle' behavior - and if they are engaged twice, it would produce a toggle-untoggle sequence.

__Defect:__ When a shortcut key used by the menu is triggered, we'd receive two callbacks - one for the menu item itself, and one from our input handling infrastructure. 

__Fix:__ In Revery, add a hook to know whether the menu item was triggered via a keypress or by some other gesture: https://github.com/revery-ui/revery/pull/1044 If the menu item was triggered via a keypress, ignore the menu event, and let the input handling infrastructure take care of executing the command.