### PR TITLE
fix(extension/#2676): Part 1 - Fix error message with missing extension dependency

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+ - #3007 - Extensions: Show 'missing dependency' activation error to user
+
 ### Performance
 
 ### Documentation

--- a/src/Exthost/ExtensionActivationError.re
+++ b/src/Exthost/ExtensionActivationError.re
@@ -1,5 +1,6 @@
 open Oni_Core;
 
+[@deriving show]
 type t =
   | Message(string)
   | MissingDependency(ExtensionId.t);
@@ -9,7 +10,7 @@ let toString =
   | Message(str) => str
   | MissingDependency(extensionId) =>
     Printf.sprintf(
-      "Missing extension dependency missing: %s",
+      "Missing required extension: %s",
       ExtensionId.toString(extensionId),
     );
 

--- a/src/Exthost/ExtensionActivationError.re
+++ b/src/Exthost/ExtensionActivationError.re
@@ -1,0 +1,31 @@
+open Oni_Core;
+
+type t =
+  | Message(string)
+  | MissingDependency(ExtensionId.t);
+
+let toString =
+  fun
+  | Message(str) => str
+  | MissingDependency(extensionId) =>
+    Printf.sprintf(
+      "Missing extension dependency missing: %s",
+      ExtensionId.toString(extensionId),
+    );
+
+module Decode = {
+  open Json.Decode;
+  let message = string |> map(str => Message(str));
+
+  let missingDependency =
+    obj(({field, _}) => {field.required("dependency", ExtensionId.decode)})
+    |> map(extensionId => MissingDependency(extensionId));
+
+  let decode =
+    one_of([
+      ("message", message),
+      ("missingDependency", missingDependency),
+    ]);
+};
+
+let decode = Decode.decode;

--- a/src/Exthost/ExtensionId.re
+++ b/src/Exthost/ExtensionId.re
@@ -15,3 +15,5 @@ let decode =
   );
 
 let encode = Json.Encode.string;
+
+let toString = Fun.id;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -19,6 +19,7 @@ module DocumentSelector = DocumentSelector;
 module DocumentSymbol = DocumentSymbol;
 module Edit = Edit;
 module Eol = Eol;
+module ExtensionActivationError = ExtensionActivationError;
 module ExtensionActivationReason = ExtensionActivationReason;
 module ExtensionId = ExtensionId;
 module Files = Files;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -146,6 +146,13 @@ module Edit: {
   };
 };
 
