### PR TITLE
fix(ux): Transparent status bar shows pane tabs underneath

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -22,6 +22,7 @@
 - #3194 - Completion: Fix enter key deleting text after closing pairs (fixes #3191)
 - #3197 - Vim: Fix hang when using the `experimental.viml` setting (fixes #3196 - thanks @amiralies!)
 - #3205 - Editor: Update highlights and diagnostics immediately on buffer update (fixes #2620, #1459)
+- #3207 - Status Bar: Fix ghost text in some themes with transparent statusbar colors
 
 ### Performance
 

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -834,73 +834,75 @@ module View = {
         : Feature_Configuration.GlobalConfiguration.inactiveWindowOpacity.get(
             config,
           );
-    <View style={Styles.pane(~opacity, ~isFocused, ~theme, ~height)}>
-      <View style=Styles.resizer>
-        <ResizeHandle.Horizontal
-          onDrag={delta =>
-            dispatch(Msg.resizeHandleDragged(int_of_float(delta)))
-          }
-          onDragComplete={() => dispatch(Msg.resizeCommitted)}
-        />
-      </View>
-      <View style=Styles.header>
-        <View style=Styles.tabs>
-          <PaneTab
-            uiFont
-            theme
-            title="Problems"
-            onClick=problemsTabClicked
-            isActive={isSelected(Diagnostics, pane)}
-          />
-          <PaneTab
-            uiFont
-            theme
-            title="Notifications"
-            onClick=notificationsTabClicked
-            isActive={isSelected(Notifications, pane)}
-          />
-          <PaneTab
-            uiFont
-            theme
-            title="Locations"
-            onClick=locationsTabClicked
-            isActive={isSelected(Locations, pane)}
-          />
-          <PaneTab
-            uiFont
-            theme
-            title="Output"
-            onClick=outputTabClicked
-            isActive={isSelected(Output, pane)}
-          />
-        </View>
-        <View style=Styles.buttons>
-          <paneButton dispatch theme pane={pane.selected} />
-          <closeButton dispatch theme />
-        </View>
-      </View>
-      <View style=Styles.content>
-        <content
-          isFocused
-          iconTheme
-          languageInfo
-          diagnosticsList={pane.diagnosticsView}
-          locationsList={pane.locationsView}
-          notificationsList={pane.notificationsView}
-          selected={selected(pane)}
-          outputPane={pane.outputPane}
-          theme
-          dispatch
-          uiFont
-          editorFont
-          diagnosticDispatch={msg => dispatch(DiagnosticsList(msg))}
-          locationsDispatch={msg => dispatch(LocationsList(msg))}
-          notificationsDispatch={msg => dispatch(NotificationsList(msg))}
-          outputDispatch={msg => dispatch(OutputPane(msg))}
-          workingDirectory
-        />
-      </View>
-    </View>;
+    height == 0
+      ? React.empty
+      : <View style={Styles.pane(~opacity, ~isFocused, ~theme, ~height)}>
+          <View style=Styles.resizer>
+            <ResizeHandle.Horizontal
+              onDrag={delta =>
+                dispatch(Msg.resizeHandleDragged(int_of_float(delta)))
+              }
+              onDragComplete={() => dispatch(Msg.resizeCommitted)}
+            />
+          </View>
+          <View style=Styles.header>
+            <View style=Styles.tabs>
+              <PaneTab
+                uiFont
+                theme
+                title="Problems"
+                onClick=problemsTabClicked
+                isActive={isSelected(Diagnostics, pane)}
+              />
+              <PaneTab
+                uiFont
+                theme
+                title="Notifications"
+                onClick=notificationsTabClicked
+                isActive={isSelected(Notifications, pane)}
+              />
+              <PaneTab
+                uiFont
+                theme
+                title="Locations"
+                onClick=locationsTabClicked
+                isActive={isSelected(Locations, pane)}
+              />
+              <PaneTab
+                uiFont
+                theme
+                title="Output"
+                onClick=outputTabClicked
+                isActive={isSelected(Output, pane)}
+              />
+            </View>
+            <View style=Styles.buttons>
+              <paneButton dispatch theme pane={pane.selected} />
+              <closeButton dispatch theme />
+            </View>
+          </View>
+          <View style=Styles.content>
+            <content
+              isFocused
+              iconTheme
+              languageInfo
+              diagnosticsList={pane.diagnosticsView}
+              locationsList={pane.locationsView}
+              notificationsList={pane.notificationsView}
+              selected={selected(pane)}
+              outputPane={pane.outputPane}
+              theme
+              dispatch
+              uiFont
+              editorFont
+              diagnosticDispatch={msg => dispatch(DiagnosticsList(msg))}
+              locationsDispatch={msg => dispatch(LocationsList(msg))}
+              notificationsDispatch={msg => dispatch(NotificationsList(msg))}
+              outputDispatch={msg => dispatch(OutputPane(msg))}
+              workingDirectory
+            />
+          </View>
+        </View>;
   };
 };
 


### PR DESCRIPTION
__Issue:__ For some themes that have a transparent status bar color, the bottom pane tabs can peak through underneath:

<img width="826" alt="Screen Shot 2021-03-02 at 6 01 18 PM" src="https://user-images.githubusercontent.com/13532591/109741500-0bde1200-7b82-11eb-8876-aef89a57f6bf.png">

__Defect:__ Onivim is always rendering the pane view, even when closed

__Fix:__ Don't render the pane when closed