### PR TITLE
fix(completion/#3191): Refine completions when cursor is moved w/o buffer update

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -19,6 +19,7 @@
 - #3183 - Auto-update: Default auto-update channel should match source build
 - #3184 - Explorer: Fix shrinking when changing paths
 - #3160 - Windows: Reload configuration on save
+- #3194 - Completion: Fix enter key deleting text after closing pairs (fixes #3191)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -470,20 +470,22 @@ let configurationChanged = (~config, model) => {
     ),
 };
 
-let cursorMoved = (~maybeBuffer, ~previous, ~current, model) => {
+let cursorMoved =
+    (~languageConfiguration, ~buffer, ~previous, ~current, model) => {
   let completion =
-    Completion.cursorMoved(~previous, ~current, model.completion);
+    Completion.cursorMoved(
+      ~languageConfiguration,
+      ~buffer,
+      ~current,
+      model.completion,
+    );
 
   let documentHighlights =
-    maybeBuffer
-    |> Option.map(buffer =>
-         DocumentHighlights.cursorMoved(
-           ~buffer,
-           ~cursor=current,
-           model.documentHighlights,
-         )
-       )
-    |> Option.value(~default=model.documentHighlights);
+    DocumentHighlights.cursorMoved(
+      ~buffer,
+      ~cursor=current,
+      model.documentHighlights,
+    );
 
   let signatureHelp =
     SignatureHelp.cursorMoved(~previous, ~current, model.signatureHelp);

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -114,7 +114,8 @@ let configurationChanged: (~config: Config.resolver, model) => model;
 
 let cursorMoved:
   (
-    ~maybeBuffer: option(Oni_Core.Buffer.t),
+    ~languageConfiguration: Oni_Core.LanguageConfiguration.t,
+    ~buffer: Oni_Core.Buffer.t,
     ~previous: CharacterPosition.t,
     ~current: CharacterPosition.t,
     model

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -258,12 +258,25 @@ module Internal = {
 
     let languageSupport =
       if (prevCursor != newCursor) {
-        Feature_LanguageSupport.cursorMoved(
-          ~maybeBuffer,
-          ~previous=prevCursor,
-          ~current=newCursor,
-          state.languageSupport,
-        );
+        maybeBuffer
+        |> Option.map(buffer => {
+             let languageConfiguration =
+               buffer
+               |> Oni_Core.Buffer.getFileType
+               |> Oni_Core.Buffer.FileType.toString
+               |> Exthost.LanguageInfo.getLanguageConfiguration(
+                    state.languageInfo,
+                  )
+               |> Option.value(~default=LanguageConfiguration.default);
+             Feature_LanguageSupport.cursorMoved(
+               ~languageConfiguration,
+               ~buffer,
+               ~previous=prevCursor,
+               ~current=newCursor,
+               state.languageSupport,
+             );
+           })
+        |> Option.value(~default=state.languageSupport);
       } else {
         state.languageSupport;
       };
@@ -1796,12 +1809,25 @@ let update =
 
       let languageSupport' =
         if (originalCursor != newCursor) {
-          Feature_LanguageSupport.cursorMoved(
-            ~maybeBuffer,
-            ~previous=originalCursor,
-            ~current=newCursor,
-            languageSupport,
-          );
+          maybeBuffer
+          |> Option.map(buffer => {
+               let languageConfiguration =
+                 buffer
+                 |> Oni_Core.Buffer.getFileType
+                 |> Oni_Core.Buffer.FileType.toString
+                 |> Exthost.LanguageInfo.getLanguageConfiguration(
+                      state.languageInfo,
+                    )
+                 |> Option.value(~default=LanguageConfiguration.default);
+               Feature_LanguageSupport.cursorMoved(
+                 ~languageConfiguration,
+                 ~buffer,
+                 ~previous=originalCursor,
+                 ~current=newCursor,
+                 state.languageSupport,
+               );
+             })
+          |> Option.value(~default=state.languageSupport);
         } else {
           languageSupport;
         };


### PR DESCRIPTION
__Issue:__ As described in #3191 - pressing <kbd>enter</kbd> on a line after jumping over closing pairs could cause an errant completion to remove the closing pairs.

__Defect:__ The primary bug is that, after pressing the closing pair, completion remains open at the previous 'meet' - it should be closed after pressing the closing pair, which is a non-word character. The `cursorMoved` logic used an unreliable heuristic for deciding if the current completion meet should be kept, which failed in this case .

__Fix:__ Run the 'refine' logic, which updates the completion meet position + runs fuzzy matching on any matches, when the cursor moves. This requires a little bit of extra plumbing - bringing the current `LanguageConfiguration` as `refine` depends on it. Finally, remove the previous `cursorMoved` logic.

Fixes #3191 