### PR TITLE
fix(vim/#2968): Cursor management in command-line mode

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -5,6 +5,7 @@
 - #3008 - SCM: Fix index-out-of-bound exception when rendering diff markers
 - #3007 - Extensions: Show 'missing dependency' activation error to user
 - #3011 - Vim: Visual Block - Handle 'I' and 'A' in visual block mode (fixes #1633)
+- #3020 - Vim: Fix incsearch cursor movement (fixes #2968)
 
 ### Performance
 

--- a/integration_test/RegressionCommandLineNoCompletionTest.re
+++ b/integration_test/RegressionCommandLineNoCompletionTest.re
@@ -10,7 +10,7 @@ runTest(
   dispatch(KeyboardInput({isText: true, input: ":"}));
 
   wait(~name="Mode switches to command line", (state: State.t) =>
-    Selectors.mode(state) == Vim.Mode.CommandLine
+    Vim.Mode.isCommandLine(Selectors.mode(state))
   );
 
   dispatch(KeyboardInput({isText: true, input: "e"}));

--- a/integration_test/VimIncsearchScrollTest.re
+++ b/integration_test/VimIncsearchScrollTest.re
@@ -1,0 +1,65 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(~name="VimIncsearchScrollTest", ({dispatch, wait, input, key, _}) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    Selectors.mode(state) |> Vim.Mode.isNormal
+  );
+
+  let largeCFile = getAssetPath("large-c-file.c");
+  dispatch(Actions.OpenFileByPath(largeCFile, None, None));
+
+  // Wait for file to load
+  wait(
+    ~timeout=30.0,
+    ~name="Validate buffer is loaded",
+    (state: State.t) => {
+      let fileType =
+        Selectors.getActiveBuffer(state)
+        |> Option.map(Buffer.getFileType)
+        |> Option.map(Buffer.FileType.toString);
+
+      fileType == Some("c");
+    },
+  );
+
+  // Start searching in the file:
+  input("/");
+
+  // Validate we're now in command line
+  wait(~name="Mode switches to command line", (state: State.t) => {
+    Vim.Mode.isCommandLine(Selectors.mode(state))
+  });
+
+  // Search for something far down, that should trigger a scroll
+  // "xor" is on line 983...
+  input("\"xor");
+
+  // Validate editor has scrolled
+  wait(~name="Validate editor has scrolled some distance", (state: State.t) => {
+    let scrollY =
+      state.layout
+      |> Feature_Layout.activeEditor
+      |> Feature_Editor.Editor.scrollY;
+
+    scrollY > 100.;
+  });
+
+  // Cancel search, we should scroll back up...
+  key(EditorInput.Key.Escape);
+
+  // Validate editor has scrolled back to top
+  wait(
+    ~name="Validate editor is back to start",
+    ~timeout=30.,
+    (state: State.t) => {
+      let scrollY =
+        state.layout
+        |> Feature_Layout.activeEditor
+        |> Feature_Editor.Editor.scrollY;
+
+      scrollY < 1.;
+    },
+  );
+});

--- a/integration_test/VimlRemapCmdlineTest.re
+++ b/integration_test/VimlRemapCmdlineTest.re
@@ -16,7 +16,7 @@ runTest(~name="Viml Remap ö -> :", ({dispatch, wait, runEffects, input, _}) => 
   input("ö");
 
   wait(~name="Mode switches to command line", (state: State.t) => {
-    Selectors.mode(state) == Vim.Mode.CommandLine
+    Vim.Mode.isCommandLine(Selectors.mode(state))
   });
 
   input("e");

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -22,8 +22,9 @@
    SCMGitTest SyntaxHighlightPhpTest SyntaxHighlightTextMateTest
    SyntaxHighlightTreesitterTest AddRemoveSplitTest TerminalSetPidTitleTest
    TerminalConfigurationTest TypingBatchedTest TypingUnbatchedTest
-   VimSimpleRemapTest VimlRemapCmdlineTest ClipboardChangeTest
-   VimScriptLocalFunctionTest ZenModeSingleFileModeTest ZenModeSplitTest)
+   VimIncsearchScrollTest VimSimpleRemapTest VimlRemapCmdlineTest
+   ClipboardChangeTest VimScriptLocalFunctionTest ZenModeSingleFileModeTest
+   ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
@@ -58,8 +59,9 @@
    SyntaxServerParentPidCorrectTest.exe SyntaxServerReadExceptionTest.exe
    TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
    AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
