### PR TITLE
fix(editor): Rubber-banding while scrolling w/ high key repeat

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -10,6 +10,7 @@
 - #3020 - Vim: Fix incsearch cursor movement (fixes #2968)
 - #3023 - Keybindings: Fix default - add quotes around "when" (thanks @noahhaasis!)
 - #3027 - Vim: Command-line completion - fix 'set no' completion
+- #3029 - Editor: Fix rubber-banding while scrolling with high key-repeat set
 
 ### Performance
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1041,7 +1041,7 @@ let isScrollAnimated = ({isScrollAnimated, isAnimationOverride, _}) => {
   };
 };
 
-let exposePrimaryCursor = editor =>
+let exposePrimaryCursor = (~isSmallJump=false, editor) =>
   if (!hasSetSize(editor)) {
     // If the size hasn't been set yet - don't try to expose the cursor.
     // We don't know about the viewport to do a good job.
@@ -1098,10 +1098,10 @@ let exposePrimaryCursor = editor =>
           0.,
         );
 
-      let isSmallJump =
-        !Spring.isActive(editor.scrollY)
-        && Float.abs(adjustedScrollY -. scrollY) < lineHeightInPixels(editor)
-        *. 1.1;
+      //let isSmallJump = true;
+        // !Spring.isActive(editor.scrollY)
+        // && Float.abs(adjustedScrollY -. scrollY) < lineHeightInPixels(editor)
+        // *. 1.1;
 
       let animated = editor |> isScrollAnimated;
       {
@@ -1142,7 +1142,22 @@ let isCursorFullyVisible = editor => {
 let mode = ({mode, _}) => mode;
 
 let setMode = (mode, editor) => {
-  {...editor, mode} |> exposePrimaryCursor;
+  open EditorCoreTypes;
+  let previousCursor = getPrimaryCursor(editor);
+  let editor' = {...editor, mode};
+  let newCursor = getPrimaryCursor(editor');
+
+  if (CharacterPosition.equals(previousCursor, newCursor)) {
+    editor'
+  } else {
+    let delta = CharacterPosition.(abs(LineNumber.toZeroBased(previousCursor.line) - LineNumber.toZeroBased(newCursor.line)));
+    let isSmallJumpLinewise = delta <= 1;
+    prerr_endline ("DELTA: " ++ string_of_int(delta));
+    let isSmallJump = isSmallJumpLinewise;
+    prerr_endline ("ISSMALLJUMP: " ++ string_of_bool(isSmallJump));
+    editor' |> exposePrimaryCursor(~isSmallJump);
+    
+  }
 };
 
 let getLeftVisibleColumn = view => {

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -137,7 +137,7 @@ let setLineNumbers:
 let lineNumbers: t => [ | `Off | `On | `Relative | `RelativeOnly];
 
 // [exposePrimaryCursor(editor)] ensures the primary cursor is visible - adjusting the scroll if it isnot.
-let exposePrimaryCursor: (~isSmallJump: bool=?, t) => t;
+let exposePrimaryCursor: (~disableAnimation: bool=?, t) => t;
 
 let getNearestMatchingPair:
   (

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -137,7 +137,7 @@ let setLineNumbers:
 let lineNumbers: t => [ | `Off | `On | `Relative | `RelativeOnly];
 
 // [exposePrimaryCursor(editor)] ensures the primary cursor is visible - adjusting the scroll if it isnot.
-let exposePrimaryCursor: t => t;
+let exposePrimaryCursor: (~isSmallJump: bool=?, t) => t;
 
 let getNearestMatchingPair:
   (


### PR DESCRIPTION
__Issue:__ On OSX, with high key repeat set (via this stackoverflow post: https://apple.stackexchange.com/questions/10467/how-to-increase-keyboard-key-repeat-rate-on-os-x) - the 'smooth scroll' exhibits some rubber-banding at the edges.

__Defect:__ When a high-key repeat is set, the input actually takes priority, and is starving the animation - so we get the cursor moving, but the smooth-scroll isn't keeping up. This can cause a bounce or rubber-banding, depending on when the animation gets executed.

__Fix:__ There was an existing strategy to mitigate this - when the jump is small, don't bother animating. This works well for holding down the `j`/`k` keys. However, there was a bug in our strategy - the delta was calculated based on the animated scroll position, and because it was out-of-date, we'd see it as a 'large' jump and continue animating. 

This tweaks the fix so that, instead of using the animation values, use the cursor position in buffer-space - if the jump is within a single line, or a single character, assume it's a small jump and disable animation.