### PR TITLE
feat(snippets): Initial session / lifecycle management

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,7 +1,7 @@
 ### Features 
 
 - #3024 - Editor: Snippet Support - Multi-select handler
-- #3047, #3052, #3056 - Editor: Snippet Feature
+- #3047, #3052, #3056, #3059 - Editor: Snippet Feature
 
 ### Bug Fixes
 

--- a/bench/lib/EditorSurfaceBench.re
+++ b/bench/lib/EditorSurfaceBench.re
@@ -42,6 +42,7 @@ let editor = (editor, buffer, state: State.t) => {
     languageInfo=Exthost.LanguageInfo.initial
     grammarRepository=Oni_Syntax.GrammarRepository.empty
     uiFont=Oni_Core.UiFont.default
+    snippets=Feature_Snippets.initial
     renderOverlays={(~gutterWidth as _) => <Revery.UI.View />}
   />;
 };

--- a/src/Core/Mode.re
+++ b/src/Core/Mode.re
@@ -18,6 +18,7 @@ type t =
   | Operator({pending: Vim.Operator.pending})
   | CommandLine
   // Additional modes
+  | Snippet
   | TerminalInsert
   | TerminalNormal
   | TerminalVisual({range: VisualRange.t});
@@ -47,6 +48,7 @@ let toString =
   | Replace(_) => "Replace"
   | Operator({pending}) => Vim.Operator.toString(pending)
   | CommandLine => "Command Line"
+  | Snippet => "Snippet"
   | TerminalInsert => "Terminal Insert"
   | TerminalNormal => "Terminal Normal"
   | TerminalVisual({range}) =>

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -335,6 +335,7 @@ let%component make =
       languageConfiguration
       bufferSyntaxHighlights
       mode
+      snippets
       isActiveSplit
       gutterWidth
       bufferPixelWidth={int_of_float(layout.bufferWidthInPixels)}

--- a/src/Feature/Editor/EditorSurface.re
+++ b/src/Feature/Editor/EditorSurface.re
@@ -154,6 +154,7 @@ let%component make =
                 ~tokenTheme,
                 ~languageSupport,
                 ~scm,
+                ~snippets: Feature_Snippets.model,
                 ~windowIsFocused,
                 ~perFileTypeConfig: Oni_Core.Config.fileTypeResolver,
                 ~renderOverlays,

--- a/src/Feature/Editor/SnippetVisualizer.re
+++ b/src/Feature/Editor/SnippetVisualizer.re
@@ -1,0 +1,81 @@
+open EditorCoreTypes;
+open Oni_Core;
+open Feature_Snippets;
+
+open Revery.Draw;
+
+module Log = (
+  val Oni_Core.Log.withNamespace("Feature_Editor.SnippetVisualizer")
+);
+
+let snippetPaint = Skia.Paint.make();
+
+let draw = (~context: Draw.context, session: Feature_Snippets.Session.t) => {
+  let color = Revery.Color.toSkia(Revery.Color.rgba(0., 0., 0., 0.1));
+  Skia.Paint.setColor(snippetPaint, color);
+  let width = float(context.width);
+  let height = float(context.height);
+
+  let (topPixel, _) =
+    Editor.bufferBytePositionToPixel(
+      ~position=
+        BytePosition.{
+          line: Session.startLine(session),
+          byte: ByteIndex.zero,
+        },
+      context.editor,
+    );
+
+  CanvasContext.drawRectLtwh(
+    ~left=0.,
+    ~top=0.,
+    ~height=topPixel.y,
+    ~width,
+    ~paint=snippetPaint,
+    context.canvasContext,
+  );
+
+  Oni_Components.ScrollShadow.Shadow.render(
+    ~color=Revery.Color.rgba(0., 0., 0., 0.1),
+    ~opacity=1.0,
+    ~direction=Up,
+    ~x=0.,
+    ~y=topPixel.y -. 5.,
+    ~width,
+    ~height=5.,
+    ~context=Revery.Draw.CanvasContext.(context.canvasContext.canvas),
+  );
+  // CanvasContext.drawRectLtwh(
+  //   ~left=0.,
+  //   ~top=topPixel.y,
+  //   ~height=2.,
+  //   ~width,
+  //   ~paint=snippetPaint,
+  //   context.canvasContext,
+  // );
+
+  let (bottomPixel, _) =
+    Editor.bufferBytePositionToPixel(
+      ~position=
+        BytePosition.{line: Session.stopLine(session), byte: ByteIndex.zero},
+      context.editor,
+    );
+  CanvasContext.drawRectLtwh(
+    ~left=0.,
+    ~top=bottomPixel.y,
+    ~height=height -. bottomPixel.y,
+    ~width,
+    ~paint=snippetPaint,
+    context.canvasContext,
+  );
+  Oni_Components.ScrollShadow.Shadow.render(
+    ~color=Revery.Color.rgba(0., 0., 0., 0.22),
+    ~opacity=1.0,
+    ~direction=Down,
+    ~x=0.,
+    ~y=bottomPixel.y,
+    ~width,
+    ~height=5.,
+    ~context=Revery.Draw.CanvasContext.(context.canvasContext.canvas),
+  );
+};

