### PR TITLE
fix(snippet): Convert choices to placeholders

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -39,6 +39,7 @@
 - #3057 - Theming: Turn down shadow intensity for light themes (related #3095)
 - #3133 - Completion: Implement shift+escape to close all popups w/o switching modes (fixes #3120)
 - #3134 - Snippets: Only show snippet visualizer for active editor
+- #3135 - Snippets: Convert choices to placeholders
 
 ### Performance
 


### PR DESCRIPTION

Choice items in snippets aren't fully supported yet, but in the meantime, we should still gracefully handle these by converting them to placeholders.

Discovered this in testing out the [Markdown Snippets](https://open-vsx.org/extension/robole/markdown-snippets) extension - some of the task snippets like this would fail:
```
  "Insert task list": {
    "prefix": "task",
    "body": ["- [${1| ,x|}] ${2:text}", "${0}"],
    "description": "Insert task list"
  },
```

However, after this fix, they work (with the choice treated as a placeholder):

![2021-02-11 17 00 37](https://user-images.githubusercontent.com/13532591/107718442-cb7a2b00-6c8a-11eb-914b-14895ae0fd4a.gif)