### PR TITLE
fix(input/#2850): Add 'timeout' for remapped keys

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -29,6 +29,7 @@
 - #3086 - Snippets: Fix clash with completion / document highlights feature
 - #3085 - Snippets: Fix drop-shadow calculation at end of buffer
 - #3091 - Snippets: Fix auto-closing pairs when placeholders are on same line
+- #3102 - Vim / Input: Implement mapping timeout (fixes #2850)
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -124,7 +124,7 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `vim.leader` __(_string_)__ - Specify a custom [leader key](./key-bindings#leader-key).
 
-- `input.timeout` __(_int_ default: `1000`)__ Sets the timeout, in milliseconds, when Onivim is waiting for a pending chord. When the timeout is reached, any pending keys that are partially mapped will be flushed. Equivalent to the `timeoutlen` Vim setting.
+- `vim.timeout` __(_int_ default: `1000`)__ Sets the timeout, in milliseconds, when Onivim is waiting for a pending chord. When the timeout is reached, any pending keys that are partially mapped will be flushed. Equivalent to the `timeoutlen` Vim setting. Can be set to `0` to disable the timeout entirely.
 
 ### Layout
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -124,6 +124,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `vim.leader` __(_string_)__ - Specify a custom [leader key](./key-bindings#leader-key).
 
+- `input.timeout` __(_int_ default: `1000`)__ Sets the timeout, in milliseconds, when Onivim is waiting for a pending chord. When the timeout is reached, any pending keys that are partially mapped will be flushed. Equivalent to the `timeoutlen` Vim setting.
+
 ### Layout
 
 - `workbench.editor.showTabs` __(_bool_ default: `true`)__ - When `false`, hides the editor tabs.

--- a/integration_test/VimRemapTimeoutTest.re
+++ b/integration_test/VimRemapTimeoutTest.re
@@ -1,0 +1,53 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+runTest(
+  ~name="VimRemapTimeoutTest", ({dispatch, wait, runEffects, input, _}) => {
+  wait(~name="Initial mode is normal", (state: State.t) =>
+    Selectors.mode(state) |> Vim.Mode.isNormal
+  );
+
+  // Set low input timeout: 250ms
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "timeoutlen 250"}),
+  );
+  runEffects();
+
+  // Use inoremap to set up jk -> <ESC> binding
+  dispatch(
+    VimExecuteCommand({allowAnimation: true, command: "inoremap jk <ESC>"}),
+  );
+  runEffects();
+
+  input("i");
+  wait(~name="Mode is now insert", (state: State.t) =>
+    Selectors.mode(state) |> Vim.Mode.isInsert
+  );
+
+  input("j");
+
+  // Verify we are in a 'pending' input state...
+  wait(~name="`j` should be consumed", (state: State.t) =>
+    Feature_Input.consumedKeys(state.input) != []
+  );
+
+  // ... and then the timeout is reached, dropping the `j` into the buffer.
+  wait(
+    ~timeout=5.0,
+    ~name="j should be emitted to buffer",
+    (state: State.t) => {
+      let buffer = Selectors.getActiveBuffer(state) |> Option.get;
+
+      let line =
+        if (Buffer.getNumberOfLines(buffer) > 0) {
+          buffer |> Buffer.getLine(0) |> BufferLine.raw;
+        } else {
+          "";
+        };
+
+      // Verify character
+      line == "j" && Feature_Input.consumedKeys(state.input) == [];
+    },
+  );
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -23,8 +23,9 @@
    SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
    AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
    TypingBatchedTest TypingUnbatchedTest VimIncsearchScrollTest
-   VimSimpleRemapTest VimlRemapCmdlineTest ClipboardChangeTest
-   VimScriptLocalFunctionTest ZenModeSingleFileModeTest ZenModeSplitTest)
+   VimRemapTimeoutTest VimSimpleRemapTest VimlRemapCmdlineTest
+   ClipboardChangeTest VimScriptLocalFunctionTest ZenModeSingleFileModeTest
+   ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
@@ -61,7 +62,7 @@
    TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
    AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
    VimIncsearchScrollTest.exe VimScriptLocalFunctionTest.exe
-   VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
+   VimRemapTimeoutTest.exe VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
    ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe ClipboardChangeTest.exe
    large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
    test.lf test-syntax.php utf8.txt utf8-test-file.htm

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -152,7 +152,7 @@ module Configuration = {
   let timeout =
     setting(
       ~vim=VimSettings.timeout,
-      "input.timeout",
+      "vim.timeout",
       CustomDecoders.timeout,
       ~default=Timeout(Revery.Time.seconds(1)),
     );

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -22,8 +22,8 @@ let keyCandidateToString = keyCandidate => {
 };
 
 type timeout =
-| NoTimeout
-| Timeout(Revery.Time.t);
+  | NoTimeout
+  | Timeout(Revery.Time.t);
 
 // VIM SETTINGS
 
@@ -31,22 +31,25 @@ module VimSettings = {
   open Config.Schema;
   open VimSetting.Schema;
 
-  let timeout = vim2("timeout", "timeoutlen", (maybeTimeout, maybeTimeoutLen) => {
-    let maybeTimeoutBool = maybeTimeout |> OptionEx.flatMap(VimSetting.decode_value_opt(bool));
-    let maybeTimeoutLenInt = maybeTimeoutLen |> OptionEx.flatMap(VimSetting.decode_value_opt(int));
-    switch ((maybeTimeoutBool, maybeTimeoutLenInt)) {
-    | (None, Some(timeoutLength)) 
-    | (Some(true), Some(timeoutLength)) => Some(Timeout(Revery.Time.milliseconds(timeoutLength)))
+  let timeout =
+    vim2("timeout", "timeoutlen", (maybeTimeout, maybeTimeoutLen) => {
+      let maybeTimeoutBool =
+        maybeTimeout |> OptionEx.flatMap(VimSetting.decode_value_opt(bool));
+      let maybeTimeoutLenInt =
+        maybeTimeoutLen |> OptionEx.flatMap(VimSetting.decode_value_opt(int));
+      switch (maybeTimeoutBool, maybeTimeoutLenInt) {
+      | (None, Some(timeoutLength))
+      | (Some(true), Some(timeoutLength)) =>
+        Some(Timeout(Revery.Time.milliseconds(timeoutLength)))
 
-    | (Some(true), None) => Some(Timeout(Revery.Time.seconds(1)));
+      | (Some(true), None) => Some(Timeout(Revery.Time.seconds(1)))
 
-    | (Some(false), _) => Some(NoTimeout)
+      | (Some(false), _) => Some(NoTimeout)
 
-    | (None, None) => None
-    };
-  });
-
-}
+      | (None, None) => None
+      };
+    });
+};
 
 // CONFIGURATION
 module Configuration = {
@@ -105,35 +108,45 @@ module Configuration = {
           ),
       );
 
-      module Timeout = {
-        let decode = Json.Decode.(one_of([
-          ("bool", bool |> map(
-            fun
-            | true => Timeout(Revery.Time.seconds(1))
-            | false => NoTimeout
-          )),
-          ("int", int |> map(time =>
-            Timeout(Revery.Time.seconds(time))
-          ))
-        ]));
+    module Timeout = {
+      let decode =
+        Json.Decode.(
+          one_of([
+            (
+              "bool",
+              bool
+              |> map(
+                   fun
+                   | true => Timeout(Revery.Time.seconds(1))
+                   | false => NoTimeout,
+                 ),
+            ),
+            ("int", int |> map(time => Timeout(Revery.Time.seconds(time)))),
+          ])
+        );
 
-        let encode = Json.Encode.(fun
-        | NoTimeout => bool(false)
-        | Timeout(time) => int(time |> Revery.Time.toFloatSeconds |> int_of_float)
-        )
-      };
+      let encode =
+        Json.Encode.(
+          fun
+          | NoTimeout => bool(false)
+          | Timeout(time) =>
+            int(time |> Revery.Time.toFloatSeconds |> int_of_float)
+        );
+    };
 
-      let timeout = custom(
-        ~decode=Timeout.decode,
-        ~encode=Timeout.encode,
-      );
+    let timeout = custom(~decode=Timeout.decode, ~encode=Timeout.encode);
   };
 
   let leaderKey =
     setting("vim.leader", CustomDecoders.physicalKey, ~default=None);
 
   let timeout =
