### PR TITLE
feat(snippets): Initial cursor / placeholder positioning

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,7 +1,7 @@
 ### Features 
 
 - #3024 - Editor: Snippet Support - Multi-select handler
-- #3047 - Editor: Snippet Feature
+- #3047, #3052 - Editor: Snippet Feature
 
 ### Bug Fixes
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -831,6 +831,10 @@ let getPrimaryCursorByte = editor =>
     BytePosition.{line: EditorCoreTypes.LineNumber.zero, byte: ByteIndex.zero}
   };
 
+let setCursors = (cursors, editor) => {
+  {...editor, mode: Insert({cursors: cursors})};
+};
+
 let setSelections = (selections: list(ByteRange.t), editor) => {
   let mapRange = (r: ByteRange.t) => {
     open ByteRange;

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -92,6 +92,7 @@ let getHorizontalScrollbarMetrics: (t, int) => scrollbarMetrics;
 let getCursors: t => list(BytePosition.t);
 let setWrapMode: (~wrapMode: WrapMode.t, t) => t;
 
+let setCursors: (list(BytePosition.t), t) => t;
 let setSelections: (list(ByteRange.t), t) => t;
 
 let horizontalScrollbarThickness: t => int;

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -14,6 +14,8 @@ let initial: model;
 type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | ErrorMessage(string)
+  | SetCursors(list(BytePosition.t))
+  | SetSelections(list(ByteRange.t))
   | Nothing;
 
 module Snippet: {

--- a/src/Feature/Snippets/Snippet.re
+++ b/src/Feature/Snippets/Snippet.re
@@ -334,7 +334,7 @@ module Placeholder = {
                          },
                          stop: {
                            line: lineNumber,
-                           byte: ByteIndex.ofInt(offset + len),
+                           byte: ByteIndex.ofInt(offset + len - 1),
                          },
                        },
                      ),

--- a/src/Feature/Snippets/Snippet.re
+++ b/src/Feature/Snippets/Snippet.re
@@ -1,3 +1,4 @@
+open EditorCoreTypes;
 open Oni_Core;
 open Utility;
 open Snippet_internal;
@@ -6,7 +7,7 @@ open Snippet_internal;
 type raw = list(Snippet_internal.t);
 
 [@deriving show]
-type t = list(Snippet_internal.t);
+type snippet = list(Snippet_internal.t);
 
 let parse: string => result(raw, string) =
   str => {
@@ -132,6 +133,370 @@ let%test_module "parse" =
      };
    });
 
