### PR TITLE
fix(buffers): Filetype picker not working correctly w/ no workspace

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,6 +37,7 @@
 - #3227 - Configuration: Allow string numbers as font sizes
 - #3230 - Font: Treat "FiraCode-Regular.ttf" as default font
 - #3233 - Formatting: Fix buffer de-sync when applying formatting edits (fixes #2196, #2820)
+- #3239 - Buffers: Fix filetype picker not working as expected without an active workspace
 
 ### Performance
 

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -144,7 +144,7 @@ let modified = model => {
 
 [@deriving show]
 type command =
-  | ChangeFiletype({ maybeBufferId: option(int) })
+  | ChangeFiletype({maybeBufferId: option(int)})
   | DetectIndentation;
 
 [@deriving show({with_path: false})]
@@ -225,7 +225,8 @@ module Msg = {
     Update({update, oldBuffer, newBuffer, triggerKey});
   };
 
-  let selectFileTypeClicked = (~bufferId: int) => Command(ChangeFiletype({maybeBufferId: Some(bufferId)}));
+  let selectFileTypeClicked = (~bufferId: int) =>
+    Command(ChangeFiletype({maybeBufferId: Some(bufferId)}));
 };
 
 type outmsg =
@@ -248,7 +249,6 @@ type outmsg =
   | BufferModifiedSet(int, bool)
   | ShowMenu(Exthost.LanguageInfo.t => Feature_Quickmenu.Schema.menu(msg))
   | NotifyInfo(string);
-
 
 module Configuration = {
   open Config.Schema;
@@ -417,23 +417,24 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
     (model', eff);
 
   | Command(command) =>
-
     switch (command) {
     | ChangeFiletype({maybeBufferId}) =>
       let menuFn = (languageInfo: Exthost.LanguageInfo.t) => {
-        let bufferId = maybeBufferId |> Option.value(~default=activeBufferId); 
+        let bufferId = maybeBufferId |> Option.value(~default=activeBufferId);
         let items = Exthost.LanguageInfo.languages(languageInfo);
 
         Feature_Quickmenu.Schema.menu(
-          ~onItemSelected=(language) => FileTypeChanged({
-            id: bufferId,
-            fileType: Buffer.FileType.explicit(language),
-          }),
-         ~toString=Fun.id,
-         items
-        )
+          ~onItemSelected=
+            language =>
+              FileTypeChanged({
+                id: bufferId,
+                fileType: Buffer.FileType.explicit(language),
+              }),
+          ~toString=Fun.id,
+          items,
+        );
       };
-      (model, ShowMenu(menuFn))
+      (model, ShowMenu(menuFn));
 
     | DetectIndentation =>
       let maybeBuffer = IntMap.find_opt(activeBufferId, model.buffers);
@@ -629,8 +630,8 @@ module Commands = {
       ~category="Editor",
       ~title="Select file type",
       "workbench.action.editor.changeLanguageMode",
-      Command(ChangeFiletype({maybeBufferId: None}))
-    )
+      Command(ChangeFiletype({maybeBufferId: None})),
+    );
 };
 
 let sub = model =>
@@ -661,7 +662,8 @@ module Contributions = {
       indentSize.spec,
     ];
 
-  let commands = Commands.[changeFiletype, detectIndentation] |> Command.Lookup.fromList;
+  let commands =
+    Commands.[changeFiletype, detectIndentation] |> Command.Lookup.fromList;
 
   let keybindings =
     Feature_Input.Schema.[

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -244,7 +244,7 @@ type outmsg =
       preview: bool,
     })
   | BufferModifiedSet(int, bool)
-  | ShowMenu(Feature_Quickmenu.Schema.menu(msg))
+  | ShowMenu(Exthost.LanguageInfo.t => Feature_Quickmenu.Schema.menu(msg))
   | NotifyInfo(string);
 
 

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -80,7 +80,7 @@ type outmsg =
       preview: bool,
     })
   | BufferModifiedSet(int, bool)
-  | ShowMenu(Feature_Quickmenu.Schema.menu(msg))
+  | ShowMenu(Exthost.LanguageInfo.t => Feature_Quickmenu.Schema.menu(msg))
   | NotifyInfo(string);
 
 // UPDATE

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -82,7 +82,10 @@ type outmsg =
       preview: bool,
     })
   | BufferModifiedSet(int, bool)
