### PR TITLE
fix(editor): Minimap out of sync when scrolling large files

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -5,6 +5,7 @@
 - #3141 - Windows: Reload keybindings on save
 - #3145 - Vim: Don't crash on confirm flag with substitute ex command (fixes #1159, related #2965)
 - #3142 - Windows: Explorer - Directory nodes not expanding (fixes #3092, #2213)
+- #3147 - Editor: Fix minimap scroll synchronization for large files
 
 ### Performance
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1155,7 +1155,8 @@ let isScrollAnimated = ({isScrollAnimated, isAnimationOverride, _}) => {
 
 let synchronizeMinimapScroll = (~animated, editor) => {
   // Set up minimap scroll
-  let newScrollY = animated ? Spring.get(editor.scrollY) : Spring.getTarget(editor.scrollY);
+  let newScrollY =
+    animated ? Spring.get(editor.scrollY) : Spring.getTarget(editor.scrollY);
   let {pixelHeight, _} = editor;
   let viewLines = editor |> totalViewLines;
   let availableScroll =
@@ -1172,8 +1173,8 @@ let synchronizeMinimapScroll = (~animated, editor) => {
   let minimapScrollY =
     scrollPercentage *. float_of_int(availableMinimapScroll);
 
-  {...editor, minimapScrollY}
-}
+  {...editor, minimapScrollY};
+};
 
 let exposePrimaryCursor = (~disableAnimation=false, editor) =>
   if (!hasSetSize(editor)) {
@@ -1357,7 +1358,6 @@ let getContentPixelWidth = editor => {
 let scrollToPixelY = (~animated, ~pixelY as newScrollY, editor) => {
   let originalScrollY = Spring.getTarget(editor.scrollY);
   let animated = editor |> isScrollAnimated && animated;
-  let {pixelHeight, _} = editor;
   let viewLines = editor |> totalViewLines;
   let newScrollY = max(0., newScrollY);
   let availableScroll =
@@ -1365,16 +1365,6 @@ let scrollToPixelY = (~animated, ~pixelY as newScrollY, editor) => {
     *. lineHeightInPixels(editor)
     +. InlineElements.getAllReservedSpace(editor.inlineElements);
   let newScrollY = min(newScrollY, availableScroll);
-
-  let scrollPercentage =
-    newScrollY /. (availableScroll -. float_of_int(pixelHeight));
-  let minimapLineSize =
-    Constants.minimapCharacterWidth + Constants.minimapCharacterHeight;
-  let linesInMinimap = pixelHeight / minimapLineSize;
-  let availableMinimapScroll =
-    max(viewLines - linesInMinimap, 0) * minimapLineSize;
-  let newMinimapScroll =
-    scrollPercentage *. float_of_int(availableMinimapScroll);
 
   // For small  jumps - ie, a single line, just teleport.
   let isSmallJump =
@@ -1388,7 +1378,7 @@ let scrollToPixelY = (~animated, ~pixelY as newScrollY, editor) => {
     animationNonce:
       instant ? editor.animationNonce : editor.animationNonce + 1,
     scrollY: Spring.set(~instant, ~position=newScrollY, editor.scrollY),
-  } 
+  }
   |> synchronizeMinimapScroll(~animated=!instant);
 };
 
@@ -2028,14 +2018,15 @@ let update = (msg, editor) => {
            };
          });
 
-    let editor' = {
-      ...editor,
-      scrollX: Spring.update(msg, editor.scrollX),
-      scrollY: Spring.update(msg, editor.scrollY),
-      yankHighlight: yankHighlight',
-      animationNonce: editor.animationNonce + 1,
-    }
-    |> synchronizeMinimapScroll(~animated=true);
+    let editor' =
+      {
+        ...editor,
+        scrollX: Spring.update(msg, editor.scrollX),
+        scrollY: Spring.update(msg, editor.scrollY),
+        yankHighlight: yankHighlight',
+        animationNonce: editor.animationNonce + 1,
+      }
+      |> synchronizeMinimapScroll(~animated=true);
 
     editor'
     |> withSteadyCursor(e =>


### PR DESCRIPTION
__Issue:__ When scrolling to the bottom of a large file, the minimap does not scroll alongside the cursor

__Defect:__ Onivim wasn't synchronizing the `minimapScrollY` with the current scroll in some cases

__Fix:__
- Refactor the minimap-scroll-synchronization to a helper function
- Call into the scroll synchronization in the missed code paths