### PR TITLE
fix(snippets): Fix auto-closing pairs failing when placeholders are on same line

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #3078 - Auto-Update: Notify user when update fails due to missing key (fixes #3070)
 - #3086 - Snippets: Fix clash with completion / document highlights feature
 - #3085 - Snippets: Fix drop-shadow calculation at end of buffer
+- #3091 - Snippets: Fix auto-closing pairs when placeholders are on same line
 
 ### Performance
 

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -542,6 +542,48 @@ describe("Multi-cursor", ({describe, _}) => {
 
       dispose();
     });
+    test("multi-cursor auto-closing pairs, same line", ({expect, _}) => {
+      let buf = resetBuffer();
+
+      let autoClosingPairs =
+        AutoClosingPairs.create(
+          AutoClosingPairs.[AutoPair.{opening: "{", closing: "}"}],
+        );
+
+      let mode =
+        input(
+          ~autoClosingPairs,
+          ~mode=
+            Vim.Mode.Insert({
+              cursors: [
+                BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.(zero + 1),
+                },
+                BytePosition.{
+                  line: LineNumber.(zero),
+                  byte: ByteIndex.(zero + 2),
+                },
+              ],
+            }),
+          "{",
+        );
+
+      let line1 = Buffer.getLine(buf, LineNumber.zero);
+
+      expect.string(line1).toEqual(
+        "{}T{}h{}is is the first line of a test file",
+      );
+
+      let _: Vim.Mode.t = input(~autoClosingPairs, ~mode, "a");
+
+      let line1 = Buffer.getLine(buf, LineNumber.zero);
+
+      expect.string(line1).toEqual(
+        "{a}T{a}h{a}is is the first line of a test file",
+      );
+    });
     test("insert / backspace", ({expect, _}) => {
       let buf = resetBuffer();
 

--- a/test/reason-libvim/MultiCursorTest.re
+++ b/test/reason-libvim/MultiCursorTest.re
@@ -547,9 +547,9 @@ describe("Multi-cursor", ({describe, _}) => {
 
       let autoClosingPairs =
         AutoClosingPairs.create(
+          ~allowBefore=[" "],
           AutoClosingPairs.[AutoPair.{opening: "{", closing: "}"}],
         );
-
       let mode =
         input(
           ~autoClosingPairs,
@@ -559,11 +559,11 @@ describe("Multi-cursor", ({describe, _}) => {
                 BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
                 BytePosition.{
                   line: LineNumber.(zero),
-                  byte: ByteIndex.(zero + 1),
+                  byte: ByteIndex.(zero + 4),
                 },
                 BytePosition.{
                   line: LineNumber.(zero),
-                  byte: ByteIndex.(zero + 2),
+                  byte: ByteIndex.(zero + 7),
                 },
               ],
             }),
@@ -573,7 +573,7 @@ describe("Multi-cursor", ({describe, _}) => {
       let line1 = Buffer.getLine(buf, LineNumber.zero);
 
       expect.string(line1).toEqual(
-        "{}T{}h{}is is the first line of a test file",
+        "{}This{} is{} the first line of a test file",
       );
 
       let _: Vim.Mode.t = input(~autoClosingPairs, ~mode, "a");
@@ -581,7 +581,7 @@ describe("Multi-cursor", ({describe, _}) => {
       let line1 = Buffer.getLine(buf, LineNumber.zero);
 
       expect.string(line1).toEqual(
-        "{a}T{a}h{a}is is the first line of a test file",
+        "{a}This{a} is{a} the first line of a test file",
       );
     });
     test("insert / backspace", ({expect, _}) => {


### PR DESCRIPTION
__Issue:__ Auto-closing pairs weren't handled correctly in snippets, when multiple placeholders are on the same line:

![2021-02-04 11 50 02](https://user-images.githubusercontent.com/13532591/106947652-803aa800-66df-11eb-9c5e-4b196dd37003.gif)



__Defect:__ This is actually a bug with our 'multiple-insert-mode-cursor' support. There is a primary cursor, along with zero or more secondary cursors. The secondary cursors get sorted in descending order by position, so changes to those don't impact other cursors. However, the primary cursor needs to 'push' the secondary cursors if the position changes - it's often before all the other cursors.

The byte delta to adjust subsequent cursor positions was based on the delta in the primary cursor position. This isn't adequate, though, as in the case of auto-closing pairs - `(|)`, the cursor only moves _one_ character but _two_ characters are inserted. Therefore, we need to account for the change in byte length instead of cursor position.

__Fix:__ Add a test case; switch the delta calculation to use byte length instead of byte position.

![2021-02-04 11 51 50](https://user-images.githubusercontent.com/13532591/106947669-86c91f80-66df-11eb-9493-6b58d4eab210.gif)
