### PR TITLE
fix(keybindings): Fix 'Open keybindings file' command

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -32,7 +32,7 @@
 - #3207 - Status Bar: Fix ghost text in some themes with transparent statusbar colors
 - #3217 - CLI: Add -v version flag (fixes #3209)
 - #3225 - Extension - C#: Fix language server not starting on Windows (fixes #3204)
-- #3226 - Keybindings: Fix issue open keybindings.json from the command palette
+- #3226 - Keybindings: Fix issue opening keybindings.json from the command palette
 
 ### Performance
 

--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -31,6 +31,7 @@
 - #3205 - Editor: Update highlights and diagnostics immediately on buffer update (fixes #2620, #1459)
 - #3207 - Status Bar: Fix ghost text in some themes with transparent statusbar colors
 - #3217 - CLI: Add -v version flag (fixes #3209)
+- #3226 - Keybindings: Fix issue open keybindings.json from the command palette
 
 ### Performance
 

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -177,6 +177,7 @@ type outmsg =
       toKeys: string,
       error: string,
     })
+  | OpenFile(FpExp.t(FpExp.absolute))
   | TimedOut;
 
 type execute =
@@ -191,7 +192,8 @@ type execute =
 type command =
   | ShowDebugInput
   | EnableKeyDisplayer
-  | DisableKeyDisplayer;
+  | DisableKeyDisplayer
+  | OpenKeybindingsFile;
 
 [@deriving show]
 type msg =