-   VimScriptLocalFunctionTest.exe VimSimpleRemapTest.exe
-   VimlRemapCmdlineTest.exe ZenModeSingleFileModeTest.exe
-   ZenModeSplitTest.exe ClipboardChangeTest.exe large-c-file.c lsan.supp
-   some-test-file.json some-test-file.txt test.crlf test.lf test-syntax.php
-   utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf PlugScriptLocal.vim))
+   VimIncsearchScrollTest.exe VimScriptLocalFunctionTest.exe
+   VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
+   ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe ClipboardChangeTest.exe
+   large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
+   test.lf test-syntax.php utf8.txt utf8-test-file.htm
+   Inconsolata-Regular.ttf PlugScriptLocal.vim))

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -178,17 +178,18 @@ let runTest =
   let _: unit => unit =
     Revery.Tick.interval(
       ~name="Integration Test Ticker",
-      _ => {
-        let state = currentState^;
-        Revery.Utility.HeadlessWindow.render(
-          headlessWindow,
-          <Oni_UI.Root state dispatch=uiDispatch^ />,
-        );
-      },
-      // Revery.Utility.HeadlessWindow.takeScreenshot(
-      //   headlessWindow,
-      //   "screenshot.png",
-      // );
+      _ =>
+        {
+          let state = currentState^;
+          Revery.Utility.HeadlessWindow.render(
+            headlessWindow,
+            <Oni_UI.Root state dispatch=uiDispatch^ />,
+          );
+        },
+        // Revery.Utility.HeadlessWindow.takeScreenshot(
+        //   headlessWindow,
+        //   "screenshot.png",
+        // );
       Revery.Time.zero,
     );
 

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -178,18 +178,17 @@ let runTest =
   let _: unit => unit =
     Revery.Tick.interval(
       ~name="Integration Test Ticker",
-      _ =>
-        {
-          let state = currentState^;
-          Revery.Utility.HeadlessWindow.render(
-            headlessWindow,
-            <Oni_UI.Root state dispatch=uiDispatch^ />,
-          );
-        },
-        // Revery.Utility.HeadlessWindow.takeScreenshot(
-        //   headlessWindow,
-        //   "screenshot.png",
-        // );
+      _ => {
+        let state = currentState^;
+        Revery.Utility.HeadlessWindow.render(
+          headlessWindow,
+          <Oni_UI.Root state dispatch=uiDispatch^ />,
+        );
+      },
+      // Revery.Utility.HeadlessWindow.takeScreenshot(
+      //   headlessWindow,
+      //   "screenshot.png",
+      // );
       Revery.Time.zero,
     );
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1328,7 +1328,7 @@ let mapCursor = (~f, editor) => {
     // When scrolling in operator pending, cancel the pending operator
     | Operator({cursor, _}) => Vim.Mode.Normal({cursor: f(cursor)})
     // Don't do anything for command line mode
-    | CommandLine => CommandLine
+    | CommandLine({cursor}) => CommandLine({cursor: f(cursor)})
     | Normal({cursor}) => Normal({cursor: f(cursor)})
     | Visual(curr) =>
       Visual(Vim.VisualRange.{...curr, cursor: f(curr.cursor)})

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1328,7 +1328,8 @@ let mapCursor = (~f, editor) => {
     // When scrolling in operator pending, cancel the pending operator
     | Operator({cursor, _}) => Vim.Mode.Normal({cursor: f(cursor)})
     // Don't do anything for command line mode
-    | CommandLine({cursor}) => CommandLine({cursor: f(cursor)})
+    | CommandLine({cursor, text, commandCursor, commandType}) =>
+      CommandLine({text, commandCursor, commandType, cursor: f(cursor)})
     | Normal({cursor}) => Normal({cursor: f(cursor)})
     | Visual(curr) =>
       Visual(Vim.VisualRange.{...curr, cursor: f(curr.cursor)})

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -6,7 +6,7 @@ module Internal = {
     | Vim.Mode.Visual(range) =>
       Mode.TerminalVisual({range: Oni_Core.VisualRange.ofVim(range)})
     | Vim.Mode.Operator({pending, _}) => Mode.Operator({pending: pending})
-    | Vim.Mode.CommandLine => Mode.CommandLine
+    | Vim.Mode.CommandLine(_) => Mode.CommandLine
     | _ => Mode.TerminalNormal;
 };
 

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -44,7 +44,7 @@ let current: State.t => Oni_Core.Mode.t =
            | Vim.Mode.Replace({cursor}) => Mode.Replace({cursor: cursor})
            | Vim.Mode.Operator({pending, _}) =>
              Mode.Operator({pending: pending})
-           | Vim.Mode.CommandLine => Mode.CommandLine
+           | Vim.Mode.CommandLine(_) => Mode.CommandLine
            },
        );
   };

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -123,7 +123,8 @@ module Effects = {
         })
       | Replace({cursor}) =>
         Replace({cursor: adjustBytePositionForEdit(cursor, edit)})
