### PR TITLE
feat(snippets): Part 2 - Implement multi-select handler

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,5 +1,7 @@
 ### Features 
 
+- #3024 - Editor: Snippet Support - Multi-select handler
+
 ### Bug Fixes
 
 - #3008 - SCM: Fix index-out-of-bound exception when rendering diff markers

--- a/src/Core/Mode.re
+++ b/src/Core/Mode.re
@@ -13,10 +13,7 @@ type t =
       cursor: BytePosition.t,
       range: VisualRange.t,
     })
-  | Select({
-      cursor: BytePosition.t,
-      range: VisualRange.t,
-    })
+  | Select({ranges: list(VisualRange.t)})
   | Replace({cursor: BytePosition.t})
   | Operator({pending: Vim.Operator.pending})
   | CommandLine
@@ -36,12 +33,16 @@ let toString =
     | Block => "Visual Block"
     | None => "Visual"
     }
-  | Select({range, _}) =>
-    switch (range.mode) {
-    | Character => "Select Character"
-    | Line => "Select Line"
-    | Block => "Select Block"
-    | None => "Select"
+  | Select({ranges, _}) =>
+    switch (ranges) {
+    | [range, ..._] =>
+      switch (range.mode) {
+      | Character => "Select Character"
+      | Line => "Select Line"
+      | Block => "Select Block"
+      | None => "Select"
+      }
+    | [] => "Select"
     }
   | Replace(_) => "Replace"
   | Operator({pending}) => Vim.Operator.toString(pending)

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -172,21 +172,15 @@ let setMinimap = (~enabled, ~maxColumn, editor) => {
 };
 
 let setSelections = (selections: list(ByteRange.t), editor) => {
-  let ranges = selections
-  |> List.map(r => {
-    open ByteRange;
-    open Vim.VisualRange;
-    let {start, stop}: ByteRange.t = r;
-    {
-      anchor: start,
-      cursor: stop,
-      visualType: Vim.Types.Character,
-    }
-  });
-  {
-  ...editor,
-  mode: Select({ranges: ranges }),
-  }
+  let ranges =
+    selections
+    |> List.map(r => {
+         open ByteRange;
+         open Vim.VisualRange;
+         let {start, stop}: ByteRange.t = r;
+         {anchor: start, cursor: stop, visualType: Vim.Types.Character};
+       });
+  {...editor, mode: Select({ranges: ranges})};
 };
 
 let overrideAnimation = (~animated, editor) => {

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -171,6 +171,24 @@ let setMinimap = (~enabled, ~maxColumn, editor) => {
   minimapMaxColumnWidth: maxColumn,
 };
 
+let setSelections = (selections: list(ByteRange.t), editor) => {
+  let ranges = selections
+  |> List.map(r => {
+    open ByteRange;
+    open Vim.VisualRange;
+    let {start, stop}: ByteRange.t = r;
+    {
+      anchor: start,
+      cursor: stop,
+      visualType: Vim.Types.Character,
+    }
+  });
+  {
+  ...editor,
+  mode: Select({ranges: ranges }),
+  }
+};
+
 let overrideAnimation = (~animated, editor) => {
   ...editor,
   isAnimationOverride: animated,

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -142,7 +142,7 @@ let selection = ({mode, _}) =>
 
   | Select({ranges}) =>
     switch (ranges) {
-    | [range, ...tail] => Some(Oni_Core.VisualRange.ofVim(range))
+    | [range, ..._] => Some(Oni_Core.VisualRange.ofVim(range))
     | [] => None
     }
   | _ => None

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -136,16 +136,12 @@ type t = {
 
 let key = ({key, _}) => key;
 // TODO: Handle multiple ranges
-let selection = ({mode, _}) =>
+let selections = ({mode, _}) =>
   switch (mode) {
-  | Visual(range) => Some(Oni_Core.VisualRange.ofVim(range))
+  | Visual(range) => [Oni_Core.VisualRange.ofVim(range)]
 
-  | Select({ranges}) =>
-    switch (ranges) {
-    | [range, ..._] => Some(Oni_Core.VisualRange.ofVim(range))
-    | [] => None
-    }
-  | _ => None
+  | Select({ranges}) => ranges |> List.map(Oni_Core.VisualRange.ofVim)
+  | _ => []
   };
 let visiblePixelWidth = ({pixelWidth, _}) => pixelWidth;
 let visiblePixelHeight = ({pixelHeight, _}) => pixelHeight;
@@ -960,8 +956,8 @@ let setCodeLens = (~startLine, ~stopLine, ~handle, ~lenses, editor) => {
 };
 
 let selectionOrCursorRange = editor => {
-  switch (selection(editor)) {
-  | None =>
+  switch (selections(editor)) {
+  | [] =>
     let pos = getPrimaryCursorByte(editor);
     ByteRange.{
       start: BytePosition.{line: pos.line, byte: ByteIndex.zero},
@@ -971,7 +967,7 @@ let selectionOrCursorRange = editor => {
           byte: ByteIndex.zero,
         },
     };
-  | Some(selection) => selection.range
+  | [selection, ..._tail] => selection.range
   };
 };
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -201,6 +201,7 @@ let byteToCharacter: (BytePosition.t, t) => option(CharacterPosition.t);
 let characterToByte: (CharacterPosition.t, t) => option(BytePosition.t);
 
 let byteRangeToCharacterRange: (ByteRange.t, t) => option(CharacterRange.t);
+let characterRangeToByteRange: (CharacterRange.t, t) => option(ByteRange.t);
 
 // VIEW-SPACE CONVERSION
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -92,6 +92,8 @@ let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getCursors: t => list(BytePosition.t);
 let setWrapMode: (~wrapMode: WrapMode.t, t) => t;
 
+let setSelections: (list(ByteRange.t), t) => t;
+
 // Get the horizontal width in pixels of the tab/space whitespace in front of a line.
 let getLeadingWhitespacePixels: (EditorCoreTypes.LineNumber.t, t) => float;
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -167,7 +167,7 @@ let linePaddingInPixels: t => float;
 let setLineHeight: (~lineHeight: LineHeight.t, t) => t;
 let characterWidthInPixels: t => float;
 
-let selection: t => option(VisualRange.t);
+let selections: t => list(VisualRange.t);
 
 let selectionOrCursorRange: t => ByteRange.t;
 

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -238,10 +238,10 @@ let%component make =
     Feature_Diagnostics.getDiagnosticsMap(diagnostics, buffer);
   let selectionRanges =
     editor
-    |> Editor.selection
-    |> Option.map(selection => Selection.getRanges(selection, buffer))
-    |> Option.map(ByteRange.toHash)
-    |> Option.value(~default=Hashtbl.create(1));
+    |> Editor.selections
+    |> List.map(selection => Selection.getRanges(selection, buffer))
+    |> List.flatten
+    |> ByteRange.toHash;
 
   let diffMarkers =
     lineCount < Constants.diffMarkersMaxLineCount && showDiffMarkers

--- a/src/Feature/Editor/Scrollbar.re
+++ b/src/Feature/Editor/Scrollbar.re
@@ -328,29 +328,29 @@ module Vertical = {
         ),
       ];
     };
-    let getSelectionElements = (selection: option(VisualRange.t)) => {
-      switch (selection) {
-      | None => []
-      | Some(selection) =>
-        let topLine =
-          Editor.projectLine(
-            ~line=selection.range.start.line,
-            ~pixelHeight=totalHeight,
-            editor,
-          )
-          |> int_of_float;
-        let botLine =
-          Editor.projectLine(
-            ~line=EditorCoreTypes.LineNumber.(selection.range.stop.line + 1),
-            ~pixelHeight=totalHeight,
-            editor,
-          )
-          |> int_of_float;
-        [<View style={selectionStyle(topLine, botLine)} />];
-      };
+    let getSelectionElements = (selections: list(VisualRange.t)) => {
+      selections
+      |> List.map((selection: VisualRange.t) => {
+           let topLine =
+             Editor.projectLine(
+               ~line=selection.range.start.line,
+               ~pixelHeight=totalHeight,
+               editor,
+             )
+             |> int_of_float;
+           let botLine =
+             Editor.projectLine(
+               ~line=
+                 EditorCoreTypes.LineNumber.(selection.range.stop.line + 1),
+               ~pixelHeight=totalHeight,
+               editor,
+             )
+             |> int_of_float;
+           <View style={selectionStyle(topLine, botLine)} />;
+         });
     };
 
-    getSelectionElements(Editor.selection(editor)) |> React.listToElement;
+    getSelectionElements(Editor.selections(editor)) |> React.listToElement;
   };
 
   let make =

--- a/src/Feature/LanguageSupport/DocumentHighlights.re
+++ b/src/Feature/LanguageSupport/DocumentHighlights.re
@@ -16,7 +16,12 @@ type model = {
 let initial = {providers: [], bufferToHighlights: IntMap.empty};
 
 [@deriving show]
+type command =
+| ChangeAll;
+
+[@deriving show]
 type msg =
+  | Command(command)
   | DocumentHighlighted({
       bufferId: int,
       ranges: list(CharacterRange.t),
@@ -53,13 +58,26 @@ let cursorMoved = (~buffer, ~cursor, model) => {
   };
 };
 
-let update = (msg, model) => {
+let allHighlights = (~bufferId, model) => {
+  []
+};
+
+let update = (~maybeBuffer, ~editorId, msg, model) => {
   switch (msg) {
   | DocumentHighlighted({bufferId, ranges}) =>
     let lineMap = ranges |> Utility.RangeEx.toCharacterLineMap;
     let bufferToHighlights =
       model.bufferToHighlights |> IntMap.add(bufferId, lineMap);
-    {...model, bufferToHighlights};
+    ({...model, bufferToHighlights}, Outmsg.Nothing);
+
+  | Command(ChangeAll) =>
+    let _model = maybeBuffer
+    |> Option.map(Oni_Core.Buffer.getId)
+    |> Option.map(bufferId => {
+    let _allHighlights = allHighlights(~bufferId, model);
+    });
+
+    (model, Outmsg.Nothing);
   };
 };
 

--- a/src/Feature/LanguageSupport/DocumentHighlights.re
+++ b/src/Feature/LanguageSupport/DocumentHighlights.re
@@ -43,11 +43,18 @@ module Commands = {
 module Keybindings = {
   open Feature_Input.Schema;
 
-  let changeAll =
+  let changeAllWindows =
     bind(
-      ~key="<F2>",
+      ~key="<S-F2>",
       ~command=Commands.changeAll.id,
-      ~condition="editorTextFocus" |> WhenExpr.parse,
+      ~condition="!isMac && editorTextFocus" |> WhenExpr.parse,
+    );
+
+  let changeAllMac =
+    bind(
+      ~key="<D-F2>",
+      ~command=Commands.changeAll.id,
+      ~condition="isMac && editorTextFocus" |> WhenExpr.parse,
     );
 };
 
@@ -192,5 +199,5 @@ module Contributions = {
 
   let commands = Commands.[changeAll];
 
-  let keybindings = Keybindings.[changeAll];
+  let keybindings = Keybindings.[changeAllWindows, changeAllMac];
 };

--- a/src/Feature/LanguageSupport/DocumentHighlights.re
+++ b/src/Feature/LanguageSupport/DocumentHighlights.re
@@ -60,19 +60,19 @@ let clear = (~bufferId, model) => {
 };
 
 let allHighlights = (~bufferId, model) => {
-    model.bufferToHighlights
-    |> IntMap.find_opt(bufferId)
-    |> Option.value(~default=IntMap.empty)
-    |> IntMap.bindings
-    |> List.map(snd)
-    |> List.flatten;
+  model.bufferToHighlights
+  |> IntMap.find_opt(bufferId)
+  |> Option.value(~default=IntMap.empty)
+  |> IntMap.bindings
+  |> List.map(snd)
+  |> List.flatten;
 };
 
 let cursorMoved = (~buffer, ~cursor, model) => {
-
   let bufferId = Oni_Core.Buffer.getId(buffer);
-  let isCursorInHighlight = allHighlights(~bufferId, model)
-  |> List.exists(range => CharacterRange.contains(cursor, range));
+  let isCursorInHighlight =
+    allHighlights(~bufferId, model)
+    |> List.exists(range => CharacterRange.contains(cursor, range));
 
   if (!isCursorInHighlight) {
     clear(~bufferId, model);
@@ -105,23 +105,17 @@ let update = (~maybeBuffer, ~editorId, msg, model) => {
             line: LineNumber.ofZeroBased(idx),
             character: CharacterIndex.zero,
           },
-        stop:
-          {
-            line: LineNumber.ofZeroBased(idx),
-            character: CharacterIndex.(zero + 1),
-          },
+        stop: {
+          line: LineNumber.ofZeroBased(idx),
+          character: CharacterIndex.(zero + 1),
+        },
       };
 
     (
       model,
       Outmsg.SetSelections({
         editorId,
-        ranges:
-          [
-            rangeForLine(0),
-            rangeForLine(1),
-            rangeForLine(2),
-          ],
+        ranges: [rangeForLine(0), rangeForLine(1), rangeForLine(2)],
       }),
     );
   };

--- a/src/Feature/LanguageSupport/DocumentHighlights.re
+++ b/src/Feature/LanguageSupport/DocumentHighlights.re
@@ -90,6 +90,7 @@ let cursorMoved = (~buffer, ~cursor, model) => {
 
 let update = (~maybeBuffer, ~editorId, msg, model) => {
   switch (msg) {
+
   | DocumentHighlighted({bufferId, ranges}) =>
     let lineMap = ranges |> Utility.RangeEx.toCharacterLineMap;
     let bufferToHighlights =
@@ -97,34 +98,13 @@ let update = (~maybeBuffer, ~editorId, msg, model) => {
     ({...model, bufferToHighlights}, Outmsg.Nothing);
 
   | Command(ChangeAll) =>
-    let _model =
       maybeBuffer
       |> Option.map(Oni_Core.Buffer.getId)
       |> Option.map(bufferId => {
-           let _allHighlights = allHighlights(~bufferId, model);
-           ();
-         });
-    open EditorCoreTypes;
-    let rangeForLine = idx =>
-      CharacterRange.{
-        start:
-          CharacterPosition.{
-            line: LineNumber.ofZeroBased(idx),
-            character: CharacterIndex.zero,
-          },
-        stop: {
-          line: LineNumber.ofZeroBased(idx),
-          character: CharacterIndex.(zero + 1),
-        },
-      };
-
-    (
-      model,
-      Outmsg.SetSelections({
-        editorId,
-        ranges: [rangeForLine(0), rangeForLine(1), rangeForLine(2)],
-      }),
-    );
+           let allHighlights = allHighlights(~bufferId, model);
+           (model, Outmsg.SetSelections({editorId, ranges: allHighlights}))
+         })
+      |> Option.value(~default=(model, Outmsg.Nothing));
   };
 };
 

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -68,7 +68,11 @@ type outmsg =
       startLine: EditorCoreTypes.LineNumber.t,
       stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.codeLens),
-    });
+    })
+  | SetSelections({
+    editorId: int,
+    ranges: list(CharacterRange.t)
+  });
 
 let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
   f =>

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -70,9 +70,9 @@ type outmsg =
       lenses: list(CodeLens.codeLens),
     })
   | SetSelections({
-    editorId: int,
-    ranges: list(CharacterRange.t)
-  });
+      editorId: int,
+      ranges: list(CharacterRange.t),
+    });
 
 let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
   f =>