@@ -543,6 +545,14 @@ module Internal = {
 
 let update = (msg, model) => {
   switch (msg) {
+  | Command(OpenKeybindingsFile) => 
+  let eff = model.keybindingLoader
+  |> KeybindingsLoader.getFilePath
+  |> Option.map(path => OpenFile(path))
+  |> Option.value(~default=Nothing);
+  (
+    model, eff
+  )
   | Command(ShowDebugInput) => (model, DebugInputShown)
   | Command(DisableKeyDisplayer) => (
       {...model, keyDisplayer: None},
@@ -644,6 +654,14 @@ let update = (msg, model) => {
 module Commands = {
   open Feature_Commands.Schema;
 
+    let openDefaultKeybindingsFile =
+      define(
+        ~category="Preferences",
+        ~title="Open keybindings file",
+        "workbench.action.openDefaultKeybindingsFile",
+        Command(OpenKeybindingsFile),
+      );
+
   let showInputState =
     define(
       ~category="Debug",
@@ -719,7 +737,7 @@ module ContextKeys = {
 
 module Contributions = {
   let commands =
-    Commands.[showInputState, enableKeyDisplayer, disableKeyDisplayer];
+    Commands.[showInputState, enableKeyDisplayer, disableKeyDisplayer, openDefaultKeybindingsFile];
 
   let configuration = Configuration.[leaderKey.spec, timeout.spec];
 

--- a/src/Feature/Input/Feature_Input.re
+++ b/src/Feature/Input/Feature_Input.re
@@ -545,14 +545,13 @@ module Internal = {
 
 let update = (msg, model) => {
   switch (msg) {
-  | Command(OpenKeybindingsFile) => 
-  let eff = model.keybindingLoader
-  |> KeybindingsLoader.getFilePath
-  |> Option.map(path => OpenFile(path))
-  |> Option.value(~default=Nothing);
-  (
-    model, eff
-  )
+  | Command(OpenKeybindingsFile) =>
+    let eff =
+      model.keybindingLoader
+      |> KeybindingsLoader.getFilePath
+      |> Option.map(path => OpenFile(path))
+      |> Option.value(~default=Nothing);
+    (model, eff);
   | Command(ShowDebugInput) => (model, DebugInputShown)
   | Command(DisableKeyDisplayer) => (
       {...model, keyDisplayer: None},
@@ -654,13 +653,13 @@ let update = (msg, model) => {
 module Commands = {
   open Feature_Commands.Schema;
 
-    let openDefaultKeybindingsFile =
-      define(
-        ~category="Preferences",
-        ~title="Open keybindings file",
-        "workbench.action.openDefaultKeybindingsFile",
-        Command(OpenKeybindingsFile),
-      );
+  let openDefaultKeybindingsFile =
+    define(
+      ~category="Preferences",
+      ~title="Open keybindings file",
+      "workbench.action.openDefaultKeybindingsFile",
+      Command(OpenKeybindingsFile),
+    );
 
   let showInputState =
     define(
@@ -737,7 +736,12 @@ module ContextKeys = {
 
 module Contributions = {
   let commands =
-    Commands.[showInputState, enableKeyDisplayer, disableKeyDisplayer, openDefaultKeybindingsFile];
+    Commands.[
+      showInputState,
+      enableKeyDisplayer,
+      disableKeyDisplayer,
+      openDefaultKeybindingsFile,
+    ];
 
   let configuration = Configuration.[leaderKey.spec, timeout.spec];
 

--- a/src/Feature/Input/Feature_Input.rei
+++ b/src/Feature/Input/Feature_Input.rei
@@ -13,6 +13,7 @@ type outmsg =
       toKeys: string,
       error: string,
     })
+  | OpenFile(FpExp.t(FpExp.absolute))
   | TimedOut;
 
 [@deriving show]

--- a/src/Feature/Input/KeybindingsLoader.re
+++ b/src/Feature/Input/KeybindingsLoader.re
@@ -47,6 +47,11 @@ let notifyFileSaved = path =>
       orig;
     };
 
+let getFilePath: t => option(FpExp.t(FpExp.absolute)) =
+  fun
+  | None => None
+  | File({filePath, _}) => Some(filePath);
+
 let sub =
   fun
   | None => Isolinear.Sub.none

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -109,7 +109,6 @@ type t =
       option([ | `Horizontal | `Vertical | `NewTab]),
       option(CharacterPosition.t),
     )
-  | OpenConfigFile(string)
   | Pasted({
       rawText: string,
       isMultiLine: bool,

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -21,6 +21,12 @@ let copyFilePath =
     CopyActiveFilepathToClipboard,
   );
 
+let noop =
+  register(
+    "noop",
+    Noop
+  );
+
 let command = cmd => CommandInvoked({command: cmd, arguments: `Null});
 
 let undo = register("undo", command("undo"));

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -21,11 +21,7 @@ let copyFilePath =
     CopyActiveFilepathToClipboard,
   );
 
-let noop =
-  register(
-    "noop",
-    Noop
-  );
+let noop = register("noop", Noop);
 
 let command = cmd => CommandInvoked({command: cmd, arguments: `Null});
 

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -97,14 +97,6 @@ module Oni = {
 
 module Workbench = {
   module Action = {
-    let openDefaultKeybindingsFile =
-      register(
-        ~category="Preferences",
-        ~title="Open keybindings file",
-        "workbench.action.openDefaultKeybindingsFile",
-        OpenConfigFile("keybindings.json"),
-      );
-
     let showCommands =
       register(
         ~title="Show All Commands",

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -560,6 +560,9 @@ let update =
             error,
           ),
         )
+
+      | OpenFile(fp) => Internal.openFileEffect(FpExp.toString(fp))
+
       | TimedOut =>
         Isolinear.Effect.createWithDispatch(~name="Input.timeout", dispatch =>
           dispatch(KeyTimeout)


### PR DESCRIPTION
While investigating #3206 - I observed that the 'Preferences: Open keybindings file' was failing to actually open the file.

This looks like a regression from https://github.com/onivim/oni2/pull/3188 , which inactivated the `OpenConfigFile` action. 

This fixes it by plumbing the command back in, via the `Feature_Input` command list.

> WORKAROUND: `oni2 ~/.config/oni2/keybindings.json` on OSX / Linux