### PR TITLE
fix(signature-help): Signature help staying open across snippet placeholders

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -31,6 +31,7 @@
 - #3085 - Snippets: Fix drop-shadow calculation at end of buffer
 - #3091 - Snippets: Fix auto-closing pairs when placeholders are on same line
 - #3102 - Vim / Input: Implement mapping timeout (fixes #2850)
+- #3122 - Signature Help: Close signature help when traversing snippet placeholders
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -472,7 +472,10 @@ let cursorMoved = (~maybeBuffer, ~previous, ~current, model) => {
          )
        )
     |> Option.value(~default=model.documentHighlights);
-  {...model, completion, documentHighlights};
+
+  let signatureHelp =
+    SignatureHelp.cursorMoved(~previous, ~current, model.signatureHelp);
+  {...model, completion, documentHighlights, signatureHelp};
 };
 
 let startInsertMode = (~config, ~maybeBuffer, model) => {

--- a/src/Feature/LanguageSupport/SignatureHelp.re
+++ b/src/Feature/LanguageSupport/SignatureHelp.re
@@ -119,6 +119,18 @@ module Session = {
     {...model, latestSignatureHelpResult: latestResult'};
   };
 
+  let cursorMoved =
+      (
+        ~previous: EditorCoreTypes.CharacterPosition.t,
+        ~current: EditorCoreTypes.CharacterPosition.t,
+        model,
+      ) =>
+    if (CharacterPosition.isWithinOneCharacter(previous, current)) {
+      model;
+    } else {
+      {...model, latestMeet: None, latestSignatureHelpResult: None};
+    };
+
   let bufferUpdated = (~languageConfiguration, ~buffer, ~activeCursor, model) => {
     let maybeMeet =
       SignatureHelpMeet.fromBufferPosition(
@@ -285,6 +297,13 @@ let bufferUpdated = (~languageConfiguration, ~buffer, ~activeCursor, model) => {
            session,
          )
        );
+  {...model, sessions: sessions'};
+};
+
+let cursorMoved = (~previous, ~current, model) => {
+  let sessions' =
+    model.sessions
+    |> List.map(session => Session.cursorMoved(~previous, ~current, session));
   {...model, sessions: sessions'};
 };
 

--- a/src/editor-core-types/CharacterPosition.re
+++ b/src/editor-core-types/CharacterPosition.re
@@ -4,6 +4,14 @@ type t = {
   character: CharacterIndex.t,
 };
 
+let isWithinOneCharacter = (a: t, b: t) => {
+  a.line == b.line
+  && abs(
+       CharacterIndex.toInt(a.character) - CharacterIndex.toInt(b.character),
+     )
+  <= 1;
+};
+
 let equals = (a, b) => {
   a.line == b.line && a.character == b.character;
 };

--- a/src/editor-core-types/CharacterPosition.rei
+++ b/src/editor-core-types/CharacterPosition.rei
@@ -8,3 +8,5 @@ let zero: t;
 
 let equals: (t, t) => bool;
 let (==): (t, t) => bool;
+
+let isWithinOneCharacter: (t, t) => bool;


### PR DESCRIPTION
__Issue:__ When signature help is opened in a snippet, the signature-help popup can stay open as placeholders are being traversed:

![2021-02-09 12 59 51](https://user-images.githubusercontent.com/13532591/107428022-ec9a1a80-6ad6-11eb-9c51-1cc955eb58a2.gif)

(after pressing `tab` to move to the final placeholder on the next line, the signature help pop-up stays open and follows the cursor)

__Defect:__ The signature help feature doesn't know that the cursor has changed position, and doesn't have logic to clear if the position is not correct.

__Fix:__ Add a `cursorMoved` function, like for completion - if the cursor moves across a line, or more than a character, expire the current signature help session.

