### PR TITLE
fix(vim): Command line completion - ':set no' does not complete as expected

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -8,6 +8,7 @@
 - #3016 - Extensions: Fix memory leak in extension host language features (fixes #3009)
 - #3019 - Extensions: Fix activation error for Ionide.Ionide-fsharp extension (fixes #2974)
 - #3020 - Vim: Fix incsearch cursor movement (fixes #2968)
+- #3027 - Vim: Command-line completion - fix 'set no' completion
 
 ### Performance
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -493,12 +493,12 @@ let start =
       let context = Oni_Model.VimContext.current(getState());
       let completions = Vim.CommandLine.getCompletions(~context, ());
 
-      let completions = if (StringEx.startsWith(~prefix="set no", text)) {
-        completions
-        |> Array.map(name => "no" ++ name)
-      } else {
-        completions
-      };
+      let completions =
+        if (StringEx.startsWith(~prefix="set no", text)) {
+          completions |> Array.map(name => "no" ++ name);
+        } else {
+          completions;
+        };
 
       Log.debugf(m => m("  got %n completions.", Array.length(completions)));
 
@@ -513,7 +513,7 @@ let start =
               highlight: [],
               handle: None,
             }
-            },
+          },
           completions,
         );
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -493,11 +493,18 @@ let start =
       let context = Oni_Model.VimContext.current(getState());
       let completions = Vim.CommandLine.getCompletions(~context, ());
 
+      let completions = if (StringEx.startsWith(~prefix="set no", text)) {
+        completions
+        |> Array.map(name => "no" ++ name)
+      } else {
+        completions
+      };
+
       Log.debugf(m => m("  got %n completions.", Array.length(completions)));
 
       let items =
         Array.map(
-          name =>
+          name => {
             Actions.{
               name,
               category: None,
@@ -505,6 +512,7 @@ let start =
               command: () => Noop,
               highlight: [],
               handle: None,
+            }
             },
           completions,
         );


### PR DESCRIPTION
__Issue:__ For command-line completion, when trying to complete a setting like `:set nosmoothscroll`, the completions don't account for the `no`:

![2021-01-21 15 30 26](https://user-images.githubusercontent.com/13532591/105425225-ca129100-5bfd-11eb-8e67-481b85ea825f.gif)

...which is jarring, and confusing.

__Fix:__ Add a special case - when the commands are negated, prefix them with `no`, and use our existing completion machinery:

![2021-01-21 15 32 45](https://user-images.githubusercontent.com/13532591/105425312-faf2c600-5bfd-11eb-9b5e-b35a897a4c6f.gif)
