### PR TITLE
feat(snippets): Implement whitespace normalization

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,7 +1,7 @@
 ### Features 
 
 - #3024 - Editor: Snippet Support - Multi-select handler
-- #3047, #3052 - Editor: Snippet Feature
+- #3047, #3052, #3056 - Editor: Snippet Feature
 
 ### Bug Fixes
 


### PR DESCRIPTION
The `/t` character for snippets needs to be normalized to match the indentation settings of the current buffer - this impements that functionality and adds a basic test.