### PR TITLE
fix(extensions): Large VSIX extensions are failing to install

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -31,6 +31,7 @@
 - #3085 - Snippets: Fix drop-shadow calculation at end of buffer
 - #3091 - Snippets: Fix auto-closing pairs when placeholders are on same line
 - #3102 - Vim / Input: Implement mapping timeout (fixes #2850)
+- #3123 - Extensions: Fix failure to install extensions over 10MB from open-vsx
 
 ### Performance
 

--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -244,3 +244,17 @@ __Pass:__
 - [ ] Win
 - [ ] OSX
 - [ ] Linux
+
+# 10. Extension Management
+
+# 10.1 Install large extension (`redhat.java`)
+
+- Open Onivim 2
+- Go to extensions pane (Command+Shift+X / Control+Shift+X)
+- Install `redhat.java` 
+- Validate installation is successful
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux

--- a/node/download.js
+++ b/node/download.js
@@ -1,4 +1,7 @@
 const followRedirects = require("follow-redirects");
+
+// The default for `follow-redirects` is to limit the body to 10 MB...
+// which isn't large enough for big extensions available on open-vsx.
 followRedirects.maxBodyLength = 128 * 1024 * 1024; // 1024 MB
 
 const http = followRedirects.http

--- a/node/download.js
+++ b/node/download.js
@@ -1,8 +1,8 @@
-const followRedirects = require("follow-redirects");
+const followRedirects = require("follow-redirects")
 
 // The default for `follow-redirects` is to limit the body to 10 MB...
 // which isn't large enough for big extensions available on open-vsx.
-followRedirects.maxBodyLength = 128 * 1024 * 1024; // 1024 MB
+followRedirects.maxBodyLength = 128 * 1024 * 1024 // 1024 MB
 
 const http = followRedirects.http
 const https = followRedirects.https
@@ -25,4 +25,4 @@ const file = fs.createWriteStream(destPath)
 
 requestFn(url, (response) => {
     response.pipe(file)
-});
+})

--- a/node/download.js
+++ b/node/download.js
@@ -1,5 +1,8 @@
-const http = require("follow-redirects").http
-const https = require("follow-redirects").https
+const followRedirects = require("follow-redirects");
+followRedirects.maxBodyLength = 128 * 1024 * 1024; // 1024 MB
+
+const http = followRedirects.http
+const https = followRedirects.https
 const fs = require("fs")
 
 const url = new URL(process.argv[2])
@@ -19,4 +22,4 @@ const file = fs.createWriteStream(destPath)
 
 requestFn(url, (response) => {
     response.pipe(file)
-})
+});

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@onivim/vscode-exthost": "1.52.1001",
-    "follow-redirects": "1.13.0",
+    "follow-redirects": "1.13.2",
     "fs-extra": "^8.1.0",
     "sudo-prompt": "^9.0.0",
     "yauzl": "^2.5.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -67,10 +67,10 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
-follow-redirects@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+follow-redirects@1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
+  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
 
 fs-extra@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
__Issue:__ Reported on Discord - `redhat.java` extension was all of a sudden failing to install.

__Defect:__ Onivim uses the [`follow-redirects`](https://www.npmjs.com/package/follow-redirects) library to handle `302` redirects. The URL `https://open-vsx.org/api/redhat/java/0.74.0/file/redhat.java-0.74.0.vsix` actually gets redirected. `follow-redirects` has a default limit of 10MB for downloads, otherwise it will fail.

__Fix:__ Increase size limit to accommodate extensions on open-vsx, so that the download will complete.

__Next steps:__
- The download speed using `follow-redirects` seems to be slow. Hopefully, we can switch to @zbaylin 's libcurl work eventually: https://github.com/zbaylin/ocurl-luv-test