+module ExtensionActivationError: {
+  [@deriving show]
+  type t =
+    | Message(string)
+    | MissingDependency(ExtensionId.t);
+};
+
 module ExtensionActivationReason: {
   type t;
 
@@ -158,6 +165,8 @@ module ExtensionActivationReason: {
 module ExtensionId: {
   [@deriving show]
   type t = string;
+
+  let toString: t => string;
 
   let decode: Json.decoder(t);
 };

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1224,7 +1224,10 @@ module Msg: {
           extensionId: ExtensionId.t,
           error: ExtensionActivationError.t,
         })
-      | ExtensionRuntimeError({extensionId: ExtensionId.t, errorsJson: list(Yojson.Safe.t)});
+      | ExtensionRuntimeError({
+          extensionId: ExtensionId.t,
+          errorsJson: list(Yojson.Safe.t),
+        });
   };
 
   module FileSystem: {

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -151,6 +151,8 @@ module ExtensionActivationError: {
   type t =
     | Message(string)
     | MissingDependency(ExtensionId.t);
+
+  let toString: t => string;
 };
 
 module ExtensionActivationReason: {
@@ -182,17 +184,6 @@ module DefinitionLink: {
 
   let decode: Json.decoder(t);
 };
-
-// module DocumentFilter: {
-//   [@deriving show]
-//   type t;
-
-//   let matches: (~filetype: string, t) => bool;
-
-//   let decode: Json.decoder(t);
-
-//   let toString: t => string;
-// };
 
 module DocumentSelector: {
   [@deriving show]
@@ -1229,12 +1220,11 @@ module Msg: {
           activateCallTime: int,
           activateResolvedTime: int,
         })
-      //activationEvent: option(string),
       | ExtensionActivationError({
           extensionId: ExtensionId.t,
-          errorMessage: string,
+          error: ExtensionActivationError.t,
         })
-      | ExtensionRuntimeError({extensionId: ExtensionId.t});
+      | ExtensionRuntimeError({extensionId: ExtensionId.t, errorsJson: list(Yojson.Safe.t)});
   };
 
   module FileSystem: {

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -542,7 +542,10 @@ module ExtensionService = {
         extensionId: ExtensionId.t,
         error: ExtensionActivationError.t,
       })
-    | ExtensionRuntimeError({extensionId: ExtensionId.t, errorsJson: list(Yojson.Safe.t)});
+    | ExtensionRuntimeError({
+        extensionId: ExtensionId.t,
+        errorsJson: list(Yojson.Safe.t),
+      });
 
   let handle = (method, args: Yojson.Safe.t) => {
     Base.Result.Let_syntax.(
@@ -603,10 +606,13 @@ module ExtensionService = {
               activateResolvedTime,
             }),
           );
-        | ("$onExtensionRuntimeError", `List([extensionIdJson, ...errorsJson])) =>
+        | (
+            "$onExtensionRuntimeError",
+            `List([extensionIdJson, ...errorsJson]),
+          ) =>
           let%bind extensionId =
             extensionIdJson |> Internal.decode_value(ExtensionId.decode);
-          Ok(ExtensionRuntimeError({extensionId: extensionId, errorsJson}));
+          Ok(ExtensionRuntimeError({extensionId, errorsJson}));
 
         | _ => Error("Unhandled method: " ++ method)
         };

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -616,9 +616,10 @@ let update = (~extHostClient, msg, model) => {
         Printf.sprintf(
           "Extension runtime error %s:%s",
           Exthost.ExtensionId.toString(extensionId),
-          Yojson.Safe.to_string(`List(errorsJson))
+          Yojson.Safe.to_string(`List(errorsJson)),
         ),
-      ))
+      ),
+    )
 
   | Exthost(ActivateExtension({extensionId, _})) => (
       Internal.markActivated(extensionId, model),

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -608,15 +608,31 @@ let getExtensions = Internal.getExtensions;
 
 let update = (~extHostClient, msg, model) => {
   switch (msg) {
-  | Exthost(WillActivateExtension(_))
-  | Exthost(ExtensionRuntimeError(_)) => (model, Nothing)
+  | Exthost(WillActivateExtension(_)) => (model, Nothing)
+
+  | Exthost(ExtensionRuntimeError({extensionId, errorsJson})) => (
+      model,
+      NotifyFailure(
+        Printf.sprintf(
+          "Extension runtime error %s:%s",
+          Exthost.ExtensionId.toString(extensionId),
+          Yojson.Safe.to_string(`List(errorsJson))
+        ),
+      ))
+
   | Exthost(ActivateExtension({extensionId, _})) => (
       Internal.markActivated(extensionId, model),
       Nothing,
     )
-  | Exthost(ExtensionActivationError({errorMessage, _})) => (
+  | Exthost(ExtensionActivationError({error, extensionId})) => (
       model,
-      NotifyFailure(Printf.sprintf("Error: %s", errorMessage)),
+      NotifyFailure(
+        Printf.sprintf(
+          "Error activating extension %s: %s",
+          Exthost.ExtensionId.toString(extensionId),
+          Exthost.ExtensionActivationError.toString(error),
+        ),
+      ),
     )
   | Exthost(DidActivateExtension({extensionId, _})) => (
       Internal.markActivated(extensionId, model),


### PR DESCRIPTION
__Issue:__ When an extension has a required dependency that is not installed, Onivim would fail to activate the extension silently.

__Defect:__ Onivim was not properly handling the extension activation error - usually, it's a `string`, but in the case of a missing dependency, it is a JSON object - the parser was only handling the string case.

__Fix:__ Implement a decoder to handle either case. Bubble up the activation error to the user.

Related #2676 
Related #1058 