-    setting(~vim=VimSettings.timeout, "input.timeout", CustomDecoders.timeout, ~default=Timeout(Revery.Time.seconds(1)));
+    setting(
+      ~vim=VimSettings.timeout,
+      "input.timeout",
+      CustomDecoders.timeout,
+      ~default=Timeout(Revery.Time.seconds(1)),
+    );
 };
 
 // MSG
@@ -145,7 +158,8 @@ type outmsg =
       fromKeys: string,
       toKeys: string,
       error: string,
-    });
+    })
+  | TimedOut;
 
 type execute =
   InputStateMachine.execute =
@@ -309,7 +323,6 @@ type model = {
   userBindings: list(InputStateMachine.uniqueId),
   inputStateMachine: InputStateMachine.t,
   keyDisplayer: option(KeyDisplayer.t),
-
   // Keep track of the input tick - an incrementing number on every input event -
   // such that we can provide a unique id for the timer to flush on timeout.
   inputTick: int,
@@ -407,7 +420,8 @@ let keyDown =
       ...model,
       inputStateMachine: inputStateMachine',
       keyDisplayer: keyDisplayer',
-    } |> incrementTick,
+    }
+    |> incrementTick,
     effects,
   );
 };
@@ -440,7 +454,8 @@ let text = (~text, ~time, {inputStateMachine, keyDisplayer, _} as model) => {
       ...model,
       inputStateMachine: inputStateMachine',
       keyDisplayer: keyDisplayer',
-    } |> incrementTick,
+    }
+    |> incrementTick,
     effects,
   );
 };
