### PR TITLE
fix(snippet): Only show highlight for active editor

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -35,6 +35,7 @@
 - #3122 - Signature Help: Close signature help when traversing snippet placeholders
 - #3123 - Extensions: Fix failure to install extensions over 10MB from open-vsx
 - #3054 - Extensions: Completion - Implement 'isIncomplete' handler (fixes #3022, #2359)
+- #3134 - Snippets: Only show snippet visualizer for active editor
 
 ### Performance
 

--- a/src/Feature/Editor/SnippetVisualizer.re
+++ b/src/Feature/Editor/SnippetVisualizer.re
@@ -18,7 +18,9 @@ let draw =
   let isShadowEnabled =
     Feature_Configuration.GlobalConfiguration.shadows.get(config);
 
-  if (!isShadowEnabled) {
+  let isCurrentEditor = Editor.getId(context.editor) == Feature_Snippets.Session.editorId(session);
+
+  if (!isShadowEnabled || !isCurrentEditor) {
     ();
   } else {
     let color = Revery.Color.toSkia(Revery.Color.rgba(0., 0., 0., 0.1));

--- a/src/Feature/Editor/SnippetVisualizer.re
+++ b/src/Feature/Editor/SnippetVisualizer.re
@@ -23,7 +23,9 @@ let draw =
   let isShadowEnabled =
     Feature_Configuration.GlobalConfiguration.shadows.get(config);
 
-  let isCurrentEditor = Editor.getId(context.editor) == Feature_Snippets.Session.editorId(session);
+  let isCurrentEditor =
+    Editor.getId(context.editor)
+    == Feature_Snippets.Session.editorId(session);
 
   if (!isShadowEnabled || !isCurrentEditor) {
     ();

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -23,6 +23,8 @@ module Session = {
   let stopLine = ({startLine, lineCount, _}) =>
     EditorCoreTypes.LineNumber.(startLine + lineCount);
 
+  let editorId = ({editorId, _}) => editorId;
+
   let start = (~editorId, ~position: BytePosition.t, ~snippet) => {
     let lines = ResolvedSnippet.toLines(snippet);
     let placeholders = ResolvedSnippet.placeholders(snippet);

--- a/src/Feature/Snippets/Feature_Snippets.rei
+++ b/src/Feature/Snippets/Feature_Snippets.rei
@@ -23,6 +23,8 @@ module Session: {
 
   let startLine: t => EditorCoreTypes.LineNumber.t;
   let stopLine: t => EditorCoreTypes.LineNumber.t;
+
+  let editorId: t => int;
 };
 
 let session: model => option(Session.t);


### PR DESCRIPTION
__Issue:__ When a snippet session is active, all visible splits would show the snippet visualizer UI.

__Fix:__ Only show the snippet visualizer for the active editor.