### PR TITLE
fix(extension/#2640): Elm - Fix diagnostic display

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -58,6 +58,7 @@
 - #2991 - OSX: Fix shortcut keys double-triggering events
 - #2993 - CodeLens: Handle null command id & label icons
 - #2995 - Extensions: Fix bug with 3-param http/https request (fixes #2981)
+- #2999 - Extensions: Elm - fix bug with diagnostics not displaying (fixes #2640)
 
 ### Performance
 

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -70,6 +70,13 @@ module Effects = {
           dispatch(toMsg());
         })
       );
+
+    let modelSaved = (~uri, client, toMsg) => {
+      Isolinear.Effect.createWithDispatch(~name="exthost.modelSaved", dispatch => {
+        Exthost.Request.Documents.acceptModelSaved(~uri, client);
+        dispatch(toMsg());
+      });
+    };
   };
   module FileSystemEventService = {
     let onFileEvent = (~events, extHostClient) =>

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -33,6 +33,10 @@ module Effects: {
         unit => 'msg
       ) =>
       Isolinear.Effect.t('msg);
+
+    let modelSaved:
+      (~uri: Oni_Core.Uri.t, Exthost.Client.t, unit => 'msg) =>
+      Isolinear.Effect.t('msg);
   };
 
   module FileSystemEventService: {

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1115,7 +1115,13 @@ let update =
             },
           extHostClient,
         );
-      (state, eff);
+
+      let modelSavedEff =
+        Service_Exthost.Effects.Documents.modelSaved(
+          ~uri=Buffer.getUri(buffer), extHostClient, () =>
+          Noop
+        );
+      (state, Isolinear.Effect.batch([eff, modelSavedEff]));
 
     | BufferUpdated({update, newBuffer, oldBuffer, triggerKey}) =>
       let fileType =


### PR DESCRIPTION
__Issue:__ Diagnostics weren't displaying in the elm extension

__Defect:__ Diagnostics are computed on save, but we weren't sending the appropriate event to the extension host to let it know when a save occurred.

__Fix:__ Notify extension host on save

With that, we get diagnostics:
![image](https://user-images.githubusercontent.com/13532591/104788805-02225b80-5748-11eb-819b-2f5dc06b2b6d.png)

Fixes #2640 
Related #1058 