### PR TITLE
fix(extensions/#2979): fix order of extensions

### DIFF
--- a/src/Service/Extensions/Sub.re
+++ b/src/Service/Extensions/Sub.re
@@ -32,7 +32,7 @@ module SearchSub =
               maybeRemainingCount:
                 Some(totalSize - offset - newExtensionCount),
               searchText: query.searchText,
-              items: extensions @ query.items,
+              items: query.items @ extensions,
             };
           dispatch(Ok(newQuery));
         },


### PR DESCRIPTION
With the current implementation, subsequent subquery was prepending the
results to the previous results while we should be appending and thus
keeping the sought match at the top

Previously:
![ExtensionSearch](https://user-images.githubusercontent.com/7096437/104790103-e5614480-5796-11eb-80bb-31e8ab50ec17.gif)

New:
![ExtensionSearchNew](https://user-images.githubusercontent.com/7096437/104790496-a4b5fb00-5797-11eb-9459-821b201a8acf.gif)

