### PR TITLE
fix(exthost): Fix some command / codelens parsing failures

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -55,6 +55,7 @@
 - #2984 - Editor: Fix extraneous clones of editor on Control+Tab (fixes #2988)
 - #2978 - Input: Fix `m-` modifier behavior (fixes #2963)
 - #2990 - Signature Help: Fix blocking `esc` key press back to normal mode
+- #2993 - CodeLens: Handle null command id & label icons
 
 ### Performance
 

--- a/src/Components/Label.re
+++ b/src/Components/Label.re
@@ -10,10 +10,7 @@ open Oni_Core;
 
 module Styles = {
   open Style;
-  let text = (~color) => [
-    textWrap(TextWrapping.NoWrap),
-    Style.color(color),
-  ];
+  let text = (~color) => [textWrap(TextWrapping.Wrap), Style.color(color)];
 };
 
 let textToElement = (~color, ~font: UiFont.t, ~text) => {

--- a/src/Exthost/Command.re
+++ b/src/Exthost/Command.re
@@ -2,7 +2,7 @@ open Oni_Core;
 
 [@deriving show]
 type t = {
-  id: string,
+  id: option(string),
   label: option(Label.t),
 };
 
@@ -11,7 +11,7 @@ module Decode = {
     Json.Decode.(
       obj(({field, _}) =>
         {
-          id: field.required("id", string),
+          id: field.optional("id", string),
           label: field.optional("title", Label.decode),
         }
       )
@@ -23,7 +23,7 @@ module Encode = {
   open Json.Encode;
   let encode = lens =>
     obj([
-      ("id", lens.id |> string),
+      ("id", lens.id |> nullable(string)),
       ("title", lens.label |> nullable(Label.encode)),
     ]);
 };

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -30,7 +30,7 @@ module Label: {
 module Command: {
   [@deriving show]
   type t = {
-    id: string,
+    id: option(string),
     label: option(Label.t),
   };
 

--- a/src/Feature/LanguageSupport/CodeLens.re
+++ b/src/Feature/LanguageSupport/CodeLens.re
@@ -181,7 +181,11 @@ module View = {
   open Revery.UI;
   let make = (~leftMargin, ~theme, ~uiFont: Oni_Core.UiFont.t, ~codeLens, ()) => {
     let foregroundColor = CodeLensColors.foreground.from(theme);
-    let text = text(codeLens);
+    let label =
+      Exthost.CodeLens.(codeLens.command)
+      |> OptionEx.flatMap((command: Exthost.Command.t) => command.label)
+      |> Option.value(~default=Exthost.Label.ofString("(null)"));
+
     <View
       style=Style.[
         marginTop(4),
@@ -190,16 +194,7 @@ module View = {
         flexGrow(1),
         flexShrink(0),
       ]>
-      <Text
-        text
-        fontFamily={uiFont.family}
-        fontSize={uiFont.size}
-        style=Style.[
-          color(foregroundColor),
-          flexGrow(1),
-          textWrap(Revery.TextWrapping.Wrap),
-        ]
-      />
+      <Oni_Components.Label font=uiFont color=foregroundColor label />
     </View>;
   };
 };

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -247,7 +247,7 @@ module Internal = {
            ~versionId=version,
            ~lines,
            ~modeId,
-           ~isDirty=true,
+           ~isDirty=false,
            Uri.fromPath(filePath),
          );
        });

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -174,7 +174,7 @@ let create =
           }),
         ) =>
         let command =
-          command |> Option.map(({id, _}: Exthost.Command.t) => id);
+          command |> OptionEx.flatMap(({id, _}: Exthost.Command.t) => id);
         dispatch(
           Actions.StatusBar(
             Feature_StatusBar.ItemAdded(

--- a/test/Exthost/LanguageFeaturesTest.re
+++ b/test/Exthost/LanguageFeaturesTest.re
@@ -96,7 +96,7 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
                              Some(
                                Exthost.Label.ofString("codelens: command1"),
                              ),
-                           id: "codelens.command1",
+                           id: Some("codelens.command1"),
                          },
                        ),
                    },
@@ -110,7 +110,7 @@ describe("LanguageFeaturesTest", ({describe, _}) => {
                              Some(
                                Exthost.Label.ofString("codelens: command2"),
                              ),
-                           id: "codelens.command2",
+                           id: Some("codelens.command2"),
                          },
                        ),
                    },

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -56,7 +56,10 @@ describe("Editor", ({describe, _}) => {
           },
         command:
           Some(
-            Command.{id: Some(uniqueId), label: Some(Label.ofString(uniqueId))},
+            Command.{
+              id: Some(uniqueId),
+              label: Some(Label.ofString(uniqueId)),
+            },
           ),
       }
     );

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -56,7 +56,7 @@ describe("Editor", ({describe, _}) => {
           },
         command:
           Some(
-            Command.{id: uniqueId, label: Some(Label.ofString(uniqueId))},
+            Command.{id: Some(uniqueId), label: Some(Label.ofString(uniqueId))},
           ),
       }
     );


### PR DESCRIPTION
__Issue:__ Some extensions have codelenses that fail to display in Onivim

__Defect:__ Some extensions will pass a command without an `id` - our parsing logic assumed that an `id` would always be present, and thus, those codelens would fail to decode and not be shown. In addition, some extensions will use labelled icons like `${ellipsis}` in codelens, which we weren't handling.

__Fix:__ 
1) Update our `Command` model to reflect the optional id
2) Use the `Label` renderer for codelens