@@ -454,7 +469,16 @@ let keyUp = (~config, ~scancode, ~context, {inputStateMachine, _} as model) => {
       ~context,
       inputStateMachine,
     );
-  ({...model, inputStateMachine: inputStateMachine'} |> incrementTick, effects);
+  (
+    {...model, inputStateMachine: inputStateMachine'} |> incrementTick,
+    effects,
+  );
+};
+
+let timeout = (~context, {inputStateMachine, _} as model) => {
+  let (inputStateMachine', effects) =
+    InputStateMachine.timeout(~context, inputStateMachine);
+  ({...model, inputStateMachine: inputStateMachine'}, effects);
 };
 
 let candidates = (~config, ~context, {inputStateMachine, _}) => {
@@ -688,9 +712,7 @@ let update = (msg, model) => {
       Nothing,
     )
 
-  | Timeout => 
-  prerr_endline ("TODO");
-  (model, Nothing)
+  | Timeout => (model, TimedOut)
 
   | KeyDisplayer(msg) =>
     let keyDisplayer' =
@@ -733,20 +755,29 @@ module Commands = {
 
 // SUBSCRIPTION
 
-let sub = ({keyDisplayer, inputTick, _}) => {
-  let sub1 = switch (keyDisplayer) {
-  | None => Isolinear.Sub.none
-  | Some(kd) =>
-    KeyDisplayer.sub(kd) |> Isolinear.Sub.map(msg => KeyDisplayer(msg))
-  };
+let sub = (~config, {keyDisplayer, inputTick, inputStateMachine, _}) => {
+  let sub1 =
+    switch (keyDisplayer) {
+    | None => Isolinear.Sub.none
+    | Some(kd) =>
+      KeyDisplayer.sub(kd) |> Isolinear.Sub.map(msg => KeyDisplayer(msg))
+    };
 
-  let sub2 = Service_Time.Sub.once(
-    ~uniqueId="Feature_Input.keyExpirer:" ++ string_of_int(inputTick), 
-    ~delay=Revery.Time.seconds(1),
-    ~msg=(~current as _) => {
-      Timeout
-    }
-  );
+  let sub2 =
+    switch (Configuration.timeout.get(config)) {
+    | NoTimeout => Isolinear.Sub.none
+    | Timeout(delay) =>
+      if (InputStateMachine.isPending(inputStateMachine)) {
+        Service_Time.Sub.once(
+          ~uniqueId="Feature_Input.keyExpirer:" ++ string_of_int(inputTick),
+          ~delay,
+          ~msg=(~current as _) => {
+          Timeout
+        });
+      } else {
+        Isolinear.Sub.none;
+      }
+    };
 
   [sub1, sub2] |> Isolinear.Sub.batch;
 };

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -11,7 +11,8 @@ type outmsg =
       fromKeys: string,
       toKeys: string,
       error: string,
-    });
+    })
+  | TimedOut;
 
 [@deriving show]
 type command;
@@ -97,6 +98,9 @@ let keyDown:
   ) =>
   (model, list(effect));
 
+let timeout:
+  (~context: WhenExpr.ContextKeys.t, model) => (model, list(effect));
+
 let text:
   (~text: string, ~time: Revery.Time.t, model) => (model, list(effect));
 
@@ -143,7 +147,7 @@ let update: (msg, model) => (model, outmsg);
 
 // SUBSCRIPTION
 
-let sub: model => Isolinear.Sub.t(msg);
+let sub: (~config: Config.resolver, model) => Isolinear.Sub.t(msg);
 
 // CONTRIBUTIONS
 

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -52,12 +52,13 @@ type t =
       scancode: int,
       time: [@opaque] Revery.Time.t,
     })
+  | TextInput(string, [@opaque] Revery.Time.t)
   | KeyUp({
       scancode: int,
       time: [@opaque] Revery.Time.t,
     })
+  | KeyTimeout
   | Logging(Feature_Logging.msg)
-  | TextInput(string, [@opaque] Revery.Time.t)
   // TODO: This should be a function call - wired up from an input feature
   // directly to the consumer of the keyboard action.
   // In addition, in the 'not-is-text' case, we should strongly type the keys.

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -500,6 +500,10 @@ let update =
             error,
           ),
         )