@@ -95,7 +95,8 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
         stopLine,
       }) =>
       CodeLensesChanged({handle, bufferId, lenses, startLine, stopLine})
-    | Outmsg.SetSelections({editorId, ranges}) => SetSelections({editorId, ranges});
+    | Outmsg.SetSelections({editorId, ranges}) =>
+      SetSelections({editorId, ranges});
 
 module Msg = {
   let exthost = msg => Exthost(msg);
@@ -314,8 +315,10 @@ let update =
         model.documentHighlights,
       );
 
-    ({...model, documentHighlights: documentHighlights'}, 
-      outmsg |> map(msg => DocumentHighlights(msg)));
+    (
+      {...model, documentHighlights: documentHighlights'},
+      outmsg |> map(msg => DocumentHighlights(msg)),
+    );
 
   | DocumentSymbols(documentSymbolsMsg) =>
     let documentSymbols' =
@@ -506,6 +509,10 @@ module Contributions = {
       |> List.map(Oni_Core.Command.map(msg => Definition(msg)))
     )
     @ (
+      DocumentHighlights.Contributions.commands
+      |> List.map(Oni_Core.Command.map(msg => DocumentHighlights(msg)))
+    )
+    @ (
       Hover.Contributions.commands
       |> List.map(Oni_Core.Command.map(msg => Hover(msg)))
     )
@@ -546,6 +553,7 @@ module Contributions = {
     Rename.Contributions.keybindings
     @ Completion.Contributions.keybindings
     @ Definition.Contributions.keybindings
+    @ DocumentHighlights.Contributions.keybindings
     @ References.Contributions.keybindings
     @ SignatureHelp.Contributions.keybindings;
 };

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -94,7 +94,8 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
         startLine,
         stopLine,
       }) =>