-      | CommandLine => CommandLine
+      | CommandLine({cursor}) =>
+        CommandLine({cursor: adjustBytePositionForEdit(cursor, edit)})
       | Operator({cursor, pending}) =>
         Operator({cursor: adjustBytePositionForEdit(cursor, edit), pending})
       | Visual(_) as vis => vis

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -31,7 +31,7 @@ let quitAll = () =>
 module Effects = {
   let paste = (~toMsg, text) => {
     Isolinear.Effect.createWithDispatch(~name="vim.clipboardPaste", dispatch => {
-      let isCmdLineMode = Vim.Mode.current() == Vim.Mode.CommandLine;
+      let isCmdLineMode = Vim.Mode.isCommandLine(Vim.Mode.current());
       let isInsertMode = Vim.Mode.isInsert(Vim.Mode.current());
 
       if (isInsertMode || isCmdLineMode) {

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -123,8 +123,13 @@ module Effects = {
         })
       | Replace({cursor}) =>
         Replace({cursor: adjustBytePositionForEdit(cursor, edit)})
-      | CommandLine({cursor}) =>
-        CommandLine({cursor: adjustBytePositionForEdit(cursor, edit)})
+      | CommandLine({commandType, text, commandCursor, cursor}) =>
+        CommandLine({
+          commandType,
+          text,
+          commandCursor,
+          cursor: adjustBytePositionForEdit(cursor, edit),
+        })
       | Operator({cursor, pending}) =>
         Operator({cursor: adjustBytePositionForEdit(cursor, edit), pending})
       | Visual(_) as vis => vis

--- a/src/reason-libvim/CommandLine.re
+++ b/src/reason-libvim/CommandLine.re
@@ -7,11 +7,7 @@ let getCompletions = (~context: Context.t=Context.current(), ()) => {
   completions;
 };
 
-let getText = Native.vimCommandLineGetText;
-
 let getPosition = Native.vimCommandLineGetPosition;
-
-let getType = Native.vimCommandLineGetType;
 
 let onEnter = f => Event.add(f, Listeners.commandLineEnter);
 let onLeave = f => Event.add(f, Listeners.commandLineLeave);

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -3,7 +3,7 @@ open EditorCoreTypes;
 type t =
   | Normal({cursor: BytePosition.t})
   | Insert({cursors: list(BytePosition.t)})
-  | CommandLine({ cursor: BytePosition. t})
+  | CommandLine({cursor: BytePosition.t})
   | Replace({cursor: BytePosition.t})
   | Visual(VisualRange.t)
   | Operator({

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -3,7 +3,12 @@ open EditorCoreTypes;
 type t =
   | Normal({cursor: BytePosition.t})
   | Insert({cursors: list(BytePosition.t)})
-  | CommandLine({cursor: BytePosition.t})
+  | CommandLine({
+      text: string,
+      commandCursor: ByteIndex.t,
+      commandType: Types.cmdlineType,
+      cursor: BytePosition.t,
+    })
   | Replace({cursor: BytePosition.t})
   | Visual(VisualRange.t)
   | Operator({
@@ -41,7 +46,11 @@ let current = () => {
   switch (nativeMode) {
   | Native.Normal => Normal({cursor: cursor})
   | Native.Visual => Visual(VisualRange.current())
-  | Native.CommandLine => CommandLine({cursor: cursor})
+  | Native.CommandLine =>
+    let commandCursor = Native.vimCommandLineGetPosition() |> ByteIndex.ofInt;
+    let commandType = Native.vimCommandLineGetType();
+    let text = Native.vimCommandLineGetText() |> Option.value(~default="");
+    CommandLine({cursor, commandCursor, commandType, text});
   | Native.Replace => Replace({cursor: cursor})
   | Native.Operator =>
     Operator({

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -3,7 +3,7 @@ open EditorCoreTypes;
 type t =
   | Normal({cursor: BytePosition.t})
   | Insert({cursors: list(BytePosition.t)})
-  | CommandLine
+  | CommandLine({ cursor: BytePosition. t})
   | Replace({cursor: BytePosition.t})
   | Visual(VisualRange.t)
   | Operator({
@@ -16,7 +16,7 @@ let show = (mode: t) => {
   switch (mode) {
   | Normal(_) => "Normal"
   | Visual(_) => "Visual"
-  | CommandLine => "CommandLine"
+  | CommandLine(_) => "CommandLine"
   | Replace(_) => "Replace"
   | Operator(_) => "Operator"
   | Insert(_) => "Insert"
@@ -32,7 +32,7 @@ let cursors =
   | Visual(range) => [range |> VisualRange.cursor]
   | Operator({cursor, _}) => [cursor]
   | Select(range) => [range |> VisualRange.cursor]
-  | CommandLine => [];
+  | CommandLine({cursor, _}) => [cursor];
 
 let current = () => {
   let nativeMode: Native.mode = Native.vimGetMode();
@@ -41,7 +41,7 @@ let current = () => {
   switch (nativeMode) {
   | Native.Normal => Normal({cursor: cursor})
   | Native.Visual => Visual(VisualRange.current())
-  | Native.CommandLine => CommandLine
+  | Native.CommandLine => CommandLine({cursor: cursor})
   | Native.Replace => Replace({cursor: cursor})
   | Native.Operator =>
     Operator({
@@ -66,6 +66,11 @@ let isSelect =
 let isInsert =
   fun
   | Insert(_) => true
+  | _ => false;
+
+let isCommandLine =
+  fun
+  | CommandLine(_) => true
   | _ => false;
 
 let isNormal =
@@ -139,7 +144,7 @@ let trySet = newMode => {
   // These modes cannot be explicitly transitioned to currently
   | Operator(_)
   | Replace(_)
-  | CommandLine => ()
+  | CommandLine(_) => ()
   };
 
   current();

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -206,7 +206,6 @@ let runWith = (~context: Context.t, f) => {
 
   BufferInternal.checkCurrentBufferForUpdate();
 
-  // Some gnarly state management here - check if we are entering
   if (!Mode.isCommandLine(mode) || !Mode.isCommandLine(prevMode)) {
     if (Mode.isCommandLine(mode)) {
       Event.dispatch(

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -206,7 +206,8 @@ let runWith = (~context: Context.t, f) => {
 
   BufferInternal.checkCurrentBufferForUpdate();
 
-  if (mode != prevMode) {
+  // Some gnarly state management here - check if we are entering
+  if (!Mode.isCommandLine(mode) || !Mode.isCommandLine(prevMode)) {
     if (Mode.isCommandLine(mode)) {
       Event.dispatch(
         CommandLineInternal.getState(),

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -207,15 +207,15 @@ let runWith = (~context: Context.t, f) => {
   BufferInternal.checkCurrentBufferForUpdate();
 
   if (mode != prevMode) {
-    if (mode == CommandLine) {
+    if (Mode.isCommandLine(mode)) {
       Event.dispatch(
         CommandLineInternal.getState(),
         Listeners.commandLineEnter,
       );
-    } else if (prevMode == CommandLine) {
+    } else if (Mode.isCommandLine(prevMode)) {
       Event.dispatch((), Listeners.commandLineLeave);
     };
-  } else if (mode == CommandLine) {
+  } else if (Mode.isCommandLine(mode)) {
     Event.dispatch(
       CommandLineInternal.getState(),
       Listeners.commandLineUpdate,

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -102,7 +102,12 @@ module Mode: {
   type t =
     | Normal({cursor: BytePosition.t})
     | Insert({cursors: list(BytePosition.t)})
-    | CommandLine({cursor: BytePosition.t})
+    | CommandLine({
+        text: string,
+        commandCursor: ByteIndex.t,
+        commandType: Types.cmdlineType,
+        cursor: BytePosition.t,
+      })
     | Replace({cursor: BytePosition.t})
     | Visual(VisualRange.t)
     | Operator({
@@ -192,9 +197,8 @@ module CommandLine: {
   type t = Types.cmdline;
 
   let getCompletions: (~context: Context.t=?, unit) => array(string);
-  let getText: unit => option(string);
+
   let getPosition: unit => int;
-  let getType: unit => Types.cmdlineType;
 
   let onEnter: (Event.handler(t), unit) => unit;
   let onLeave: (Event.handler(unit), unit) => unit;

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -102,7 +102,7 @@ module Mode: {
   type t =
     | Normal({cursor: BytePosition.t})
     | Insert({cursors: list(BytePosition.t)})
-    | CommandLine
+    | CommandLine({cursor: BytePosition.t})
     | Replace({cursor: BytePosition.t})
     | Visual(VisualRange.t)
     | Operator({
@@ -113,6 +113,7 @@ module Mode: {
 
   let current: unit => t;
 
+  let isCommandLine: t => bool;
   let isInsert: t => bool;
   let isNormal: t => bool;
   let isVisual: t => bool;

--- a/test/reason-libvim/CommandLineTest.re
+++ b/test/reason-libvim/CommandLineTest.re
@@ -15,16 +15,22 @@ describe("CommandLine", ({describe, _}) => {
   describe("getType", ({test, _}) =>
     test("simple command line", ({expect, _}) => {
       let _ = reset();
-      input(":");
-      expect.bool(CommandLine.getType() == Types.Ex).toBe(true);
+      let ({mode, _}: Vim.Context.t, _) = Vim.input(":");
+
+      let getType =
+        fun
+        | Vim.Mode.CommandLine({commandType, _}) => Some(commandType)
+        | _ => None;
+
+      expect.equal(getType(mode), Some(Types.Ex));
       key("<esc>");
 
-      input("/");
-      expect.bool(CommandLine.getType() == Types.SearchForward).toBe(true);
+      let ({mode, _}: Vim.Context.t, _) = Vim.input("/");
+      expect.equal(getType(mode), Some(Types.SearchForward));
       key("<esc>");
 
-      input("?");
-      expect.bool(CommandLine.getType() == Types.SearchReverse).toBe(true);
+      let ({mode, _}: Vim.Context.t, _) = Vim.input("?");
+      expect.equal(getType(mode), Some(Types.SearchReverse));
       key("<esc>");
     })
   );
@@ -277,26 +283,20 @@ describe("CommandLine", ({describe, _}) => {
       let _ = reset();
 
       input(":");
-      input("a");
+      let ({mode, _}: Vim.Context.t, _) = Vim.input("a");
 
-      switch (CommandLine.getText()) {
-      | Some(v) => expect.string(v).toEqual("a")
-      | None => expect.int(0).toBe(1)
-      };
+      let getText =
+        fun
+        | Vim.Mode.CommandLine({text, _}) => Some(text)
+        | _ => None;
 
-      input("b");
+      expect.equal(getText(mode), Some("a"));
 
-      switch (CommandLine.getText()) {
-      | Some(v) => expect.string(v).toEqual("ab")
-      | None => expect.int(0).toBe(1)
-      };
+      let ({mode, _}: Vim.Context.t, _) = Vim.input("b");
+      expect.equal(getText(mode), Some("ab"));
 
-      input("c");
-
-      switch (CommandLine.getText()) {
-      | Some(v) => expect.string(v).toEqual("abc")
-      | None => expect.int(0).toBe(1)
-      };
+      let ({mode, _}: Vim.Context.t, _) = Vim.input("c");
+      expect.equal(getText(mode), Some("abc"));
     })
   );
 


### PR DESCRIPTION
__Issue:__ There were a couple related issues with the cursor in command-line mode:
1) When exiting command-line mode, the cursor could 'flash' at the top of the file
2) When running a search command, the viewport would not scroll to the first match

__Defect:__ Both issues stem from the fact that Onivim was ignoring editor-cursor-position changes during search. 

For the first issue, when exiting command-line mode, there would be a brief transitional state where the editor is focused in CommandLine mode, but no cursor would be available - so it would be rendered at the default (0,0) position. This would be rectified once the mode transition completed and the cursor position is reset. 

For the second issue, `libvim` was properly updating the cursor position when searching, but that cursor position was being ignored.

__Fix:__ Track the editor cursor position during the course of the command-line interaction

Fixes #2968 
Related #1551 