### PR TITLE
fix(layout/#3035): Zen Mode - Show splits when zen mode is enabled

### DIFF
--- a/src/Feature/Layout/View.re
+++ b/src/Feature/Layout/View.re
@@ -485,7 +485,6 @@ module Layout = {
         ~model as layout,
         ~config,
         ~isFocused,
-        ~isZenMode,
         ~showTabs,
         ~uiFont,
         ~theme,
@@ -501,16 +500,7 @@ module Layout = {
       let children =
         switch (maybeDimensions) {
         | Some((width, height)) =>
-          let positioned =
-            isZenMode
-              ? Positioned.fromWindow(
-                  0,
-                  0,
-                  width,
-                  height,
-                  layout.activeGroupId,
-                )
-              : Positioned.fromLayout(0, 0, width, height, tree);
+          let positioned = Positioned.fromLayout(0, 0, width, height, tree);
 
           let renderWindow = id =>
             switch (groupById(id, layout)) {
@@ -581,7 +571,6 @@ let make =
       model={activeLayout(model)}
       config
       isFocused
-      isZenMode
       showTabs
       uiFont
       theme


### PR DESCRIPTION
__Issue:__ The current 'zen-mode' behavior doesn't show splits. This is problematic for a few reasons (detailed in more depth in #3035), but primarily:
1) When going to zen mode from a view with splits, the context of the additional splits is lost, and the navigation behavior is confusing
2) When in zen mode, and creating a split via `:vsp`, there is no feedback that a split is created - extra confusing when the editor starts  in single-file mode (zen mode) by default.

__Fix:__ Show splits in zen mode. This follows the same precedent as Code/Codium. If the no-split behavior is desired, we could add an additional zen-mode specific configuration setting for it.

Fixes #3035 