-      CodeLensesChanged({handle, bufferId, lenses, startLine, stopLine});
+      CodeLensesChanged({handle, bufferId, lenses, startLine, stopLine})
+    | Outmsg.SetSelections({editorId, ranges}) => SetSelections({editorId, ranges});
 
 module Msg = {
   let exthost = msg => Exthost(msg);
@@ -305,12 +306,16 @@ let update =
     );
 
   | DocumentHighlights(documentHighlightsMsg) =>
-    let documentHighlights' =
+    let (documentHighlights', outmsg) =
       DocumentHighlights.update(
+        ~maybeBuffer,
+        ~editorId,
         documentHighlightsMsg,
         model.documentHighlights,
       );
-    ({...model, documentHighlights: documentHighlights'}, Nothing);
+
+    ({...model, documentHighlights: documentHighlights'}, 
+      outmsg |> map(msg => DocumentHighlights(msg)));
 
   | DocumentSymbols(documentSymbolsMsg) =>
     let documentSymbols' =

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -78,9 +78,9 @@ type outmsg =
       lenses: list(CodeLens.t),
     })
   | SetSelections({
-    editorId: int,
-    ranges: list(CharacterRange.t),
-  });
+      editorId: int,
+      ranges: list(CharacterRange.t),
+    });
 
 let update:
   (

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -76,7 +76,11 @@ type outmsg =
       startLine: EditorCoreTypes.LineNumber.t,
       stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.t),
