### PR TITLE
fix(extension/#3099): golang.go activation error

### DIFF
--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -245,8 +245,8 @@ module InitData: {
       globalStorageHome: option(Oni_Core.Uri.t),
       workspaceStorageHome: option(Oni_Core.Uri.t),
       userHome: option(Oni_Core.Uri.t),
-       webviewResourceRoot: string,
-       webviewCspSource: string,
+      webviewResourceRoot: string,
+      webviewCspSource: string,
       // TODO
       /*
        appLanguage: string,

--- a/src/Exthost/Extension/Exthost_Extension.rei
+++ b/src/Exthost/Extension/Exthost_Extension.rei
@@ -245,13 +245,13 @@ module InitData: {
       globalStorageHome: option(Oni_Core.Uri.t),
       workspaceStorageHome: option(Oni_Core.Uri.t),
       userHome: option(Oni_Core.Uri.t),
+       webviewResourceRoot: string,
+       webviewCspSource: string,
       // TODO
       /*
        appLanguage: string,
        appUriScheme: string,
        appSettingsHome: option(Uri.t),
-       webviewResourceRoot: string,
-       webviewCspSource: string,
        useHostProxy: boolean,
        */
     };

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -118,12 +118,12 @@ module Environment = {
     globalStorageHome: option(Uri.t),
     workspaceStorageHome: option(Uri.t),
     userHome: option(Uri.t),
+    webviewResourceRoot: string,
+    webviewCspSource: string,
     // TODO
     /*
      appUriScheme: string,
      appSettingsHome: option(Uri.t),
-     webviewResourceRoot: string,
-     webviewCspSource: string,
      useHostProxy: boolean,
      */
   };
@@ -147,6 +147,12 @@ module Environment = {
       Oni_Core.Filesystem.getUserDataDirectory()
       |> Result.to_option
       |> Option.map(Uri.fromFilePath),
+     // Currently, Onivim does not support webview integrations -
+     // once those are added, these resource / csp roots will need to be updated.
+     // They are placeholders right now to unblock extensions that try to create webviews,
+     // ie: `golang.go` in https://github.com/onivim/oni2/issues/3099
+     webviewResourceRoot: "onivim-resource://{{resource}}",
+     webviewCspSource: "onivim-csp://{{resource}}",
   };
 };
 

--- a/src/Exthost/Extension/InitData.re
+++ b/src/Exthost/Extension/InitData.re
@@ -147,12 +147,12 @@ module Environment = {
       Oni_Core.Filesystem.getUserDataDirectory()
       |> Result.to_option
       |> Option.map(Uri.fromFilePath),
-     // Currently, Onivim does not support webview integrations -
-     // once those are added, these resource / csp roots will need to be updated.
-     // They are placeholders right now to unblock extensions that try to create webviews,
-     // ie: `golang.go` in https://github.com/onivim/oni2/issues/3099
-     webviewResourceRoot: "onivim-resource://{{resource}}",
-     webviewCspSource: "onivim-csp://{{resource}}",
+    // Currently, Onivim does not support webview integrations -
+    // once those are added, these resource / csp roots will need to be updated.
+    // They are placeholders right now to unblock extensions that try to create webviews,
+    // ie: `golang.go` in https://github.com/onivim/oni2/issues/3099
+    webviewResourceRoot: "onivim-resource://{{resource}}",
+    webviewCspSource: "onivim-csp://{{resource}}",
   };
 };
 

--- a/test/Exthost/WebviewTest.re
+++ b/test/Exthost/WebviewTest.re
@@ -1,6 +1,5 @@
 open TestFramework;
 