-  | ShowMenu(Exthost.LanguageInfo.t => Feature_Quickmenu.Schema.menu(msg))
+  | ShowMenu(
+      (Exthost.LanguageInfo.t, IconTheme.t) =>
+      Feature_Quickmenu.Schema.menu(msg),
+    )
   | NotifyInfo(string);
 
 // UPDATE

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -60,6 +60,8 @@ module Msg: {
       ~triggerKey: option(string)
     ) =>
     msg;
+
+  let selectFileTypeClicked: (~bufferId: int) => msg;
 };
 
 type outmsg =

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -80,6 +80,7 @@ type outmsg =
       preview: bool,
     })
   | BufferModifiedSet(int, bool)
+  | ShowMenu(Feature_Quickmenu.Schema.menu(msg))
   | NotifyInfo(string);
 
 // UPDATE

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -3,8 +3,8 @@
  (public_name Oni2.feature.buffers)
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.core Oni2.exthost
-   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu Oni2.service.exthost
-   Oni2.service.font Revery isolinear base)
+   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu
+   Oni2.service.exthost Oni2.service.font Revery isolinear base)
  (preprocess
   (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx
     ppx_inline_test)))

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -3,7 +3,7 @@
  (public_name Oni2.feature.buffers)
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.core Oni2.exthost
-   Oni2.feature.commands Oni2.feature.configuration Oni2.service.exthost
+   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu Oni2.service.exthost
    Oni2.service.font Revery isolinear base)
  (preprocess
   (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -6,13 +6,15 @@ module Schema: {
   type menu('outmsg);
 
   module Renderer: {
-    type t('item) = (
-      ~theme: ColorTheme.Colors.t,
-      ~font: UiFont.t,
-      ~text: string,
-      ~highlights: list((int, int)),
-      'item
-    ) => Revery.UI.element;
+    type t('item) =
+      (
+        ~theme: ColorTheme.Colors.t,
+        ~font: UiFont.t,
+        ~text: string,
+        ~highlights: list((int, int)),
+        'item
+      ) =>
+      Revery.UI.element;
 
     let default: t(_);
   };
@@ -22,7 +24,7 @@ module Schema: {
       ~onItemFocused: 'item => 'outmsg=?,
       ~onItemSelected: 'item => 'outmsg=?,
       ~onCancelled: unit => 'outmsg=?,
-      ~itemRenderer: Renderer.t('item) =?,
+      ~itemRenderer: Renderer.t('item)=?,
       ~toString: 'item => string,
       list('item)
     ) =>

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -17,7 +17,9 @@ module Schema: {
       Revery.UI.element;
 
     let default: t(_);
-    // let defaultWithIcon: ('item => IconTheme.IconDefinition.t) => t('item);
+
+    let defaultWithIcon:
+      ('item => option(IconTheme.IconDefinition.t)) => t('item);
   };
 
   let menu:

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -17,6 +17,7 @@ module Schema: {
       Revery.UI.element;
 
     let default: t(_);
+    // let defaultWithIcon: ('item => IconTheme.IconDefinition.t) => t('item);
   };
 
   let menu:

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -5,11 +5,24 @@ open Oni_Core;
 module Schema: {
   type menu('outmsg);
 
+  module Renderer: {
+    type t('item) = (
+      ~theme: ColorTheme.Colors.t,
+      ~font: UiFont.t,
+      ~text: string,
+      ~highlights: list((int, int)),
+      'item
+    ) => Revery.UI.element;
+
+    let default: t(_);
+  };
+
   let menu:
     (
       ~onItemFocused: 'item => 'outmsg=?,
       ~onItemSelected: 'item => 'outmsg=?,
       ~onCancelled: unit => 'outmsg=?,
+      ~itemRenderer: Renderer.t('item) =?,
       ~toString: 'item => string,
       list('item)
     ) =>

--- a/src/Feature/Quickmenu/MenuItem.re
+++ b/src/Feature/Quickmenu/MenuItem.re
@@ -1,6 +1,5 @@
 open Revery;
 open Revery.UI;
-open Oni_Core;
 
 module FontAwesome = Oni_Components.FontAwesome;
 module FontIcon = Oni_Components.FontIcon;
@@ -52,32 +51,7 @@ module Styles = {
 
 let noop = () => ();
 
-let make =
-    (
-      ~icon=None,
-      ~label,
-      ~isFocused,
-      ~theme,
-      ~onClick=noop,
-      ~onMouseOver=noop,
-      (),
-    ) => {
-  let iconView =
-    switch (icon) {
-    | Some(v) =>
-      IconTheme.IconDefinition.(
-        <Text
-          style={Styles.icon(v.fontColor)}
-          fontFamily={Revery.Font.Family.fromFile("seti.ttf")}
-          fontSize=Constants.iconSize
-          text={FontIcon.codeToIcon(v.fontCharacter)}
-        />
-      )
-
-    | None =>
-      <Text style={Styles.icon(Revery.Colors.transparentWhite)} text="" />
-    };
-
+let make = (~label, ~isFocused, ~theme, ~onClick=noop, ~onMouseOver=noop, ()) => {
   let labelView =
     switch (label) {
     // | `Text(text) =>
@@ -94,7 +68,6 @@ let make =
     <View
       onMouseOver={_ => onMouseOver()}
       style={Styles.container(~theme, ~isFocused)}>
-      iconView
       labelView
     </View>
   </Sneakable>;

--- a/src/Feature/Quickmenu/Schema.re
+++ b/src/Feature/Quickmenu/Schema.re
@@ -42,7 +42,7 @@ module Renderer = {
       ];
   };
 
-  let default: t(_) =
+  let common: t(_) =
     (~theme, ~font: UiFont.t, ~text, ~highlights, _item) => {
       let style = Styles.label(~theme);
       let normalStyle = style(~highlighted=false);
@@ -57,19 +57,33 @@ module Renderer = {
       />;
     };
 
+  let default = (~theme, ~font, ~text, ~highlights, item) => {
+    // Reserve the icon space to be consistent with menus w/ icons
+    [
+      <Text style={Styles.icon(Revery.Colors.transparentWhite)} text="" />,
+      common(~theme, ~font, ~text, ~highlights, item),
+    ]
+    |> React.listToElement;
+  };
+
   let defaultWithIcon =
       (iconSelector, ~theme, ~font, ~text, ~highlights, item) => {
-    let labelView = default(~theme, ~font, ~text, ~highlights, item);
+    let labelView = common(~theme, ~font, ~text, ~highlights, item);
     let icon = iconSelector(item);
     let iconView =
-      Oni_Core.IconTheme.IconDefinition.(
-        <Text
-          style={Styles.icon(icon.fontColor)}
-          fontFamily={Revery.Font.Family.fromFile("seti.ttf")}
-          fontSize=Constants.iconSize
-          text={Oni_Components.FontIcon.codeToIcon(icon.fontCharacter)}
-        />
-      );
+      switch (icon) {
+      | Some(icon) =>
+        Oni_Core.IconTheme.IconDefinition.(
+          <Text
+            style={Styles.icon(icon.fontColor)}
+            fontFamily={Revery.Font.Family.fromFile("seti.ttf")}
+            fontSize=Constants.iconSize
+            text={Oni_Components.FontIcon.codeToIcon(icon.fontCharacter)}
+          />
+        )
+      | None =>
+        <Text style={Styles.icon(Revery.Colors.transparentWhite)} text="" />
+      };
 
     [iconView, labelView] |> Revery.UI.React.listToElement;
   };

--- a/src/Feature/Quickmenu/Schema.re
+++ b/src/Feature/Quickmenu/Schema.re
@@ -11,11 +11,30 @@ type internal('item, 'outmsg) = {
 type menu('outmsg) =
   | Menu(internal('item, 'outmsg)): menu('outmsg);
 
+module Renderer = {
+  type t('item) = (
+    ~theme: ColorTheme.Colors.t,
+    ~font: UiFont.t,
+    ~text: string,
+    ~highlights: list((int, int)),
+    'item
+  ) => Revery.UI.element;
+
+  let default: t(_) = (
+    ~theme as _,
+    ~font as _,
+    ~text as _,
+    ~highlights as _,
+    _item
+  ) => Revery.UI.React.empty
+}
+
 let menu:
   (
     ~onItemFocused: 'item => 'outmsg=?,
     ~onItemSelected: 'item => 'outmsg=?,
     ~onCancelled: unit => 'outmsg=?,
+    ~itemRenderer: Renderer.t('item) = ?,
     ~toString: 'item => string,
     list('item)
   ) =>
@@ -24,9 +43,11 @@ let menu:
     ~onItemFocused=?,
     ~onItemSelected=?,
     ~onCancelled=?,
+    ~itemRenderer=Renderer.default,
     ~toString,
     initialItems,
-  ) =>
+  ) => {
+    ignore(itemRenderer);
     Menu({
       onItemFocused,
       onItemSelected,
@@ -34,6 +55,7 @@ let menu:
       toString,
       items: initialItems,
     });
+   };
 
 let mapFunction: ('a => 'b, 'item => 'a, 'item) => 'b =
   (f, orig, item) => {

--- a/src/Feature/Quickmenu/View.re
+++ b/src/Feature/Quickmenu/View.re
@@ -144,7 +144,6 @@ let make =
           onClick={() => onSelect(index)}
           theme
           label={`Custom(elem)}
-          //icon={item.icon}
           onMouseOver={() => onFocusedChange(index)}
           isFocused
         />;

--- a/src/Feature/Quickmenu/View.re
+++ b/src/Feature/Quickmenu/View.re
@@ -136,30 +136,15 @@ let make =
     };
 
     let renderItem = index => {
-      switch (Schema.Instance.itemAndHighlights(~index, current)) {
+      switch (Schema.Instance.render(~index, ~theme, ~font, current)) {
       | None => React.empty
-      | Some((text, highlights)) =>
+      | Some(elem) =>
         let isFocused = Some(index) == focused;
-
-        let style = Styles.label(~theme);
-        // TODO:
-        let normalStyle = style(~highlighted=false);
-        let highlightStyle = style(~highlighted=true);
-        let labelView =
-          <HighlightText
-            fontFamily={font.family}
-            fontSize=12.
-            style=normalStyle
-            highlightStyle
-            text
-            highlights
-          />;
-
         <MenuItem
           onClick={() => onSelect(index)}
           theme
-          label={`Custom(labelView)}
-          // icon={item.icon}
+          label={`Custom(elem)}
+          //icon={item.icon}
           onMouseOver={() => onFocusedChange(index)}
           isFocused
         />;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -195,11 +195,6 @@ and quickmenuVariant =
   | OpenBuffersPicker
   | Wildmenu([@opaque] Vim.Types.cmdlineType)
   | ThemesPicker([@opaque] list(Feature_Theme.theme))
-  | FileTypesPicker({
-      bufferId: int,
-      languages:
-        list((string, option(Oni_Core.IconTheme.IconDefinition.t))),
-    })
   | Extension({
       id: int,
       hasItems: bool,

--- a/src/Model/Quickmenu.re
+++ b/src/Model/Quickmenu.re
@@ -18,11 +18,6 @@ and variant =
     | OpenBuffersPicker
     | Wildmenu(Vim.Types.cmdlineType)
     | ThemesPicker(list(Feature_Theme.theme))
-    | FileTypesPicker({
-        bufferId: int,
-        languages:
-          list((string, option(Oni_Core.IconTheme.IconDefinition.t))),
-      })
     | Extension({
         id: int,
         hasItems: bool,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1090,8 +1090,10 @@ let update =
           Isolinear.Effect.createWithDispatch(
             ~name="statusBar.fileTypePicker", dispatch => {
             dispatch(
-              Actions.Buffers(Feature_Buffers.Msg.selectFileTypeClicked(~bufferId)
-            ))
+              Actions.Buffers(
+                Feature_Buffers.Msg.selectFileTypeClicked(~bufferId),
+              ),
+            )
           }),
         );
 
@@ -1118,11 +1120,12 @@ let update =
     switch (outmsg) {
     | Nothing => (state, Effect.none)
 
-    | ShowMenu(menuFn) => 
-      let menu = menuFn(state.languageInfo)
-      |> Feature_Quickmenu.Schema.map(msg => Buffers(msg));
+    | ShowMenu(menuFn) =>
+      let menu =
+        menuFn(state.languageInfo)
+        |> Feature_Quickmenu.Schema.map(msg => Buffers(msg));
       let quickmenu = Feature_Quickmenu.show(~menu, state.newQuickmenu);
-      ({...state, newQuickmenu: quickmenu}, Isolinear.Effect.none)
+      ({...state, newQuickmenu: quickmenu}, Isolinear.Effect.none);
 
     | NotifyInfo(msg) => (
         state,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1117,6 +1117,12 @@ let update =
     switch (outmsg) {
     | Nothing => (state, Effect.none)
 
+    | ShowMenu(menuFn) => 
+      let menu = menuFn(state.languageInfo)
+      |> Feature_Quickmenu.Schema.map(msg => Buffers(msg));
+      let quickmenu = Feature_Quickmenu.show(~menu, state.newQuickmenu);
+      ({...state, newQuickmenu: quickmenu}, Isolinear.Effect.none)
+
     | NotifyInfo(msg) => (
         state,
         Internal.notificationEffect(~kind=Info, msg),

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1122,7 +1122,7 @@ let update =
 
     | ShowMenu(menuFn) =>
       let menu =
-        menuFn(state.languageInfo)
+        menuFn(state.languageInfo, state.iconTheme)
         |> Feature_Quickmenu.Schema.map(msg => Buffers(msg));
       let quickmenu = Feature_Quickmenu.show(~menu, state.newQuickmenu);
       ({...state, newQuickmenu: quickmenu}, Isolinear.Effect.none);

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1072,25 +1072,26 @@ let update =
           |> Feature_Layout.activeEditor
           |> Feature_Editor.Editor.getBufferId;
 
-        let languages =
-          state.languageInfo
-          |> Exthost.LanguageInfo.languages
-          |> List.map(language =>
-               (
-                 language,
-                 Oni_Core.IconTheme.getIconForLanguage(
-                   state.iconTheme,
-                   language,
-                 ),
-               )
-             );
+        // TODO: Port to buffer filetype picker
+        // let languages =
+        //   state.languageInfo
+        //   |> Exthost.LanguageInfo.languages
+        //   |> List.map(language =>
+        //        (
+        //          language,
+        //          Oni_Core.IconTheme.getIconForLanguage(
+        //            state.iconTheme,
+        //            language,
+        //          ),
+        //        )
+        //      );
         (
           state',
           Isolinear.Effect.createWithDispatch(
             ~name="statusBar.fileTypePicker", dispatch => {
             dispatch(
-              Actions.QuickmenuShow(FileTypesPicker({bufferId, languages})),
-            )
+              Actions.Buffers(Feature_Buffers.Msg.selectFileTypeClicked(~bufferId)
+            ))
           }),
         );
 

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -257,45 +257,6 @@ let start = () => {
         Isolinear.Effect.none,
       );
 
-    | QuickmenuShow(FileTypesPicker({bufferId, languages})) =>
-      if (Feature_Workspace.openedFolder(workspace) == None) {
-        let items =
-          makeBufferCommands(workspace, languageInfo, iconTheme, buffers);
-
-        (
-          Some({...Quickmenu.defaults(OpenBuffersPicker), items}),
-          Isolinear.Effect.none,
-        );
-      } else {
-        let items =
-          languages
-          |> List.map(((fileType, maybeIcon)) => {
-               Actions.{
-                 category: None,
-                 name: fileType,
-                 command: () =>
-                   Buffers(
-                     Feature_Buffers.Msg.fileTypeChanged(
-                       ~bufferId,
-                       ~fileType=Oni_Core.Buffer.FileType.explicit(fileType),
-                     ),
-                   ),
-                 icon: maybeIcon,
-                 highlight: [],
-                 handle: None,
-               }
-             })
-          |> Array.of_list;
-
-        (
-          Some({
-            ...Quickmenu.defaults(FileTypesPicker({bufferId, languages})),
-            items,
-          }),
-          Isolinear.Effect.none,
-        );
-      }
-
     | QuickmenuPaste(text) => (
         Option.map(
           (Quickmenu.{inputText, _} as state) => {
@@ -660,8 +621,6 @@ let subscriptions = (ripgrep, dispatch) => {
             state.iconTheme,
             state.config,
           )
-
-      | FileTypesPicker(_) => [filter(query, quickmenu.items)]
 
       | Wildmenu(_) => []
       };


### PR DESCRIPTION
__Issue:__ When opening the select-filetype menu (for example, clicking the filetype in the statusbar) - if there is no workspace active, the menu will show available buffers instead of filetypes.

__Defect:__ Errant logic in the QuickmenuStoreConnector.

__Fix:__ Fix errant logic, take opportunity to migrate the file-type picker to the new quickmenu feature. Requires adding icon renderer to the new quickmenu feature.