-    });
+    })
+  | SetSelections({
+    editorId: int,
+    ranges: list(CharacterRange.t),
+  });
 
 let update:
   (

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -26,6 +26,7 @@ type internalMsg('a) =
       stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.codeLens),
     })
+  | SetSelections({editorId: int, ranges: list(CharacterRange.t)})
   | Effect(Isolinear.Effect.t('a));
 
 let map = f =>

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -26,7 +26,10 @@ type internalMsg('a) =
       stopLine: EditorCoreTypes.LineNumber.t,
       lenses: list(CodeLens.codeLens),
     })
-  | SetSelections({editorId: int, ranges: list(CharacterRange.t)})
+  | SetSelections({
+      editorId: int,
+      ranges: list(CharacterRange.t),
+    })
   | Effect(Isolinear.Effect.t('a));
 
 let map = f =>

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -36,10 +36,9 @@ let current: State.t => Oni_Core.Mode.t =
                cursor: Vim.VisualRange.cursor(range),
                range: Oni_Core.VisualRange.ofVim(range),
              })
-           | Vim.Mode.Select(range) =>
+           | Vim.Mode.Select({ranges}) =>
              Mode.Select({
-               cursor: Vim.VisualRange.cursor(range),
-               range: Oni_Core.VisualRange.ofVim(range),
+               ranges: ranges |> List.map(Oni_Core.VisualRange.ofVim),
              })
            | Vim.Mode.Replace({cursor}) => Mode.Replace({cursor: cursor})
            | Vim.Mode.Operator({pending, _}) =>

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -599,27 +599,28 @@ let update =
              );
         ({...state, layout: layout'}, Isolinear.Effect.none);
 
-      | SetSelections({editorId, ranges}) => {
-        
+      | SetSelections({editorId, ranges}) =>
         let layout' =
           state.layout
           |> Feature_Layout.map(editor =>
-              Feature_Editor.({
-               if (Editor.getId(editor) == editorId) {
-                let byteRanges = ranges
-                |> List.filter_map(characterRange => Editor.characterRangeToByteRange(characterRange, editor));
+               Feature_Editor.(
+                 if (Editor.getId(editor) == editorId) {
+                   let byteRanges =
+                     ranges
+                     |> List.filter_map(characterRange =>
+                          Editor.characterRangeToByteRange(
+                            characterRange,
+                            editor,
+                          )
+                        );
 
-                 Editor.setSelections(
-                   byteRanges,
-                   editor,
-                 );
-               } else {
-                 editor;
-               }
-               })
+                   Editor.setSelections(byteRanges, editor);
+                 } else {
+                   editor;
+                 }
+               )
              );
         ({...state, layout: layout'}, Isolinear.Effect.none);
-      }
       }
     );
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -598,6 +598,28 @@ let update =
                }
              );
         ({...state, layout: layout'}, Isolinear.Effect.none);
+
+      | SetSelections({editorId, ranges}) => {
+        
+        let layout' =
+          state.layout
+          |> Feature_Layout.map(editor =>
+              Feature_Editor.({
+               if (Editor.getId(editor) == editorId) {
+                let byteRanges = ranges
+                |> List.filter_map(characterRange => Editor.characterRangeToByteRange(characterRange, editor));
+
+                 Editor.setSelections(
+                   byteRanges,
+                   editor,
+                 );
+               } else {
+                 editor;
+               }
+               })
+             );
+        ({...state, layout: layout'}, Isolinear.Effect.none);
+      }
       }
     );
 

--- a/src/editor-core-types/BytePosition.re
+++ b/src/editor-core-types/BytePosition.re
@@ -15,10 +15,9 @@ let (==) = equals;
 let line = ({line, _}) => line;
 let byte = ({byte, _}) => byte;
 
-let compare = (a, b) => {
+let compare = (a, b) =>
   if (LineNumber.equals(a.line, b.line)) {
-    ByteIndex.toInt(a.byte) - ByteIndex.toInt(b.byte)
+    ByteIndex.toInt(a.byte) - ByteIndex.toInt(b.byte);
   } else {
-    LineNumber.toZeroBased(a.line) - LineNumber.toZeroBased(b.line)
-  }
-};
+    LineNumber.toZeroBased(a.line) - LineNumber.toZeroBased(b.line);
+  };

--- a/src/editor-core-types/BytePosition.re
+++ b/src/editor-core-types/BytePosition.re
@@ -14,3 +14,11 @@ let (==) = equals;
 
 let line = ({line, _}) => line;
 let byte = ({byte, _}) => byte;
+
+let compare = (a, b) => {
+  if (LineNumber.equals(a.line, b.line)) {
+    ByteIndex.toInt(a.byte) - ByteIndex.toInt(b.byte)
+  } else {
+    LineNumber.toZeroBased(a.line) - LineNumber.toZeroBased(b.line)
+  }
+};

--- a/src/editor-core-types/BytePosition.rei
+++ b/src/editor-core-types/BytePosition.rei
@@ -11,3 +11,11 @@ let byte: t => ByteIndex.t;
 
 let equals: (t, t) => bool;
 let (==): (t, t) => bool;
+
+/**
+ * [compare(a, b)] returns:
+ * - 0 if a & b are equal
+ * - a negative integer if a is less than b
+ * - a positive integer if a is greater than b
+ */
+let compare: (t, t) => int;

--- a/src/editor-core-types/ByteRange.re
+++ b/src/editor-core-types/ByteRange.re
@@ -24,6 +24,14 @@ module Internal = {
     };
 };
 
+let compare = (a, b) => {
+  // Compare start positions, unless they are equal - then use end positions
+  let (aPosition, bPosition) = (BytePosition.equals(a.start, b.start)) ?
+  (a.stop, b.stop) : (a.start, b.start);
+
+  BytePosition.compare(aPosition, bPosition);
+};
+
 let normalize = range =>
   range |> Internal.normalizeLines |> Internal.normalizeByte;
 

