### PR TITLE
fix(explorer): Fix explorer shrinking when switching directories

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -17,6 +17,7 @@
 - #3170 - CLI - Windows: Allocate console with `-f --silent`
 - #3180 - Explorer: Fix explorer disappearing when changing into current path
 - #3183 - Auto-update: Default auto-update channel should match source build
+- #3184 - Explorer: Fix shrinking when changing paths
 
 ### Performance
 

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -106,7 +106,15 @@ let setRoot = (~rootPath, model) =>
       ...model,
       fileExplorer:
         rootPath
-        |> Option.map(rootPath => Component_FileExplorer.initial(~rootPath)),
+        |> Option.map(rootPath =>
+             model.fileExplorer
+             |> Option.map(explorer =>
+                  Component_FileExplorer.setRoot(~rootPath, explorer)
+                )
+             |> Option.value(
+                  ~default=Component_FileExplorer.initial(~rootPath),
+                )
+           ),
     };
   };
 

--- a/src/Feature/Workspace/Feature_Workspace.re
+++ b/src/Feature/Workspace/Feature_Workspace.re
@@ -34,12 +34,14 @@ type model = {
   workingDirectory: string,
   openedFolder: option(string),
   rootName: string,
+  lastPickFromFilePicker: bool,
 };
 
 let initial = (~openedFolder: option(string), workingDirectory) => {
   workingDirectory,
   openedFolder,
   rootName: Filename.basename(workingDirectory),
+  lastPickFromFilePicker: false,
 };
 
 let openedFolder = ({openedFolder, _}) => openedFolder;
@@ -51,7 +53,10 @@ let rootName = ({rootName, _}) => rootName;
 type outmsg =
   | Nothing
   | Effect(Isolinear.Effect.t(msg))
-  | WorkspaceChanged(option(string));
+  | WorkspaceChanged({
+      path: option(string),
+      shouldFocusExplorer: bool,
+    });
 
 module Effects = {
   let changeDirectory = (path: FpExp.t(FpExp.absolute)) =>
@@ -84,18 +89,28 @@ let update = (msg, model) => {
         workingDirectory,
         rootName: Filename.basename(workingDirectory),
         openedFolder: Some(workingDirectory),
+        // Reset lastPickFromFilePicker once we've actually changed
+        lastPickFromFilePicker: false,
       },
-      WorkspaceChanged(Some(workingDirectory)),
+      WorkspaceChanged({
+        path: Some(workingDirectory),
+        // If the workspace change came from the open-folder dialog,
+        // focus the explorer.
+        shouldFocusExplorer: model.lastPickFromFilePicker,
+      }),
     )
 
   | Command(CloseFolder) => (
       {...model, rootName: "", openedFolder: None},
-      WorkspaceChanged(None),
+      WorkspaceChanged({path: None, shouldFocusExplorer: false}),
     )
 
   | Command(OpenFolder) => (model, Effect(Effects.pickFolder))
 
-  | FolderPicked(path) => (model, Effect(Effects.changeDirectory(path)))
+  | FolderPicked(path) => (
+      {...model, lastPickFromFilePicker: true},
+      Effect(Effects.changeDirectory(path)),
+    )
 
   | Noop => (model, Nothing)
   };

--- a/src/Feature/Workspace/Feature_Workspace.rei
+++ b/src/Feature/Workspace/Feature_Workspace.rei
@@ -22,7 +22,10 @@ let rootName: model => string;
 type outmsg =
   | Nothing
   | Effect(Isolinear.Effect.t(msg))
-  | WorkspaceChanged(option(string));
+  | WorkspaceChanged({
+      path: option(string),
+      shouldFocusExplorer: bool,
+    });
 
 let update: (msg, model) => (model, outmsg);
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -2061,7 +2061,7 @@ let update =
         eff |> Isolinear.Effect.map(msg => Workspace(msg)),
       )
 
-    | WorkspaceChanged(maybeWorkspaceFolder) =>
+    | WorkspaceChanged({path: maybeWorkspaceFolder, shouldFocusExplorer}) =>
       let maybeExplorerFolder =
         maybeWorkspaceFolder
         |> OptionEx.flatMap(FpExp.absoluteCurrentPlatform);
@@ -2090,8 +2090,12 @@ let update =
         );
 
       let state' =
-        {...state, fileExplorer, sideBar}
-        |> FocusManager.push(Focus.FileExplorer);
+        if (shouldFocusExplorer) {
+          {...state, fileExplorer, sideBar}
+          |> FocusManager.push(Focus.FileExplorer);
+        } else {
+          {...state, fileExplorer, sideBar};
+        };
       (state', eff);
     };
 


### PR DESCRIPTION
This fixes a couple of issues with the explorer:

1) When switching directories, the explorer could 'shrink' and only show a single row
2) When switching directories, focus would move to the explorer