### PR TITLE
fix(signature-help): Fix warning for 'editor.parameterHints.enabled' default

### DIFF
--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -506,7 +506,8 @@ module Contributions = {
   let configuration =
     CodeLens.Contributions.configuration
     @ Completion.Contributions.configuration
-    @ DocumentHighlights.Contributions.configuration;
+    @ DocumentHighlights.Contributions.configuration
+    @ SignatureHelp.Contributions.configuration;
 
   let contextKeys =
     [


### PR DESCRIPTION
Missed wiring up configuration defaults in #2990 