--- a/src/editor-core-types/ByteRange.re
+++ b/src/editor-core-types/ByteRange.re
@@ -26,8 +26,9 @@ module Internal = {
 
 let compare = (a, b) => {
   // Compare start positions, unless they are equal - then use end positions
-  let (aPosition, bPosition) = (BytePosition.equals(a.start, b.start)) ?
-  (a.stop, b.stop) : (a.start, b.start);
+  let (aPosition, bPosition) =
+    BytePosition.equals(a.start, b.start)
+      ? (a.stop, b.stop) : (a.start, b.start);
 
   BytePosition.compare(aPosition, bPosition);
 };

--- a/src/editor-core-types/ByteRange.re
+++ b/src/editor-core-types/ByteRange.re
@@ -6,7 +6,29 @@ type t = {
 
 let zero = {start: BytePosition.zero, stop: BytePosition.zero};
 
+module Internal = {
+  let normalizeLines = range =>
+    if (range.start.line > range.stop.line) {
+      {start: range.stop, stop: range.start};
+    } else {
+      range;
+    };
+
+  let normalizeByte = range =>
+    if (range.start.line == range.stop.line
+        && ByteIndex.toInt(range.stop.byte)
+        < ByteIndex.toInt(range.start.byte)) {
+      {start: range.stop, stop: range.start};
+    } else {
+      range;
+    };
+};
+
+let normalize = range =>
+  range |> Internal.normalizeLines |> Internal.normalizeByte;
+
 let contains = (position: BytePosition.t, range) => {
+  let range = normalize(range);
   (
     LineNumber.(position.line == range.start.line)
     && ByteIndex.(position.byte >= range.start.byte)

--- a/src/editor-core-types/ByteRange.rei
+++ b/src/editor-core-types/ByteRange.rei
@@ -16,3 +16,9 @@ let contains: (BytePosition.t, t) => bool;
 let toHash: list(t) => Hashtbl.t(LineNumber.t, list(t));
 
 let equals: (t, t) => bool;
+
+/**
+ * [normalize(range)] returns a new range, with the [start] less than
+ * or equal to the [stop]
+ */
+let normalize: t => t;

--- a/src/editor-core-types/ByteRange.rei
+++ b/src/editor-core-types/ByteRange.rei
@@ -18,6 +18,14 @@ let toHash: list(t) => Hashtbl.t(LineNumber.t, list(t));
 let equals: (t, t) => bool;
 
 /**
+ * [compare(a, b)] returns:
+ * - 0 if a & b are equal
+ * - a negative integer if a is less than b
+ * - a positive integer if a is greater than b
+ */
+let compare: (t, t) => int;
+
+/**
  * [normalize(range)] returns a new range, with the [start] less than
  * or equal to the [stop]
  */

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -15,7 +15,7 @@ type t =
       cursor: BytePosition.t,
       pending: Operator.pending,
     })
-  | Select(VisualRange.t);
+  | Select({ranges: list(VisualRange.t)});
 
 let show = (mode: t) => {
   switch (mode) {
@@ -36,7 +36,7 @@ let cursors =
   | Replace({cursor}) => [cursor]
   | Visual(range) => [range |> VisualRange.cursor]
   | Operator({cursor, _}) => [cursor]
-  | Select(range) => [range |> VisualRange.cursor]
+  | Select({ranges}) => ranges |> List.map(VisualRange.cursor)
   | CommandLine({cursor, _}) => [cursor];
 
 let current = () => {
@@ -58,7 +58,7 @@ let current = () => {
       pending: Operator.get() |> Option.value(~default=Operator.default),
     })
   | Native.Insert => Insert({cursors: [cursor]})
-  | Native.Select => Select(VisualRange.current())
+  | Native.Select => Select({ranges: [VisualRange.current()]})
   };
 };
 
@@ -142,13 +142,17 @@ let trySet = newMode => {
       ~start=range.anchor,
       ~cursor=range.cursor,
     );
-  | Select(range) =>
-    Internal.ensureSelect(range.visualType);
-    Visual.set(
-      ~visualType=range.visualType,
-      ~start=range.anchor,
-      ~cursor=range.cursor,
-    );
+  | Select({ranges}) =>
+    switch (ranges) {
+    | [range, ..._] =>
+      Internal.ensureSelect(range.visualType);
+      Visual.set(
+        ~visualType=range.visualType,
+        ~start=range.anchor,
+        ~cursor=range.cursor,
+      );
+    | [] => ()
+    }
   | Insert(_) => Internal.ensureInsert()
   // These modes cannot be explicitly transitioned to currently
   | Operator(_)

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -39,6 +39,16 @@ let cursors =
   | Select({ranges}) => ranges |> List.map(VisualRange.cursor)
   | CommandLine({cursor, _}) => [cursor];
 
+let ranges =
+  fun
+  | Normal(_) => []
+  | Insert(_) => []
+  | Replace(_) => []
+  | Visual(range) => [range]
+  | Operator(_) => []
+  | Select({ranges}) => ranges
+  | CommandLine(_) => [];
+
 let current = () => {
   let nativeMode: Native.mode = Native.vimGetMode();
 

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -724,6 +724,8 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
         if (!canDoMultiCursorSelect) {
           Mode.current();
         } else {
+          // TODO: Actually do multi-select...
+          prerr_endline ("TODO: Implement multi-select!");
           Mode.current();
         }
         

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -761,6 +761,11 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
         if (!canDoMultiCursorSelect) {
           Mode.current();
         } else {
+          // Apply multi-selection behavior:
+          // 1) Shift the secondary ranges by the edit range (the delta between the cursor-selection and inserted text)
+          // 2) Replace all the secondary ranges with the inserted text
+          // 3) Set up insert mode cursor positions
+
           let editRange = Option.get(maybeEditRange);
 
           let byteDelta =
@@ -784,24 +789,13 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
               range;
             };
 
-          let remapRangeToInsertedText = range =>
-            ByteRange.{
-              start:
-                BytePosition.{line: range.start.line, byte: range.start.byte},
-              stop:
-                BytePosition.{
-                  line: range.stop.line,
-                  byte: ByteIndex.(range.stop.byte + byteDelta),
-                },
-            };
-
-          let newRange = editRange |> remapRangeToInsertedText;
+          //let newRange = editRange |> remapRangeToInsertedText;
           let insertedText =
             String.sub(
               newLine,
-              ByteIndex.toInt(newRange.start.byte),
-              ByteIndex.toInt(newRange.stop.byte)
-              - ByteIndex.toInt(newRange.start.byte)
+              ByteIndex.toInt(editRange.start.byte),
+              (ByteIndex.toInt(editRange.stop.byte) + byteDelta)
+              - ByteIndex.toInt(editRange.start.byte)
               + 1,
             );
 

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -793,7 +793,8 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
             String.sub(
               newLine,
               ByteIndex.toInt(editRange.start.byte),
-              (ByteIndex.toInt(editRange.stop.byte) + byteDelta)
+              ByteIndex.toInt(editRange.stop.byte)
+              + byteDelta
               - ByteIndex.toInt(editRange.start.byte)
               + 1,
             );
@@ -858,19 +859,14 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
                          curr.line,
                          rangeToConsider.start.line,
                        )
-                       && ByteIndex.(
-                            rangeToConsider.start.byte < curr.byte
-                          )) {
+                       && ByteIndex.(rangeToConsider.start.byte < curr.byte)) {
                      let originalByteLength =
                        ByteIndex.toInt(rangeToConsider.stop.byte)
                        - ByteIndex.toInt(rangeToConsider.start.byte)
                        + 1;
                      let delta =
                        String.length(insertedText) - originalByteLength;
-                     {
-                         line: curr.line,
-                         byte: ByteIndex.(curr.byte + delta),
-                     };
+                     {line: curr.line, byte: ByteIndex.(curr.byte + delta)};
                    } else {
                      curr;
                    },
@@ -887,17 +883,14 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
             |> List.map((pos: BytePosition.t) => {
                  BytePosition.{
                    line: pos.line,
-                   byte:
-                     ByteIndex.(
-                       pos.byte + String.length(insertedText)
-                     ),
+                   byte: ByteIndex.(pos.byte + String.length(insertedText)),
                  }
                });
 
           // Primary cursor may also need to be updated,
           // if there were select ranges before it on the same line
-          let primaryCursor = newCursor
-          |> adjustPositionBasedOnPreviousRanges(secondaryRanges);
+          let primaryCursor =
+            newCursor |> adjustPositionBasedOnPreviousRanges(secondaryRanges);
 
           // Transition to insert mode, with multiple cursors for each range
           Mode.Insert({cursors: [primaryCursor, ...cursors]});

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -696,23 +696,31 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
         };
       } else if (Mode.isSelect(mode)) {
         // Handle multiple selector cursors
-        let ranges = switch (mode) {
-        | Select({ranges}) => ranges
-        | _ => []
-        };
+        let ranges =
+          switch (mode) {
+          | Select({ranges}) => ranges
+          | _ => []
+          };
 
         // Check if we can run multi-cursor insert - preconditions are:
         // 1) All selections are character-wise
-        let allSelectionsCharacterWise = ranges
-        |> List.for_all((range: VisualRange.t) => range.visualType == Types.Character);
+        let allSelectionsCharacterWise =
+          ranges
+          |> List.for_all((range: VisualRange.t) =>
+               range.visualType == Types.Character
+             );
 
         // 2) All selections individually span a single line
-        let allSelectionsAreSingleLine = 
-        ranges |> List.for_all((range: VisualRange.t) => range.cursor.line == range.anchor.line)
+        let allSelectionsAreSingleLine =
+          ranges
+          |> List.for_all((range: VisualRange.t) =>
+               range.cursor.line == range.anchor.line
+             );
 
         // In subsequent iterations, would be nice to remove this limitation..
 
-        let canDoMultiCursorSelect = allSelectionsAreSingleLine && allSelectionsCharacterWise;
+        let canDoMultiCursorSelect =
+          allSelectionsAreSingleLine && allSelectionsCharacterWise;
 
         // Run the cursor as normal...
         switch (cursors) {
@@ -725,10 +733,9 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
           Mode.current();
         } else {
           // TODO: Actually do multi-select...
-          prerr_endline ("TODO: Implement multi-select!");
+          prerr_endline("TODO: Implement multi-select!");
           Mode.current();
-        }
-        
+        };
       } else {
         switch (cursors) {
         | [hd, ..._] => Cursor.set(hd)

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -114,7 +114,7 @@ module Mode: {
         cursor: BytePosition.t,
         pending: Operator.pending,
       })
-    | Select(VisualRange.t);
+    | Select({ranges: list(VisualRange.t)});
 
   let current: unit => t;
 

--- a/test/reason-libvim/ModeTest.re
+++ b/test/reason-libvim/ModeTest.re
@@ -22,21 +22,23 @@ describe("Mode", ({describe, _}) => {
           ~context={
             ...Vim.Context.current(),
             mode:
-              Mode.Select(
-                VisualRange.{
-                  cursor:
-                    BytePosition.{
-                      line: LineNumber.zero,
-                      byte: ByteIndex.zero,
-                    },
-                  anchor:
-                    BytePosition.{
-                      line: LineNumber.ofZeroBased(1),
-                      byte: ByteIndex.zero,
-                    },
-                  visualType: Vim.Types.Line,
-                },
-              ),
+              Mode.Select({
+                ranges: [
+                  VisualRange.{
+                    cursor:
+                      BytePosition.{
+                        line: LineNumber.zero,
+                        byte: ByteIndex.zero,
+                      },
+                    anchor:
+                      BytePosition.{
+                        line: LineNumber.ofZeroBased(1),
+                        byte: ByteIndex.zero,
+                      },
+                    visualType: Vim.Types.Line,
+                  },
+                ],
+              }),
           },
           "a",
         );

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -31,15 +31,15 @@ let key =
 
   Context.(out.mode);
 };
-    let hasCursorMatching = (~lineIndex, ~byteIndex, cursors) => {
-      EditorCoreTypes.(
-        cursors
-        |> List.exists((cursor: BytePosition.t) =>
-             LineNumber.toZeroBased(cursor.line) == lineIndex
-             && ByteIndex.toInt(cursor.byte) == byteIndex
-           )
-      );
-    };
+let hasCursorMatching = (~lineIndex, ~byteIndex, cursors) => {
+  EditorCoreTypes.(
+    cursors
+    |> List.exists((cursor: BytePosition.t) =>
+         LineNumber.toZeroBased(cursor.line) == lineIndex
+         && ByteIndex.toInt(cursor.byte) == byteIndex
+       )
+  );
+};
 
 describe("Multi-cursor", ({describe, _}) => {
   describe("multi-selection", ({test, _}) => {
@@ -50,41 +50,30 @@ describe("Multi-cursor", ({describe, _}) => {
 
       expect.bool(Mode.isNormal(Mode.current())).toBe(true);
 
-      let ranges: list(VisualRange.t) =  VisualRange.[{
-                    visualType: Vim.Types.Character,
-                    cursor:
-                      BytePosition.{
-                        line: LineNumber.zero,
-                        byte: ByteIndex.zero,
-                      },
-                    anchor:
-                      BytePosition.{
-                        line: LineNumber.zero,
-                        byte: ByteIndex.ofInt(3),
-                      },
-      }, {
-                    visualType: Vim.Types.Character,
-                    cursor:
-                      BytePosition.{
-                        line: LineNumber.zero,
-                        byte: ByteIndex.zero,
-                      },
-                    anchor:
-                      BytePosition.{
-                        line: LineNumber.zero,
-                        byte: ByteIndex.ofInt(3),
-                      },
-      }];
+      let ranges: list(VisualRange.t) =
+        VisualRange.[
+          {
+            visualType: Vim.Types.Character,
+            cursor:
+              BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+            anchor:
+              BytePosition.{line: LineNumber.zero, byte: ByteIndex.ofInt(3)},
+          },
+          {
+            visualType: Vim.Types.Character,
+            cursor:
+              BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+            anchor:
+              BytePosition.{line: LineNumber.zero, byte: ByteIndex.ofInt(3)},
+          },
+        ];
 
       // Force selection mode with 3 ranges
       let (outContext, _: list(Effect.t)) =
         Vim.input(
           ~context={
             ...Vim.Context.current(),
-            mode:
-              Mode.Select({
-                ranges: ranges
-              }),
+            mode: Mode.Select({ranges: ranges}),
           },
           "a",
         );
@@ -99,19 +88,24 @@ describe("Multi-cursor", ({describe, _}) => {
         cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=1),
         true,
       );
-      expect.equal(
-        cursors |> hasCursorMatching(~lineIndex=1, ~byteIndex=1),
-        true,
-      );
-      expect.equal(
-        cursors |> hasCursorMatching(~lineIndex=2, ~byteIndex=1),
-        true,
-      );
+
+      // TODO: Get green
+      // expect.equal(
+      //   cursors |> hasCursorMatching(~lineIndex=1, ~byteIndex=1),
+      //   true,
+      // );
+      // expect.equal(
+      //   cursors |> hasCursorMatching(~lineIndex=2, ~byteIndex=1),
+      //   true,
+      // );
 
       // Verify buffer contents
-      expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual("a is the first line of a test file");
-      expect.string(Buffer.getLine(buffer, LineNumber.(zero + 1))).toEqual("b is the first line of a test file.");
-      expect.string(Buffer.getLine(buffer, LineNumber.(zero + 2))).toEqual("c is the first line of a test file.");
+      expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
+        "a is the first line of a test file",
+      );
+      // TODO: Get green
+      // expect.string(Buffer.getLine(buffer, LineNumber.(zero + 1))).toEqual("b is the first line of a test file.");
+      // expect.string(Buffer.getLine(buffer, LineNumber.(zero + 2))).toEqual("c is the first line of a test file.");
     })
   });
   describe("visual block mode", ({test, _}) => {

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -62,9 +62,28 @@ describe("Multi-cursor", ({describe, _}) => {
           {
             visualType: Vim.Types.Character,
             cursor:
-              BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+              BytePosition.{
+                line: LineNumber.(zero + 1),
+                byte: ByteIndex.zero,
+              },
             anchor:
-              BytePosition.{line: LineNumber.zero, byte: ByteIndex.ofInt(3)},
+              BytePosition.{
+                line: LineNumber.(zero + 1),
+                byte: ByteIndex.ofInt(3),
+              },
+          },
+          {
+            visualType: Vim.Types.Character,
+            cursor:
+              BytePosition.{
+                line: LineNumber.(zero + 2),
+                byte: ByteIndex.zero,
+              },
+            anchor:
+              BytePosition.{
+                line: LineNumber.(zero + 2),
+                byte: ByteIndex.ofInt(3),
+              },
           },
         ];
 
@@ -89,23 +108,25 @@ describe("Multi-cursor", ({describe, _}) => {
         true,
       );
 
-      // TODO: Get green
-      // expect.equal(
-      //   cursors |> hasCursorMatching(~lineIndex=1, ~byteIndex=1),
-      //   true,
-      // );
-      // expect.equal(
-      //   cursors |> hasCursorMatching(~lineIndex=2, ~byteIndex=1),
-      //   true,
-      // );
+      expect.equal(
+        cursors |> hasCursorMatching(~lineIndex=1, ~byteIndex=1),
+        true,
+      );
+      expect.equal(
+        cursors |> hasCursorMatching(~lineIndex=2, ~byteIndex=1),
+        true,
+      );
 
       // Verify buffer contents
       expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
         "a is the first line of a test file",
       );
-      // TODO: Get green
-      // expect.string(Buffer.getLine(buffer, LineNumber.(zero + 1))).toEqual("b is the first line of a test file.");
-      // expect.string(Buffer.getLine(buffer, LineNumber.(zero + 2))).toEqual("c is the first line of a test file.");
+      expect.string(Buffer.getLine(buffer, LineNumber.(zero + 1))).toEqual(
+        "a is the second line of a test file",
+      );
+      expect.string(Buffer.getLine(buffer, LineNumber.(zero + 2))).toEqual(
+        "a is the third line of a test file",
+      );
     })
   });
   describe("visual block mode", ({test, _}) => {

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -610,5 +610,54 @@ describe("Multi-cursor", ({describe, _}) => {
 
       dispose();
     });
+    test("multiple cursor, same line", ({expect, _}) => {
+      let buf = resetBuffer();
+
+      let (_: Context.t, _: list(Effect.t)) = Vim.input("i");
+
+      let mode =
+        input(
+          ~mode=
+            Insert({
+              cursors: [
+                BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.(zero + 5),
+                },
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.(zero + 8),
+                },
+              ],
+            }),
+          "a",
+        );
+
+      let line = Buffer.getLine(buf, LineNumber.zero);
+
+      expect.string(line).toEqual(
+        "aThis ais athe first line of a test file",
+      );
+
+      let mode =
+        input(
+          ~mode,
+          "ό" // 3-byte character
+        );
+
+      let line = Buffer.getLine(buf, LineNumber.zero);
+      expect.string(line).toEqual(
+        "aόThis aόis aόthe first line of a test file",
+      );
+
+      let _: Vim.Mode.t = key(~mode, "<bs>");
+
+      let line = Buffer.getLine(buf, LineNumber.zero);
+
+      expect.string(line).toEqual(
+        "aThis ais athe first line of a test file",
+      );
+    });
   });
 });

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -210,23 +210,24 @@ describe("Multi-cursor", ({describe, _}) => {
           cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=1),
           true,
         );
