### PR TITLE
docs(building): reorder instruction

### DIFF
--- a/docs/docs/for-developers/building.md
+++ b/docs/docs/for-developers/building.md
@@ -40,6 +40,13 @@ Some Linux distributions may need other packages:
 
 ## Build and Run
 
+### Clone repository
+
+```sh
+git clone https://github.com/onivim/oni2
+cd oni2
+```
+
 ### Install node dependencies
 
 ```sh
@@ -58,9 +65,6 @@ node install-node-deps.js
 > __NOTE:__ On macOS, if you receive an `error: Too many open files`, you can run `ulimit -Sn 4096` to increase the file limit. More info at [esy/esy#1057](https://github.com/esy/esy/issues/1057)
 
 ```sh
-git clone https://github.com/onivim/oni2
-cd oni2
-
 # Install dependencies in package.json
 esy install
 


### PR DESCRIPTION
The first step on [Building from Source](https://onivim.github.io/docs/for-developers/building) should be cloning the repo and cd'ing into it. 

I had my friend asking me where can they get `install-node-deps.js` from. If we were to clone repo firstly, cd into it, all the following commands in the instructions work out of the box.

Removing clone from down the line, moving it as one of the top steps.