### PR TITLE
fix(snippets): Implement TM_SELECTED_TEXT snippet variable

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -31,6 +31,7 @@
 - #3085 - Snippets: Fix drop-shadow calculation at end of buffer
 - #3091 - Snippets: Fix auto-closing pairs when placeholders are on same line
 - #3102 - Vim / Input: Implement mapping timeout (fixes #2850)
+- #3121 - Snippets: Add support for the $TM_SELECTED_TEXT snippet variable
 
 ### Performance
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -197,6 +197,8 @@ let scrollPage: (~count: int, t) => t;
 
 let getCharacterWidth: t => float;
 
+let singleLineSelectedText: t => option(string);
+
 // Given a start position and a delta screen lines,
 // figure out a destination byte position.
 let moveScreenLines:

--- a/src/Feature/Editor/EditorBuffer.re
+++ b/src/Feature/Editor/EditorBuffer.re
@@ -9,3 +9,9 @@ let font = Oni_Core.Buffer.getFont;
 
 let fileType = Oni_Core.Buffer.getFileType;
 let measure = Oni_Core.Buffer.measure;
+
+let hasLine = (lineNumber, buffer) => {
+  let lineIdx = EditorCoreTypes.LineNumber.toZeroBased(lineNumber);
+  let lineCount = numberOfLines(buffer);
+  lineIdx >= 0 && lineIdx < lineCount;
+};

--- a/src/Feature/Editor/EditorBuffer.rei
+++ b/src/Feature/Editor/EditorBuffer.rei
@@ -9,6 +9,7 @@ let id: t => int;
 let getEstimatedMaxLineLength: t => int;
 let numberOfLines: t => int;
 let line: (int, t) => Oni_Core.BufferLine.t;
+let hasLine: (EditorCoreTypes.LineNumber.t, t) => bool;
 let font: t => Oni_Core.Font.t;
 let fileType: t => Oni_Core.Buffer.FileType.t;
 let measure: (Uchar.t, t) => float;

--- a/src/Model/SnippetVariables.re
+++ b/src/Model/SnippetVariables.re
@@ -37,7 +37,10 @@ let current = (state: State.t, variable) => {
   // Textmate Variables
 
   // TODO
-  | "TM_SELECTED_TEXT" => Some("TM_SELECTED_TEXT")
+  | "TM_SELECTED_TEXT" =>
+    editor
+    |> Feature_Editor.Editor.singleLineSelectedText
+    |> OptionEx.or_(Some(""))
 
   | "TM_CURRENT_LINE" =>
     maybeBuffer

--- a/src/editor-core-types/ByteRange.re
+++ b/src/editor-core-types/ByteRange.re
@@ -71,3 +71,5 @@ let toHash = ranges => {
 };
 
 let equals = (a, b) => BytePosition.(a.start == b.start && a.stop == b.stop);
+
+let isSingleLine = range => range.start.line == range.stop.line;

--- a/src/editor-core-types/ByteRange.rei
+++ b/src/editor-core-types/ByteRange.rei
@@ -30,3 +30,5 @@ let compare: (t, t) => int;
  * or equal to the [stop]
  */
 let normalize: t => t;
+
+let isSingleLine: t => bool;

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -336,4 +336,47 @@ describe("Editor", ({describe, _}) => {
       expect.equal(Editor.getCharacterUnderMouse(editor'), None);
     })
   });
+
+  describe("singleLineSelectedText", ({test, _}) => {
+    test("no selection in normal mode", ({expect, _}) => {
+      let (editor, _buffer) = create([|"abc"|]);
+
+      let maybeSelectedText =
+        editor
+        |> Editor.setMode(Vim.Mode.Normal({cursor: BytePosition.zero}))
+        |> Editor.singleLineSelectedText;
+
+      expect.option(maybeSelectedText).toBeNone();
+    });
+    test("select single character", ({expect, _}) => {
+      let (editor, _buffer) = create([|"abc"|]);
+
+      let maybeSelectedText =
+        editor
+        |> Editor.setSelections([ByteRange.zero])
+        |> Editor.singleLineSelectedText;
+
+      expect.equal(maybeSelectedText, Some("a"));
+    });
+    test("select past entire line", ({expect, _}) => {
+      let (editor, _buffer) = create([|"abc"|]);
+
+      let maybeSelectedText =
+        editor
+        |> Editor.setSelections([
+             ByteRange.{
+               start:
+                 BytePosition.{line: LineNumber.zero, byte: ByteIndex.zero},
+               stop:
+                 BytePosition.{
+                   line: LineNumber.zero,
+                   byte: ByteIndex.(zero + 100),
+                 },
+             },
+           ])
+        |> Editor.singleLineSelectedText;
+
+      expect.equal(maybeSelectedText, Some("abc"));
+    });
+  });
 });


### PR DESCRIPTION
This adds support for the `$TM_SELECTED_TEXT` snippet variable, which was missing previously