### PR TITLE
feat(snippets): Insert snippet command

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,8 +1,9 @@
 ### Features 
 
-- #3024 - Editor: Snippet Support - Multi-select handler
-- #3047, #3052, #3056, #3059, #3061, #3064 - Editor: Core Snippet Feature Work
-- #3067 - Editor: Integrate snippets provided by extensions
+- #3024 - Snippet Support - Multi-select handler
+- #3047, #3052, #3056, #3059, #3061, #3064 - Snippets: Core Feature Work
+- #3067 - Snippets: Integrate snippets provided by extensions
+- #3090 - Snippets: Add insert snippet command
 
 ### Bug Fixes
 

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -374,11 +374,11 @@ type msg =
   | Command(command)
   | SnippetInserted([@opaque] Session.t)
   | SnippetInsertionError(string)
-  | InsertInternal({ snippetString: string});
+  | InsertInternal({snippetString: string});
 
 module Msg = {
   let insert = (~snippet) => InsertInternal({snippetString: snippet});
-}
+};
 
 type model = {maybeSession: option(Session.t)};
 
@@ -601,20 +601,18 @@ let update =
                ~position=cursorPosition,
                ~snippet,
              )
-           | None => 
-           // TODO: Wire up menu
-           prerr_endline ("!! TODO");
-           Isolinear.Effect.none
+           | None =>
+             // TODO: Wire up menu
+             prerr_endline("!! TODO");
+             Isolinear.Effect.none;
            }
          })
       |> Option.value(~default=Isolinear.Effect.none);
-      (model, Effect(eff));
+    (model, Effect(eff));
 
-    | InsertInternal({snippetString}) =>
-      // TODO
-      (model, Nothing);
-
-
+  | InsertInternal({snippetString}) =>
+    // TODO
+    (model, Nothing)
   };
 
 module Commands = {
@@ -655,18 +653,18 @@ module Commands = {
       });
 
     let decode =
-      nullable(one_of([
-        // TODO: Decoder for getting snippet by name
-        ("snippets", snippets),
-      ]));
+      nullable(
+        one_of([
+          // TODO: Decoder for getting snippet by name
+          ("snippets", snippets),
+        ]),
+      );
 
     let snippetResult = json |> decode_value(decode);
 
     switch (snippetResult) {
     | Ok(snippet) =>
-      Command(
-        InsertSnippet({maybeSnippet: snippet, maybeMeetColumn: None}),
-      )
+      Command(InsertSnippet({maybeSnippet: snippet, maybeMeetColumn: None}))
     | Error(msg) => SnippetInsertionError(string_of_error(msg))
     };
   };

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -373,7 +373,12 @@ type command =
 type msg =
   | Command(command)
   | SnippetInserted([@opaque] Session.t)
-  | SnippetInsertionError(string);
+  | SnippetInsertionError(string)
+  | InsertInternal({ snippetString: string});
+
+module Msg = {
+  let insert = (~snippet) => InsertInternal({snippetString: snippet});
+}
 
 type model = {maybeSession: option(Session.t)};
 
@@ -596,12 +601,20 @@ let update =
                ~position=cursorPosition,
                ~snippet,
              )
-           | None => Isolinear.Effect.none
+           | None => 
+           // TODO: Wire up menu
+           prerr_endline ("!! TODO");
+           Isolinear.Effect.none
            }
          })
       |> Option.value(~default=Isolinear.Effect.none);
+      (model, Effect(eff));
 
-    (model, Effect(eff));
+    | InsertInternal({snippetString}) =>
+      // TODO
+      (model, Nothing);
+
+
   };
 
 module Commands = {
@@ -642,17 +655,17 @@ module Commands = {
       });
 
     let decode =
-      one_of([
+      nullable(one_of([
         // TODO: Decoder for getting snippet by name
         ("snippets", snippets),
-      ]);
+      ]));
 
     let snippetResult = json |> decode_value(decode);
 
     switch (snippetResult) {
     | Ok(snippet) =>
       Command(
-        InsertSnippet({maybeSnippet: Some(snippet), maybeMeetColumn: None}),
+        InsertSnippet({maybeSnippet: snippet, maybeMeetColumn: None}),
       )
     | Error(msg) => SnippetInsertionError(string_of_error(msg))
     };

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -635,8 +635,28 @@ let update =
     )
 
   | InsertInternal({snippetString}) =>
