### PR TITLE
fix(input): Fix incorrect default input timeout

### DIFF
--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -139,7 +139,12 @@ module Configuration = {
           fun
           | NoTimeout => bool(false)
           | Timeout(time) =>
-            int(time |> Revery.Time.toFloatSeconds |> int_of_float)
+            int(
+              time
+              |> Revery.Time.toFloatSeconds
+              |> (t => t *. 1000.)
+              |> int_of_float,
+            )
         );
     };
 


### PR DESCRIPTION
Related to #3102 - fix a bug where the default timeout is interpreted as `0.001` seconds instead of `1` second