### PR TITLE
fix(cli/#3209): Add -v version flag

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -23,6 +23,7 @@
 - #3197 - Vim: Fix hang when using the `experimental.viml` setting (fixes #3196 - thanks @amiralies!)
 - #3205 - Editor: Update highlights and diagnostics immediately on buffer update (fixes #2620, #1459)
 - #3207 - Status Bar: Fix ghost text in some themes with transparent statusbar colors
+- #3217 - CLI: Add -v version flag (fixes #3209)
 
 ### Performance
 

--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -139,6 +139,7 @@ let parse = (~getenv: string => option(string), args) => {
     [
       ("-c", String(str => vimExCommands := [str, ...vimExCommands^]), ""),
       ("-f", Unit(setAttached), ""),
+      ("-v", setEffect(PrintVersion), ""),
       ("--nofork", Unit(setAttached), ""),
       ("--debug", Unit(() => logLevel := Some(Timber.Level.debug)), ""),
       ("--trace", Unit(() => logLevel := Some(Timber.Level.trace)), ""),

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -22,6 +22,12 @@ let spec =
       Arg.Set(stayAttached),
       " Stay attached to the foreground terminal.",
     ),
+    ("-v", passthroughAndStayAttached, " Print version information."),
+    (
+      "-f",
+      Arg.Set(stayAttached),
+      " Stay attached to the foreground terminal.",
+    ),
     (
       "--nofork",
       Arg.Set(stayAttached),

--- a/test/Cli/IntegrationTest.re
+++ b/test/Cli/IntegrationTest.re
@@ -14,6 +14,15 @@ describe("CLI Integration Tests", ({describe, _}) => {
       )
     });
 
+    test("-v should show output", _ => {
+      TestRunner.(
+        startWithArgs(["-v"])
+        |> validateOutputContains("Onivim 2")
+        |> validateExitStatus(WEXITED(0))
+        |> finish
+      )
+    });
+
     test("--list-extensions should show extensions", _ => {
       TestRunner.(
         startWithArgs([


### PR DESCRIPTION
Fixes #3209 - thanks for logging the issue @jerabaul !

Some CLI applications use `-v` to also specify `--verbose`, if paired with other arguments - a potential improvement to consider (right now, we don't have `--verbose` logging - just `--debug` and `--trace`)