### PR TITLE
refactor(configuration): Move auto-closing pairs to new configuration model

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -19,3 +19,4 @@
 ### Infrastructure / Refactoring
 
 - #3156 - Dependency: reason-native (dir/fp/fs) -> e16590c
+- #3164 - Configuration: Move "editor.autoClosingBrackets" to new model

--- a/src/Core/ConfigurationParser.re
+++ b/src/Core/ConfigurationParser.re
@@ -52,22 +52,6 @@ let parseVimUseSystemClipboardSetting = json => {
   };
 };
 
-let parseAutoClosingBrackets:
-  Yojson.Safe.t => ConfigurationValues.autoClosingBrackets =
-  json =>
-    switch (json) {
-    | `Bool(true) => LanguageDefined
-    | `Bool(false) => Never
-    | `String(autoClosingBrackets) =>
-      let autoClosingBrackets = String.lowercase_ascii(autoClosingBrackets);
-      switch (autoClosingBrackets) {
-      | "never" => Never
-      | "languagedefined" => LanguageDefined
-      | _ => Never
-      };
-    | _ => Never
-    };
-
 let parseString = (~default="", json) =>
   switch (json) {
   | `String(v) => v
@@ -88,13 +72,6 @@ type parseFunction =
 type configurationTuple = (string, parseFunction);
 
 let configurationParsers: list(configurationTuple) = [
-  (
-    "editor.autoClosingBrackets",
-    (config, json) => {
-      ...config,
-      editorAutoClosingBrackets: parseAutoClosingBrackets(json),
-    },
-  ),
   (
     "explorer.autoReveal",
     (config, json) => {

--- a/src/Core/ConfigurationValues.re
+++ b/src/Core/ConfigurationValues.re
@@ -11,15 +11,9 @@ type vimUseSystemClipboard = {
   paste: bool,
 };
 
-[@deriving show({with_path: false})]
-type autoClosingBrackets =
-  | Never
-  | LanguageDefined;
-
 type autoReveal = [ | `HighlightAndScroll | `HighlightOnly | `NoReveal];
 
 type t = {
-  editorAutoClosingBrackets: autoClosingBrackets,
   explorerAutoReveal: autoReveal,
   workbenchActivityBarVisible: bool,
   workbenchColorTheme: string,
@@ -40,7 +34,6 @@ type t = {
 };
 
 let default = {
-  editorAutoClosingBrackets: LanguageDefined,
   explorerAutoReveal: `HighlightAndScroll,
   workbenchActivityBarVisible: true,
   workbenchColorTheme: Constants.defaultTheme,

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -4,6 +4,7 @@ open Oni_Core.Utility;
 open Config.Schema;
 
 module CustomDecoders: {
+  let autoClosingPairs: Config.Schema.codec([ | `LanguageDefined | `Never]);
   let whitespace:
     Config.Schema.codec([ | `All | `Boundary | `Selection | `None]);
   let lineNumbers:
@@ -71,6 +72,41 @@ module CustomDecoders: {
           fun
           | `Off => string("off")
           | `On => string("on")
+        ),
+    );
+
+  let autoClosingPairs =
+    custom(
+      ~decode=
+        Json.Decode.(
+          one_of([
+            (
+              "autoClosingPairs.bool",
+              bool
+              |> map(
+                   fun
+                   | false => `Never
+                   | true => `LanguageDefined,
+                 ),
+            ),
+            (
+              "autoClosingPairs.string",
+              string
+              |> map(str => {
+                   switch (String.lowercase_ascii(str)) {
+                   | "never" => `Never
+                   | "languagedefined" => `LanguageDefined
+                   | _ => `Never
+                   }
+                 }),
+            ),
+          ])
+        ),
+      ~encode=
+        Json.Encode.(
+          fun
+          | `Never => string("never")
+          | `LanguageDefined => string("languagedefined")
         ),
     );
 
@@ -226,6 +262,13 @@ module VimSettings = {
 open CustomDecoders;
 
 module Codecs = Feature_Configuration.GlobalConfiguration.Codecs;
+
+let autoClosingPairs =
+  setting(
+    "editor.autoClosingBrackets",
+    CustomDecoders.autoClosingPairs,
+    ~default=`LanguageDefined,
+  );
 
 let detectIndentation =
   setting("editor.detectIndentation", bool, ~default=true);


### PR DESCRIPTION
This moves the `editor.autoClosingBrackets` configuration option to the new configuration model. 

Functionally, this should behave the same - although it now supports filetype-specific settings, which wasn't working correctly in the old model, like:
```
"[json]": {
   "editor.autoClosingBrackets": "never"
}
```