### PR TITLE
feat(snippets): Implement placeholder sync

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,7 +1,7 @@
 ### Features 
 
 - #3024 - Editor: Snippet Support - Multi-select handler
-- #3047, #3052, #3056, #3059, #3061 - Editor: Snippet Feature
+- #3047, #3052, #3056, #3059, #3061, #3064 - Editor: Snippet Feature
 
 ### Bug Fixes
 

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -1,4 +1,5 @@
 open Oni_Core;
+open Utility;
 open EditorCoreTypes;
 open Oniguruma;
 
@@ -36,12 +37,20 @@ let%test "clips at first placeholder w/ default" = {
 };
 
 module Session = {
+  type placeholder = {
+    placeholderIndex: int,
+    // The current line of the current placeholder, in snippet-space
+    snippetLineIndex: int,
+    // Snippet line contents - used for synchronization
+    lineContents: string,
+    numberOfPlaceholdersInLine: int,
+  };
   type t = {
     editorId: int,
     snippet: Snippet.t,
     startLine: LineNumber.t,
     lineCount: int,
-    currentPlaceholder: int,
+    currentPlaceholder: option(placeholder),
   };
 
   let startLine = ({startLine, _}) => startLine;
@@ -49,8 +58,37 @@ module Session = {
     EditorCoreTypes.LineNumber.(startLine + lineCount);
 
   let start = (~editorId, ~position: BytePosition.t, ~snippet) => {
+    let lines = Snippet.toLines(snippet);
     let placeholders = Snippet.placeholders(snippet);
     let currentPlaceholder = Snippet.Placeholder.initial(placeholders);
+    let maybePlaceholderLine =
+      Snippet.getFirstLineIndexWithPlaceholder(
+        ~index=currentPlaceholder,
+        snippet,
+      );
+    let maybePlaceholderCount =
+      maybePlaceholderLine
+      |> Option.map(line => {
+           Snippet.getPlaceholderCountForLine(
+             ~index=currentPlaceholder,
+             ~line,
+             snippet,
+           )
+         });
+
+    let currentPlaceholder =
+      OptionEx.map2(
+        (placeholderLine, placeholderCount) =>
+          {
+            placeholderIndex: currentPlaceholder,
+            snippetLineIndex: placeholderLine,
+            numberOfPlaceholdersInLine: placeholderCount,
+            lineContents: lines[placeholderLine],
+          },
+        maybePlaceholderLine,
+        maybePlaceholderCount,
+      );
+
     let lineCount = List.length(snippet);
     {
       editorId,
@@ -92,38 +130,239 @@ module Session = {
     };
   };
 
-  let next = ({snippet, currentPlaceholder, _} as session) => {
-    let placeholders = Snippet.placeholders(snippet);
+  // [synchronize(~buffer, state)] updates our internal snippet state to reflect any updates
+  let synchronize =
+      (
+        ~buffer: Oni_Core.Buffer.t,
+        {snippet, currentPlaceholder, startLine, _} as session,
+      ) => {
+    currentPlaceholder
+    |> OptionEx.flatMap(
+         (
+           {
+             placeholderIndex,
+             snippetLineIndex,
+             lineContents,
+             numberOfPlaceholdersInLine,
+           } as cur,
+         ) => {
+         let bufferLineIdx =
+           LineNumber.(startLine + snippetLineIndex) |> LineNumber.toZeroBased;
 
-    let newPlaceholder =
-      Snippet.Placeholder.next(~placeholder=currentPlaceholder, placeholders);
-    {...session, currentPlaceholder: newPlaceholder};
+         if (bufferLineIdx < Buffer.getNumberOfLines(buffer)) {
+           let newLineContents =
+             Buffer.getLine(bufferLineIdx, buffer) |> BufferLine.raw;
+
+           // If the 'before' line is equal to our new line, nothing happened -
+           // we're already synchronized
+           if (String.equal(lineContents, newLineContents)) {
+             Some(session);
+           } else {
+             // The lines are _not_ equal, so let's figure out the delta,
+             // and then update the current placeholder in the snippet to reflect
+             // the new state.
+             let originalLineLength = String.length(lineContents);
+             let newLineLength = String.length(newLineContents);
+
+             // Calculate the delta in characters.
+             let delta = newLineLength - originalLineLength;
+
+             // However, we also need to account for the number of placeholders in line
+             // - if there are two placeholders, there will be twice the delta.
+
+             let placeholderCount =
+               Snippet.getPlaceholderCountForLine(
+                 ~index=placeholderIndex,
+                 ~line=snippetLineIndex,
+                 snippet,
+               );
+             if (placeholderCount > 0) {
+               let normalizedDelta = delta / placeholderCount;
+               let placeholders = Snippet.placeholders(snippet);
+
+               // Now... we need to find the original range to get the
+               // exact substring text.
+               Snippet.Placeholder.positions(
+                 ~placeholders,
+                 ~index=placeholderIndex,
+                 snippet,
+               )
+               |> OptionEx.flatMap(positions => {
+                    let line =
+                      EditorCoreTypes.LineNumber.ofZeroBased(
+                        snippetLineIndex,
+                      );
+                    switch (positions) {
+                    | Snippet.Placeholder.Positions(_) =>
+                      Some(
+                        ByteRange.{
+                          start: {
+                            line,
+                            byte: ByteIndex.zero,
+                          },
+                          stop: {
+                            line,
+                            byte: ByteIndex.ofInt(-1),
+                          },
+                        },
+                      )
+                    | Snippet.Placeholder.Ranges(ranges) =>
+                      let rangesForLine =
+                        ranges
+                        |> List.filter((range: ByteRange.t) =>
+                             range.start.line == line
+                           )
+                        |> List.sort(EditorCoreTypes.ByteRange.compare);
+
+                      List.nth_opt(rangesForLine, 0);
+                    };
+                  })
+               |> OptionEx.flatMap((originalRange: ByteRange.t) => {
+                    let startByte = originalRange.start.byte;
+                    let stopByte = originalRange.stop.byte;
+                    let originalByteLength =
+                      ByteIndex.toInt(stopByte)
+                      - ByteIndex.toInt(startByte)
+                      + 1;
+                    let newByteLength = normalizedDelta + originalByteLength;
+                    // We erased past the placeholder, so time to close the session..
+                    if (newByteLength < 0) {
+                      None;
+                    } else if (newByteLength == 0) {
+                      Some("");
+                    } else {
+                      let newText =
+                        String.sub(
+                          newLineContents,
+                          ByteIndex.toInt(startByte),
+                          newByteLength,
+                        );
+                      prerr_endline("NEWTEXT: |" ++ newText ++ "|");
+                      Some(newText);
+                    };
+                  })
+               |> Option.map(newPlaceholderText => {
+                    let snippet' =
+                      Snippet.updatePlaceholder(
+                        ~index=placeholderIndex,
+                        ~text=newPlaceholderText,
+                        snippet,
+                      );
+
+                    {
+                      ...session,
+                      snippet: snippet',
+                      currentPlaceholder:
+                        Some({...cur, lineContents: newLineContents}),
+                    };
+                  });
+             } else {
+               None;
+             };
+           };
+         } else {
+           None;
+         };
+       });
   };
 
-  let previous = ({snippet, currentPlaceholder, _} as session) => {
-    let placeholders = Snippet.placeholders(snippet);
+  let next = (~buffer, {snippet, currentPlaceholder, _} as session) => {
+    synchronize(~buffer, session)
+    |> Option.map(session => {
+         let {snippet, currentPlaceholder, _} = session;
+         let placeholders = Snippet.placeholders(snippet);
 
-    let newPlaceholder =
-      Snippet.Placeholder.previous(
-        ~placeholder=currentPlaceholder,
-        placeholders,
-      );
-    {...session, currentPlaceholder: newPlaceholder};
+         let currentPlaceholder': option(placeholder) =
+           currentPlaceholder
+           |> OptionEx.flatMap(placeholder => {
+                let newPlaceholder =
+                  Snippet.Placeholder.next(
+                    ~placeholder=placeholder.placeholderIndex,
+                    placeholders,
+                  );
+                Snippet.getFirstLineIndexWithPlaceholder(
+                  ~index=newPlaceholder,
+                  snippet,
+                )
+                |> Option.map(line => {
+                     let count =
+                       Snippet.getPlaceholderCountForLine(
+                         ~index=newPlaceholder,
+                         ~line,
+                         snippet,
+                       );
+                     let lines = Snippet.toLines(snippet);
+                     {
+                       placeholderIndex: newPlaceholder,
+                       snippetLineIndex: line,
+                       lineContents: lines[line],
+                       numberOfPlaceholdersInLine: count,
+                     };
+                   });
+              });
+         {...session, currentPlaceholder: currentPlaceholder'};
+       });
+  };
+
+  let previous = (~buffer, {snippet, currentPlaceholder, _} as session) => {
+    synchronize(~buffer, session)
+    |> Option.map(session => {
+         let {snippet, currentPlaceholder, _} = session;
+         let placeholders = Snippet.placeholders(snippet);
+
+         let currentPlaceholder': option(placeholder) =
+           currentPlaceholder
+           |> OptionEx.flatMap(placeholder => {
+                let newPlaceholder =
+                  Snippet.Placeholder.previous(
+                    ~placeholder=placeholder.placeholderIndex,
+                    placeholders,
+                  );
+                Snippet.getFirstLineIndexWithPlaceholder(
+                  ~index=newPlaceholder,
+                  snippet,
+                )
+                |> Option.map(line => {
+                     let count =
+                       Snippet.getPlaceholderCountForLine(
+                         ~index=newPlaceholder,
+                         ~line,
+                         snippet,
+                       );
+                     let lines = Snippet.toLines(snippet);
+                     {
+                       placeholderIndex: newPlaceholder,
+                       snippetLineIndex: line,
+                       lineContents: lines[line],
+                       numberOfPlaceholdersInLine: count,
+                     };
+                   });
+              });
+         {...session, currentPlaceholder: currentPlaceholder'};
+       });
   };
 
   let getPlaceholderPositions = ({snippet, currentPlaceholder, startLine, _}) => {
     let placeholders = Snippet.placeholders(snippet);
-    Snippet.Placeholder.positions(
-      ~placeholders,
-      ~index=currentPlaceholder,
-      snippet,
-    )
+    currentPlaceholder
+    |> Option.map(({placeholderIndex, _}) => placeholderIndex)
+    |> OptionEx.flatMap(placeholderIndex => {
+         Snippet.Placeholder.positions(
+           ~placeholders,
+           ~index=placeholderIndex,
+           snippet,
+         )
+       })
     |> Option.map(remapPositions(~startLine));
   };
 
   let isComplete = ({snippet, currentPlaceholder, _}) => {
     let placeholders = Snippet.placeholders(snippet);
-    Snippet.Placeholder.final(placeholders) == currentPlaceholder;
+    switch (currentPlaceholder) {
+    | None => true
+    | Some({placeholderIndex, _}) =>
+      placeholderIndex == Snippet.Placeholder.final(placeholders)
+    };
   };
 };
 
@@ -190,20 +429,25 @@ module Effects = {
 
     let lines = Snippet.toLines(resolvedSnippet);
 
-    let session = Session.start(~editorId, ~snippet, ~position);
+    if (Array.length(lines) > 0) {
+      let session =
+        Session.start(~editorId, ~snippet=resolvedSnippet, ~position);
 
-    let toMsg =
-      fun
-      | Ok () => SnippetInserted(session)
-      | Error(msg) => SnippetInsertionError(msg);
+      let toMsg =
+        fun
+        | Ok () => SnippetInserted(session)
+        | Error(msg) => SnippetInsertionError(msg);
 
-    Service_Vim.Effects.setLines(
-      ~bufferId,
-      ~start=position.line,
-      ~stop=LineNumber.(position.line + 1),
-      ~lines,
-      toMsg,
-    );
+      Service_Vim.Effects.setLines(
+        ~bufferId,
+        ~start=position.line,
+        ~stop=LineNumber.(position.line + 1),
+        ~lines,
+        toMsg,
+      );
+    } else {
+      Isolinear.Effect.none;
+    };
   };
 };
 
@@ -234,52 +478,58 @@ let update = (~maybeBuffer, ~editorId, ~cursorPosition, msg, model) =>
 
   // TODO
   | Command(JumpToNextPlaceholder) =>
-    model.maybeSession
-    |> Option.map(session => {
-         let session' = Session.next(session);
+    maybeBuffer
+    |> OptionEx.flatMap(buffer => {
+         model.maybeSession
+         |> OptionEx.flatMap(Session.next(~buffer))
+         |> Option.map(session' => {
+              let outmsg =
+                session'
+                |> Session.getPlaceholderPositions
+                |> Option.map(positions => {
+                     switch (positions) {
+                     | Snippet.Placeholder.Ranges(ranges) =>
+                       SetSelections(ranges)
+                     | Snippet.Placeholder.Positions(positions) =>
+                       SetCursors(positions)
+                     }
+                   })
+                |> Option.value(~default=Nothing);
 
-         let outmsg =
-           session'
-           |> Session.getPlaceholderPositions
-           |> Option.map(positions => {
-                switch (positions) {
-                | Snippet.Placeholder.Ranges(ranges) => SetSelections(ranges)
-                | Snippet.Placeholder.Positions(positions) =>
-                  SetCursors(positions)
-                }
-              })
-           |> Option.value(~default=Nothing);
-
-         if (Session.isComplete(session')) {
-           ({maybeSession: None}, outmsg);
-         } else {
-           ({maybeSession: Some(session')}, outmsg);
-         };
+              if (Session.isComplete(session')) {
+                ({maybeSession: None}, outmsg);
+              } else {
+                ({maybeSession: Some(session')}, outmsg);
+              };
+            })
        })
     |> Option.value(~default=(model, Nothing))
 
   | Command(JumpToPreviousPlaceholder) =>
-    model.maybeSession
-    |> Option.map(session => {
-         let session' = Session.previous(session);
+    maybeBuffer
+    |> OptionEx.flatMap(buffer => {
+         model.maybeSession
+         |> OptionEx.flatMap(Session.previous(~buffer))
+         |> Option.map(session' => {
+              let outmsg =
+                session'
+                |> Session.getPlaceholderPositions
+                |> Option.map(positions => {
+                     switch (positions) {
+                     | Snippet.Placeholder.Ranges(ranges) =>
+                       SetSelections(ranges)
+                     | Snippet.Placeholder.Positions(positions) =>
+                       SetCursors(positions)
+                     }
+                   })
+                |> Option.value(~default=Nothing);
 
-         let outmsg =
-           session'
-           |> Session.getPlaceholderPositions
-           |> Option.map(positions => {
-                switch (positions) {
-                | Snippet.Placeholder.Ranges(ranges) => SetSelections(ranges)
-                | Snippet.Placeholder.Positions(positions) =>
-                  SetCursors(positions)
-                }
-              })
-           |> Option.value(~default=Nothing);
-
-         if (Session.isComplete(session')) {
-           ({maybeSession: None}, outmsg);
-         } else {
-           ({maybeSession: Some(session')}, outmsg);
-         };
+              if (Session.isComplete(session')) {
+                ({maybeSession: None}, outmsg);
+              } else {
+                ({maybeSession: Some(session')}, outmsg);
+              };
+            })
        })
     |> Option.value(~default=(model, Nothing))
 

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -230,7 +230,6 @@ module Session = {
                           ByteIndex.toInt(startByte),
                           newByteLength,
                         );
-                      prerr_endline("NEWTEXT: |" ++ newText ++ "|");
                       Some(newText);
                     };
                   })

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -138,14 +138,7 @@ module Session = {
       ) => {
     currentPlaceholder
     |> OptionEx.flatMap(
-         (
-           {
-             placeholderIndex,
-             snippetLineIndex,
-             lineContents,
-             numberOfPlaceholdersInLine,
-           } as cur,
-         ) => {
+         ({placeholderIndex, snippetLineIndex, lineContents, _} as cur) => {
          let bufferLineIdx =
            LineNumber.(startLine + snippetLineIndex) |> LineNumber.toZeroBased;
 
@@ -266,7 +259,7 @@ module Session = {
        });
   };
 
-  let next = (~buffer, {snippet, currentPlaceholder, _} as session) => {
+  let next = (~buffer, session) => {
     synchronize(~buffer, session)
     |> Option.map(session => {
          let {snippet, currentPlaceholder, _} = session;
@@ -304,7 +297,7 @@ module Session = {
        });
   };
 
-  let previous = (~buffer, {snippet, currentPlaceholder, _} as session) => {
+  let previous = (~buffer, session) => {
     synchronize(~buffer, session)
     |> Option.map(session => {
          let {snippet, currentPlaceholder, _} = session;

--- a/src/Feature/Snippets/Snippet.re
+++ b/src/Feature/Snippets/Snippet.re
@@ -731,6 +731,43 @@ let updatePlaceholder = (~index: int, ~text: string, snippet: snippet) => {
   snippet |> List.map(segments => segments |> List.map(map));
 };
 
+let getFirstLineIndexWithPlaceholder = (~index: int, snippet: snippet) => {
+  let rec hasPlaceholder = segments =>
+    switch (segments) {
+    | [] => false
+    | [Placeholder({index: placeholderIndex, contents}), ...tail] =>
+      if (placeholderIndex == index) {
+        true;
+      } else {
+        hasPlaceholder(contents) || hasPlaceholder(tail);
+      }
+    | [_other, ...tail] => hasPlaceholder(tail)
+    };
+
+  let snippetsWithIndices =
+    snippet
+    |> List.mapi((idx, snippetLine) => (idx, snippetLine))
+    |> List.filter(((_idx, snippetLine)) => hasPlaceholder(snippetLine));
+
+  List.nth_opt(snippetsWithIndices, 0) |> Option.map(fst);
+};
+
+let getPlaceholderCountForLine = (~index: int, ~line: int, snippet: snippet) => {
+  let rec countPlaceholders = (acc, segments) =>
+    switch (segments) {
+    | [] => acc
+    | [Placeholder({index: placeholderIndex, contents}), ...tail] =>
+      let acc' = placeholderIndex == index ? acc + 1 : acc;
+      let placeholderCount = countPlaceholders(0, contents);
+      countPlaceholders(acc' + placeholderCount, tail);
+    | [_other, ...tail] => countPlaceholders(acc, tail)
+    };
+
+  List.nth_opt(snippet, line)
+  |> Option.map(countPlaceholders(0))
+  |> Option.value(~default=0);
+};
+
 let%test_module "updatePlaceholder" =
   (module
    {


### PR DESCRIPTION
This implements placeholder synchronization, such that the snippet model is updated to reflect the current line state when shifting placeholders via `tab` or `shift`+`tab`. This enables handling of more intricate snippets:

![2021-01-29 13 00 02](https://user-images.githubusercontent.com/13532591/106326862-0794a100-6232-11eb-9fc0-e19567d158a3.gif)

__Next steps:__
- Integrate extension-provided snippets
- Integrate user-provided snippets
- Add documentation
