### PR TITLE
fix(snippets): Update completion to be aware of active snippets

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -24,6 +24,7 @@
 - #3066 - Vim / Input: Fix ':map' condition (fixes #3049)
 - #3055 - Extensions: Implement 'vscode.openFolder' handler (related #3042)
 - #3076 - Terminal: Add `ONIVIM_TERMINAL` environment variable (fixes #3068)
+- #3086 - Snippets: Fix clash with completion / document highlights feature
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -542,7 +542,6 @@ let isActive = (model: model) => {
 
 let reset = model =>
   if (model.isInsertMode && !model.isSnippetMode) {
-    prerr_endline("STARTING");
     {
       ...model,
       providers: model.providers |> List.map(Session.start),
@@ -550,7 +549,6 @@ let reset = model =>
       selection: None,
     };
   } else {
-    prerr_endline("STOPPING");
     {
       ...model,
       providers: model.providers |> List.map(Session.stop),

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -447,11 +447,13 @@ type model = {
   allItems: array((CharacterPosition.t, Filter.result(CompletionItem.t))),
   selection: Selection.t,
   isInsertMode: bool,
+  isSnippetMode: bool,
   acceptOnEnter: bool,
 };
 
 let initial = {
   isInsertMode: false,
+  isSnippetMode: false,
   acceptOnEnter: false,
   providers: [
     Session.create(
@@ -532,25 +534,48 @@ let focused = ({allItems, selection, _}) => {
 };
 
 let isActive = (model: model) => {
-  model.isInsertMode && model.allItems |> Array.length > 0;
+  model.isInsertMode
+  && !model.isSnippetMode
+  && model.allItems
+  |> Array.length > 0;
 };
 
-let startInsertMode = model => {
-  {
-    ...model,
-    isInsertMode: true,
-    providers: model.providers |> List.map(Session.start),
-    allItems: [||],
-    selection: None,
+let reset = model =>
+  if (model.isInsertMode && !model.isSnippetMode) {
+    prerr_endline("STARTING");
+    {
+      ...model,
+      providers: model.providers |> List.map(Session.start),
+      allItems: [||],
+      selection: None,
+    };
+  } else {
+    prerr_endline("STOPPING");
+    {
+      ...model,
+      providers: model.providers |> List.map(Session.stop),
+      allItems: [||],
+      selection: None,
+    };
   };
+
+let startInsertMode = model => {
+  {...model, isInsertMode: true} |> reset;
 };
 
 let stopInsertMode = model => {
-  ...model,
-  isInsertMode: false,
-  providers: model.providers |> List.map(Session.stop),
-  allItems: [||],
-  selection: None,
+  {...model, isInsertMode: false} |> reset;
+};
+
+// There are some bugs with completion in snippet mode -
+// including the 'tab' key being overloaded. Need to fix
+// these and gate with a configuration setting, like:
+// `editor.suggest.snippetsPreventQuickSuggestions`
+let startSnippet = model => {
+  {...model, isSnippetMode: true} |> reset;
+};
+let stopSnippet = model => {
+  {...model, isSnippetMode: false} |> reset;
 };
 
 let register =

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -492,6 +492,16 @@ let stopInsertMode = model => {
   };
 };
 
+let startSnippet = model => {
+  ...model,
+  completion: Completion.startSnippet(model.completion),
+};
+
+let stopSnippet = model => {
+  ...model,
+  completion: Completion.stopSnippet(model.completion),
+};
+
 let isFocused = ({rename, _}) => Rename.isFocused(rename);
 
 module Contributions = {

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -131,6 +131,10 @@ let startInsertMode:
   model;
 
 let stopInsertMode: model => model;
+
+let startSnippet: model => model;
+let stopSnippet: model => model;
+
 let isFocused: model => bool;
 
 let sub:

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -525,7 +525,6 @@ let update =
        })
     |> Option.value(~default=(model, Nothing))
 
-  // TODO
   | Command(JumpToNextPlaceholder) =>
     maybeBuffer
     |> OptionEx.flatMap(buffer => {

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -681,12 +681,12 @@ module Contributions = {
       bind(
         ~key="<TAB>",
         ~command=Commands.nextPlaceholder.id,
-        ~condition="editorTextFocus && inSnippetMode" |> WhenExpr.parse,
+        ~condition="editorTextFocus && inSnippetMode && !suggestWidgetVisible" |> WhenExpr.parse,
       ),
       bind(
         ~key="<S-TAB>",
         ~command=Commands.previousPlaceholder.id,
-        ~condition="editorTextFocus && inSnippetMode" |> WhenExpr.parse,
+        ~condition="editorTextFocus && inSnippetMode && !suggestWidgetVisible" |> WhenExpr.parse,
       ),
     ];
   };

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -681,12 +681,16 @@ module Contributions = {
       bind(
         ~key="<TAB>",
         ~command=Commands.nextPlaceholder.id,
-        ~condition="editorTextFocus && inSnippetMode && !suggestWidgetVisible" |> WhenExpr.parse,
+        ~condition=
+          "editorTextFocus && inSnippetMode && !suggestWidgetVisible"
+          |> WhenExpr.parse,
       ),
       bind(
         ~key="<S-TAB>",
         ~command=Commands.previousPlaceholder.id,
-        ~condition="editorTextFocus && inSnippetMode && !suggestWidgetVisible" |> WhenExpr.parse,
+        ~condition=
+          "editorTextFocus && inSnippetMode && !suggestWidgetVisible"
+          |> WhenExpr.parse,
       ),
     ];
   };

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1647,6 +1647,18 @@ let update =
         state.snippets,
       );
 
+    let updateLanguageSupport = (languageSupport, oldLayout, newLayout) => {
+      let originalCursor = Feature_Layout.activeEditor(oldLayout) |> Feature_Editor.Editor.getPrimaryCursor;
+
+      let newCursor = Feature_Layout.activeEditor(newLayout) |> Feature_Editor.Editor.getPrimaryCursor;
+
+      if (originalCursor != newCursor) {
+        Feature_LanguageSupport.cursorMoved(~maybeBuffer, ~previous=originalCursor, ~current=newCursor, languageSupport)
+      } else {
+        languageSupport
+      }
+    };
+
     let (layout', eff) =
       switch (outmsg) {
       | Nothing => (state.layout, Isolinear.Effect.none)
@@ -1685,7 +1697,9 @@ let update =
           eff |> Isolinear.Effect.map(msg => Actions.Snippets(msg)),
         )
       };
-    ({...state, layout: layout', snippets: snippets'}, eff);
+
+      let languageSupport' = updateLanguageSupport(state.languageSupport, state.layout, layout');
+    ({...state, layout: layout', languageSupport: languageSupport', snippets: snippets'}, eff);
 
   // TODO: This should live in the terminal feature project
   | TerminalFont(Service_Font.FontLoaded(font)) => (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1648,15 +1648,24 @@ let update =
       );
 
     let updateLanguageSupport = (languageSupport, oldLayout, newLayout) => {
-      let originalCursor = Feature_Layout.activeEditor(oldLayout) |> Feature_Editor.Editor.getPrimaryCursor;
+      let originalCursor =
+        Feature_Layout.activeEditor(oldLayout)
+        |> Feature_Editor.Editor.getPrimaryCursor;
 
-      let newCursor = Feature_Layout.activeEditor(newLayout) |> Feature_Editor.Editor.getPrimaryCursor;
+      let newCursor =
+        Feature_Layout.activeEditor(newLayout)
+        |> Feature_Editor.Editor.getPrimaryCursor;
 
       if (originalCursor != newCursor) {
-        Feature_LanguageSupport.cursorMoved(~maybeBuffer, ~previous=originalCursor, ~current=newCursor, languageSupport)
+        Feature_LanguageSupport.cursorMoved(
+          ~maybeBuffer,
+          ~previous=originalCursor,
+          ~current=newCursor,
+          languageSupport,
+        );
       } else {
-        languageSupport
-      }
+        languageSupport;
+      };
     };
 
     let (layout', eff) =
@@ -1698,8 +1707,17 @@ let update =
         )
       };
 
-      let languageSupport' = updateLanguageSupport(state.languageSupport, state.layout, layout');
-    ({...state, layout: layout', languageSupport: languageSupport', snippets: snippets'}, eff);
+    let languageSupport' =
+      updateLanguageSupport(state.languageSupport, state.layout, layout');
+    (
+      {
+        ...state,
+        layout: layout',
+        languageSupport: languageSupport',
+        snippets: snippets',
+      },
+      eff,
+    );
 
   // TODO: This should live in the terminal feature project
   | TerminalFont(Service_Font.FontLoaded(font)) => (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -210,7 +210,7 @@ module Internal = {
     let maybeBuffer = Selectors.getActiveBuffer(state);
 
     let wasInInsertMode =
-      Vim.Mode.isInsert(
+      Vim.Mode.isInsertOrSelect(
         state.layout
         |> Feature_Layout.activeEditor
         |> Feature_Editor.Editor.mode,
@@ -224,7 +224,7 @@ module Internal = {
     let (layout, editorEffect) = updateEditors(~scope, ~msg, state.layout);
 
     let isInInsertMode =
-      Vim.Mode.isInsert(
+      Vim.Mode.isInsertOrSelect(
         layout |> Feature_Layout.activeEditor |> Feature_Editor.Editor.mode,
       );
 
@@ -245,7 +245,9 @@ module Internal = {
         state.languageSupport;
       };
 
+    let wasInSnippetMode = Feature_Snippets.isActive(state.snippets);
     let snippets' = Feature_Snippets.modeChanged(~mode, state.snippets);
+    let isInSnippetMode = Feature_Snippets.isActive(snippets');
 
     let languageSupport' =
       if (isInInsertMode != wasInInsertMode) {
@@ -259,10 +261,21 @@ module Internal = {
         languageSupport;
       };
 
+    let languageSupport'' =
+      if (wasInSnippetMode != isInSnippetMode) {
+        if (isInSnippetMode) {
+          Feature_LanguageSupport.startSnippet(languageSupport');
+        } else {
+          Feature_LanguageSupport.stopSnippet(languageSupport');
+        };
+      } else {
+        languageSupport';
+      };
+
     let state = {
       ...state,
       layout,
-      languageSupport: languageSupport',
+      languageSupport: languageSupport'',
       snippets: snippets',
     };
     (state, editorEffect);
@@ -1631,11 +1644,14 @@ let update =
     let editor = Feature_Layout.activeEditor(state.layout);
     let editorId = editor |> Feature_Editor.Editor.getId;
 
+    let config = Selectors.configResolver(state);
     let cursorPosition = editor |> Feature_Editor.Editor.getPrimaryCursorByte;
 
     let resolverFactory = () => {
       Oni_Model.SnippetVariables.current(state);
     };
+
+    let wasSnippetActive = Feature_Snippets.isActive(state.snippets);
 
     let (snippets', outmsg) =
       Feature_Snippets.update(
@@ -1647,24 +1663,64 @@ let update =
         state.snippets,
       );
 
+    let isSnippetActive = Feature_Snippets.isActive(snippets');
+
+    prerr_endline(
+      Printf.sprintf(
+        "isSnippetActive: %b wasSnippetActive: %b",
+        isSnippetActive,
+        wasSnippetActive,
+      ),
+    );
+
     let updateLanguageSupport = (languageSupport, oldLayout, newLayout) => {
+      let originalEditor = Feature_Layout.activeEditor(oldLayout);
       let originalCursor =
-        Feature_Layout.activeEditor(oldLayout)
-        |> Feature_Editor.Editor.getPrimaryCursor;
+        originalEditor |> Feature_Editor.Editor.getPrimaryCursor;
 
-      let newCursor =
-        Feature_Layout.activeEditor(newLayout)
-        |> Feature_Editor.Editor.getPrimaryCursor;
+      let originalMode = originalEditor |> Feature_Editor.Editor.mode;
+      let wasInInsert = Vim.Mode.isInsertOrSelect(originalMode);
 
-      if (originalCursor != newCursor) {
-        Feature_LanguageSupport.cursorMoved(
-          ~maybeBuffer,
-          ~previous=originalCursor,
-          ~current=newCursor,
-          languageSupport,
-        );
+      let newEditor = Feature_Layout.activeEditor(newLayout);
+      let newCursor = newEditor |> Feature_Editor.Editor.getPrimaryCursor;
+      let newMode = newEditor |> Feature_Editor.Editor.mode;
+      let isInInsert = Vim.Mode.isInsertOrSelect(newMode);
+
+      let languageSupport' =
+        if (originalCursor != newCursor) {
+          Feature_LanguageSupport.cursorMoved(
+            ~maybeBuffer,
+            ~previous=originalCursor,
+            ~current=newCursor,
+            languageSupport,
+          );
+        } else {
+          languageSupport;
+        };
+
+      let languageSupport'' =
+        if (wasInInsert != isInInsert) {
+          if (isInInsert) {
+            Feature_LanguageSupport.startInsertMode(
+              ~config,
+              ~maybeBuffer,
+              languageSupport',
+            );
+          } else {
+            Feature_LanguageSupport.stopInsertMode(languageSupport');
+          };
+        } else {
+          languageSupport';
+        };
+
+      if (wasSnippetActive != isSnippetActive) {
+        if (isSnippetActive) {
+          Feature_LanguageSupport.startSnippet(languageSupport'');
+        } else {
+          Feature_LanguageSupport.stopSnippet(languageSupport'');
+        };
       } else {
-        languageSupport;
+        languageSupport'';
       };
     };
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1665,14 +1665,6 @@ let update =
 
     let isSnippetActive = Feature_Snippets.isActive(snippets');
 
-    prerr_endline(
-      Printf.sprintf(
-        "isSnippetActive: %b wasSnippetActive: %b",
-        isSnippetActive,
-        wasSnippetActive,
-      ),
-    );
-
     let updateLanguageSupport = (languageSupport, oldLayout, newLayout) => {
       let originalEditor = Feature_Layout.activeEditor(oldLayout);
       let originalCursor =

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -220,8 +220,8 @@ let start =
       state |> Model.EditorVisibleRanges.getVisibleBuffersAndRanges;
     let activeEditor = state.layout |> Feature_Layout.activeEditor;
 
-    let isInsertMode =
-      activeEditor |> Feature_Editor.Editor.mode |> Vim.Mode.isInsert;
+    let isInsertOrSelectMode =
+      activeEditor |> Feature_Editor.Editor.mode |> Vim.Mode.isInsertOrSelect;
 
     let isAnimatingScroll =
       activeEditor |> Feature_Editor.Editor.isAnimatingScroll;
@@ -372,7 +372,7 @@ let start =
       |> Option.map(activeBuffer => {
            Feature_LanguageSupport.sub(
              ~config,
-             ~isInsertMode,
+             ~isInsertMode=isInsertOrSelectMode,
              ~isAnimatingScroll,
              ~activeBuffer,
              ~activePosition,

--- a/src/reason-libvim/Mode.re
+++ b/src/reason-libvim/Mode.re
@@ -87,6 +87,8 @@ let isInsert =
   | Insert(_) => true
   | _ => false;
 
+let isInsertOrSelect = mode => isInsert(mode) || isSelect(mode);
+
 let isCommandLine =
   fun
   | CommandLine(_) => true

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -120,6 +120,7 @@ module Mode: {
 
   let isCommandLine: t => bool;
   let isInsert: t => bool;
+  let isInsertOrSelect: t => bool;
   let isNormal: t => bool;
   let isVisual: t => bool;
   let isSelect: t => bool;


### PR DESCRIPTION
This PR fixes some bugs with snippets integrating with language features (notably completion and document highlights).

First, when entering a snippet, the language features wouldn't be aware we've transitioned to insert/select mode, so need to notify that feature.

Second, in `select` mode, we'd render document highlights, which would be jarring as additional highlights come in around the selection.