### PR TITLE
fix(build): support libintl discovery on OSX ARM

### DIFF
--- a/src/reason-libvim/config/discover.re
+++ b/src/reason-libvim/config/discover.re
@@ -15,7 +15,7 @@ let getLibIntlPath = () =>
   try({
     let ic =
       Unix.open_process_in(
-        "find /usr/local/Cellar -name libintl.a -print 2>/dev/null",
+        "find /usr/local/Cellar /opt/homebrew/Cellar -name libintl.a -print 2>/dev/null",
       );
     let path = input_line(ic);
     let () = close_in(ic);


### PR DESCRIPTION
```changelog
Homebrew's Cellar has new location on ARM Macs: /opt/homebrew/Cellar.
This change adds this path in order to find libintl library.

Related to #2708.
```