### PR TITLE
fix(input/#3049): Fix :map condition

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -20,6 +20,7 @@
 - #3052 - Input: Fix key being 'eaten' after executing remapped key (fixes #3048)
 - #3060 - Snippets: Fix parser handling of stand-alone curly braces
 - #3044 - Search: Add `search.exclude` configuration option (fixes #2115 - thanks @joseeMDS!)
+- #3066 - Vim / Input: Fix ':map' condition (fixes #3049)
 
 ### Performance
 

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -276,12 +276,12 @@ let initial = keybindings => {
              );
              ism;
 
-           | Ok(ResolvedBinding({matcher, condition, command})) =>
+           | Ok(ResolvedBinding({matcher, condition, command, _})) =>
              let (ism, _bindingId) =
                InputStateMachine.addBinding(matcher, condition, command, ism);
              ism;
 
-           | Ok(ResolvedRemap({allowRecursive, matcher, condition, toKeys})) =>
+           | Ok(ResolvedRemap({allowRecursive, matcher, condition, toKeys, _})) =>
              let (ism, _bindingId) =
                InputStateMachine.addMapping(
                  ~allowRecursive,
@@ -506,7 +506,7 @@ module Internal = {
              let (ism, bindings) = acc;
              let (ism', bindingId) =
                switch (resolvedBinding) {
-               | ResolvedBinding({matcher, condition, command}) =>
+               | ResolvedBinding({matcher, condition, command, _}) =>
                  InputStateMachine.addBinding(
                    matcher,
                    condition,
@@ -514,7 +514,7 @@ module Internal = {
                    ism,
                  )
 
-               | ResolvedRemap({allowRecursive, matcher, condition, toKeys}) =>
+               | ResolvedRemap({allowRecursive, matcher, condition, toKeys, _}) =>
                  InputStateMachine.addMapping(
                    ~allowRecursive,
                    matcher,

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -123,13 +123,32 @@ module Schema = {
         matcher: EditorInput.Matcher.t,
         command: InputStateMachine.execute,
         condition: WhenExpr.ContextKeys.t => bool,
+        rawCondition: WhenExpr.t,
       })
     | ResolvedRemap({
         allowRecursive: bool,
         matcher: EditorInput.Matcher.t,
         toKeys: list(EditorInput.KeyPress.t),
         condition: WhenExpr.ContextKeys.t => bool,
+        rawCondition: WhenExpr.t,
       });
+
+  let resolvedToString = fun
+  | ResolvedBinding({matcher, command, rawCondition, _}) => {
+    Printf.sprintf("Binding - command: %s matcher: %s when: %s",
+      InputStateMachine.executeToString(command),
+      EditorInput.Matcher.toString(matcher),
+      WhenExpr.show(rawCondition),
+    )
+  }
+  | ResolvedRemap({allowRecursive, matcher, toKeys, rawCondition, _}) => {
+    Printf.sprintf("Remap - rec: %b, matcher: %s to: %s when: %s",
+      allowRecursive,
+      EditorInput.Matcher.toString(matcher),
+      toKeys |> List.map(EditorInput.KeyPress.toString) |> String.concat(","),
+      WhenExpr.show(rawCondition),
+    )
+  };
 
   let bind = (~key, ~command, ~condition) =>
     Binding({key, command, arguments: `Null, condition});
@@ -167,6 +186,7 @@ module Schema = {
              matcher,
              command: InputStateMachine.NamedCommand({command, arguments}),
              condition: evaluateCondition(condition),
+             rawCondition: condition,
            })
          });
 
@@ -191,6 +211,7 @@ module Schema = {
             matcher,
             condition: evaluateCondition(condition),
             toKeys,
+            rawCondition: condition,
           })
         },
         maybeMatcher,

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -133,22 +133,27 @@ module Schema = {
         rawCondition: WhenExpr.t,
       });
 
-  let resolvedToString = fun
-  | ResolvedBinding({matcher, command, rawCondition, _}) => {
-    Printf.sprintf("Binding - command: %s matcher: %s when: %s",
-      InputStateMachine.executeToString(command),
-      EditorInput.Matcher.toString(matcher),
-      WhenExpr.show(rawCondition),
-    )
-  }
-  | ResolvedRemap({allowRecursive, matcher, toKeys, rawCondition, _}) => {
-    Printf.sprintf("Remap - rec: %b, matcher: %s to: %s when: %s",
-      allowRecursive,
-      EditorInput.Matcher.toString(matcher),
-      toKeys |> List.map(EditorInput.KeyPress.toString) |> String.concat(","),
-      WhenExpr.show(rawCondition),
-    )
-  };
+  let resolvedToString =
+    fun
+    | ResolvedBinding({matcher, command, rawCondition, _}) => {
+        Printf.sprintf(
+          "Binding - command: %s matcher: %s when: %s",
+          InputStateMachine.executeToString(command),
+          EditorInput.Matcher.toString(matcher),
+          WhenExpr.show(rawCondition),
+        );
+      }
+    | ResolvedRemap({allowRecursive, matcher, toKeys, rawCondition, _}) => {
+        Printf.sprintf(
+          "Remap - rec: %b, matcher: %s to: %s when: %s",
+          allowRecursive,
+          EditorInput.Matcher.toString(matcher),
+          toKeys
+          |> List.map(EditorInput.KeyPress.toString)
+          |> String.concat(","),
+          WhenExpr.show(rawCondition),
+        );
+      };
 
   let bind = (~key, ~command, ~condition) =>
     Binding({key, command, arguments: `Null, condition});
@@ -475,7 +480,9 @@ module Internal = {
              | Terminal => "terminalFocus" |> parse
              | InsertAndCommandLine =>
                "insertMode || commandLineFocus" |> parse
-             | All => WhenExpr.Value(True);
+             | NormalAndVisualAndSelectAndOperator =>
+               "selectMode || normalMode || visualMode || operatorPending"
+               |> parse;
            }
          );
 

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -281,7 +281,9 @@ let initial = keybindings => {
                InputStateMachine.addBinding(matcher, condition, command, ism);
              ism;
 
-           | Ok(ResolvedRemap({allowRecursive, matcher, condition, toKeys, _})) =>
+           | Ok(
+               ResolvedRemap({allowRecursive, matcher, condition, toKeys, _}),
+             ) =>
              let (ism, _bindingId) =
                InputStateMachine.addMapping(
                  ~allowRecursive,
@@ -514,7 +516,13 @@ module Internal = {
                    ism,
                  )
 
-               | ResolvedRemap({allowRecursive, matcher, condition, toKeys, _}) =>
+               | ResolvedRemap({
+                   allowRecursive,
+                   matcher,
+                   condition,
+                   toKeys,
+                   _,
+                 }) =>
                  InputStateMachine.addMapping(
                    ~allowRecursive,
                    matcher,

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -52,6 +52,8 @@ module Schema: {
 
   type resolvedKeybinding;
 
+  let resolvedToString: resolvedKeybinding => string;
+
   let resolve: keybinding => result(resolvedKeybinding, string);
 };
 

--- a/src/Feature/Input/InputStateMachine.re
+++ b/src/Feature/Input/InputStateMachine.re
@@ -10,6 +10,10 @@ type execute =
     })
   | VimExCommand(string);
 
+let executeToString = fun
+| NamedCommand({command, _}) => command
+| VimExCommand(command) => command;
+
 module Input =
   EditorInput.Make({
     type context = WhenExpr.ContextKeys.t;

--- a/src/Feature/Input/InputStateMachine.re
+++ b/src/Feature/Input/InputStateMachine.re
@@ -10,9 +10,10 @@ type execute =
     })
   | VimExCommand(string);
 
-let executeToString = fun
-| NamedCommand({command, _}) => command
-| VimExCommand(command) => command;
+let executeToString =
+  fun
+  | NamedCommand({command, _}) => command
+  | VimExCommand(command) => command;
 
 module Input =
   EditorInput.Make({

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -71,6 +71,9 @@ let start = maybeKeyBindingsFilePath => {
              m("Loading %i keybindings", List.length(keyBindings))
            );
 
+           keyBindings
+           |> List.iteri((idx, binding) => Log.tracef(m => m("Binding %d: %s", idx, Feature_Input.Schema.resolvedToString(binding))));
+
            dispatch(
              Actions.Input(
                Feature_Input.Msg.keybindingsUpdated(keyBindings),

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -72,7 +72,15 @@ let start = maybeKeyBindingsFilePath => {
            );
 
            keyBindings
-           |> List.iteri((idx, binding) => Log.tracef(m => m("Binding %d: %s", idx, Feature_Input.Schema.resolvedToString(binding))));
+           |> List.iteri((idx, binding) =>
+                Log.tracef(m =>
+                  m(
+                    "Binding %d: %s",
+                    idx,
+                    Feature_Input.Schema.resolvedToString(binding),
+                  )
+                )
+              );
 
            dispatch(
              Actions.Input(

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -130,6 +130,8 @@ module Matcher: {
     // - 's' would get resolved as 's', 'S' would get resolved as 'Shift+s'
     // (Vim style parsing)
     (~explicitShiftKeyNeeded: bool, string) => result(t, string);
+
+  let toString: t => string;
 };
 
 module type Input = {

--- a/src/editor-input/Matcher.re
+++ b/src/editor-input/Matcher.re
@@ -34,3 +34,12 @@ let parse = (~explicitShiftKeyNeeded, str) => {
 
   str |> Lexing.from_string |> parse |> flatMap(finish);
 };
+
+let toString = fun
+| AllKeysReleased => "<AllKeysReleased>"
+| Sequence(keyPresses) => {
+  let keyString = keyPresses
+  |> List.map(KeyPress.toString)
+  |> String.concat(",");
+  Printf.sprintf("Sequence(%s)", keyString);
+}

--- a/src/editor-input/Matcher.re
+++ b/src/editor-input/Matcher.re
@@ -35,11 +35,11 @@ let parse = (~explicitShiftKeyNeeded, str) => {
   str |> Lexing.from_string |> parse |> flatMap(finish);
 };
 
-let toString = fun
-| AllKeysReleased => "<AllKeysReleased>"
-| Sequence(keyPresses) => {
-  let keyString = keyPresses
-  |> List.map(KeyPress.toString)
-  |> String.concat(",");
-  Printf.sprintf("Sequence(%s)", keyString);
-}
+let toString =
+  fun
+  | AllKeysReleased => "<AllKeysReleased>"
+  | Sequence(keyPresses) => {
+      let keyString =
+        keyPresses |> List.map(KeyPress.toString) |> String.concat(",");
+      Printf.sprintf("Sequence(%s)", keyString);
+    };

--- a/src/reason-libvim/Mapping.re
+++ b/src/reason-libvim/Mapping.re
@@ -10,7 +10,7 @@ type mode =
   | Operator // omap, onoremap
   | Terminal // tmap, tnoremap
   | InsertAndCommandLine // :map!
-  | All; // :map;
+  | NormalAndVisualAndSelectAndOperator; // :map;
 
 module ScriptId = {
   [@deriving show]

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -470,7 +470,7 @@ module Mapping: {
     | Operator // omap, onoremap
     | Terminal // tmap, tnoremap
     | InsertAndCommandLine // :map!
-    | All; // :map;
+    | NormalAndVisualAndSelectAndOperator; // :map;
 
   module ScriptId: {
     [@deriving show]

--- a/test/reason-libvim/MappingTest.re
+++ b/test/reason-libvim/MappingTest.re
@@ -61,7 +61,15 @@ describe("Mapping / Unmapping", ({describe, _}) => {
         Vim.command("inoremap jj <esc>");
 
       let (_context, effects) = Vim.command("unmap jj");
-      expect.equal(effects, [Unmap({mode: NormalAndVisualAndSelectAndOperator, keys: Some("jj")})]);
+      expect.equal(
+        effects,
+        [
+          Unmap({
+            mode: NormalAndVisualAndSelectAndOperator,
+            keys: Some("jj"),
+          }),
+        ],
+      );
     })
   });
 
@@ -69,7 +77,10 @@ describe("Mapping / Unmapping", ({describe, _}) => {
     test("mapclear", ({expect, _}) => {
       let (_context, effects) = Vim.command("mapclear");
 
-      expect.equal(effects, [Unmap({mode: NormalAndVisualAndSelectAndOperator, keys: None})]);
+      expect.equal(
+        effects,
+        [Unmap({mode: NormalAndVisualAndSelectAndOperator, keys: None})],
+      );
     })
   });
 });

--- a/test/reason-libvim/MappingTest.re
+++ b/test/reason-libvim/MappingTest.re
@@ -42,7 +42,7 @@ describe("Mapping / Unmapping", ({describe, _}) => {
         [
           Map(
             Mapping.{
-              mode: All,
+              mode: NormalAndVisualAndSelectAndOperator,
               fromKeys: "jj",
               toValue: "<esc>",
               expression: false,
@@ -61,7 +61,7 @@ describe("Mapping / Unmapping", ({describe, _}) => {
         Vim.command("inoremap jj <esc>");
 
       let (_context, effects) = Vim.command("unmap jj");
-      expect.equal(effects, [Unmap({mode: All, keys: Some("jj")})]);
+      expect.equal(effects, [Unmap({mode: NormalAndVisualAndSelectAndOperator, keys: Some("jj")})]);
     })
   });
 
@@ -69,7 +69,7 @@ describe("Mapping / Unmapping", ({describe, _}) => {
     test("mapclear", ({expect, _}) => {
       let (_context, effects) = Vim.command("mapclear");
 
-      expect.equal(effects, [Unmap({mode: All, keys: None})]);
+      expect.equal(effects, [Unmap({mode: NormalAndVisualAndSelectAndOperator, keys: None})]);
     })
   });
 });


### PR DESCRIPTION
__Issue:__ In #3049 , the `:map <Enter> o<Esc>` was being utilized even in command-line mode.

__Defect:__ `:map` should only impact normal/visual/select/operator-pending modes, and not impact insert/command-line modes.

__Fix:__ Correct the condition for the `:map` command. In addition, while looking through the logs, I realized we were missing trace logging of keybindings, so implement that as well.

Fixes #3049 