### PR TITLE
fix(configuration): Allow string as font size

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -31,6 +31,7 @@
 - #3205 - Editor: Update highlights and diagnostics immediately on buffer update (fixes #2620, #1459)
 - #3207 - Status Bar: Fix ghost text in some themes with transparent statusbar colors
 - #3217 - CLI: Add -v version flag (fixes #3209)
+- #3227 - Configuration: Allow string numbers as font sizes
 
 ### Performance
 


### PR DESCRIPTION
Small tweak to configuration options that take font sizes - like `"editor.fontSize"` and `"terminal.integrated.fontSize"` - allow string values, if they are able to be parsed to a number.