### PR TITLE
fix(extensions/#2981): Listener function error with 3-param https request call

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -57,6 +57,7 @@
 - #2990 - Signature Help: Fix blocking `esc` key press back to normal mode
 - #2991 - OSX: Fix shortcut keys double-triggering events
 - #2993 - CodeLens: Handle null command id & label icons
+- #2995 - Extensions: Fix bug with 3-param http/https request (fixes #2981)
 
 ### Performance
 

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onivim/vscode-exthost": "1.52.1000",
+    "@onivim/vscode-exthost": "1.52.1001",
     "follow-redirects": "1.13.0",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@onivim/vscode-exthost@1.52.1000":
-  version "1.52.1000"
-  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.52.1000.tgz#f69523da388b9595662ff12c600fe5fe0c2150ae"
-  integrity sha512-MuW8QfmHPj9q5D37lHdavUZG5cuCanTF8hZ1k/sCGbWKBCVCHPOtQ74pxRFa91t+JCXDTpzXdiW6DBLh+fIjDA==
+"@onivim/vscode-exthost@1.52.1001":
+  version "1.52.1001"
+  resolved "https://registry.yarnpkg.com/@onivim/vscode-exthost/-/vscode-exthost-1.52.1001.tgz#22139888543b604a2babb94c200693290fca4220"
+  integrity sha512-SbvMucGhnAnz7pwkcuv8sjgOLB8bdldYMm9d/c8Vhgm3yNwtDefsRcvmXyiXidCHRBoKk/ZRvO+9Ua7OiAMV/Q==
   dependencies:
     graceful-fs "4.2.3"
     iconv-lite-umd "0.6.8"

--- a/test/Exthost/HttpRequestTest.re
+++ b/test/Exthost/HttpRequestTest.re
@@ -1,6 +1,5 @@
 open TestFramework;
 
-open Oni_Core;
 open Exthost;
 
 let waitForMessage = (~name, f, context) => {

--- a/test/Exthost/HttpRequestTest.re
+++ b/test/Exthost/HttpRequestTest.re
@@ -1,0 +1,62 @@
+open TestFramework;
+
+open Oni_Core;
+open Exthost;
+
+let waitForMessage = (~name, f, context) => {
+  context
+  |> Test.waitForMessage(
+       ~name,
+       fun
+       | Msg.MessageService(ShowMessage({message, severity, _})) =>
+         f(severity, message)
+       | _ => false,
+     );
+};
+
+describe("HttpRequestTest", ({test, _}) => {
+  test("Execute a (url, cb) request in extension host", _ => {
+    Test.startWithExtensions(["oni-http-request"])
+    |> Test.waitForExtensionActivation("oni-http-request")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="http.request2",
+         ),
+       )
+    |> waitForMessage(~name="request success", (severity, message) =>
+         switch (severity) {
+         | Info => true
+         | Error => 
+         prerr_endline ("Got error: " ++ message);
+         false
+         | _ => assert(false)
+         }
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+
+  // Regression test for #2981 - ensure 3-param requests work correctly
+  test("#2981: Execute a (url, options, cb) request in extension host", _ => {
+    Test.startWithExtensions(["oni-http-request"])
+    |> Test.waitForExtensionActivation("oni-http-request")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="http.request3",
+         ),
+       )
+    |> waitForMessage(~name="request success", (severity, message) =>
+         switch (severity) {
+         | Info => true
+         | Error => 
+         prerr_endline ("Got error: " ++ message);
+         false
+         | _ => assert(false)
+         }
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+});

--- a/test/Exthost/HttpRequestTest.re
+++ b/test/Exthost/HttpRequestTest.re
@@ -24,18 +24,19 @@ describe("HttpRequestTest", ({test, _}) => {
            ~command="http.request2",
          ),
        )
-    |> waitForMessage(~name="request success", (severity, message) =>
+    |> waitForMessage(
+         ~name="wait for request result (2-param)", (severity, message) =>
          switch (severity) {
          | Info => true
-         | Error => 
-         prerr_endline ("Got error: " ++ message);
-         false
+         | Error =>
+           prerr_endline("Got error: " ++ message);
+           false;
          | _ => assert(false)
          }
        )
     |> Test.terminate
     |> Test.waitForProcessClosed
-  })
+  });
 
   // Regression test for #2981 - ensure 3-param requests work correctly
   test("#2981: Execute a (url, options, cb) request in extension host", _ => {
@@ -47,16 +48,17 @@ describe("HttpRequestTest", ({test, _}) => {
            ~command="http.request3",
          ),
        )
-    |> waitForMessage(~name="request success", (severity, message) =>
+    |> waitForMessage(
+         ~name="wait for request result (3-param)", (severity, message) =>
          switch (severity) {
          | Info => true
-         | Error => 
-         prerr_endline ("Got error: " ++ message);
-         false
+         | Error =>
+           prerr_endline("Got error: " ++ message);
+           false;
          | _ => assert(false)
          }
        )
     |> Test.terminate
     |> Test.waitForProcessClosed
-  })
+  });
 });

