### PR TITLE
fix(menubar/#3108): Fix command invocation from menu items

### DIFF
--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -229,3 +229,18 @@ __Pass:__
 - [ ] Win
 - [ ] OSX
 - [ ] Linux
+
+# 10. Menubar
+
+## 10.1 Verify simple command 
+
+Regression test for #3108
+
+- Open Onivim 2
+- Click on File -> Open Folder
+- Verify Open Folder dialog is shown
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -28,7 +28,7 @@ module Internal = {
   let executeCommandEffect = (command, arguments) => {
     Isolinear.Effect.createWithDispatch(
       ~name="features.executeCommand", dispatch =>
-      dispatch(Actions.CommandInvoked({command, arguments}))
+      dispatch(Actions.KeybindingInvoked({command, arguments}))
     );
   };
 


### PR DESCRIPTION
__Issue:__ The menu-bar items are (mostly) not executing when clicked.

__Defect:__ In #3084 , part of #3055 was reverted - a refactoring of consolidating the `CommandInvoked` and `KeybindingInvoked` actions. However, one spot was missed, causing it not to trigger correctly (in the effect handler of `Feature_Menubar`

__Fix:__ Revert the change in the `executeCommandEffect`, used by `Feature_MenuBar`, as well.

__Todo:__
- [x] Verify OSX
- [x] Verify Linux
- [x] Verify Windows
- [x] Add manual test case