### PR TITLE
fix(input/#3084): Input loop when executing command

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -22,6 +22,7 @@
 - #3060 - Snippets: Fix parser handling of stand-alone curly braces
 - #3044 - Search: Add `search.exclude` configuration option (fixes #2115 - thanks @joseeMDS!)
 - #3066 - Vim / Input: Fix ':map' condition (fixes #3049)
+- #3055 - Extensions: Implement 'vscode.openFolder' handler (related #3042)
 - #3076 - Terminal: Add `ONIVIM_TERMINAL` environment variable (fixes #3068)
 - #3078 - Auto-Update: Notify user when update fails due to missing key (fixes #3070)
 - #3086 - Snippets: Fix clash with completion / document highlights feature

--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -22,7 +22,7 @@
 - #3060 - Snippets: Fix parser handling of stand-alone curly braces
 - #3044 - Search: Add `search.exclude` configuration option (fixes #2115 - thanks @joseeMDS!)
 - #3066 - Vim / Input: Fix ':map' condition (fixes #3049)
-- #3055 - Extensions: Implement 'vscode.openFolder' handler (related #3042)
+- #3055, #3088 - Extensions: Implement 'vscode.openFolder' handler (related #3042)
 - #3076 - Terminal: Add `ONIVIM_TERMINAL` environment variable (fixes #3068)
 - #3078 - Auto-Update: Notify user when update fails due to missing key (fixes #3070)
 - #3086 - Snippets: Fix clash with completion / document highlights feature

--- a/integration_test/ClipboardInsertModePasteEmptyTest.re
+++ b/integration_test/ClipboardInsertModePasteEmptyTest.re
@@ -23,7 +23,12 @@ runTest(
 
   /* Simulate multiple events getting dispatched before running effects */
   dispatch(KeyboardInput({isText: true, input: "A"}));
-  dispatch(Command("editor.action.clipboardPasteAction"));
+  dispatch(
+    CommandInvoked({
+      command: "editor.action.clipboardPasteAction",
+      arguments: `Null,
+    }),
+  );
   dispatch(KeyboardInput({isText: true, input: "B"}));
 
   runEffects();

--- a/integration_test/Regression3084CommandLoopTest.re
+++ b/integration_test/Regression3084CommandLoopTest.re
@@ -1,0 +1,46 @@
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+let keybindings =
+  Some({|
+[
+  {"key": "jj", "command": "vim.esc", "when": "insertMode"}
+]
+|});
+
+runTest(
+  ~keybindings,
+  ~name="Regression3048CommandLoopTest",
+  ({wait, input, staysTrue, _}) => {
+    wait(~name="Initial mode is normal", (state: State.t) =>
+      Selectors.mode(state) |> Vim.Mode.isNormal
+    );
+
+    input("i");
+    wait(~name="Mode is now insert", (state: State.t) =>
+      Selectors.mode(state) |> Vim.Mode.isInsert
+    );
+
+    input("a");
+    input("j");
+    input("j");
+
+    wait(~name="Mode is back to normal", (state: State.t) =>
+      Selectors.mode(state) |> Vim.Mode.isNormal
+    );
+
+    input("i");
+    wait(~name="Mode is insert", (state: State.t) =>
+      Selectors.mode(state) |> Vim.Mode.isInsert
+    );
+  
+    // With #3084, we had an infinite cycle with the command - 
+    // in this case, with our `jj` key binding, it would cause
+    // `vim.esc` to be continually dispatched.
+    // So to exercise this case - we need to make sure we don't switch back a mode.
+
+    staysTrue(~timeout=1.0, ~name="Should stay in insert mode", (state: State.t) =>
+      Selectors.mode(state) |> Vim.Mode.isInsert
+    );
+}
+);

--- a/integration_test/Regression3084CommandLoopTest.re
+++ b/integration_test/Regression3084CommandLoopTest.re
@@ -33,14 +33,15 @@ runTest(
     wait(~name="Mode is insert", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isInsert
     );
-  
-    // With #3084, we had an infinite cycle with the command - 
+
+    // With #3084, we had an infinite cycle with the command -
     // in this case, with our `jj` key binding, it would cause
     // `vim.esc` to be continually dispatched.
     // So to exercise this case - we need to make sure we don't switch back a mode.
 
-    staysTrue(~timeout=1.0, ~name="Should stay in insert mode", (state: State.t) =>
+    staysTrue(
+      ~timeout=1.0, ~name="Should stay in insert mode", (state: State.t) =>
       Selectors.mode(state) |> Vim.Mode.isInsert
     );
-}
+  },
 );

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -16,6 +16,7 @@
    SyntaxServerMessageExceptionTest SyntaxServerParentPidTest
    SyntaxServerParentPidCorrectTest SyntaxServerReadExceptionTest
    Regression1671Test Regression2349EnewTest Regression2988SwitchEditorTest
+   Regression3084CommandLoopTest
    RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
    RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
    RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
@@ -48,6 +49,7 @@
    LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
    QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
    Regression2349EnewTest.exe Regression2988SwitchEditorTest.exe
+   Regression3084CommandLoopTest.exe
    RegressionCommandLineNoCompletionTest.exe
    RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
    RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -16,16 +16,15 @@
    SyntaxServerMessageExceptionTest SyntaxServerParentPidTest
    SyntaxServerParentPidCorrectTest SyntaxServerReadExceptionTest
    Regression1671Test Regression2349EnewTest Regression2988SwitchEditorTest
-   Regression3084CommandLoopTest
-   RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
-   RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
-   RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
-   SCMGitTest SyntaxHighlightPhpTest SyntaxHighlightTextMateTest
-   SyntaxHighlightTreesitterTest AddRemoveSplitTest TerminalSetPidTitleTest
-   TerminalConfigurationTest TypingBatchedTest TypingUnbatchedTest
-   VimIncsearchScrollTest VimSimpleRemapTest VimlRemapCmdlineTest
-   ClipboardChangeTest VimScriptLocalFunctionTest ZenModeSingleFileModeTest
-   ZenModeSplitTest)
+   Regression3084CommandLoopTest RegressionCommandLineNoCompletionTest
+   RegressionFontFallbackTest RegressionFileModifiedIndicationTest
+   RegressionNonExistentDirectory RegressionVspEmptyInitialBufferTest
+   RegressionVspEmptyExistingBufferTest SCMGitTest SyntaxHighlightPhpTest
+   SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
+   AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
+   TypingBatchedTest TypingUnbatchedTest VimIncsearchScrollTest
+   VimSimpleRemapTest VimlRemapCmdlineTest ClipboardChangeTest
+   VimScriptLocalFunctionTest ZenModeSingleFileModeTest ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install

--- a/integration_test/lib/Types.re
+++ b/integration_test/lib/Types.re
@@ -5,6 +5,8 @@ type runEffectsFunction = unit => unit;
 type waiter = Model.State.t => bool;
 type waitForState = (~name: string, ~timeout: float=?, waiter) => unit;
 
+type staysTrueFunction = (~name: string, ~timeout: float, waiter) => unit;
+
 type inputFunction = (~modifiers: EditorInput.Modifiers.t=?, string) => unit;
 
 type keyFunction =
@@ -16,6 +18,7 @@ type testContext = {
   runEffects: runEffectsFunction,
   input: inputFunction,
   key: keyFunction,
+  staysTrue: staysTrueFunction,
 };
 
 type testCallback = testContext => unit;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -17,7 +17,10 @@ type t =
   | Exthost(Feature_Exthost.msg)
   | Syntax(Feature_Syntax.msg)
   | Changelog(Feature_Changelog.msg)
-  | Command(string)
+  | CommandInvoked({
+      command: string,
+      arguments: Yojson.Safe.t,
+    })
   | Commands(Feature_Commands.msg(t))
   | Configuration(Feature_Configuration.msg)
   | ConfigurationParseError(string)
@@ -40,10 +43,6 @@ type t =
   // Reload keybindings from configuration
   | KeyBindingsReload
   | KeyBindingsParseError(string)
-  | KeybindingInvoked({
-      command: string,
-      arguments: Yojson.Safe.t,
-    })
   | KeyDown({
       key: EditorInput.KeyCandidate.t,
       scancode: int,

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -40,6 +40,10 @@ type t =
   | FileChanged(Service_FileWatcher.event)
   | FileSystem(Feature_FileSystem.msg)
   | KeyBindingsSet([@opaque] list(Feature_Input.Schema.resolvedKeybinding))
+  | KeybindingInvoked({
+      command: string,
+      arguments: Yojson.Safe.t,
+    })
   // Reload keybindings from configuration
   | KeyBindingsReload
   | KeyBindingsParseError(string)

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -21,24 +21,26 @@ let copyFilePath =
     CopyActiveFilepathToClipboard,
   );
 
-let undo = register("undo", Command("undo"));
-let redo = register("redo", Command("redo"));
+let command = cmd => CommandInvoked({command: cmd, arguments: `Null});
 
-let indent = register("indent", Command("indent"));
-let outdent = register("outdent", Command("outdent"));
+let undo = register("undo", command("undo"));
+let redo = register("redo", command("redo"));
+
+let indent = register("indent", command("indent"));
+let outdent = register("outdent", command("outdent"));
 
 module Editor = {
   module Action = {
     let indentLines =
       register(
         "editor.action.indentLines",
-        Command("editor.action.indentLines"),
+        command("editor.action.indentLines"),
       );
 
     let outdentLines =
       register(
         "editor.action.outdentLines",
-        Command("editor.action.outdentLines"),
+        command("editor.action.outdentLines"),
       );
   };
 };
@@ -58,7 +60,7 @@ module Oni = {
       ~category="Help",
       ~title="Open changelog",
       "oni.changelog",
-      Command("oni.changelog"),
+      command("oni.changelog"),
     );
 
   module System = {
@@ -68,7 +70,7 @@ module Oni = {
         ~title="Add Oni2 to System PATH",
         ~isEnabledWhen=WhenExpr.parse("isMac && !symLinkExists"), // NOTE: symLinkExists only defined in command palette
         "system.addToPath",
-        Command("system.addToPath"),
+        command("system.addToPath"),
       );
 
     let removeFromPath =
@@ -77,18 +79,18 @@ module Oni = {
         ~title="Remove Oni2 from System PATH",
         ~isEnabledWhen=WhenExpr.parse("isMac && symLinkExists"), // NOTE: symLinkExists only defined in command palette
         "system.removeFromPath",
-        Command("system.removeFromPath"),
+        command("system.removeFromPath"),
       );
   };
 
   module Vim = {
-    let esc = register("vim.esc", Command("vim.esc"));
+    let esc = register("vim.esc", command("vim.esc"));
     let tutor =
       register(
         ~category="Help",
         ~title="Open Vim Tutor",
         "vim.tutor",
-        Command("vim.tutor"),
+        command("vim.tutor"),
       );
   };
 
@@ -181,35 +183,11 @@ module Workbench = {
     let closeQuickOpen =
       register("workbench.action.closeQuickOpen", QuickmenuClose);
 
-    let zoomIn =
-      register(
-        ~category="View",
-        ~title="Zoom In",
-        "workbench.action.zoomIn",
-        Command("workbench.action.zoomIn"),
-      );
-
-    let zoomOut =
-      register(
-        ~category="View",
-        ~title="Zoom Out",
-        "workbench.action.zoomOut",
-        Command("workbench.action.zoomOut"),
-      );
-
-    let zoomReset =
-      register(
-        ~category="View",
-        ~title="Reset Zoom",
-        "workbench.action.zoomReset",
-        Command("workbench.action.zoomReset"),
-      );
-
     module Files = {
       let save =
         register(
           "workbench.action.files.save",
-          Command("workbench.action.files.save"),
+          command("workbench.action.files.save"),
         );
     };
   };

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -40,7 +40,7 @@ let start = () => {
 
   let updater = (state: State.t, action) => {
     switch (action) {
-    | Command(cmd) =>
+    | CommandInvoked({command: cmd, _}) =>
       switch (StringMap.find_opt(cmd, commandMap)) {
       | Some(v) => (state, v(state, cmd))
       | None => (state, Isolinear.Effect.none)

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -50,6 +50,11 @@ let create =
 
         promise;
 
+      | Commands(ExecuteCommand({command, args, _})) =>
+        // TODO: Is this really the right action?
+        dispatch(Actions.CommandInvoked({command, arguments: `List(args)}));
+        Lwt.return(Reply.okEmpty);
+
       | Configuration(RemoveConfigurationOption({key, _})) =>
         dispatch(
           Actions.ConfigurationTransform(

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -28,7 +28,7 @@ module Internal = {
   let executeCommandEffect = (command, arguments) => {
     Isolinear.Effect.createWithDispatch(
       ~name="features.executeCommand", dispatch =>
-      dispatch(Actions.KeybindingInvoked({command, arguments}))
+      dispatch(Actions.CommandInvoked({command, arguments}))
     );
   };
 

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -130,7 +130,7 @@ let start = (window: option(Revery.Window.t), runEffects) => {
         Actions.VimExecuteCommand({allowAnimation: true, command}),
       ]
     | Feature_Input.(Execute(NamedCommand({command, arguments}))) => [
-        Actions.CommandInvoked({command, arguments}),
+        Actions.KeybindingInvoked({command, arguments}),
       ]
     | Feature_Input.Text(text) => handleTextEffect(~isText=true, state, text)
     | Feature_Input.Unhandled({key, isProducedByRemap}) =>

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -130,7 +130,7 @@ let start = (window: option(Revery.Window.t), runEffects) => {
         Actions.VimExecuteCommand({allowAnimation: true, command}),
       ]
     | Feature_Input.(Execute(NamedCommand({command, arguments}))) => [
-        Actions.KeybindingInvoked({command, arguments}),
+        Actions.CommandInvoked({command, arguments}),
       ]
     | Feature_Input.Text(text) => handleTextEffect(~isText=true, state, text)
     | Feature_Input.Unhandled({key, isProducedByRemap}) =>

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -117,7 +117,7 @@ let start = maybeKeyBindingsFilePath => {
         |> Isolinear.Effect.map(msg => Actions.Notification(msg)),
       )
 
-    | KeybindingInvoked({command, arguments}) =>
+    | CommandInvoked({command, arguments}) =>
       if (command |> Utility.StringEx.startsWith(~prefix=":")) {
         (
           state,

--- a/src/Store/KeyBindingsStoreConnector.re
+++ b/src/Store/KeyBindingsStoreConnector.re
@@ -107,17 +107,17 @@ let start = maybeKeyBindingsFilePath => {
 
   let updater = (state: State.t, action: Actions.t) => {
     switch (action) {
-    | Actions.Init => (state, loadKeyBindingsEffect(true))
+    | Init => (state, loadKeyBindingsEffect(true))
 
-    | Actions.KeyBindingsReload => (state, loadKeyBindingsEffect(false))
+    | KeyBindingsReload => (state, loadKeyBindingsEffect(false))
 
-    | Actions.KeyBindingsParseError(msg) => (
+    | KeyBindingsParseError(msg) => (
         state,
         Feature_Notification.Effects.create(~kind=Error, msg)
         |> Isolinear.Effect.map(msg => Actions.Notification(msg)),
       )
 
-    | CommandInvoked({command, arguments}) =>
+    | KeybindingInvoked({command, arguments}) =>
       if (command |> Utility.StringEx.startsWith(~prefix=":")) {
         (
           state,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -799,15 +799,19 @@ let start =
         synchronizeViml(configuration),
       )
 
-    | Command("undo") => (state, undoEffect)
-    | Command("redo") => (state, redoEffect)
-    | Command("workbench.action.files.save") => (state, saveEffect)
-    | Command("indent") => (state, indentEffect)
-    | Command("outdent") => (state, outdentEffect)
-    | Command("editor.action.indentLines") => (state, indentEffect)
-    | Command("editor.action.outdentLines") => (state, outdentEffect)
-    | Command("vim.esc") => (state, escapeEffect)
-    | Command("vim.tutor") => (state, openTutorEffect)
+    | CommandInvoked({command, _}) =>
+      switch (command) {
+      | "undo" => (state, undoEffect)
+      | "redo" => (state, redoEffect)
+      | "workbench.action.files.save" => (state, saveEffect)
+      | "indent" => (state, indentEffect)
+      | "outdent" => (state, outdentEffect)
+      | "editor.action.indentLines" => (state, indentEffect)
+      | "editor.action.outdentLines" => (state, outdentEffect)
+      | "vim.esc" => (state, escapeEffect)
+      | "vim.tutor" => (state, openTutorEffect)
+      | _ => (state, Isolinear.Effect.none)
+      }
     | VimExecuteCommand({allowAnimation, command}) => (
         state,
         commandEffect(~allowAnimation, command),


### PR DESCRIPTION
__Issue:__ #3055 introduced a regression, in the course of refactoring the `CommandInvoked` and `KeybindingInvoked` to a consolidated action, causing an infinite loop of action dispatches.

__Defect:__ Prior to the refactoring, the `KeybindingInvoked` would itself dispatch a `CommandInvoked`. After the refactoring, there were cases, hit in #3055 , where a `CommandInvoked` would itself dispatch a `CommandInvoked`, endlessly. The easiest repro is to bind a key to a command - the command would get endlessly dispatched.

__Fix:__ Remove the infinite loop and bring back the `KeybindingInvoked` action. There's a subtle difference at the moment between how these commands are treated. Add an integration test to exercise the case in #3084 

Fixes #3084 , brings back the work in #3055