### PR TITLE
fix(language-support): Implement shift+escape to close all language support popups

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -35,6 +35,7 @@
 - #3122 - Signature Help: Close signature help when traversing snippet placeholders
 - #3123 - Extensions: Fix failure to install extensions over 10MB from open-vsx
 - #3054 - Extensions: Completion - Implement 'isIncomplete' handler (fixes #3022, #2359)
+- #3133 - Completion: Implement shift+escape to close all popups without switching modes
 
 ### Performance
 

--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,7 +37,7 @@
 - #3054 - Extensions: Completion - Implement 'isIncomplete' handler (fixes #3022, #2359)
 - #3129 - Snippets: Replace visual/select range on insert
 - #3057 - Theming: Turn down shadow intensity for light themes (related #3095)
-- #3133 - Completion: Implement shift+escape to close all popups without switching modes
+- #3133 - Completion: Implement shift+escape to close all popups w/o switching modes (fixes #3120)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -98,6 +98,8 @@ module Session = {
         Session({...session, state: state'});
       };
 
+  let cancel = complete([]);
+
   let start =
     fun
     | Session(session) => Session({...session, state: NotStarted});
@@ -643,6 +645,13 @@ let startInsertMode = model => {
 
 let stopInsertMode = model => {
   {...model, isInsertMode: false} |> reset;
+};
+
+let cancel = model => {
+  ...model,
+  providers: model.providers |> List.map(Session.cancel),
+  allItems: [||],
+  selection: None,
 };
 
 // There are some bugs with completion in snippet mode -


### PR DESCRIPTION
__Issue:__ In insert mode, pressing `Shift+escape` should close both the signature help and suggest pop-ups, without switching to normal mode. However, this only worked for signature help.

__Fix:__ Implement a common command to close both these, and bind to `Shift+Escape`

Fixes #3120 