### PR TITLE
fix(completion/#3032): Only de-dup keyword completion items

### DIFF
--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -497,26 +497,49 @@ let recomputeAllItems = (~snippetSortOrder, providers: list(Session.t)) => {
   |> List.fold_left(
        (acc, session) => {
          let itemMap = session |> Session.filteredItems;
+
          // When we have the same key coming from different providers, need to decide between them
-         StringMap.union(
+         StringMap.merge(
            (
              _key,
-             (locA, itemA: Filter.result(CompletionItem.t)),
-             (locB, itemB: Filter.result(CompletionItem.t)),
+             maybeA:
+               option(
+                 (CharacterPosition.t, Filter.result(CompletionItem.t)),
+               ),
+             maybeB:
+               option(
+                 list(
+                   (CharacterPosition.t, Filter.result(CompletionItem.t)),
+                 ),
+               ),
            ) =>
-             if (CompletionItem.prefer(itemA.item, itemB.item) < 0) {
-               Some((locA, itemA));
-             } else {
-               Some((locB, itemB));
+             switch (maybeA, maybeB) {
+             | (None, None) => None
+             | (Some(a), None) => Some([a])
+             | (None, Some(_) as b) => b
+             | (Some(a), Some(b)) => Some([a, ...b])
              },
-           acc,
            itemMap,
+           acc,
          );
        },
        StringMap.empty,
      )
+  |> StringMap.map(items => {
+       switch (items) {
+       // If one or zero items, just keep as-is
+       | [] => []
+       | [item] => [item]
+       // If multiple - remove keywords
+       | items =>
+         items
+         |> List.filter(item =>
+              !(Filter.(snd(item).item) |> CompletionItem.isKeyword)
+            )
+       }
+     })
   |> StringMap.bindings
-  |> List.map(snd)
+  |> List.concat_map(snd)
   |> List.fast_sort(((_loc, a), (_loc, b)) =>
        CompletionItemSorter.compare(~snippetSortOrder, a, b)
      )

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -64,6 +64,8 @@ let keyword = (~sortOrder: int, ~isFuzzyMatching, keyword) => {
   };
 };
 
+let isKeyword = ({kind, _}) => kind == Exthost.CompletionKind.Keyword;
+
 let snippet = (~isFuzzyMatching, ~prefix: string, snippet: string) => {
   chainedCacheId: None,
   handle: None,
@@ -80,24 +82,4 @@ let snippet = (~isFuzzyMatching, ~prefix: string, snippet: string) => {
   additionalTextEdits: [],
   command: None,
   isFuzzyMatching,
-};
-
-let prefer = (itemA, itemB) => {
-  switch (itemA.handle, itemB.handle) {
-  // Prefer items with a handle - in other words, items that come from the extension host
-  | (Some(_), None) => (-1)
-  | (None, Some(_)) => 1
-  // They both have a handle, or neither does... use sort text to break the tie
-  | (Some(_), Some(_))
-  | (None, None) =>
-    if (String.compare(
-          String.uppercase_ascii(itemA.sortText),
-          String.uppercase_ascii(itemB.sortText),
-        )
-        <= 0) {
-      (-1);
-    } else {
-      1;
-    }
-  };
 };


### PR DESCRIPTION
__Issue:__ When multiple completion items with the same label show up, we were filtering out all but one - first, preferring items from a `requestCompletionItems` call (vs keywords, and now snippets), and then picking the one that most closely matched the sort text.

This had a couple of issues, though:
- With snippets, now, there are often cases where Onivim should show both the snippet and a completion item
- In #3032, there were cases where multiple `createContext` completions should be available (and would have different auto-import behavior).

__Fix:__ Update the de-dup behavior in #2581 to _only_ de-dup keywords

Fixes #3032 