### PR TITLE
fix(syntax/#2985): PHP syntax highlights not showing

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -57,6 +57,7 @@
 - #2990 - Signature Help: Fix blocking `esc` key press back to normal mode
 - #2991 - OSX: Fix shortcut keys double-triggering events
 - #2993 - CodeLens: Handle null command id & label icons
+- #2997 - Syntax: Fix regression in syntax highlighting for PHP (fixes #2985)
 
 ### Performance
 

--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -35,20 +35,6 @@
 				"language": "php",
 				"scopeName": "source.php",
 				"path": "./syntaxes/php.tmLanguage.json"
-			},
-			{
-				"language": "php",
-				"scopeName": "text.html.php",
-				"path": "./syntaxes/html.tmLanguage.json",
-				"embeddedLanguages": {
-					"text.html": "html",
-					"source.php": "php",
-					"source.sql": "sql",
-					"text.xml": "xml",
-					"source.js": "javascript",
-					"source.json": "json",
-					"source.css": "css"
-				}
 			}
 		],
 		"snippets": [

--- a/integration_test/SyntaxHighlightPhpTest.re
+++ b/integration_test/SyntaxHighlightPhpTest.re
@@ -2,27 +2,26 @@ open Oni_Core;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
-let uniqueColorCount: list(ThemeToken.t) => int = tokens => {
+let uniqueColorCount: list(ThemeToken.t) => int =
+  tokens => {
+    let rec loop = (uniqueCount, maybeLastForeground, tokens) => {
+      switch (tokens) {
+      | [] => uniqueCount
+      | [(hd: ThemeToken.t), ...tail] =>
+        switch (maybeLastForeground) {
+        | None => loop(uniqueCount + 1, Some(hd.foregroundColor), tail)
+        | Some(color) =>
+          if (Revery.Color.equals(color, hd.foregroundColor)) {
+            loop(uniqueCount, Some(hd.foregroundColor), tail);
+          } else {
+            loop(uniqueCount + 1, Some(hd.foregroundColor), tail);
+          }
+        }
+      };
+    };
 
-  let rec loop = (uniqueCount, maybeLastForeground, tokens) => {
-    switch (tokens) {
-    | [] => uniqueCount
-    | [(hd: ThemeToken.t), ...tail] => 
-      switch (maybeLastForeground) {
-      | None => 
-      loop(uniqueCount + 1, Some(hd.foregroundColor), tail)
-      | Some(color) => 
-        if(Revery.Color.equals(color, hd.foregroundColor)) {
-        loop(uniqueCount, Some(hd.foregroundColor), tail)
-      } else {
-        loop(uniqueCount + 1, Some(hd.foregroundColor), tail)
-      }
-      }
-    }
-  }
-
-  loop(0, None, tokens);
-};
+    loop(0, None, tokens);
+  };
 
 // Integration test - verify we get highlights for PHP
 // Regression test for #2985
@@ -40,8 +39,7 @@ runTest(~name="SyntaxHighlightPhpTest", ({dispatch, wait, _}) => {
   dispatch(Actions.OpenFileByPath(testFile, None, None));
 
   // Wait for highlights to show up
-  wait(
-    ~name="Verify we get syntax highlights", (state: State.t) => {
+  wait(~name="Verify we get syntax highlights", (state: State.t) => {
     state
     |> Selectors.getActiveBuffer
     |> Option.map(Buffer.getId)
@@ -53,13 +51,9 @@ runTest(~name="SyntaxHighlightPhpTest", ({dispatch, wait, _}) => {
              state.syntaxHighlights,
            );
 
+         let uniqueTokenColors = tokens |> uniqueColorCount;
 
-         let uniqueTokenColors = tokens
-         |> uniqueColorCount;
-
-         prerr_endline ("TOKENS: " ++ string_of_int(List.length(tokens)));
-         prerr_endline ("UNIQUE token colors: " ++ string_of_int(uniqueTokenColors));
-         uniqueTokenColors > 1
+         uniqueTokenColors > 1;
        })
     |> Option.value(~default=false)
   });

--- a/integration_test/SyntaxHighlightPhpTest.re
+++ b/integration_test/SyntaxHighlightPhpTest.re
@@ -1,0 +1,66 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+let uniqueColorCount: list(ThemeToken.t) => int = tokens => {
+
+  let rec loop = (uniqueCount, maybeLastForeground, tokens) => {
+    switch (tokens) {
+    | [] => uniqueCount
+    | [(hd: ThemeToken.t), ...tail] => 
+      switch (maybeLastForeground) {
+      | None => 
+      loop(uniqueCount + 1, Some(hd.foregroundColor), tail)
+      | Some(color) => 
+        if(Revery.Color.equals(color, hd.foregroundColor)) {
+        loop(uniqueCount, Some(hd.foregroundColor), tail)
+      } else {
+        loop(uniqueCount + 1, Some(hd.foregroundColor), tail)
+      }
+      }
+    }
+  }
+
+  loop(0, None, tokens);
+};
+
+// Integration test - verify we get highlights for PHP
+// Regression test for #2985
+runTest(~name="SyntaxHighlightPhpTest", ({dispatch, wait, _}) => {
+  wait(~name="Capture initial state", (state: State.t) =>
+    Selectors.mode(state) |> Vim.Mode.isNormal
+  );
+  wait(~name="Wait for syntax server", ~timeout=10.0, (state: State.t) => {
+    Feature_Syntax.isSyntaxServerRunning(state.syntaxHighlights)
+  });
+
+  let testFile = getAssetPath("test-syntax.php");
+
+  // Create a buffer
+  dispatch(Actions.OpenFileByPath(testFile, None, None));
+
+  // Wait for highlights to show up
+  wait(
+    ~name="Verify we get syntax highlights", (state: State.t) => {
+    state
+    |> Selectors.getActiveBuffer
+    |> Option.map(Buffer.getId)
+    |> Option.map(bufferId => {
+         let tokens =
+           Feature_Syntax.getTokens(
+             ~bufferId,
+             ~line=EditorCoreTypes.LineNumber.(zero),
+             state.syntaxHighlights,
+           );
+
+
+         let uniqueTokenColors = tokens
+         |> uniqueColorCount;
+
+         prerr_endline ("TOKENS: " ++ string_of_int(List.length(tokens)));
+         prerr_endline ("UNIQUE token colors: " ++ string_of_int(uniqueTokenColors));
+         uniqueTokenColors > 1
+       })
+    |> Option.value(~default=false)
+  });
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -19,11 +19,11 @@
    RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
    RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
    RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
-   SCMGitTest SyntaxHighlightPhpTest SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
-   AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
-   TypingBatchedTest TypingUnbatchedTest VimSimpleRemapTest
-   VimlRemapCmdlineTest ClipboardChangeTest VimScriptLocalFunctionTest
-   ZenModeSingleFileModeTest ZenModeSplitTest)
+   SCMGitTest SyntaxHighlightPhpTest SyntaxHighlightTextMateTest
+   SyntaxHighlightTreesitterTest AddRemoveSplitTest TerminalSetPidTitleTest
+   TerminalConfigurationTest TypingBatchedTest TypingUnbatchedTest
+   VimSimpleRemapTest VimlRemapCmdlineTest ClipboardChangeTest
+   VimScriptLocalFunctionTest ZenModeSingleFileModeTest ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
@@ -54,13 +54,12 @@
    SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
    SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
    SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
-   SyntaxHighlightPhpTest.exe
-   SyntaxServerParentPidTest.exe SyntaxServerParentPidCorrectTest.exe
-   SyntaxServerReadExceptionTest.exe TerminalSetPidTitleTest.exe
-   TerminalConfigurationTest.exe AddRemoveSplitTest.exe TypingBatchedTest.exe
-   TypingUnbatchedTest.exe VimScriptLocalFunctionTest.exe
-   VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
-   ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe ClipboardChangeTest.exe
-   large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
-   test.lf test-syntax.php utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf
-   PlugScriptLocal.vim))
+   SyntaxHighlightPhpTest.exe SyntaxServerParentPidTest.exe
+   SyntaxServerParentPidCorrectTest.exe SyntaxServerReadExceptionTest.exe
+   TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
+   AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
+   VimScriptLocalFunctionTest.exe VimSimpleRemapTest.exe
+   VimlRemapCmdlineTest.exe ZenModeSingleFileModeTest.exe
+   ZenModeSplitTest.exe ClipboardChangeTest.exe large-c-file.c lsan.supp
+   some-test-file.json some-test-file.txt test.crlf test.lf test-syntax.php
+   utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf PlugScriptLocal.vim))

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -19,7 +19,7 @@
    RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
    RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
    RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
-   SCMGitTest SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
+   SCMGitTest SyntaxHighlightPhpTest SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
    AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
    TypingBatchedTest TypingUnbatchedTest VimSimpleRemapTest
    VimlRemapCmdlineTest ClipboardChangeTest VimScriptLocalFunctionTest
@@ -54,6 +54,7 @@
    SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
    SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
    SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
+   SyntaxHighlightPhpTest.exe
    SyntaxServerParentPidTest.exe SyntaxServerParentPidCorrectTest.exe
    SyntaxServerReadExceptionTest.exe TerminalSetPidTitleTest.exe
    TerminalConfigurationTest.exe AddRemoveSplitTest.exe TypingBatchedTest.exe
@@ -61,5 +62,5 @@
    VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
    ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe ClipboardChangeTest.exe
    large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
-   test.lf utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf
+   test.lf test-syntax.php utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf
    PlugScriptLocal.vim))

--- a/integration_test/test-syntax.php
+++ b/integration_test/test-syntax.php
@@ -1,0 +1,1 @@
+<?php echo "Hello, world!" ?>

--- a/src/Core/ThemeToken.re
+++ b/src/Core/ThemeToken.re
@@ -30,8 +30,8 @@ let toString =
   Printf.sprintf(
     "ColorizedToken - index: %d foreground: %s background: %s scope: %s bold: %b italic: %b",
     index,
-    backgroundColor |> Revery.Color.toString,
     foregroundColor |> Revery.Color.toString,
+    backgroundColor |> Revery.Color.toString,
     syntaxScope |> SyntaxScope.toString,
     bold,
     italic,


### PR DESCRIPTION
__Issue:__ PHP syntax highlights are no longer showing by default

__Defect:__ https://github.com/onivim/oni2/pull/2889 upgraded the extensions, but the PHP extension has a new dependency on `embeddedLanguages`, which our current textmate implementation does not handle correctly

__Fix:__ Remove the `embeddedLanguages` for now - add a regression / canary test to ensure we don't break this in the future.

Fixes #2985 
Tracking `embeddedLanguage` support in #2998