--- a/src/Feature/Editor/SnippetVisualizer.re
+++ b/src/Feature/Editor/SnippetVisualizer.re
@@ -1,5 +1,4 @@
 open EditorCoreTypes;
-open Oni_Core;
 open Feature_Snippets;
 
 open Revery.Draw;

--- a/src/Feature/Editor/SurfaceView.re
+++ b/src/Feature/Editor/SurfaceView.re
@@ -57,6 +57,7 @@ let%component make =
                 ~bufferSyntaxHighlights,
                 ~maybeYankHighlights,
                 ~mode,
+                ~snippets: Feature_Snippets.model,
                 ~isActiveSplit,
                 ~gutterWidth,
                 ~bufferPixelWidth,
@@ -233,6 +234,10 @@ let%component make =
             indentation,
           );
         };
+
+        snippets
+        |> Feature_Snippets.session
+        |> Option.iter(SnippetVisualizer.draw(~context));
 
         ContentView.render(
           ~context,

--- a/src/Feature/Editor/dune
+++ b/src/Feature/Editor/dune
@@ -5,7 +5,7 @@
  (libraries Oni2.editor-core-types Oni2.core Oni2.components Oni2.exthost
    Oni2.component.animation Oni2.syntax Oni2.feature.configuration
    Oni2.feature.diagnostics Oni2.feature.scm Oni2.feature.theme
-   Oni2.feature.language_support Oni2.feature.syntax Oni2.service.font
-   Oni2.service.os Oni2.service.time Revery libvim)
+   Oni2.feature.language_support Oni2.feature.snippets Oni2.feature.syntax
+   Oni2.service.font Oni2.service.os Oni2.service.time Revery libvim)
  (preprocess
   (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -112,7 +112,7 @@ module Session = {
 type command =
   | JumpToNextPlaceholder
   | JumpToPreviousPlaceholder
-  | InsertSnippet([@opaque] Snippet.t); // TODO: How to have payload
+  | InsertSnippet([@opaque] Snippet.t);
 
 [@deriving show]
 type msg =
@@ -127,18 +127,21 @@ let session = ({maybeSession}) => maybeSession;
 let isActive = ({maybeSession}) => maybeSession != None;
 
 let modeChanged = (~mode, model) => {
-  let isModeValid = Vim.Mode.(switch(mode) {
-  | Select(_)
-  | Insert(_) => true
-  | _ => false
-  });
+  let isModeValid =
+    Vim.Mode.(
+      switch (mode) {
+      | Select(_)
+      | Insert(_) => true
+      | _ => false
+      }
+    );
 
   if (!isModeValid) {
-    {maybeSession: None}
+    {maybeSession: None};
   } else {
-    model
-  }
-}
+    model;
+  };
+};
 
 let initial = {maybeSession: None};
 

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -281,7 +281,7 @@ let update = (~maybeBuffer, ~editorId, ~cursorPosition, msg, model) =>
            ({maybeSession: Some(session')}, outmsg);
          };
        })
-    |> Option.value(~default=(model, Nothing));
+    |> Option.value(~default=(model, Nothing))
 
   | Command(InsertSnippet(snippet)) =>
     let eff =

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -126,6 +126,20 @@ let session = ({maybeSession}) => maybeSession;
 
 let isActive = ({maybeSession}) => maybeSession != None;
 
+let modeChanged = (~mode, model) => {
+  let isModeValid = Vim.Mode.(switch(mode) {
+  | Select(_)
+  | Insert(_) => true
+  | _ => false
+  });
+
+  if (!isModeValid) {
+    {maybeSession: None}
+  } else {
+    model
+  }
+}
+
 let initial = {maybeSession: None};
 
 type outmsg =

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -44,6 +44,10 @@ module Session = {
     currentPlaceholder: int,
   };
 
+  let startLine = ({startLine, _}) => startLine;
+  let stopLine = ({startLine, lineCount, _}) =>
+    EditorCoreTypes.LineNumber.(startLine + lineCount);
+
   let start = (~editorId, ~position: BytePosition.t, ~snippet) => {
     let (currentPlaceholder, placeholders) =
       Snippet.Placeholder.initial(snippet);
@@ -118,7 +122,9 @@ type msg =
 
 type model = {maybeSession: option(Session.t)};
 
-let isActive = ({maybeSession, _}) => maybeSession != None;
+let session = ({maybeSession}) => maybeSession;
+
+let isActive = ({maybeSession}) => maybeSession != None;
 
 let initial = {maybeSession: None};
 

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -38,7 +38,6 @@ module Session = {
   type t = {
     editorId: int,
     snippet: Snippet.t,
-    placeholders: Snippet.Placeholder.t,
     startLine: LineNumber.t,
     lineCount: int,
     currentPlaceholder: int,
@@ -49,14 +48,13 @@ module Session = {
     EditorCoreTypes.LineNumber.(startLine + lineCount);
 
   let start = (~editorId, ~position: BytePosition.t, ~snippet) => {
-    let (currentPlaceholder, placeholders) =
-      Snippet.Placeholder.initial(snippet);
+    let placeholders = Snippet.placeholders(snippet);
+    let currentPlaceholder = Snippet.Placeholder.initial(placeholders);
     let lineCount = List.length(snippet);
     {
       editorId,
       snippet,
       currentPlaceholder,
-      placeholders,
       startLine: position.line,
       lineCount,
     };
@@ -93,8 +91,8 @@ module Session = {
     };
   };
 
-  let getPlaceholderPositions =
-      ({placeholders, snippet, currentPlaceholder, startLine, _}) => {
+  let getPlaceholderPositions = ({snippet, currentPlaceholder, startLine, _}) => {
+    let placeholders = Snippet.placeholders(snippet);
     Snippet.Placeholder.positions(
       ~placeholders,
       ~index=currentPlaceholder,
@@ -103,7 +101,8 @@ module Session = {
     |> Option.map(remapPositions(~startLine));
   };
 
-  let isComplete = ({placeholders, currentPlaceholder, _}) => {
+  let isComplete = ({snippet, currentPlaceholder, _}) => {
+    let placeholders = Snippet.placeholders(snippet);
     Snippet.Placeholder.final(placeholders) == currentPlaceholder;
   };
 };

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -72,4 +72,5 @@ let update:
 module Contributions: {
   let commands: list(Command.t(msg));
   let contextKeys: model => WhenExpr.ContextKeys.t;
+  let keybindings: list(Feature_Input.Schema.keybinding);
 };

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -44,6 +44,8 @@ module Session: {
 
 let session: model => option(Session.t);
 
+let isActive: model => bool;
+
 // module Session: {
 //   type t;
 

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -35,6 +35,15 @@ module Snippet: {
     t;
 };
 
+module Session: {
+  type t;
+
+  let startLine: t => EditorCoreTypes.LineNumber.t;
+  let stopLine: t => EditorCoreTypes.LineNumber.t;
+};
+
+let session: model => option(Session.t);
+
 // module Session: {
 //   type t;
 

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -46,6 +46,8 @@ let session: model => option(Session.t);
 
 let isActive: model => bool;
 
+let modeChanged: (~mode: Vim.Mode.t, model) => model;
+
 // module Session: {
 //   type t;
 

--- a/src/Feature/Snippets/Snippet.re
+++ b/src/Feature/Snippets/Snippet.re
@@ -480,6 +480,17 @@ module Placeholder = {
        );
   };
 
+  let final = placeholders => {
+    let nonZeroIndices =
+      placeholders
+      |> IntMap.bindings
+      |> List.map(fst)
+      |> List.filter(idx => idx != 0)
+      |> List.sort((a, b) => compare(a, b) * (-1));
+
+    List.nth_opt(nonZeroIndices, 0) |> Option.value(~default=0);
+  };
+
   let initial = snippet => {
     let placeholders = extractPlaceholders(snippet);
 

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -692,6 +692,7 @@ module Oni = {
     | Visual(_) => visualModeBackground
     | CommandLine => commandlineModeBackground
     | Operator(_) => operatorModeBackground
+    | Snippet
     | TerminalInsert
     | Insert(_) => insertModeBackground
     | Replace(_) => replaceModeBackground
@@ -706,6 +707,7 @@ module Oni = {
     | Visual(_) => visualModeForeground
     | CommandLine => commandlineModeForeground
     | Operator(_) => operatorModeForeground
+    | Snippet
     | TerminalInsert
     | Insert(_) => insertModeForeground
     | Replace(_) => replaceModeForeground

--- a/src/Model/ContextKeys.re
+++ b/src/Model/ContextKeys.re
@@ -197,6 +197,7 @@ let all = (state: State.t) => {
     |> Schema.map((state: State.t) => state.quickmenu)
     |> fromSchema(state),
     editors(~isFocused=isEditorFocused) |> fromSchema(state),
+    Feature_Snippets.Contributions.contextKeys(state.snippets),
     other |> fromSchema(state),
   ]);
 };

--- a/src/Model/ModeManager.re
+++ b/src/Model/ModeManager.re
@@ -14,36 +14,41 @@ let current: State.t => Oni_Core.Mode.t =
   (state: State.t) => {
     let activeEditorMode =
       state.layout |> Feature_Layout.activeEditor |> Feature_Editor.Editor.mode;
-    state
-    |> Selectors.getActiveTerminal
-    |> Option.map((Feature_Terminal.{insertMode, _}) => {
-         insertMode
-           ? Mode.TerminalInsert
-           : Internal.getTerminalNormalMode(activeEditorMode)
-       })
-    |> Option.value(
-         ~default=
-           switch (activeEditorMode) {
-           | Vim.Mode.Insert({cursors}) =>
-             Mode.Insert(
-               {
-                 {cursors: cursors};
-               },
-             )
-           | Vim.Mode.Normal({cursor}) => Mode.Normal({cursor: cursor})
-           | Vim.Mode.Visual(range) =>
-             Mode.Visual({
-               cursor: Vim.VisualRange.cursor(range),
-               range: Oni_Core.VisualRange.ofVim(range),
-             })
-           | Vim.Mode.Select({ranges}) =>
-             Mode.Select({
-               ranges: ranges |> List.map(Oni_Core.VisualRange.ofVim),
-             })
-           | Vim.Mode.Replace({cursor}) => Mode.Replace({cursor: cursor})
-           | Vim.Mode.Operator({pending, _}) =>
-             Mode.Operator({pending: pending})
-           | Vim.Mode.CommandLine(_) => Mode.CommandLine
-           },
-       );
+
+    if (Feature_Snippets.isActive(state.snippets)) {
+      Snippet;
+    } else {
+      state
+      |> Selectors.getActiveTerminal
+      |> Option.map((Feature_Terminal.{insertMode, _}) => {
+           insertMode
+             ? Mode.TerminalInsert
+             : Internal.getTerminalNormalMode(activeEditorMode)
+         })
+      |> Option.value(
+           ~default=
+             switch (activeEditorMode) {
+             | Vim.Mode.Insert({cursors}) =>
+               Mode.Insert(
+                 {
+                   {cursors: cursors};
+                 },
+               )
+             | Vim.Mode.Normal({cursor}) => Mode.Normal({cursor: cursor})
+             | Vim.Mode.Visual(range) =>
+               Mode.Visual({
+                 cursor: Vim.VisualRange.cursor(range),
+                 range: Oni_Core.VisualRange.ofVim(range),
+               })
+             | Vim.Mode.Select({ranges}) =>
+               Mode.Select({
+                 ranges: ranges |> List.map(Oni_Core.VisualRange.ofVim),
+               })
+             | Vim.Mode.Replace({cursor}) => Mode.Replace({cursor: cursor})
+             | Vim.Mode.Operator({pending, _}) =>
+               Mode.Operator({pending: pending})
+             | Vim.Mode.CommandLine(_) => Mode.CommandLine
+             },
+         );
+    };
   };

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -376,6 +376,7 @@ let defaultKeyBindings =
   @ Component_VimWindows.Contributions.keybindings
   @ Component_VimList.Contributions.keybindings
   @ Component_VimTree.Contributions.keybindings
+  @ Feature_Snippets.Contributions.keybindings
   @ Feature_Vim.Contributions.keybindings;
 
 type windowDisplayMode =

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -245,6 +245,8 @@ module Internal = {
         state.languageSupport;
       };
 
+    let snippets' = Feature_Snippets.modeChanged(~mode, state.snippets);
+
     let languageSupport' =
       if (isInInsertMode != wasInInsertMode) {
         if (isInInsertMode) {
@@ -257,7 +259,7 @@ module Internal = {
         languageSupport;
       };
 
-    let state = {...state, layout, languageSupport: languageSupport'};
+    let state = {...state, layout, languageSupport: languageSupport', snippets: snippets'};
     (state, editorEffect);
   };
 };

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -259,7 +259,12 @@ module Internal = {
         languageSupport;
       };
 
-    let state = {...state, layout, languageSupport: languageSupport', snippets: snippets'};
+    let state = {
+      ...state,
+      layout,
+      languageSupport: languageSupport',
+      snippets: snippets',
+    };
     (state, editorEffect);
   };
 };

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -64,6 +64,7 @@ module Parts = {
         bufferSyntaxHighlights={state.syntaxHighlights}
         diagnostics={state.diagnostics}
         scm={state.scm}
+        snippets={state.snippets}
         tokenTheme={state.tokenTheme}
         languageSupport={state.languageSupport}
         windowIsFocused={state.windowIsFocused}

--- a/test/editor-input/MatcherTest.re
+++ b/test/editor-input/MatcherTest.re
@@ -155,6 +155,12 @@ describe("Matcher", ({describe, _}) => {
           Sequence([keyPress(~modifiers=modifiersShift, Key.Function(12))]),
         ),
       );
+
+      let result = defaultParse("<S-TAB>");
+      expect.equal(
+        result,
+        Ok(Sequence([keyPress(~modifiers=modifiersShift, Key.Tab)])),
+      );
     });
     test("vscode bindings", ({expect, _}) => {
       let result = defaultParse("Ctrl+a");


### PR DESCRIPTION
This is the next step in implementing snippets - maintaining the lifecycle of the snippet (whether it is active), showing a visualization / pseudo-mode when it is active, and allowing jumping back-and-forth between placeholders - for a simple snippet like: `let ${1:name} = (${2:args}) => $0;`:

![2021-01-28 12 30 42](https://user-images.githubusercontent.com/13532591/106195307-d4d0a700-6164-11eb-9758-43af5b160f6c.gif)

Still not _quite_ ready for prime-time yet, since we need to synchronize the placeholders when they are changed (in my demo - I typed out replacements that are the same length)- but getting closer.

__Next steps:__
- Implement variable expansion
- Implement synchronization of placeholders when text changes
- Implement loading snippets from extensions
- Implement loading snippets from user repository
- Add documentation