### PR TITLE
fix(explorer): Fix explorer disappearing when cd'ing into current directory

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -15,6 +15,7 @@
 - #3166 - Windows: Fix dead key input (fixes #3157)
 - #3167 - Diagnostics: Show full path to trace file
 - #3170 - CLI - Windows: Allocate console with `-f --silent`
+- #3180 - Explorer: Fix explorer disappearing when changing into current path
 
 ### Performance
 

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -94,12 +94,21 @@ let focusOutline = model => {
     ExpandedState.implicitlyOpen(model.isSymbolOutlineExpanded),
 };
 
-let setRoot = (~rootPath, model) => {
-  ...model,
-  fileExplorer:
-    rootPath
-    |> Option.map(rootPath => Component_FileExplorer.initial(~rootPath)),
-};
+let setRoot = (~rootPath, model) =>
+  if (Option.equal(
+        FpExp.eq,
+        rootPath,
+        model.fileExplorer |> Option.map(Component_FileExplorer.root),
+      )) {
+    model;
+  } else {
+    {
+      ...model,
+      fileExplorer:
+        rootPath
+        |> Option.map(rootPath => Component_FileExplorer.initial(~rootPath)),
+    };
+  };
 
 let root = ({fileExplorer, _}) => {
   fileExplorer |> Option.map(Component_FileExplorer.root);

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -92,9 +92,10 @@ module Internal = {
       dispatch(Actions.Quit(true))
     );
 
-  let chdir = (path: FpExp.t(FpExp.absolute)) =>
+  let chdir = (path: FpExp.t(FpExp.absolute)) => {
     Feature_Workspace.Effects.changeDirectory(path)
     |> Isolinear.Effect.map(msg => Actions.Workspace(msg));
+  };
 
   let updateEditor = (~editorId, ~msg, layout) => {
     switch (Feature_Layout.editorById(editorId, layout)) {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -231,13 +231,14 @@ let start =
     );
 
   let _: unit => unit =
-    Vim.onDirectoryChanged(newDir =>
+    Vim.onDirectoryChanged(newDir => {
+      prerr_endline("NEWDIR: " ++ newDir);
       dispatch(
         Actions.Workspace(
           Feature_Workspace.Msg.workingDirectoryChanged(newDir),
         ),
-      )
-    );
+      );
+    });
 
   let _: unit => unit =
     Vim.onMessage((priority, title, message) => {

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -232,12 +232,11 @@ let start =
 
   let _: unit => unit =
     Vim.onDirectoryChanged(newDir => {
-      prerr_endline("NEWDIR: " ++ newDir);
       dispatch(
         Actions.Workspace(
           Feature_Workspace.Msg.workingDirectoryChanged(newDir),
         ),
-      );
+      )
     });
 
   let _: unit => unit =


### PR DESCRIPTION
__Issue:__ If the user `:cd`'s into the same directory that is currently open in the explorer... the explorer disappears.

__Defect:__ The explorer path gets updated to a new folder, but it is set to the 'initial' state... and the subscription that manages loading the contents is keyed to the path, so it would not trigger a refresh in this case.

__Fix:__ If the new path is the same as the previous, don't reset the file explorer to the initial state.