### PR TITLE
refactor(os/#3092): Add additional logging along readdir/node expansion path

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -36,3 +36,4 @@
 ### Infrastructure / Refactoring
 
 - #3012 - Node: Upgrade from Node 12 LTS -> Node 14 LTS (related #3009)
+- #3096 - OS: Add logging for `readdir` path (related #3092)

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -69,11 +69,30 @@ module Internal = {
 module Effects = {
   let load = (directory, configuration, ~onComplete) => {
     Isolinear.Effect.createWithDispatch(~name="explorer.load", dispatch => {
+      Log.infof(m => m("Loading nodes for directory: %s", directory));
       let ignored =
         Configuration.getValue(c => c.filesExclude, configuration);
       let promise = Internal.getDirectoryTree(directory, ignored);
 
-      Lwt.on_success(promise, tree => {dispatch(onComplete(tree))});
+      Lwt.on_success(
+        promise,
+        tree => {
+          Log.infof(m =>
+            m("Successfully loaded nodes for directory: %s", directory)
+          );
+          dispatch(onComplete(tree));
+        },
+      );
+
+      Lwt.on_failure(promise, exn => {
+        Log.errorf(m =>
+          m(
+            "Error loading directory %s: %s",
+            directory,
+            Printexc.to_string(exn),
+          )
+        )
+      });
     });
   };
 };

--- a/src/Service/OS/Service_OS.re
+++ b/src/Service/OS/Service_OS.re
@@ -44,13 +44,17 @@ module Api = {
   };
 
   let readdir = path => {
+    Log.infof(m => m("readdir called for: %s", path));
     path
     |> Internal.opendir
     |> bind(dir => {
          Internal.readdir(dir) |> Lwt.map(items => (dir, items))
        })
     |> bind(((dir, results: array(Luv.File.Dirent.t))) => {
-         Internal.closedir(dir) |> Lwt.map(() => results |> Array.to_list)
+         Log.infof(m =>
+           m("readdir returned %d items", Array.length(results))
+         );
+         Internal.closedir(dir) |> Lwt.map(() => results |> Array.to_list);
        });
   };
 


### PR DESCRIPTION
Some additional logging to help narrow down #3092 