--- a/test/collateral/extensions/oni-http-request/extension.js
+++ b/test/collateral/extensions/oni-http-request/extension.js
@@ -12,7 +12,7 @@ const https = require('https');
 function activate(context) {
 	context.subscriptions.push(
 		// Execute a 2-parameter request against an https object
-		vscode.commands.registerCommand('http.request2', (args) => {
+		vscode.commands.registerCommand('http.request2', (_args) => {
 			const req = https.request("https://httpbin.org/json", (res) => {
 				if (res.statusCode == 200) {
 					vscode.window.showInformationMessage('success');
@@ -35,7 +35,7 @@ function activate(context) {
 		// This exercises the same failure that was causing #2981 -
 		// the [agent-base] NPM package overriding the https.request,
 		// only handling 2-param arguments.
-		vscode.commands.registerCommand('http.request3', (args) => {
+		vscode.commands.registerCommand('http.request3', (_args) => {
 			const req = https.request("https://httpbin.org/json", { agent: false }, (res) => {
 				if (res.statusCode == 200) {
 					vscode.window.showInformationMessage('success');

--- a/test/collateral/extensions/oni-http-request/extension.js
+++ b/test/collateral/extensions/oni-http-request/extension.js
@@ -1,0 +1,60 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+const https = require('https');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+	context.subscriptions.push(
+		// Execute a 2-parameter request against an https object
+		vscode.commands.registerCommand('http.request2', (args) => {
+			const req = https.request("https://httpbin.org/json", (res) => {
+				if (res.statusCode == 200) {
+					vscode.window.showInformationMessage('success');
+				} else {
+					vscode.window.showErrorMessage('Unexpected status code: ' + res.statusCode)
+				}
+			});
+
+			req.on('error', (e) => {
+				vscode.window.showErrorMessage('Error: ' + e)
+			});
+
+			req.end();
+
+		})
+	);
+
+	context.subscriptions.push(
+		// Execute a 2-parameter request against an https object
+		vscode.commands.registerCommand('http.request3', (args) => {
+			const req = https.request("https://httpbin.org/json", { agent: false }, (res) => {
+				if (res.statusCode == 200) {
+					vscode.window.showInformationMessage('success');
+				} else {
+					vscode.window.showErrorMessage('Unexpected status code: ' + res.statusCode)
+				}
+			});
+
+			req.on('error', (e) => {
+				vscode.window.showErrorMessage('Error: ' + e)
+			});
+
+			req.end();
+
+		})
+	);
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-http-request/extension.js
+++ b/test/collateral/extensions/oni-http-request/extension.js
@@ -31,7 +31,10 @@ function activate(context) {
 	);
 
 	context.subscriptions.push(
-		// Execute a 2-parameter request against an https object
+		// Execute a 3-parameter request against an https object
+		// This exercises the same failure that was causing #2981 -
+		// the [agent-base] NPM package overriding the https.request,
+		// only handling 2-param arguments.
 		vscode.commands.registerCommand('http.request3', (args) => {
 			const req = https.request("https://httpbin.org/json", { agent: false }, (res) => {
 				if (res.statusCode == 200) {

--- a/test/collateral/extensions/oni-http-request/package.json
+++ b/test/collateral/extensions/oni-http-request/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "oni-http-request",
+	"description": "HTTP Request extension for Onivim tests",
+	"version": "0.0.1",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": ["*"],
+	"main": "./extension.js",
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}


### PR DESCRIPTION
__Issue:__ The terraform extension was failing with an error:

> Error: Activating 'hashicorp terraform' failed: The "listener" argument must be of type function. Received an instance of Object

__Defect:__ The extension was crashing here:
```
	https.request(url, options, res => {
			if (res.statusCode === 301 || res.statusCode === 302) { // follow redirects
				return resolve(httpsRequest(res.headers.location, options, encoding));
			}
```
when trying to resolve download locations for terraform releases. This was not specific to this plugin, but actually could crash in any 3-param call to `https.request`. (There are two overloads - a `https.request(options, cb)`, and `https.request(url, options.cb)`.

Because of the `agent-base` dependency that is brought in the node environment, it overwrites the `https.request` handler such that only the 2-param overload is accepted. More info here: https://github.com/microsoft/vscode/issues/93167

__Fix:__ Update the `proxyResolver` code to only use the 2-param overload in our node environment, which the extension host is running in - https://github.com/onivim/vscode-exthost/pull/30 . Add some test cases to ensure that both overloads can make requests

With this fix, as the language server now gets installed, get some basic language features (diagnostics, some completion, and outline) for terraform files:
![image](https://user-images.githubusercontent.com/13532591/104756239-6b867800-5710-11eb-8aff-cfd082ce0f1b.png)

Fixes #2981 
Related #1058 

Note that there is still a pending issue relating to the syntax highlights for terraform: https://github.com/onivim/oni2/issues/2220