+module Placeholder = {
+  type t = IntMap.t(list(Snippet_internal.segment));
+
+  type positions =
+    | Positions(list(BytePosition.t))
+    | Ranges(list(ByteRange.t));
+
+  type position =
+    | Position(BytePosition.t)
+    | Range(ByteRange.t);
+
+  let normalizePositions: list(position) => positions =
+    positions => {
+      let isRange =
+        fun
+        | Range(_) => true
+        | Position(_) => false;
+
+      let isAllRanges = positions |> List.for_all(isRange);
+
+      if (isAllRanges) {
+        // We can map this to a `Ranges`
+
+        let rec loop = (acc, positions) => {
+          switch (positions) {
+          | [] => acc
+          | [hd, ...tail] =>
+            switch (hd) {
+            | Range(range) => loop([range, ...acc], tail)
+            | Position(_) => loop(acc, tail)
+            }
+          };
+        };
+
+        Ranges(loop([], positions));
+      } else {
+        let rec loop = (acc, positions) => {
+          switch (positions) {
+          | [] => acc
+          | [hd, ...tail] =>
+            switch (hd) {
+            | Range(_) => loop(acc, tail)
+            | Position(pos) => loop([pos, ...acc], tail)
+            }
+          };
+        };
+
+        Positions(loop([], positions));
+      };
+    };
+
+  let hasAny = (snippet: snippet) => {
+    let rec lineHasPlaceHolder = snippetLine => {
+      switch (snippetLine) {
+      | [] => false
+      | [hd, ...tail] =>
+        switch (hd) {
+        | Text(_) => lineHasPlaceHolder(tail)
+        | Placeholder(_) => true
+        | Choice(_) => true
+        | Variable(_) => lineHasPlaceHolder(tail)
+        }
+      };
+    };
+
+    snippet |> List.exists(lineHasPlaceHolder);
+  };
+
+  // Get a placeholder as text
+  let text = (~index: int, placeholders: t) => {
+    // Add a max recursion depth... so we don't get stuck
+    // ping-ponging between recursive placeholders.
+    let calculate = (cache, index, placeholders) => {
+      placeholders
+      |> IntMap.find_opt(index)
+      |> Option.map(segments => {
+           let rec loop = (cache, acc, remaining) => {
+             switch (remaining) {
+             | [] => (cache, acc)
+             | [hd, ...tail] =>
+               switch (hd) {
+               | Text(text) => loop(cache, acc ++ text, tail)
+               | Placeholder({index: placeholderIndex, contents}) =>
+                 if (placeholderIndex == index) {
+                   // This is a nested one: ${2:${2}}... skip
+                   loop(
+                     cache,
+                     acc,
+                     tail,
+                   );
+                 } else {
+                   // A nested placeholder we haven't encountered...
+                   // is it cached or do we need to calculate it, too?
+                   switch (IntMap.find_opt(placeholderIndex, cache)) {
+                   // Not cached... let's calculate
+                   | None =>
+                     let (newCache, text) = loop(cache, "", contents);
+                     loop(newCache, acc ++ text, tail);
+
+                   | Some(text) => loop(cache, acc ++ text, tail)
+                   };
+                 }
+               | Choice({choices, _}) =>
+                 let text =
+                   List.nth_opt(choices, 0) |> Option.value(~default="");
+
+                 loop(cache, acc ++ text, tail);
+               | Variable(_) => loop(cache, acc, tail)
+               }
+             };
+           };
+
+           loop(cache, "", segments);
+         });
+    };
+
+    calculate(IntMap.empty, index, placeholders) |> Option.map(snd);
+  };
+
+  let%test_module "Placeholder.text" =
+    (module
+     {
+       let make = placeholders =>
+         placeholders
+         |> List.fold_left(
+              (acc, curr) => {
+                let (index, segments) = curr;
+                IntMap.add(index, segments, acc);
+              },
+              IntMap.empty,
+            );
+
+       let%test "simple placeholder" = {
+         let placeholders = make([(1, [Text("abc")])]);
+
+         text(~index=1, placeholders) == Some("abc");
+       };
+
+       let%test "empty placeholder" = {
+         let placeholders = make([(1, [])]);
+
+         text(~index=1, placeholders) == Some("");
+       };
+
+       let%test "non-existent placeholder" = {
+         let placeholders = make([(1, [])]);
+
+         text(~index=2, placeholders) == None;
+       };
+       let%test "nested placeholder" = {
+         let placeholders =
+           make([
+             (1, [Text("abc")]),
+             (
+               2,
+               [
+                 Text("def"),
+                 Placeholder({index: 1, contents: [Text("abc")]}),
+               ],
+             ),
+           ]);
+
+         text(~index=2, placeholders) == Some("defabc");
+       };
+     });
+
+  let positions = (~placeholders: t, ~index: int, snippet: snippet) => {
+    placeholders
+    |> IntMap.find_opt(index)
+    |> Option.map(_placeholder => {
+         let rec loop =
+                 (
+                   lineNumber: EditorCoreTypes.LineNumber.t,
+                   acc: list(position),
+                   offset: int,
+                   segments: list(Snippet_internal.segment),
+                 ) => {
+           switch (segments) {
+           | [] => (acc, offset)
+           | [hd, ...tail] =>
+             switch (hd) {
+             | Text(text) =>
+               loop(lineNumber, acc, offset + String.length(text), tail)
+
+             | Placeholder({index: placeholderIndex, contents}) =>
+               // If this is the index we're looking for, add it to our list
+               if (index == placeholderIndex) {
+                 let placeholderText =
+                   text(~index, placeholders) |> Option.value(~default="");
+                 let len = String.length(placeholderText);
+                 if (len > 0) {
+                   // Add a byte range
+                   let acc' = [
+                     Range(
+                       ByteRange.{
+                         start: {
+                           line: lineNumber,
+                           byte: ByteIndex.ofInt(offset),
+                         },
+                         stop: {
+                           line: lineNumber,
+                           byte: ByteIndex.ofInt(offset + len),
+                         },
+                       },
+                     ),
+                     ...acc,
+                   ];
+                   loop(lineNumber, acc', offset + len, tail);
+                 } else {
+                   // Add a byte position
+                   let acc' = [
+                     Position(
+                       BytePosition.{
+                         line: lineNumber,
+                         byte: ByteIndex.ofInt(offset),
+                       },
+                     ),
+                     ...acc,
+                   ];
+                   loop(lineNumber, acc', offset, tail);
+                 };
+               } else {
+                 // Have to dive into this segment...
+                 let (acc', offset') =
+                   loop(lineNumber, acc, offset, contents);
+                 loop(lineNumber, acc', offset', tail);
+               }
+
+             // TODO: Handle variable / choice
+             | Variable(_)
+             | Choice(_) => loop(lineNumber, acc, offset, tail)
+             }
+           };
+         };
+
+         snippet
+         |> List.fold_left(
+              (acc, curr) => {
+                let (idx, currentPositions) = acc;
+                let (newPositions, _offset) =
+                  loop(
+                    EditorCoreTypes.LineNumber.ofZeroBased(idx),
+                    [],
+                    0,
+                    curr,
+                  );
+                let allPositions = currentPositions @ newPositions;
+                (idx + 1, allPositions);
+              },
+              (0, []),
+            )
+         |> snd
+         |> normalizePositions;
+       });
+  };
+
+  let%test_module "Placeholder.positions" =
+    (module
+     {
+       let make = placeholders =>
+         placeholders
+         |> List.fold_left(
+              (acc, curr) => {
+                let (index, segments) = curr;
+                IntMap.add(index, segments, acc);
+              },
+              IntMap.empty,
+            );
+
+       let%test "simple empty placeholder" = {
+         let placeholder1 = [];
+         let placeholders = make([(1, placeholder1)]);
+
+         let snippet = [
+           [Text("abc"), Placeholder({index: 1, contents: placeholder1})],
+         ];
+
+         positions(~index=1, ~placeholders, snippet)
+         == Some(
+              Positions([
+                BytePosition.{
+                  line: EditorCoreTypes.LineNumber.zero,
+                  byte: ByteIndex.(zero + 3),
+                },
+              ]),
+            );
+       };
+
+       let%test "simple placeholder range" = {
+         let placeholder1 = [Text("abc")];
+         let placeholders = make([(1, placeholder1)]);
+
+         let snippet = [
+           [Text("abc"), Placeholder({index: 1, contents: placeholder1})],
+         ];
+
+         positions(~index=1, ~placeholders, snippet)
+         == Some(
+              Ranges([
+                ByteRange.{
+                  start: {
+                    line: EditorCoreTypes.LineNumber.zero,
+                    byte: ByteIndex.(zero + 3),
+                  },
+                  stop: {
+                    line: EditorCoreTypes.LineNumber.zero,
+                    byte: ByteIndex.(zero + 6),
+                  },
+                },
+              ]),
+            );
+       };
+     });
+
+  let extractPlaceholders = (snippet: snippet) => {
+    let rec populatePlaceholders = (map, segments) => {
+      switch (segments) {
+      | [] => map
+      | [hd, ...tail] =>
+        switch (hd) {
+        // Move forward...
+        | Text(_)
+        | Variable(_) => populatePlaceholders(map, tail)
+
+        // Bring in placeholders
+        | Choice({index, choices}) =>
+          let text = List.nth_opt(choices, 0) |> Option.value(~default="");
+          let map' = IntMap.add(index, [Text(text)], map);
+          populatePlaceholders(map', tail);
+
+        | Placeholder({index, contents}) =>
+          let map' = IntMap.add(index, contents, map);
+          // Handle nested placeholders
+          let map'' = populatePlaceholders(map', contents);
+          // And then continue moving across the rest of hte line
+          populatePlaceholders(map'', tail);
+        }
+      };
+    };
+
+    snippet
+    |> List.fold_left(
+         (acc, snippetLine) => {populatePlaceholders(acc, snippetLine)},
+         IntMap.empty,
+       );
+  };
+
+  let initial = snippet => {
+    let placeholders = extractPlaceholders(snippet);
+
+    let nonZeroIndices =
+      placeholders
+      |> IntMap.bindings
+      |> List.map(fst)
+      |> List.filter(idx => idx != 0)
+      |> List.sort(compare);
+
+    let initialIndex =
+      List.nth_opt(nonZeroIndices, 0) |> Option.value(~default=0);
+
+    (initialIndex, placeholders);
+  };
+};
+
 let resolve =
     (
       ~prefix: string,
@@ -139,9 +504,11 @@ let resolve =
       ~indentationSettings: Oni_Core.IndentationSettings.t,
       snippet,
     ) => {
+  // TODO: Wire up indentation settings
   ignore(indentationSettings);
 
   let lines = List.length(snippet);
+  let hasAnyPlaceholders = Placeholder.hasAny(snippet);
 
   // Keep track of the leading whitespace, so we can add it on subsequent lines
   let leadingWhitespace = StringEx.leadingWhitespace(prefix);
@@ -165,7 +532,13 @@ let resolve =
        let line'' =
          if (isLast) {
            let revLine' = line' |> List.rev;
-           [Text(postfix), ...revLine'] |> List.rev;
+           let finalPlaceholder =
+             if (!hasAnyPlaceholders) {
+               [Placeholder({index: 0, contents: []})];
+             } else {
+               [];
+             };
+           [Text(postfix)] @ finalPlaceholder @ revLine' |> List.rev;
          } else {
            line';
          };
@@ -192,7 +565,15 @@ let%test_module "resolve" =
            raw,
          );
 
-       resolved == [[Text("PREFIX"), Text("abc"), Text("POSTFIX")]];
+       resolved
+       == [
+            [
+              Text("PREFIX"),
+              Text("abc"),
+              Placeholder({index: 0, contents: []}),
+              Text("POSTFIX"),
+            ],
+          ];
      };
 
      let%test "adds prefix and postfix when multi-line" = {
@@ -209,7 +590,11 @@ let%test_module "resolve" =
        resolved
        == [
             [Text("PREFIX"), Text("abc")],
-            [Text("def"), Text("POSTFIX")],
+            [
+              Text("def"),
+              Placeholder({index: 0, contents: []}),
+              Text("POSTFIX"),
+            ],
           ];
      };
      let%test "persists whitespace across lines" = {
@@ -227,12 +612,17 @@ let%test_module "resolve" =
        == [
             [Text("  PREFIX"), Text("abc")],
             [Text("  "), Text("def")],
-            [Text("  "), Text("ghi"), Text("POSTFIX")],
+            [
+              Text("  "),
+              Text("ghi"),
+              Placeholder({index: 0, contents: []}),
+              Text("POSTFIX"),
+            ],
           ];
      };
    });
 
-let toLines = (resolvedSnippet: t) => {
+let toLines = (resolvedSnippet: snippet) => {
   let rec lineToString = (acc, line: list(Snippet_internal.segment)) =>
     switch (line) {
     | [] => acc
@@ -251,3 +641,5 @@ let toLines = (resolvedSnippet: t) => {
 
   resolvedSnippet |> List.map(lineToString("")) |> Array.of_list;
 };
+
+type t = snippet;

--- a/src/Feature/Snippets/Snippet.re
+++ b/src/Feature/Snippets/Snippet.re
@@ -439,7 +439,7 @@ module Placeholder = {
                   },
                   stop: {
                     line: EditorCoreTypes.LineNumber.zero,
-                    byte: ByteIndex.(zero + 6),
+                    byte: ByteIndex.(zero + 5),
                   },
                 },
               ]),


### PR DESCRIPTION
This implements the initial tab-stop / cursor placement when inserting a snippet

__TODO:__
- [x] Convert snippet-space positions to buffer-space positions

__Next steps:__
- Add test case for indentation settings
- Implement variable expansion
- Implement snippet session lifecycle + visualization
- Implement jumping between placeholders w/ tab + shift+tab
- Implement loading snippets from extensions
- Implement loading snippets from user repository
- Add documentation