### PR TITLE
fix(snippet): Fix special-case of parsing text if not placeholder or variable

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -40,6 +40,7 @@
 - #3133 - Completion: Implement shift+escape to close all popups w/o switching modes (fixes #3120)
 - #3134 - Snippets: Only show snippet visualizer for active editor
 - #3135 - Snippets: Convert choices to placeholders
+- #3137 - Snippets: Fix error parsing some snippets in the React TS/JS extensions
 
 ### Performance
 

--- a/src/Core/Snippet/Snippet.re
+++ b/src/Core/Snippet/Snippet.re
@@ -147,4 +147,10 @@ let%test_module "parse" =
      let%test "colon in snippet" = {
        parse("a:b") == Ok([[Text("a:b")]]);
      };
+
+     // Test case to exercise a failure to parse snippets like:
+     // https://github.com/Tom-xacademy/xa-js-snippets/blob/39bc330b9167635d44b0573e06cc1e10ccf8e891/snippets/snippets.json#L104
+     let%test "non-placeholder special case" = {
+       parse("${ data }") == Ok([[Text("${ data }")]]);
+     };
    });

--- a/src/Core/Snippet/Snippet_parser.mly
+++ b/src/Core/Snippet/Snippet_parser.mly
@@ -36,6 +36,7 @@ expr_nested:
 additionalChoices }) }
 | DOLLAR; var = VARIABLE; { Variable({name = var; default = None }) }
 | DOLLAR; LB; var = VARIABLE; COLON; default = string; RB { Variable({name = var; default = Some(default) }) }
+| DOLLAR; LB; text = TEXT; { Text("${" ^ text) }
 | text = TEXT { Text(text) }
 | numberAsText = NUMBER { Text(string_of_int(numberAsText)) }
 | variableAsText = VARIABLE { Snippet_internal.Text(variableAsText) }


### PR DESCRIPTION
__Issue:__ In testing snippet extensions, a particular snippet was failing to expand for the [React - JavaScript snippets extension](https://open-vsx.org/extension/tomi/xajssnippets) - the `_mu` snippet.

__Defect:__ There is a string in that snippet of `${ value }` - we were trying to parse that as a placeholder or variable, but it was failing. It should actually be a text value.

__Fix:__ Add a case in the snippet parser to handle falling back if the placeholder-like item cannot be reoslved.