### PR TITLE
fix(search): Add configuration defaults

### DIFF
--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -398,4 +398,5 @@ module Contributions = {
 
     [inputTextKeys, vimNavKeys, vimTreeKeys] |> unionMany;
   };
+  let configuration = Configuration.[searchExclude.spec, filesExclude.spec];
 };

--- a/src/Feature/Search/Feature_Search.rei
+++ b/src/Feature/Search/Feature_Search.rei
@@ -57,4 +57,5 @@ let make:
 module Contributions: {
   let commands: (~isFocused: bool) => list(Command.t(msg));
   let contextKeys: (~isFocused: bool, model) => WhenExpr.ContextKeys.t;
+  let configuration: list(Config.Schema.spec);
 };

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -472,6 +472,7 @@ let initial =
         Feature_Editor.Contributions.configuration,
         Feature_Input.Contributions.configuration,
         Feature_MenuBar.Contributions.configuration,
+        Feature_Search.Contributions.configuration,
         Feature_SideBar.Contributions.configuration,
         Feature_Syntax.Contributions.configuration,
         Feature_Terminal.Contributions.configuration,


### PR DESCRIPTION
__Issue:__ There is a warning in the log:
```
[WARN]  [ 9.443s] Oni2.Core.Config : Missing default value for `search.exclude`
```

__Fix:__ Wire up the configuration specs for `Feature_Search` to pick up default values