### PR TITLE
fix(scm): Index out of bounds when rendering EditorDiffMarkers

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+- #3008 - SCM: Fix index-out-of-bound exception when rendering diff markers
+
 ### Performance
 
 ### Documentation

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -2,15 +2,33 @@ open Oni_Core;
 
 open Revery.Draw;
 
+module Log = (
+  val Oni_Core.Log.withNamespace("Feature_Editor.EditorDiffMarkers")
+);
+
 [@deriving show({with_path: false})]
 type t = array(marker)
-
 and marker =
   | Modified
   | Added
   | DeletedBefore
   | DeletedAfter
   | Unmodified;
+
+let get = (~line: EditorCoreTypes.LineNumber.t, markers) => {
+  let lineIdx = line |> EditorCoreTypes.LineNumber.toZeroBased;
+
+  if (lineIdx < 0 || lineIdx >= Array.length(markers)) {
+    Log.warnf(m =>
+      m("Tried to request out-of-range marker at index: %d", lineIdx)
+    );
+    Unmodified;
+  } else {
+    markers[lineIdx];
+  };
+};
+
+let toArray = Fun.id;
 
 let generate = (~scm, buffer) =>
   Feature_SCM.getOriginalLines(buffer, scm)
@@ -119,11 +137,11 @@ let render =
   Draw.renderImmediate(
     ~context,
     (i, y) => {
-      let bufferLine =
-        Editor.viewLineToBufferLine(i, context.editor)
-        |> EditorCoreTypes.LineNumber.toZeroBased;
+      let line = Editor.viewLineToBufferLine(i, context.editor);
 
-      if (markers[bufferLine] != Unmodified) {
+      let marker = get(~line, markers);
+
+      if (marker != Unmodified) {
         renderMarker(
           ~x,
           ~y,
@@ -131,7 +149,7 @@ let render =
           ~width,
           ~canvasContext,
           ~colors,
-          markers[bufferLine],
+          marker,
         );
       };
     },
@@ -157,11 +175,10 @@ let renderMinimap =
     ~count,
     ~render=
       (i, y) => {
-        let bufferLine =
-          Editor.viewLineToBufferLine(i, editor)
-          |> EditorCoreTypes.LineNumber.toZeroBased;
+        let line = Editor.viewLineToBufferLine(i, editor);
 
-        if (markers[bufferLine] != Unmodified) {
+        let marker = get(~line, markers);
+        if (marker != Unmodified) {
           renderMarker(
             ~x,
             ~y=y -. scrollY,
@@ -169,7 +186,7 @@ let renderMinimap =
             ~width,
             ~canvasContext,
             ~colors,
-            markers[bufferLine],
+            marker,
           );
         };
       },

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -37,7 +37,7 @@ let generate = (~scm, buffer) =>
        // `deletes` is an array of bools the length of the originall lines array where `true` indicates the line has been deleted
        let (adds, deletes) = Diff.f(Buffer.getLines(buffer), originalLines);
 
-       // shift is he offset between lines that should match up at the current index;
+       // shift is the offset between lines that should match up at the current index;
        // ie. `deletes[i + shift] == adds[i]`
        let shift = ref(0);
 

--- a/src/Feature/Editor/EditorDiffMarkers.rei
+++ b/src/Feature/Editor/EditorDiffMarkers.rei
@@ -1,14 +1,18 @@
 open Oni_Core;
 
 [@deriving show]
-type t = array(marker)
+type t;
 
-and marker =
+type marker =
   | Modified
   | Added
   | DeletedBefore
   | DeletedAfter
   | Unmodified;
+
+let get: (~line: EditorCoreTypes.LineNumber.t, t) => marker;
+
+let toArray: t => array(marker);
 
 let generate: (~scm: Feature_SCM.model, Buffer.t) => option(t);
 

--- a/test/Feature/Editor/EditorDiffMarkersTest.re
+++ b/test/Feature/Editor/EditorDiffMarkersTest.re
@@ -19,7 +19,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|Unmodified, Unmodified, Added, Unmodified, Unmodified|]
@@ -38,7 +39,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|
@@ -65,7 +67,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Unmodified, DeletedBefore|]);
 
@@ -82,7 +85,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected = EditorDiffMarkers.([|DeletedBefore, Unmodified|]);
 
       switch (actual) {
@@ -98,7 +102,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected = EditorDiffMarkers.([|Unmodified, DeletedAfter|]);
 
       switch (actual) {
@@ -114,7 +119,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected = EditorDiffMarkers.([|DeletedBefore|]);
 
       switch (actual) {
@@ -130,7 +136,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Unmodified, Modified, Unmodified|]);
 
@@ -147,7 +154,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Modified, Modified, Unmodified|]);
 
@@ -164,7 +172,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|Unmodified, Modified, Added, Unmodified, Unmodified|]
@@ -183,7 +192,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Modified, DeletedBefore|]);
 
@@ -200,7 +210,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|
@@ -226,7 +237,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|
@@ -255,7 +267,8 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
+      let actual =
+        EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|

--- a/test/Feature/Editor/EditorDiffMarkersTest.re
+++ b/test/Feature/Editor/EditorDiffMarkersTest.re
@@ -19,7 +19,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|Unmodified, Unmodified, Added, Unmodified, Unmodified|]
@@ -38,7 +38,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|
@@ -65,7 +65,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Unmodified, DeletedBefore|]);
 