-open Oni_Core;
 open Exthost;
 
 let waitForMessage = (~name, f, context) => {

--- a/test/Exthost/WebviewTest.re
+++ b/test/Exthost/WebviewTest.re
@@ -1,0 +1,37 @@
+open TestFramework;
+
+open Oni_Core;
+open Exthost;
+
+let waitForMessage = (~name, f, context) => {
+  context
+  |> Test.waitForMessage(
+       ~name,
+       fun
+       | Msg.MessageService(ShowMessage({message, severity, _})) =>
+         f(severity, message)
+       | _ => false,
+     );
+};
+
+describe("WebviewTest", ({test, _}) => {
+  test("revive uri", _ => {
+    Test.startWithExtensions(["oni-webview"])
+    |> Test.waitForExtensionActivation("oni-webview")
+    |> Test.withClient(
+         Request.Commands.executeContributedCommand(
+           ~arguments=[],
+           ~command="webview.test.asWebviewUri",
+         ),
+       )
+    |> waitForMessage(~name="api call success", (severity, _message) =>
+         switch (severity) {
+         | Info => true
+         | Error => false
+         | _ => assert(false)
+         }
+       )
+    |> Test.terminate
+    |> Test.waitForProcessClosed
+  })
+});

--- a/test/collateral/extensions/oni-webview/extension.js
+++ b/test/collateral/extensions/oni-webview/extension.js
@@ -1,0 +1,42 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('webview.start', () => {
+      // Create and show panel
+      const panel = vscode.window.createWebviewPanel(
+        'test-webview',
+        'Test Webview',
+        vscode.ViewColumn.One,
+        {}
+      );
+      const onDiskPath = vscode.Uri.file(
+        path.join(context.extensionPath, 'some', 'file.gif')
+      );
+
+      // And set its HTML content
+	  // Onivim doesn't support webviews, yet, but we shouldn't crash in trying to interact with one...
+      panel.webview.html = "<html />";
+
+	  const myUri = panel.webview.asWebviewUri(onDiskPath);
+
+	  vscode.window.showInformationMessage("Success: " + myUri.toString());
+    })
+  );
+}
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+
+module.exports = {
+	activate,
+	deactivate
+}

--- a/test/collateral/extensions/oni-webview/extension.js
+++ b/test/collateral/extensions/oni-webview/extension.js
@@ -10,7 +10,7 @@ const vscode = require('vscode');
  */
 function activate(context) {
   context.subscriptions.push(
-    vscode.commands.registerCommand('webview.start', () => {
+    vscode.commands.registerCommand('webview.test.asWebviewUri', () => {
       // Create and show panel
       const panel = vscode.window.createWebviewPanel(
         'test-webview',
@@ -19,7 +19,7 @@ function activate(context) {
         {}
       );
       const onDiskPath = vscode.Uri.file(
-        path.join(context.extensionPath, 'some', 'file.gif')
+        context.extensionPath
       );
 
       // And set its HTML content

--- a/test/collateral/extensions/oni-webview/package.json
+++ b/test/collateral/extensions/oni-webview/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "oni-virtual-document",
+	"description": "Minimal HelloWorld example for VS Code",
+	"version": "0.0.1",
+	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
+	"engines": {
+		"vscode": "^1.25.0"
+	},
+	"activationEvents": ["*"],
+	"main": "./extension.js",
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	}
+}

--- a/test/collateral/extensions/oni-webview/package.json
+++ b/test/collateral/extensions/oni-webview/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "oni-virtual-document",
-	"description": "Minimal HelloWorld example for VS Code",
+	"name": "oni-webview",
+	"description": "Exercise webview API for tests",
 	"version": "0.0.1",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/helloworld-minimal-sample",
 	"engines": {


### PR DESCRIPTION
__Issue:__ The latest `golang.go` extension fails to activate in Onivim, with this error:

```
Error activating extension: golang.go: Activating extension 'golang.go' failed: Cannot read property 'replace' of undefined.
```

__Defect:__ The latest extension creates a 'welcome' webview on startup. As part of that webview, it resolves some local file paths using the [`webview.asWebviewUri`](https://code.visualstudio.com/api/extension-guides/webview#loading-local-content) API. We're not sending some data that the API expects (it uses a seed `webviewResourceRoot`, and runs `replace` on the string) and because this isn't provided, the extension host crashes running `replace` on a `null` string

__Fix:__ Even though Onivim doesn't currently support rendering webviews provided by extensions, Onivim shouldn't crash on activation when a webview is requested. We can send some placeholder data as part of our `InitData.environment`, so that the extension doesn't crash. In addition, add a test case for a webview to verify this works build-over-build.

Fixes #3099 