### PR TITLE
fix(codelens): Handle $emitCodeLens event

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -60,6 +60,7 @@
 - #2997 - Syntax: Fix regression in syntax highlighting for PHP (fixes #2985)
 - #2995 - Extensions: Fix bug with 3-param http/https request (fixes #2981)
 - #2999 - Extensions: Elm - fix bug with diagnostics not displaying (fixes #2640)
+- #3003 - Extensions: CodeLens - Handle the `$emitCodeLens` event
 
 ### Performance
 

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -710,7 +710,7 @@ module LanguageFeatures = {
     | EmitCodeLensEvent({
         eventHandle: int,
         event: Yojson.Safe.t,
-      }) // ??
+      })
     | RegisterCodeLensSupport({
         handle: int,
         selector: DocumentSelector.t,
@@ -842,8 +842,13 @@ module LanguageFeatures = {
         Ok(RegisterDocumentHighlightProvider({handle, selector}))
       | Error(error) => Error(Json.Decode.string_of_error(error))
       }
+
+    | ("$emitCodeLensEvent", `List([`Int(eventHandle)])) =>
+      Ok(EmitCodeLensEvent({eventHandle, event: `Null}))
+
     | ("$emitCodeLensEvent", `List([`Int(eventHandle), json])) =>
       Ok(EmitCodeLensEvent({eventHandle, event: json}))
+
     | (
         "$registerCodeLensSupport",
         `List([handleJson, selectorJson, eventHandleJson]),

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -135,8 +135,18 @@ let update =
     )
   | Pasted(_) => (model, Nothing)
 
-  | Exthost(RegisterCodeLensSupport({handle, selector, _})) =>
-    let codeLens' = CodeLens.register(~handle, ~selector, model.codeLens);
+  | Exthost(EmitCodeLensEvent({eventHandle, _})) =>
+    let codeLens' = CodeLens.emit(~eventHandle, model.codeLens);
+    ({...model, codeLens: codeLens'}, Nothing);
+
+  | Exthost(RegisterCodeLensSupport({handle, selector, eventHandle})) =>
+    let codeLens' =
+      CodeLens.register(
+        ~handle,
+        ~selector,
+        ~maybeEventHandle=eventHandle,
+        model.codeLens,
+      );
     ({...model, codeLens: codeLens'}, Nothing);
 
   | Exthost(RegisterDefinitionSupport({handle, selector})) =>

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -681,19 +681,21 @@ module Sub = {
 
   type codeLensesParams = {
     handle: int,
+    eventTick: int,
     client: Exthost.Client.t,
     buffer: Oni_Core.Buffer.t,
     startLine: int, // One-based start line
     stopLine: int // One-based stop line
   };
 
-  let idFromBufferRange = (~handle, ~buffer, ~startLine) => {
+  let idForCodeLens = (~handle, ~buffer, ~startLine, ~eventTick) => {
     Printf.sprintf(
-      "%d-%d-%d:%d",
+      "%d-%d-%d:%d-%d",
       handle,
       Oni_Core.Buffer.getId(buffer),
       Oni_Core.Buffer.getVersion(buffer),
       startLine,
+      eventTick,
     );
   };
 
@@ -708,8 +710,8 @@ module Sub = {
       };
 
       let name = "Service_Exthost.CodeLensesSubscription";
-      let id = ({handle, buffer, startLine, _}: params) =>
-        idFromBufferRange(~handle, ~buffer, ~startLine);
+      let id = ({handle, buffer, startLine, eventTick, _}: params) =>
+        idForCodeLens(~handle, ~buffer, ~startLine, ~eventTick);
 
       let init = (~params, ~dispatch) => {
         let active = ref(true);
@@ -799,11 +801,12 @@ module Sub = {
       };
     });
 
-  let codeLenses = (~handle, ~buffer, ~startLine, ~stopLine, ~toMsg, client) => {
+  let codeLenses =
+      (~handle, ~eventTick, ~buffer, ~startLine, ~stopLine, ~toMsg, client) => {
     let startLine = EditorCoreTypes.LineNumber.toOneBased(startLine);
     let stopLine = EditorCoreTypes.LineNumber.toOneBased(stopLine);
     CodeLensesSubscription.create(
-      {handle, buffer, client, startLine, stopLine}: codeLensesParams,
+      {handle, buffer, client, startLine, stopLine, eventTick}: codeLensesParams,
     )
     |> Isolinear.Sub.map(toMsg);
   };

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -131,6 +131,7 @@ module Sub: {
   let codeLenses:
     (
       ~handle: int,
+      ~eventTick: int,
       ~buffer: Oni_Core.Buffer.t,
       ~startLine: EditorCoreTypes.LineNumber.t,
       ~stopLine: EditorCoreTypes.LineNumber.t,


### PR DESCRIPTION
__Issue:__ The codelens feature for the [VersionLens](https://open-vsx.org/extension/pflannery/vscode-versionlens) plugin wasn't showing up until the editor is scrolled.

__Defect:__ Some extensions, like VersionLens will change codelens on the fly, or via a command, and they would message that to the editor via the exthost `$emitCodeLens` event. We weren't handling this event, so we didn't know to refresh the codelens.

__Fix:__ Handle the `$emitCodeLens` event, wire up to the provider / subscription via an `eventTick` property - always  refresh the subscription when that property changes.

This fix enables the VersionLens plugin:

![2021-01-16 09 48 53](https://user-images.githubusercontent.com/13532591/104819133-56791a00-57e0-11eb-885b-3e0f76473583.gif)

Related #1058 