@@ -82,7 +82,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected = EditorDiffMarkers.([|DeletedBefore, Unmodified|]);
 
       switch (actual) {
@@ -98,7 +98,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected = EditorDiffMarkers.([|Unmodified, DeletedAfter|]);
 
       switch (actual) {
@@ -114,7 +114,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected = EditorDiffMarkers.([|DeletedBefore|]);
 
       switch (actual) {
@@ -130,7 +130,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Unmodified, Modified, Unmodified|]);
 
@@ -147,7 +147,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Modified, Modified, Unmodified|]);
 
@@ -164,7 +164,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|Unmodified, Modified, Added, Unmodified, Unmodified|]
@@ -183,7 +183,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.([|Unmodified, Modified, DeletedBefore|]);
 
@@ -200,7 +200,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|
@@ -226,7 +226,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|
@@ -255,7 +255,7 @@ describe("EditorDiffMarkers", ({describe, _}) => {
       let buffer = makeBuffer(now);
       let scm = scm(buffer, was);
 
-      let actual = EditorDiffMarkers.generate(~scm, buffer);
+      let actual = EditorDiffMarkers.(generate(~scm, buffer) |> Option.map(toArray));
       let expected =
         EditorDiffMarkers.(
           [|

--- a/test/OniUnitTestRunner.re
+++ b/test/OniUnitTestRunner.re
@@ -5,7 +5,6 @@ Oni_Core_Utility_Test.TestFramework.cli();
 Oni_Core_WhenExpr_Test.TestFramework.cli();
 Oni_Input_Test.TestFramework.cli();
 Oni_Model_Test.TestFramework.cli();
-Oni_UI_Test.TestFramework.cli();
 Oni_Syntax_Test.TestFramework.cli();
 Feature_Editor_Test.TestFramework.cli();
 Feature_LanguageSupport_Test.TestFramework.cli();

--- a/test/OniUnitTestRunnerUI.re
+++ b/test/OniUnitTestRunnerUI.re
@@ -1,2 +1,0 @@
-Oni_Core_Test.Helpers.allocateConsoleIfNecessary();
-Oni_UI_Test.TestFramework.cli();

--- a/test/UI/TestFramework.re
+++ b/test/UI/TestFramework.re
@@ -1,7 +1,0 @@
-include Rely.Make({
-  let config =
-    Rely.TestFrameworkConfig.initialize({
-      snapshotDir: "__snapshots__",
-      projectDir: "",
-    });
-});

--- a/test/UI/dune
+++ b/test/UI/dune
@@ -1,6 +1,0 @@
-(library
- (name Oni_UI_Test)
- (library_flags
-  (-linkall -g))
- (modules (:standard))
- (libraries Oni2.core Oni2.ui rely.lib))

--- a/test/dune
+++ b/test/dune
@@ -4,7 +4,7 @@
  (modules OniUnitTestRunner)
  (package OniUnitTestRunner)
  (libraries yojson Oni_Cli_Test Oni_Core_Test Oni_Input_Test Oni_Model_Test
-   Oni_UI_Test Oni_Syntax_Test Feature_Diagnostics_Test Feature_Editor_Test
+   Oni_Syntax_Test Feature_Diagnostics_Test Feature_Editor_Test
    Feature_LanguageSupport_Test Service_Extensions_Test Service_Net_Test
    Service_OS_Test EditorCoreTypes_Test EditorInput_Test
    Exthost_Transport_Test Exthost_Test Libvim_Test Oniguruma_Test
@@ -52,13 +52,6 @@
  (modules OniUnitTestRunnerModel)
  (package OniUnitTestRunner)
  (libraries yojson Oni_Core_Test Oni_Model_Test))
-
-(executable
- (name OniUnitTestRunnerUI)
- (public_name OniUnitTestRunnerUI)
- (modules OniUnitTestRunnerUI)
- (package OniUnitTestRunner)
- (libraries Oni_Core_Test Oni_UI_Test))
 
 (executable
  (name OniUnitTestRunnerExtHost)


### PR DESCRIPTION
__Issue:__ Encountered a crash with the callstack:
```
(Invalid_argument "index out of bounds"):
Raised by primitive operation at file "src/Feature/Editor/EditorDiffMarkers.re", line 126, characters 10-29
Called from file "src/Feature/Editor/Draw.re", line 55, characters 4-59
Called from file "option.ml" (inlined), line 26, characters 32-35
Called from file "src/Feature/Editor/GutterView.re", line 139, characters 2-243
Called from file "src/Feature/Editor/GutterView.re", line 192, characters 4-232
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "src/UI/CanvasNode.re", line 31, characters 6-110
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "list.ml", line 110, characters 12-15
Called from file "src/UI/Overflow.re", line 33, characters 2-5
Called from file "src/UI/Render.re", line 100, characters 6-19
Called from file "src/UI/Render.re", line 79, characters 2-1023
Called from file "src/Core/Window.re", line 399, characters 2-17
Called from file "list.ml", line 110, characters 12-15
Called from file "src/Core/App.re", line 298, characters 6-123
Called from file "packages/reason-sdl2/src/sdl2.re", line 823, characters 10-20
Called from file "packages/reason-sdl2/src/sdl2.re", line 269, characters 17-59
Called from file "packages/reason-sdl2/src/sdl2.re", line 269, characters 17-59
Called from file "src/bin_editor/Oni2_editor.re", line 511, characters 11-26
```

__Fix:__ Add bounds check prior to accessing diff marker 

In addition, the `EditorDiffMarkersTest` was the only test in our `UI` category, so move it alongside the other `Feature_Editor` tests.