### PR TITLE
fix(extensions/#2974): Add extension override for Ionide.Ionide-fsharp

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -5,6 +5,7 @@
 - #3008 - SCM: Fix index-out-of-bound exception when rendering diff markers
 - #3007 - Extensions: Show 'missing dependency' activation error to user
 - #3011 - Vim: Visual Block - Handle 'I' and 'A' in visual block mode (fixes #1633)
+- #3019 - Extensions: Fix activation error for Ionide.Ionide-fsharp extension (fixes #2974)
 
 ### Performance
 

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -13,6 +13,20 @@ module Identifier = {
 };
 
 module Hacks = {
+  let patchIonideDependencies = (dependencies: list(Yojson.Safe.t)) => {
+    dependencies
+    |> List.map(
+         fun
+         | `String(str) =>
+           if (str == "ms-dotnettools.csharp") {
+             `String("muhammad-sammy.csharp");
+           } else {
+             `String(str);
+           }
+         | json => json,
+       );
+  };
+
   // TEMPORARY workarounds for external bugs blocking extensions
   let hacks = [
     // Workaround for https://github.com/open-vsx/publish-extensions/issues/106
@@ -23,6 +37,17 @@ module Hacks = {
         fun
         | Some(`String(str)) => Some(`String(str))
         | _ => Some(`String("2020-08-04")),
+      ),
+    ),
+    (
+      // Workaround for https://github.com/onivim/oni2/issues/2974
+      "ionide.ionide-fsharp",
+      Utility.JsonEx.update(
+        "extensionDependencies",
+        fun
+        | Some(`List(dependencies)) =>
+          Some(`List(dependencies |> patchIonideDependencies))
+        | json => json,
       ),
     ),
   ];


### PR DESCRIPTION
__Issue:__ The Ionide.Ionide-fsharp extension depends on `ms-dotnettools.csharp`, which isn't available on open-vsx

__Fix:__ The best-case fix would be to have the ionide-fsharp extension published to open-vsx and have proper dependencies. In the meantime, add a temporary override to map `ms-dotnettols.csharp` -> `muhammad-sammy.csharp` to unblock the extension.

With this change - basic language features work:
![2021-01-14 16 37 31](https://user-images.githubusercontent.com/13532591/104665774-13effa00-5687-11eb-84f0-054bc8129c6f.gif)

Fixes #2974 
Related #1058 