-    // TODO
-    (model, Nothing)
+    let eff =
+      maybeBuffer
+      |> Option.map(buffer => {
+           switch (Snippet.parse(snippetString)) {
+           | Ok(snippet) =>
+             Effect(
+               Effects.startSession(
+                 // TODO: Handle selection
+                 ~maybeMeetColumn=None,
+                 ~resolverFactory,
+                 ~buffer,
+                 ~editorId,
+                 ~position=cursorPosition,
+                 ~snippet,
+               ),
+             )
+           | Error(msg) => ErrorMessage(msg)
+           }
+         })
+      |> Option.value(~default=Nothing);
+
+    (model, eff);
   };
 
 module Commands = {

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -410,6 +410,7 @@ type outmsg =
   | ErrorMessage(string)
   | SetCursors(list(BytePosition.t))
   | SetSelections(list(ByteRange.t))
+  | ShowPicker(list(Service_Snippets.SnippetWithMetadata.t))
   | Nothing;
 
 module Effects = {
@@ -505,7 +506,7 @@ module Effects = {
 };
 
 let update =
-    (~resolverFactory, ~maybeBuffer, ~editorId, ~cursorPosition, msg, model) =>
+    (~resolverFactory, ~maybeBuffer, ~editorId, ~cursorPosition, ~extensions, msg, model) =>
   switch (msg) {
   | SnippetInsertionError(msg) => (model, ErrorMessage(msg))
 
@@ -593,22 +594,22 @@ let update =
       |> Option.map(buffer => {
            switch (maybeSnippet) {
            | Some(snippet) =>
-             Effects.startSession(
+             Effect(Effects.startSession(
                ~maybeMeetColumn,
                ~resolverFactory,
                ~buffer,
                ~editorId,
                ~position=cursorPosition,
                ~snippet,
-             )
+             ))
            | None =>
              // TODO: Wire up menu
              prerr_endline("!! TODO");
-             Isolinear.Effect.none;
+             ShowPicker([])
            }
          })
-      |> Option.value(~default=Isolinear.Effect.none);
-    (model, Effect(eff));
+      |> Option.value(~default=Nothing);
+    (model, eff);
 
   | InsertInternal({snippetString}) =>
     // TODO

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -7,6 +7,10 @@ let snippetToInsert: (~snippet: string) => string;
 [@deriving show]
 type msg;
 
+module Msg: {
+  let insert: (~snippet: string) => msg;
+}
+
 type model;
 
 let initial: model;

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -18,6 +18,7 @@ type outmsg =
   | ErrorMessage(string)
   | SetCursors(list(BytePosition.t))
   | SetSelections(list(ByteRange.t))
+  | ShowPicker(list(Service_Snippets.SnippetWithMetadata.t))
   | Nothing;
 
 module Session: {
@@ -39,6 +40,7 @@ let update:
     ~maybeBuffer: option(Buffer.t),
     ~editorId: int,
     ~cursorPosition: BytePosition.t,
+    ~extensions: Feature_Extensions.model,
     msg,
     model
   ) =>

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -7,9 +7,7 @@ let snippetToInsert: (~snippet: string) => string;
 [@deriving show]
 type msg;
 
-module Msg: {
-  let insert: (~snippet: string) => msg;
-}
+module Msg: {let insert: (~snippet: string) => msg;};
 
 type model;
 

--- a/src/Feature/Snippets/dune
+++ b/src/Feature/Snippets/dune
@@ -3,7 +3,7 @@
  (public_name Oni2.feature.snippets)
  (inline_tests)
  (libraries Oni2.core Oni2.components Oni2.feature.theme Oni2.service.os
-  Oni2.feature.extensions Oni2.service.snippets
-   Oni2.service.vim Revery isolinear)
+   Oni2.feature.extensions Oni2.service.snippets Oni2.service.vim Revery
+   isolinear)
  (preprocess
   (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Snippets/dune
+++ b/src/Feature/Snippets/dune
@@ -3,6 +3,7 @@
  (public_name Oni2.feature.snippets)
  (inline_tests)
  (libraries Oni2.core Oni2.components Oni2.feature.theme Oni2.service.os
+  Oni2.feature.extensions Oni2.service.snippets
    Oni2.service.vim Revery isolinear)
  (preprocess
   (pps ppx_let ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -205,6 +205,7 @@ and quickmenuVariant =
   | FilesPicker
   | OpenBuffersPicker
   | Wildmenu([@opaque] Vim.Types.cmdlineType)
+  | SnippetPicker(list(Service_Snippets.SnippetWithMetadata.t))
   | ThemesPicker([@opaque] list(Feature_Theme.theme))
   | FileTypesPicker({
       bufferId: int,

--- a/src/Model/Quickmenu.re
+++ b/src/Model/Quickmenu.re
@@ -17,6 +17,7 @@ and variant =
     | FilesPicker
     | OpenBuffersPicker
     | Wildmenu(Vim.Types.cmdlineType)
+    | SnippetPicker(list(Service_Snippets.SnippetWithMetadata.t))
     | ThemesPicker(list(Feature_Theme.theme))
     | FileTypesPicker({
         bufferId: int,

--- a/src/Service/Snippets/Service_Snippets.re
+++ b/src/Service/Snippets/Service_Snippets.re
@@ -83,52 +83,45 @@ module Cache = {
       promise;
     };
   };
-
 };
 
 module Internal = {
   let loadSnippetsFromFiles = (~filePaths, dispatch) => {
-        // Load all files
-        // Coalesce all promises
-        let promises =
-          filePaths |> List.map(Fp.toString) |> List.map(Cache.get);
+    // Load all files
+    // Coalesce all promises
+    let promises = filePaths |> List.map(Fp.toString) |> List.map(Cache.get);
 
-        let join = (a, b) => a @ b;
-        let promise = LwtEx.some(~default=[], join, promises);
+    let join = (a, b) => a @ b;
+    let promise = LwtEx.some(~default=[], join, promises);
 
-        Lwt.on_success(
-          promise,
-          snippets => {
-            Log.infof(m => m("Loaded %d snippets", List.length(snippets)));
-            dispatch(snippets);
-          },
+    Lwt.on_success(
+      promise,
+      snippets => {
+        Log.infof(m => m("Loaded %d snippets", List.length(snippets)));
+        dispatch(snippets);
+      },
+    );
+
+    Lwt.on_failure(
+      promise,
+      exn => {
+        Log.errorf(m =>
+          m("Error loading snippets: %s", Printexc.to_string(exn))
         );
-
-        Lwt.on_failure(
-          promise,
-          exn => {
-            Log.errorf(m =>
-              m("Error loading snippets: %s", Printexc.to_string(exn))
-            );
-            dispatch([]);
-          },
-        );
+        dispatch([]);
+      },
+    );
   };
-}
+};
 
 module Effect = {
-  let snippetFromFiles = (
-    ~filePaths,
-    toMsg
-  ) => Isolinear.Effect.createWithDispatch(
-    ~name="Service_Snippets.Effect.snippetFromFiles",
-    dispatch => {
-      Internal.loadSnippetsFromFiles(
-        ~filePaths,
-        snippets => dispatch(toMsg(snippets)),
+  let snippetFromFiles = (~filePaths, toMsg) =>
+    Isolinear.Effect.createWithDispatch(
+      ~name="Service_Snippets.Effect.snippetFromFiles", dispatch => {
+      Internal.loadSnippetsFromFiles(~filePaths, snippets =>
+        dispatch(toMsg(snippets))
       )
-    }
-  );
+    });
 };
 
 module Sub = {
@@ -147,11 +140,7 @@ module Sub = {
       let id = ({uniqueId, _}) => uniqueId;
 
       let init = (~params, ~dispatch) => {
-
-        Internal.loadSnippetsFromFiles(
-          ~filePaths=params.filePaths,
-          dispatch,
-        );
+        Internal.loadSnippetsFromFiles(~filePaths=params.filePaths, dispatch);
       };
 
       let update = (~params as _, ~state, ~dispatch as _) => state;

--- a/src/Service/Snippets/Service_Snippets.rei
+++ b/src/Service/Snippets/Service_Snippets.rei
@@ -8,10 +8,12 @@ module SnippetWithMetadata: {
 };
 
 module Effect: {
-  let snippetFromFiles: (
-    ~filePaths: list(Fp.t(Fp.absolute)),
-    list(SnippetWithMetadata.t) => 'msg
-  ) => Isolinear.Effect.t('msg);
+  let snippetFromFiles:
+    (
+      ~filePaths: list(Fp.t(Fp.absolute)),
+      list(SnippetWithMetadata.t) => 'msg
+    ) =>
+    Isolinear.Effect.t('msg);
 };
 
 module Sub: {

--- a/src/Service/Snippets/Service_Snippets.rei
+++ b/src/Service/Snippets/Service_Snippets.rei
@@ -9,7 +9,6 @@ module SnippetWithMetadata: {
 
 module Effect: {
   let snippetFromFiles: (
-    ~uniqueId: string,
     ~filePaths: list(Fp.t(Fp.absolute)),
     list(SnippetWithMetadata.t) => 'msg
   ) => Isolinear.Effect.t('msg);

--- a/src/Service/Snippets/Service_Snippets.rei
+++ b/src/Service/Snippets/Service_Snippets.rei
@@ -7,6 +7,14 @@ module SnippetWithMetadata: {
   };
 };
 
+module Effect: {
+  let snippetFromFiles: (
+    ~uniqueId: string,
+    ~filePaths: list(Fp.t(Fp.absolute)),
+    list(SnippetWithMetadata.t) => 'msg
+  ) => Isolinear.Effect.t('msg);
+};
+
 module Sub: {
   let snippetFromFiles:
     (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1751,11 +1751,13 @@ let update =
              );
         (layout', Isolinear.Effect.none);
 
-      | ShowPicker(snippetsWithMetadata) => 
+      | ShowPicker(snippetsWithMetadata) =>
         let eff =
-            Isolinear.Effect.createWithDispatch(~name="snippet.menu", dispatch => {
-              dispatch(Actions.QuickmenuShow(SnippetPicker(snippetsWithMetadata)))
-            });
+          Isolinear.Effect.createWithDispatch(~name="snippet.menu", dispatch => {
+            dispatch(
+              Actions.QuickmenuShow(SnippetPicker(snippetsWithMetadata)),
+            )
+          });
         (state.layout, eff);
 
       | Effect(eff) => (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1659,6 +1659,7 @@ let update =
         ~maybeBuffer,
         ~editorId,
         ~cursorPosition,
+        ~extensions=state.extensions,
         msg,
         state.snippets,
       );
@@ -1749,6 +1750,14 @@ let update =
                )
              );
         (layout', Isolinear.Effect.none);
+
+      | ShowPicker(snippetsWithMetadata) => 
+        let eff =
+            Isolinear.Effect.createWithDispatch(~name="snippet.menu", dispatch => {
+              dispatch(Actions.QuickmenuShow(SnippetPicker(snippetsWithMetadata)))
+            });
+        (state.layout, eff);
+
       | Effect(eff) => (
           state.layout,
           eff |> Isolinear.Effect.map(msg => Actions.Snippets(msg)),

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -256,7 +256,9 @@ let start = () => {
                category: Some(snippet.prefix),
                name: snippet.description,
                command: () =>
-                 Snippets(Feature_Snippets.Msg.insert(~snippet=snippet.snippet)),
+                 Snippets(
+                   Feature_Snippets.Msg.insert(~snippet=snippet.snippet),
+                 ),
                icon: None,
                highlight: [],
                handle: None,

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -256,7 +256,7 @@ let start = () => {
                category: Some(snippet.prefix),
                name: snippet.description,
                command: () =>
-                 Snippets(Feature_Snippets.Msg.insert(snippet.snippet)),
+                 Snippets(Feature_Snippets.Msg.insert(~snippet=snippet.snippet)),
                icon: None,
                highlight: [],
                handle: None,

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -248,6 +248,27 @@ let start = () => {
         Isolinear.Effect.none,
       );
 
+    | QuickmenuShow(SnippetPicker(snippets)) =>
+      let items =
+        snippets
+        |> List.map((snippet: Service_Snippets.SnippetWithMetadata.t) => {
+             Actions.{
+               category: Some(snippet.prefix),
+               name: snippet.description,
+               command: () =>
+                 Snippets(Feature_Snippets.Msg.insert(snippet.snippet)),
+               icon: None,
+               highlight: [],
+               handle: None,
+             }
+           })
+        |> Array.of_list;
+
+      (
+        Some({...Quickmenu.defaults(SnippetPicker(snippets)), items}),
+        Isolinear.Effect.none,
+      );
+
     | QuickmenuShow(OpenBuffersPicker) =>
       let items =
         makeBufferCommands(workspace, languageInfo, iconTheme, buffers);
@@ -614,6 +635,7 @@ let subscriptions = (ripgrep, dispatch) => {
       | EditorsPicker
       | OpenBuffersPicker => [filter(query, quickmenu.items)]
       | ThemesPicker(_) => [filter(query, quickmenu.items)]
+      | SnippetPicker(_) => [filter(query, quickmenu.items)]
 
       | Extension({hasItems, _}) =>
         hasItems ? [filter(query, quickmenu.items)] : []


### PR DESCRIPTION
This adds an `Insert Snippet` command to the command palette (and it can be also be bound to a keypress: `"editor.action.insertSnippet"`).

When the command is executed - a menu will open, showing the available snippets for the current filetype:

![2021-02-04 11 44 09](https://user-images.githubusercontent.com/13532591/106946815-719fc100-66de-11eb-86d7-05711aaee536.gif)
