### PR TITLE
fix(editor/#3149): Change word wrap configuration default to be on

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -7,6 +7,7 @@
 - #3142 - Windows: Explorer - Directory nodes not expanding (fixes #3092, #2213)
 - #3147 - Editor: Fix minimap scroll synchronization for large files
 - #3077 - Terminal: Use editor font as default (related #3062)
+- #3161 - Configuration: Turn soft word-wrap on by default (fixes #3161)
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -96,7 +96,7 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.wordBasedSuggestions` __(_bool_ default: `true`)__ When `true`, keywords are provided as completion suggestions.
 
-- `editor.wordWrap` __(_bool_ default: `false`)__ When `true`, Onivim will soft-wrap lines at the viewport boundary.
+- `editor.wordWrap` __(_bool_ default: `true`)__ When `true`, Onivim will soft-wrap lines at the viewport boundary.
 
 - `editor.rulers` __(_list of int_ default: `[]`)__ - Render vertical rulers at given columns.
 

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -312,7 +312,7 @@ let smoothScroll =
 let tabSize = setting("editor.tabSize", int, ~default=4);
 
 let wordWrap =
-  setting("editor.wordWrap", ~vim=VimSettings.wrap, wordWrap, ~default=`Off);
+  setting("editor.wordWrap", ~vim=VimSettings.wrap, wordWrap, ~default=`On);
 
 let wordWrapColumn = setting("editor.wordWrapColumn", int, ~default=80);
 


### PR DESCRIPTION
__Issue:__ Both Vim & VSCode default to having word-wrap (soft wrap) enabled, but Onivim defaults to having it off. There isn't a reason to be different from both of their default settings.

__Fix:__ Change word-wrap (soft wrap) to be on by default.

Fixes #3149 