### PR TITLE
fix(extension/#3204): C# extension is failing to start language server on Windows

### DIFF
--- a/src/Service/OS/Service_OS.re
+++ b/src/Service/OS/Service_OS.re
@@ -107,7 +107,7 @@ module Api = {
       |> Option.map(filesGlobStr => {
            let regex =
              Re.Glob.glob(~expand_braces=true, filesGlobStr) |> Re.compile;
-           p => Re.execp(regex, p);
+           p => Re.execp(regex, Utility.Path.normalizeBackSlashes(p));
          })
       |> Option.value(~default=_ => true);
     let excludeDirectoryFn =
@@ -116,7 +116,7 @@ module Api = {
            let regex =
              Re.Glob.glob(~expand_braces=true, excludeDirectoryStr)
              |> Re.compile;
-           p => Re.execp(regex, p);
+           p => Re.execp(regex, Utility.Path.normalizeBackSlashes(p));
          })
       |> Option.value(~default=_ => false);
 


### PR DESCRIPTION
__Issue:__ The C# extension is failing to start on Windows.

__Defect:__ The extension uses the `vscode.workspace.findInFiles` API to look for valid solution files and .cs files. On Windows, Onivim was not handling this API correctly. Specifically, glob paths weren't being handled correctly - a glob like `**/*.sln` wouldn't match against a Windows-style path with backslashes.

__Fix:__ Normalize paths when comparing them with a glob

Fixes #3204 