### PR TITLE
fix(auto-update): Use update channel based on source build

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -16,6 +16,7 @@
 - #3167 - Diagnostics: Show full path to trace file
 - #3170 - CLI - Windows: Allocate console with `-f --silent`
 - #3180 - Explorer: Fix explorer disappearing when changing into current path
+- #3183 - Auto-update: Default auto-update channel should match source build
 
 ### Performance
 

--- a/src/Feature/AutoUpdate/Feature_AutoUpdate.re
+++ b/src/Feature/AutoUpdate/Feature_AutoUpdate.re
@@ -1,15 +1,15 @@
 open Oni_Core;
 open Utility;
 
-let defaultUpdateChannel = {
+let defaultUpdateChannel =
   if (Oni_Core.BuildInfo.version |> StringEx.endsWith(~postfix="-staging")) {
-    "staging"
-  } else if (Oni_Core.BuildInfo.version |> StringEx.endsWith(~postfix="-nightly")) {
-    "master"
+    "staging";
+  } else if (Oni_Core.BuildInfo.version
+             |> StringEx.endsWith(~postfix="-nightly")) {
+    "master";
   } else {
-    "stable"
-  }
-};
+    "stable";
+  };
 
 type model = {
   automaticallyChecksForUpdates: bool,
@@ -42,7 +42,6 @@ let platformStr =
   | Windows(_) => "windows"
   | _ => ""
   };
-
 
 module Configuration = {
   open Config.Schema;

--- a/src/Feature/AutoUpdate/Feature_AutoUpdate.re
+++ b/src/Feature/AutoUpdate/Feature_AutoUpdate.re
@@ -1,6 +1,16 @@
 open Oni_Core;
 open Utility;
 
+let defaultUpdateChannel = {
+  if (Oni_Core.BuildInfo.version |> StringEx.endsWith(~postfix="-staging")) {
+    "staging"
+  } else if (Oni_Core.BuildInfo.version |> StringEx.endsWith(~postfix="-nightly")) {
+    "master"
+  } else {
+    "stable"
+  }
+};
+
 type model = {
   automaticallyChecksForUpdates: bool,
   releaseChannel: string,
@@ -8,7 +18,7 @@ type model = {
 
 let initial = {
   automaticallyChecksForUpdates: true,
-  releaseChannel: Oni_Core.BuildInfo.defaultUpdateChannel,
+  releaseChannel: defaultUpdateChannel,
 };
 
 [@deriving show({with_path: false})]
@@ -33,6 +43,7 @@ let platformStr =
   | _ => ""
   };
 
+
 module Configuration = {
   open Config.Schema;
 
@@ -46,7 +57,7 @@ module Configuration = {
     setting(
       "oni.app.updateReleaseChannel",
       releaseChannelCodec,
-      ~default=Oni_Core.BuildInfo.defaultUpdateChannel,
+      ~default=defaultUpdateChannel,
     );
 };
 

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -222,7 +222,7 @@ switch (eff) {
       "Starting Onivim 2 (%s / %s / %s / %s)",
       Core.BuildInfo.version,
       Core.BuildInfo.commitId,
-      Core.BuildInfo.defaultUpdateChannel,
+      Feature_AutoUpdate.defaultUpdateChannel,
       Core.BuildInfo.extensionHostVersion,
     )
   );

--- a/src/gen_buildinfo/generator.re
+++ b/src/gen_buildinfo/generator.re
@@ -9,23 +9,6 @@ let getCommitId = () => {
   commitId;
 };
 
-let getBranch = () => {
-  let ic = Unix.open_process_in("git rev-parse --abbrev-ref HEAD");
-  let branch = input_line(ic) |> String.trim |> String.lowercase_ascii;
-  let () = close_in(ic);
-  branch;
-};
-
-let getDefaultUpdateChannel = () => {
-  let currentBranch = getBranch();
-
-  if (currentBranch == "staging" || currentBranch == "stable") {
-    currentBranch;
-  } else {
-    "master";
-  };
-};
-
 let getVersion = () => {
   Yojson.Safe.from_file("../../package.json")
   |> Yojson.Safe.Util.member("version")
@@ -47,12 +30,10 @@ Printf.fprintf(
   {|
 let commitId = "%s";
 let version = "%s";
-let defaultUpdateChannel = "%s";
 let extensionHostVersion = "%s";
 |},
   getCommitId(),
   getVersion(),
-  getDefaultUpdateChannel(),
   getExtensionHostVersion(),
 );
 close_out(oc);


### PR DESCRIPTION
__Issue:__ The auto-update supports multiple update channels:
- `master` (nightly)
- `stable` 
- `staging`

The intention was that it should default to the update channel matching the build - nightly builds should default to nightly auto-updates, etc. However, this wasn't working as intended - the default was always set to `master`.

__Defect:__ The way our build script was checking the default update channel wasn't working correctly during CI builds - it would always select `"master"`.

__Fix:__ Use the version suffix to determine which update channel to use as the default