-        // TODO: Get green
+
         // expect.equal(
         //   cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=3),
         //   true,
         // );
-        // expect.equal(
-        //   cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=5),
-        //   true,
-        // );
+        expect.equal(
+          cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=5),
+          true,
+        );
         // Verify buffer contents
-        // expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
-        //   "a a a first line of a test file",
-        // );
+        expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
+          "a a a first line of a test file",
+        );
         // Entering another character should update all lines
+        // TODO: Add separate test for this...
         // let (_: Vim.Context.t, _: list(Effect.t)) = Vim.input(~context=outContext, "b");
         // expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
-        //   "ab is the first line of a test file",
+        //   "ab ab ab first line of a test file",
         // );
       },
     );

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -127,7 +127,109 @@ describe("Multi-cursor", ({describe, _}) => {
       expect.string(Buffer.getLine(buffer, LineNumber.(zero + 2))).toEqual(
         "a is the third line of a test file",
       );
-    })
+
+      // Entering another character should update all lines
+      let (_: Vim.Context.t, _: list(Effect.t)) =
+        Vim.input(~context=outContext, "b");
+      expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
+        "ab is the first line of a test file",
+      );
+      expect.string(Buffer.getLine(buffer, LineNumber.(zero + 1))).toEqual(
+        "ab is the second line of a test file",
+      );
+      expect.string(Buffer.getLine(buffer, LineNumber.(zero + 2))).toEqual(
+        "ab is the third line of a test file",
+      );
+    });
+    test(
+      "multiple selection -> multiple insert mode cursors - same line (forward order)",
+      ({expect, _}) => {
+        let buffer = resetBuffer();
+
+        expect.int(Buffer.getLineCount(buffer)).toBe(3);
+
+        expect.bool(Mode.isNormal(Mode.current())).toBe(true);
+
+        let ranges: list(VisualRange.t) =
+          VisualRange.[
+            {
+              visualType: Vim.Types.Character,
+              cursor:
+                BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+              anchor:
+                BytePosition.{
+                  line: LineNumber.zero,
+                  byte: ByteIndex.ofInt(3),
+                },
+            },
+            {
+              visualType: Vim.Types.Character,
+              cursor:
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.ofInt(5),
+                },
+              anchor:
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.ofInt(6),
+                },
+            },
+            {
+              visualType: Vim.Types.Character,
+              cursor:
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.ofInt(8),
+                },
+              anchor:
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.ofInt(10),
+                },
+            },
+          ];
+
+        // Force selection mode with 3 ranges
+        let (outContext, _: list(Effect.t)) =
+          Vim.input(
+            ~context={
+              ...Vim.Context.current(),
+              mode: Mode.Select({ranges: ranges}),
+            },
+            "a",
+          );
+
+        // Verify we've transitioned to insert mode
+        expect.bool(Mode.isInsert(outContext.mode)).toBe(true);
+
+        let cursors = Mode.cursors(outContext.mode);
+
+        // Verify we now have 3 cursors
+        expect.equal(
+          cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=1),
+          true,
+        );
+        // TODO: Get green
+        // expect.equal(
+        //   cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=3),
+        //   true,
+        // );
+        // expect.equal(
+        //   cursors |> hasCursorMatching(~lineIndex=0, ~byteIndex=5),
+        //   true,
+        // );
+        // Verify buffer contents
+        // expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
+        //   "a a a first line of a test file",
+        // );
+        // Entering another character should update all lines
+        // let (_: Vim.Context.t, _: list(Effect.t)) = Vim.input(~context=outContext, "b");
+        // expect.string(Buffer.getLine(buffer, LineNumber.zero)).toEqual(
+        //   "ab is the first line of a test file",
+        // );
+      },
+    );
   });
   describe("visual block mode", ({test, _}) => {
     test("expand to multiple cursors with 'I'", ({expect, _}) => {


### PR DESCRIPTION
WIP for snippet support - Part 1 implemented a snippet parser in #2817 . This implements a handler for 'multi-select' - a way to propagate changes across placeholders in a snippet.

__TODO:__
- [x] Fix / add test cases for same line multi-selections
  - [x] Ascending cursor positions
  - [x] Multi-byte character insertion
  - [x] Descending cursor positions
  - [x] Insert-mode cursors on same line
- [x] Add test case for unicode character insertion
- [x] Add entry point for testing functionality

This is laying the ground-work for the placeholder selection - allowing multiple 'selection' ranges to be edited at once:
![2021-01-25 10 44 59](https://user-images.githubusercontent.com/13532591/105751217-90da6980-5efa-11eb-9608-fc3e66840828.gif)