+      | TimedOut =>
+        Isolinear.Effect.createWithDispatch(~name="Input.timeout", dispatch =>
+          dispatch(KeyTimeout)
+        )
       };
 
     ({...state, input: model}, eff);

--- a/src/Store/InputStoreConnector.re
+++ b/src/Store/InputStoreConnector.re
@@ -198,7 +198,19 @@ let start = (window: option(Revery.Window.t), runEffects) => {
 
     let newState = {...state, input};
 
-    updateFromInput(newState, /*Some("Text: " ++ text),*/ actions);
+    updateFromInput(newState, actions);
+  };
+
+  let handleTimeout = (state: State.t) => {
+    let context = Model.ContextKeys.all(state);
+    let (input, effects) = Feature_Input.timeout(~context, state.input);
+
+    let actions =
+      effects |> List.map(effectToActions(state)) |> List.flatten;
+
+    let newState = {...state, input};
+
+    updateFromInput(newState, actions);
   };
 
   let handleKeyUp = (~scancode, state: State.t) => {
@@ -223,6 +235,8 @@ let start = (window: option(Revery.Window.t), runEffects) => {
       handleKeyPress(~scancode, state, time, key)
 
     | KeyUp({scancode, _}) => handleKeyUp(~scancode, state)
+
+    | KeyTimeout => handleTimeout(state)
 
     | TextInput(text, time) => handleTextInput(state, time, text)
 

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -435,7 +435,7 @@ let start =
 
     let inputSubscription =
       state.input
-      |> Feature_Input.sub
+      |> Feature_Input.sub(~config)
       |> Isolinear.Sub.map(msg => Model.Actions.Input(msg));
 
     let notificationSub =

--- a/src/editor-input/EditorInput.re
+++ b/src/editor-input/EditorInput.re
@@ -779,14 +779,15 @@ module Make = (Config: {
     // let noopKey = KeyCandidate.ofList([]);
     // let (bindings', keyDownEffects) = keyDown(~context, ~key=noopKey, ~scancode=-1, bindings);
     // let (bindings'', keyUpEffects) = keyUp(~context, ~scancode=-1, bindings');
-    let (bindings'', effects) = flush(
-      ~allowRemaps=false,
-      ~isRemap=false,
-      ~leaderKey=None,
-      ~recursionDepth=0,
-      ~context,
-      bindings
-    );
+    let (bindings'', effects) =
+      flush(
+        ~allowRemaps=false,
+        ~isRemap=false,
+        ~leaderKey=None,
+        ~recursionDepth=0,
+        ~context,
+        bindings,
+      );
 
     (bindings'', effects);
   };

--- a/src/editor-input/EditorInput.re
+++ b/src/editor-input/EditorInput.re
@@ -62,6 +62,8 @@ module type Input = {
     ) =>
     (t, list(effect));
 
+  let timeout: (~context: context, t) => (t, list(effect));
+
   let candidates:
     (~leaderKey: option(PhysicalKey.t), ~context: context, t) =>
     list((Matcher.t, command));
@@ -769,5 +771,23 @@ module Make = (Config: {
       };
 
     (bindings, initialEffects);
+  };
+
+  let timeout = (~context, bindings) => {
+    // Timeout is like pressing a non-existent key - it should flush all existing bindings
+
+    // let noopKey = KeyCandidate.ofList([]);
+    // let (bindings', keyDownEffects) = keyDown(~context, ~key=noopKey, ~scancode=-1, bindings);
+    // let (bindings'', keyUpEffects) = keyUp(~context, ~scancode=-1, bindings');
+    let (bindings'', effects) = flush(
+      ~allowRemaps=false,
+      ~isRemap=false,
+      ~leaderKey=None,
+      ~recursionDepth=0,
+      ~context,
+      bindings
+    );
+
+    (bindings'', effects);
   };
 };

--- a/src/editor-input/EditorInput.rei
+++ b/src/editor-input/EditorInput.rei
@@ -185,7 +185,9 @@ module type Input = {
       t
     ) =>
     (t, list(effect));
+
   let text: (~text: string, t) => (t, list(effect));
+
   let keyUp:
     (
       ~leaderKey: option(PhysicalKey.t)=?,
@@ -194,6 +196,8 @@ module type Input = {
       t
     ) =>
     (t, list(effect));
+
+  let timeout: (~context: context, t) => (t, list(effect));
 
   // [candidates] returns a list of available matcher / command
   // candidates, based on the current context and input state.

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -1006,6 +1006,7 @@ describe("EditorInput", ({describe, _}) => {
       expect.equal(effects, [Execute("command2"), Execute("command3")]);
     });
   });
+
   describe("enable / disable", ({test, _}) => {
     test("unhandled when bindings are disabled", ({expect, _}) => {
       let alwaysTrue = _ => true;
@@ -1039,4 +1040,118 @@ describe("EditorInput", ({describe, _}) => {
       );
     })
   });
+
+  describe("timeout", ({test, _}) => {
+    test("timeout with partial match", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             Sequence([aKeyNoModifiers, cKeyNoModifiers]),
+             _ => true,
+             "commandAC",
+           );
+
+      let (bindings, _id) =
+        bindings
+        |> Input.addBinding(
+             Sequence([aKeyNoModifiers]),
+             _ => true,
+             "commandA",
+           );
+
+      let (bindings, effects) =
+        Input.keyDown(
+          ~context=true,
+          ~scancode=aKeyScancode,
+          ~key=candidate(aKeyNoModifiers),
+          bindings,
+        );
+
+      expect.equal(effects, []);
+
+      let (_bindings, effects) =
+        Input.timeout(
+          ~context=true,
+          bindings,
+        );
+
+      expect.equal(
+        effects,
+        [
+          Execute("commandA"),
+        ],
+      );
+    });
+    test("timeout with no match", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             Sequence([aKeyNoModifiers, cKeyNoModifiers]),
+             _ => true,
+             "commandAC",
+           );
+
+      let (bindings, effects) =
+        Input.keyDown(
+          ~context=true,
+          ~scancode=aKeyScancode,
+          ~key=candidate(aKeyNoModifiers),
+          bindings,
+        );
+
+      expect.equal(effects, []);
+
+      let (_bindings, effects) =
+        Input.timeout(
+          ~context=true,
+          bindings,
+        );
+
+      expect.equal(
+        effects,
+        [
+          Unhandled({
+            key: candidate(aKeyNoModifiers),
+            isProducedByRemap: false,
+          }),
+        ],
+      );
+    });
+    test("timeout with no match, but prior text event", ({expect, _}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             Sequence([aKeyNoModifiers, cKeyNoModifiers]),
+             _ => true,
+             "commandAC",
+           );
+
+      let (bindings, effects) =
+        Input.keyDown(
+          ~context=true,
+          ~scancode=aKeyScancode,
+          ~key=candidate(aKeyNoModifiers),
+          bindings,
+        );
+
+      expect.equal(effects, []);
+
+      let (bindings, effects) = Input.text(~text="a", bindings);
+
+      expect.equal(effects, []);
+
+      let (_bindings, effects) =
+        Input.timeout(
+          ~context=true,
+          bindings,
+        );
+
+      expect.equal(
+        effects,
+        [
+          Text("a")
+        ],
+      );
+    });
+  })
 });

