### PR TITLE
fix(editor/#3036): Customizable vertical/horizontal scrollbar size

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -14,6 +14,7 @@
 - #3027 - Vim: Command-line completion - fix 'set no' completion
 - #3029 - Editor: Fix rubber-banding while scrolling with high key-repeat set
 - #3021 - Configuration: Fix zoom being reset when saving configuration (fixes #2294)
+- #3051 - Editor: Make horizontal / vertical scrollbars on editor surface configurable (fixes #3036)
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -84,6 +84,10 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
     - _"selection"_ - Render whitespace characters in visual mode selected text
     - _"none"_ - Don't render whitespace at all
 
+- `editor.scrollbar.horizontalScrollbarSize` __(_int_ default: `8`)__ - The size, in pixels, of the horizontal scroll bar on the editor surface.
+
+- `editor.scrollbar.verticalScrollbarSize` __(_int_ default: `15`)__ - The size, in pixels, of the vertical scroll bar on the editor surface.
+
 - `editor.wordBasedSuggestions` __(_bool_ default: `true`)__ When `true`, keywords are provided as completion suggestions.
 
 - `editor.wordWrap` __(_bool_ default: `false`)__ When `true`, Onivim will soft-wrap lines at the viewport boundary.

--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -65,8 +65,6 @@ let minimapCharacterHeight = 2;
  * Number of pixels between each line in the minimap
  */
 let minimapLineSpacing = 1;
-//let scrollBarThickness = 15;
-let editorHorizontalScrollBarThickness = 8;
 let scrollBarCursorSize = 2;
 let minimapMaxColumn = 120;
 let tabHeight = 35;

--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -65,7 +65,7 @@ let minimapCharacterHeight = 2;
  * Number of pixels between each line in the minimap
  */
 let minimapLineSpacing = 1;
-let scrollBarThickness = 15;
+//let scrollBarThickness = 15;
 let editorHorizontalScrollBarThickness = 8;
 let scrollBarCursorSize = 2;
 let minimapMaxColumn = 120;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -137,6 +137,7 @@ type t = {
 };
 
 let verticalScrollbarThickness = ({scrollbarVerticalWidth, _}) => scrollbarVerticalWidth;
+let horizontalScrollbarThickness = ({scrollbarHorizontalWidth, _}) => scrollbarHorizontalWidth;
 
 let key = ({key, _}) => key;
 // TODO: Handle multiple ranges
@@ -471,7 +472,12 @@ let configure = (~config, editor) => {
     EditorConfiguration.yankHighlightDuration.get(config);
 
   let scrollbarVerticalWidth =
-    EditorConfiguration.verticalScrollbarSize.get(config);
+    EditorConfiguration.verticalScrollbarSize.get(config)
+    |> IntEx.clamp(~hi=100, ~lo=1);
+
+  let scrollbarHorizontalWidth =
+    EditorConfiguration.horizontalScrollbarSize.get(config)
+    |> IntEx.clamp(~hi=100, ~lo=1);
 
   // If codelens is turned off, remove all codelens keys
 
@@ -491,6 +497,7 @@ let configure = (~config, editor) => {
     isAnimated,
     isScrollAnimated,
     scrollbarVerticalWidth,
+    scrollbarHorizontalWidth,
     yankHighlightDuration,
   }
   |> setVerticalScrollMargin(~lines=scrolloff)

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -117,6 +117,8 @@ type t = {
   wrapMode: WrapMode.t,
   wrapState: WrapState.t,
   preview: bool,
+  scrollbarVerticalWidth: int,
+  scrollbarHorizontalWidth: int,
   wrapPadding: option(float),
   // Number of lines to preserve before or after the cursor, when scrolling.
   // Like the `scrolloff` vim setting or the `editor.cursorSurroundingLines` VSCode setting.
@@ -133,6 +135,8 @@ type t = {
   isAnimationOverride: option(bool),
   animationNonce: int,
 };
+
+let verticalScrollbarThickness = ({scrollbarVerticalWidth, _}) => scrollbarVerticalWidth;
 
 let key = ({key, _}) => key;
 // TODO: Handle multiple ranges
@@ -294,6 +298,7 @@ let getLayout = editor => {
     isMinimapEnabled,
     lineNumbers,
     minimapMaxColumnWidth,
+    scrollbarVerticalWidth,
     _,
   } = editor;
   let layout: EditorLayout.t =
@@ -306,6 +311,7 @@ let getLayout = editor => {
       ~characterWidth=getCharacterWidth(editor),
       ~characterHeight=lineHeightInPixels(editor),
       ~bufferLineCount=editor |> totalViewLines,
+      ~verticalScrollBarWidth=scrollbarVerticalWidth,
       (),
     );
 
@@ -464,6 +470,9 @@ let configure = (~config, editor) => {
   let yankHighlightDuration =
     EditorConfiguration.yankHighlightDuration.get(config);
 
+  let scrollbarVerticalWidth =
+    EditorConfiguration.verticalScrollbarSize.get(config);
+
   // If codelens is turned off, remove all codelens keys
 
   let inlineElements =
@@ -481,6 +490,7 @@ let configure = (~config, editor) => {
     inlineElements,
     isAnimated,
     isScrollAnimated,
+    scrollbarVerticalWidth,
     yankHighlightDuration,
   }
   |> setVerticalScrollMargin(~lines=scrolloff)
@@ -558,6 +568,9 @@ let create = (~config, ~buffer, ~preview: bool, ()) => {
     // Animation
     isAnimationOverride: None,
     animationNonce: 0,
+
+    scrollbarHorizontalWidth: 8,
+    scrollbarVerticalWidth: 15,
   }
   |> configure(~config);
 };

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -94,6 +94,8 @@ let setWrapMode: (~wrapMode: WrapMode.t, t) => t;
 
 let setSelections: (list(ByteRange.t), t) => t;
 
+let verticalScrollbarThickness: t => int;
+
 // Get the horizontal width in pixels of the tab/space whitespace in front of a line.
 let getLeadingWhitespacePixels: (EditorCoreTypes.LineNumber.t, t) => float;
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -94,6 +94,7 @@ let setWrapMode: (~wrapMode: WrapMode.t, t) => t;
 
 let setSelections: (list(ByteRange.t), t) => t;
 
+let horizontalScrollbarThickness: t => int;
 let verticalScrollbarThickness: t => int;
 
 // Get the horizontal width in pixels of the tab/space whitespace in front of a line.

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -344,6 +344,9 @@ let rulers = setting("editor.rulers", list(int), ~default=[]);
 let verticalScrollbarSize =
   setting("editor.scrollbar.verticalScrollbarSize", int, ~default=15);
 
+let horizontalScrollbarSize =
+  setting("editor.scrollbar.horizontalScrollbarSize", int, ~default=8);
+
 let scrolloff =
   setting(
     "editor.cursorSurroundingLines",
@@ -420,6 +423,7 @@ let contributions = [
   largeFileOptimization.spec,
   enablePreview.spec,
   highlightActiveIndentGuide.spec,
+  horizontalScrollbarSize.spec,
   indentSize.spec,
   insertSpaces.spec,
   lineNumbers.spec,

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -340,6 +340,10 @@ let renderIndentGuides =
 let renderWhitespace =
   setting("editor.renderWhitespace", whitespace, ~default=`Selection);
 let rulers = setting("editor.rulers", list(int), ~default=[]);
+
+let verticalScrollbarSize =
+  setting("editor.scrollbar.verticalScrollbarSize", int, ~default=15);
+
 let scrolloff =
   setting(
     "editor.cursorSurroundingLines",
@@ -429,6 +433,7 @@ let contributions = [
   tabSize.spec,
   wordWrap.spec,
   wordWrapColumn.spec,
+  verticalScrollbarSize.spec,
   yankHighlightColor.spec,
   yankHighlightDuration.spec,
   yankHighlightEnabled.spec,

--- a/src/Feature/Editor/EditorLayout.re
+++ b/src/Feature/Editor/EditorLayout.re
@@ -25,6 +25,7 @@ let getLayout =
       ~isMinimapShown: bool,
       ~characterWidth: float,
       ~characterHeight: float,
+      ~verticalScrollBarWidth: int,
       ~bufferLineCount: int,
       (),
     ) => {
@@ -43,7 +44,7 @@ let getLayout =
   let availableWidthInPixels =
     pixelWidth
     -. lineNumberWidthInPixels
-    -. float_of_int(Constants.scrollBarThickness)
+    -. float_of_int(verticalScrollBarWidth)
     -. minimapPadding
     *. 2.;
 
@@ -101,7 +102,7 @@ let getLayout =
     -. bufferWidthInPixels
     -. float_of_int(minimapWidthInPixels)
     -. lineNumberWidthInPixels
-    -. float_of_int(Constants.scrollBarThickness)
+    -. float_of_int(verticalScrollBarWidth)
     -. minimapPadding
     *. 2.;
 

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -55,13 +55,12 @@ module Styles = {
     bottom(0),
   ];
 
-  let horizontalScrollBar = (gutterOffset, width) => [
+  let horizontalScrollBar = (~thickness, gutterOffset, width) => [
     position(`Absolute),
     bottom(0),
     left(gutterOffset),
     Style.width(width),
-    // TODO:
-    height(8),
+    height(thickness),
   ];
 };
 
@@ -314,6 +313,8 @@ let%component make =
       : <View style={Styles.inactiveCover(~colors, ~opacity=coverAmount)} />;
 
   let verticalScrollbarThickness = Editor.verticalScrollbarThickness(editor);
+  let horizontalScrollbarThickness =
+    Editor.horizontalScrollbarThickness(editor);
 
   <View style={Styles.container(~colors)} onDimensionsChanged>
     gutterView
@@ -393,6 +394,7 @@ let%component make =
     </View>
     <View
       style={Styles.horizontalScrollBar(
+        ~thickness=horizontalScrollbarThickness,
         int_of_float(gutterWidth),
         int_of_float(layout.bufferWidthInPixels),
       )}>

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -47,11 +47,11 @@ module Styles = {
     bottom(0),
   ];
 
-  let verticalScrollBar = [
+  let verticalScrollBar = (~thickness) => [
     position(`Absolute),
     top(0),
     right(0),
-    width(Constants.scrollBarThickness),
+    width(thickness),
     bottom(0),
   ];
 
@@ -60,7 +60,8 @@ module Styles = {
     bottom(0),
     left(gutterOffset),
     Style.width(width),
-    height(Constants.editorHorizontalScrollBarThickness),
+    // TODO:
+    height(8),
   ];
 };
 
@@ -88,7 +89,7 @@ let minimap =
     Style.[
       position(`Absolute),
       top(0),
-      right(Constants.scrollBarThickness),
+      right(Editor.verticalScrollbarThickness(editor)),
       width(minimapPixelWidth),
       bottom(0),
     ];
@@ -312,6 +313,8 @@ let%component make =
       ? React.empty
       : <View style={Styles.inactiveCover(~colors, ~opacity=coverAmount)} />;
 
+  let verticalScrollbarThickness = Editor.verticalScrollbarThickness(editor);
+
   <View style={Styles.container(~colors)} onDimensionsChanged>
     gutterView
     <SurfaceView
@@ -373,13 +376,14 @@ let%component make =
     />
     {renderOverlays(~gutterWidth)}
     hoverPopup
-    <View style=Styles.verticalScrollBar>
+    <View
+      style={Styles.verticalScrollBar(~thickness=verticalScrollbarThickness)}>
       <Scrollbar.Vertical
         dispatch
         editor
         matchingPair=matchingPairs
         cursorPosition
-        width=Constants.scrollBarThickness
+        width=verticalScrollbarThickness
         height=pixelHeight
         diagnostics=diagnosticsMap
         colors

--- a/src/Feature/Editor/Scrollbar.re
+++ b/src/Feature/Editor/Scrollbar.re
@@ -171,7 +171,14 @@ module Common = {
 
 module Vertical = {
   let diagnosticMarkers =
-      (~diagnostics, ~totalHeight, ~editor, ~colors: Colors.t, ()) => {
+      (
+        ~scrollBarThickness,
+        ~diagnostics,
+        ~totalHeight,
+        ~editor,
+        ~colors: Colors.t,
+        (),
+      ) => {
     IntMap.bindings(diagnostics)
     |> List.map(binding => {
          let (line, diagnostics) = binding;
@@ -197,7 +204,7 @@ module Vertical = {
              position(`Absolute),
              top(diagTop),
              right(0),
-             width(Constants.scrollBarThickness / 3),
+             width(scrollBarThickness / 3),
              height(Constants.scrollBarCursorSize),
              backgroundColor(diagColor),
            ];
@@ -420,6 +427,8 @@ module Vertical = {
         Msg.VerticalScrollbarMouseWheel({deltaWheel: (-1.0) *. deltaWheel}),
       );
 
+    let scrollBarThickness = Editor.verticalScrollbarThickness(editor);
+
     <Common
       background={colors.scrollbarSliderBackground}
       hoverBackground={colors.scrollbarSliderHoverBackground}
@@ -444,7 +453,13 @@ module Vertical = {
           <View style={Styles.cursor(~cursorLine, ~totalWidth, ~colors)} />
           <View style=Styles.absolute>
             <selectionMarkers totalHeight editor colors />
-            <diagnosticMarkers totalHeight editor diagnostics colors />
+            <diagnosticMarkers
+              scrollBarThickness
+              totalHeight
+              editor
+              diagnostics
+              colors
+            />
             <matchingPairMarkers
               matchingPair
               bufferHighlights

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -36,7 +36,10 @@ describe("Editor", ({describe, _}) => {
     |> Editor.setSize(
          ~pixelWidth=
            int_of_float(
-             3. *. aWidth +. 1.0 +. float(Constants.scrollBarThickness),
+             3.
+             *. aWidth
+             +. 1.0
+             +. float(Editor.verticalScrollbarThickness(editor)),
            ),
          ~pixelHeight=500,
        )


### PR DESCRIPTION
This adds two configuration settings:
- `editor.scrollbar.verticalScrollbarSize`
- `editor.scrollbar.horizontalScrollbarSize`

which allow for adjusting the scrollbar sizes on the editor surface:

![2021-01-26 13 36 42](https://user-images.githubusercontent.com/13532591/105909222-200b7e00-5fdc-11eb-91b9-054e0c85ad71.gif)

Fixes #3036 