--- a/test/editor-input/InputTest.re
+++ b/test/editor-input/InputTest.re
@@ -1069,18 +1069,9 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, []);
 
-      let (_bindings, effects) =
-        Input.timeout(
-          ~context=true,
-          bindings,
-        );
+      let (_bindings, effects) = Input.timeout(~context=true, bindings);
 
-      expect.equal(
-        effects,
-        [
-          Execute("commandA"),
-        ],
-      );
+      expect.equal(effects, [Execute("commandA")]);
     });
     test("timeout with no match", ({expect, _}) => {
       let (bindings, _id) =
@@ -1101,11 +1092,7 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, []);
 
-      let (_bindings, effects) =
-        Input.timeout(
-          ~context=true,
-          bindings,
-        );
+      let (_bindings, effects) = Input.timeout(~context=true, bindings);
 
       expect.equal(
         effects,
@@ -1140,18 +1127,9 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, []);
 
-      let (_bindings, effects) =
-        Input.timeout(
-          ~context=true,
-          bindings,
-        );
+      let (_bindings, effects) = Input.timeout(~context=true, bindings);
 
-      expect.equal(
-        effects,
-        [
-          Text("a")
-        ],
-      );
+      expect.equal(effects, [Text("a")]);
     });
-  })
+  });
 });


### PR DESCRIPTION
__Issue:__ By default, in Vim, when there is a mapping like: <kbd>j</kbd><kbd>k</kbd> -> <kbd>esc</kbd>, if just <kbd>j</kbd> is pressed, there is a timeout - after 1 second, the <kbd>j</kbd> would be executed as if typed (or, if there was a smaller mapping from <kbd>j</kbd>, that would be executed). Onivim didn't support this.

__Fix:__ Add `vim.timeout` configuration, as well as support for `:set timeout` and `:set timeoutlen` configuration. 

After a key gesture is completed, and there is a potential pending mapping, start a timer. If that timer is hit, flush any pending input.

Fixes #2850 