### PR TITLE
fix(formatting/#3014): 'Invalid range specified' error

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,6 +37,7 @@
 - #3227 - Configuration: Allow string numbers as font sizes
 - #3230 - Font: Treat "FiraCode-Regular.ttf" as default font
 - #3233 - Formatting: Fix buffer de-sync when applying formatting edits (fixes #2196, #2820)
+- #3240 - Formatting: Fix 'Invalid Range Specified' error (fixes #3014)
 
 ### Performance
 

--- a/src/Core/ConfigurationTransformer.re
+++ b/src/Core/ConfigurationTransformer.re
@@ -26,12 +26,12 @@ let setField = (fieldName, value, json) => {
 let setFiletypeField = (~fileType, fieldName, value, json) => {
   json
   |> Utility.JsonEx.update(
-    "[" ++ fileType ++ "]",
-    fun
-    | None => Some(`Assoc([(fieldName, value)]))
-    | Some(perFileJson) => Some(setField(fieldName, value, perFileJson))
-  );
-}
+       "[" ++ fileType ++ "]",
+       fun
+       | None => Some(`Assoc([(fieldName, value)]))
+       | Some(perFileJson) => Some(setField(fieldName, value, perFileJson)),
+     );
+};
 
 let removeField = (fieldName, json) => {
   switch (json) {

--- a/src/Core/ConfigurationTransformer.re
+++ b/src/Core/ConfigurationTransformer.re
@@ -23,6 +23,16 @@ let setField = (fieldName, value, json) => {
   };
 };
 
+let setFiletypeField = (~fileType, fieldName, value, json) => {
+  json
+  |> Utility.JsonEx.update(
+    "[" ++ fileType ++ "]",
+    fun
+    | None => Some(`Assoc([(fieldName, value)]))
+    | Some(perFileJson) => Some(setField(fieldName, value, perFileJson))
+  );
+}
+
 let removeField = (fieldName, json) => {
   switch (json) {
   | `Assoc(elems) =>

--- a/src/Core/Utility/ListEx.re
+++ b/src/Core/Utility/ListEx.re
@@ -16,6 +16,8 @@ let boundedLength = (~max, list) => {
   loop(0, list);
 };
 
+let nth_opt = (idx, list) => List.nth_opt(list, idx);
+
 /**
  * Return the last element in a list.
  */

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -78,7 +78,8 @@ type outmsg =
       editorId: int,
       ranges: list(CharacterRange.t),
     })
-  | ShowMenu(Feature_Quickmenu.Schema.menu(msg));
+  | ShowMenu(Feature_Quickmenu.Schema.menu(msg))
+  | TransformConfiguration(Oni_Core.ConfigurationTransformer.t);
 
 let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
   f =>
@@ -104,6 +105,7 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
     | Outmsg.SetSelections({editorId, ranges}) =>
       SetSelections({editorId, ranges})
     | Outmsg.ShowMenu(menu) => ShowMenu(menu |> Feature_Quickmenu.Schema.map(f))
+    | Outmsg.TransformConfiguration(transformer) => TransformConfiguration(transformer)
     ;
 
 module Msg = {
@@ -377,6 +379,13 @@ let update =
           ),
         )
       | Formatting.FormatError(errorMsg) => NotifyFailure(errorMsg)
+      | Formatting.ShowMenu(menu) =>
+        let menu' = menu
+        |> Feature_Quickmenu.Schema.map(msg => Formatting(msg));
+        ShowMenu(menu');
+
+      | Formatting.TransformConfiguration(transformer) =>
+        TransformConfiguration(transformer)
       };
 
     ({...model, formatting: formatting'}, outMsg');

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -77,7 +77,8 @@ type outmsg =
   | SetSelections({
       editorId: int,
       ranges: list(CharacterRange.t),
-    });
+    })
+  | ShowMenu(Feature_Quickmenu.Schema.menu(msg));
 
 let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
   f =>
@@ -101,7 +102,9 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
       }) =>
       CodeLensesChanged({handle, bufferId, lenses, startLine, stopLine})
     | Outmsg.SetSelections({editorId, ranges}) =>
-      SetSelections({editorId, ranges});
+      SetSelections({editorId, ranges})
+    | Outmsg.ShowMenu(menu) => ShowMenu(menu |> Feature_Quickmenu.Schema.map(f))
+    ;
 
 module Msg = {
   let exthost = msg => Exthost(msg);

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -104,9 +104,10 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
       CodeLensesChanged({handle, bufferId, lenses, startLine, stopLine})
     | Outmsg.SetSelections({editorId, ranges}) =>
       SetSelections({editorId, ranges})
-    | Outmsg.ShowMenu(menu) => ShowMenu(menu |> Feature_Quickmenu.Schema.map(f))
-    | Outmsg.TransformConfiguration(transformer) => TransformConfiguration(transformer)
-    ;
+    | Outmsg.ShowMenu(menu) =>
+      ShowMenu(menu |> Feature_Quickmenu.Schema.map(f))
+    | Outmsg.TransformConfiguration(transformer) =>
+      TransformConfiguration(transformer);
 
 module Msg = {
   let exthost = msg => Exthost(msg);
@@ -220,7 +221,12 @@ let update =
     ({...model, completion: completion'}, Nothing);
 
   | Exthost(
-      RegisterRangeFormattingSupport({handle, selector, displayName, extensionId}),
+      RegisterRangeFormattingSupport({
+        handle,
+        selector,
+        displayName,
+        extensionId,
+      }),
     ) =>
     let formatting' =
       Formatting.registerRangeFormatter(
@@ -233,7 +239,12 @@ let update =
     ({...model, formatting: formatting'}, Nothing);
 
   | Exthost(
-      RegisterDocumentFormattingSupport({handle, selector, displayName, extensionId}),
+      RegisterDocumentFormattingSupport({
+        handle,
+        selector,
+        displayName,
+        extensionId,
+      }),
     ) =>
     let formatting' =
       Formatting.registerDocumentFormatter(
@@ -356,6 +367,7 @@ let update =
   | Formatting(formatMsg) =>
     let (formatting', outMsg) =
       Formatting.update(
+        ~config,
         ~languageConfiguration,
         ~maybeSelection,
         ~maybeBuffer,
@@ -380,8 +392,8 @@ let update =
         )
       | Formatting.FormatError(errorMsg) => NotifyFailure(errorMsg)
       | Formatting.ShowMenu(menu) =>
-        let menu' = menu
-        |> Feature_Quickmenu.Schema.map(msg => Formatting(msg));
+        let menu' =
+          menu |> Feature_Quickmenu.Schema.map(msg => Formatting(msg));
         ShowMenu(menu');
 
       | Formatting.TransformConfiguration(transformer) =>

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -215,24 +215,26 @@ let update =
     ({...model, completion: completion'}, Nothing);
 
   | Exthost(
-      RegisterRangeFormattingSupport({handle, selector, displayName, _}),
+      RegisterRangeFormattingSupport({handle, selector, displayName, extensionId}),
     ) =>
     let formatting' =
       Formatting.registerRangeFormatter(
         ~handle,
         ~selector,
+        ~extensionId,
         ~displayName,
         model.formatting,
       );
     ({...model, formatting: formatting'}, Nothing);
 
   | Exthost(
-      RegisterDocumentFormattingSupport({handle, selector, displayName, _}),
+      RegisterDocumentFormattingSupport({handle, selector, displayName, extensionId}),
     ) =>
     let formatting' =
       Formatting.registerDocumentFormatter(
         ~handle,
         ~selector,
+        ~extensionId,
         ~displayName,
         model.formatting,
       );

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -602,6 +602,7 @@ module Contributions = {
     CodeLens.Contributions.configuration
     @ Completion.Contributions.configuration
     @ DocumentHighlights.Contributions.configuration
+    @ Formatting.Contributions.configuration
     @ SignatureHelp.Contributions.configuration;
 
   let contextKeys =

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -81,7 +81,8 @@ type outmsg =
       editorId: int,
       ranges: list(CharacterRange.t),
     })
-  | ShowMenu(Feature_Quickmenu.Schema.menu(msg));
+  | ShowMenu(Feature_Quickmenu.Schema.menu(msg))
+  | TransformConfiguration(ConfigurationTransformer.t)
 
 let update:
   (

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -82,7 +82,7 @@ type outmsg =
       ranges: list(CharacterRange.t),
     })
   | ShowMenu(Feature_Quickmenu.Schema.menu(msg))
-  | TransformConfiguration(ConfigurationTransformer.t)
+  | TransformConfiguration(ConfigurationTransformer.t);
 
 let update:
   (

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -80,7 +80,8 @@ type outmsg =
   | SetSelections({
       editorId: int,
       ranges: list(CharacterRange.t),
-    });
+    })
+  | ShowMenu(Feature_Quickmenu.Schema.menu(msg));
 
 let update:
   (

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -30,6 +30,18 @@ let initial = {
   activeSession: None,
 };
 
+// CONFIGURATION
+
+module Configuration = {
+  open Config.Schema;
+
+  let defaultFormatter = setting(
+    "editor.defaultFormatter",
+    nullable(string),
+    ~default=None,
+  );
+};
+
 [@deriving show]
 type command =
   | FormatDocument
@@ -375,4 +387,6 @@ module Commands = {
 
 module Contributions = {
   let commands = [Commands.formatDocument];
+
+  let configuration = [Configuration.defaultFormatter.spec];
 };

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -197,6 +197,7 @@ module Internal = {
     Feature_Quickmenu.Schema.menu(
       ~onItemSelected=toMsg,
       ~toString=Fun.id,
+      ~placeholderText="Select a default formatter...",
       itemNames,
     );
   };

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -101,7 +101,9 @@ type outmsg =
       displayName: string,
       editCount: int,
     })
-  | FormatError(string);
+  | FormatError(string)
+  | TransformConfiguration(ConfigurationTransformer.t)
+  | ShowMenu(Feature_Quickmenu.Schema.menu(msg));
 
 module Internal = {
   let clearSession = model => {...model, activeSession: None};

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -31,6 +31,7 @@ type internalMsg('a) =
       ranges: list(CharacterRange.t),
     })
   | ShowMenu(Feature_Quickmenu.Schema.menu('a))
+  | TransformConfiguration(Oni_Core.ConfigurationTransformer.t)
   | Effect(Isolinear.Effect.t('a));
 
 let map = f =>

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -30,6 +30,7 @@ type internalMsg('a) =
       editorId: int,
       ranges: list(CharacterRange.t),
     })
+  | ShowMenu(Feature_Quickmenu.Schema.menu('a))
   | Effect(Isolinear.Effect.t('a));
 
 let map = f =>

--- a/src/Feature/LanguageSupport/dune
+++ b/src/Feature/LanguageSupport/dune
@@ -5,7 +5,7 @@
  (libraries Oni2.editor-core-types Oni2.component.vimTree Oni2.core
    Oni2.syntax Oni2.feature.commands Oni2.feature.configuration
    Oni2.feature.extensions Oni2.feature.diagnostics Oni2.feature.keywords
-   Oni2.component.inputText Oni2.service.exthost Oni2.service.font
+   Oni2.feature.quickmenu Oni2.component.inputText Oni2.service.exthost Oni2.service.font
    Oni2.service.snippets Oni2.service.vim Oni2.input uucp)
  (preprocess
   (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/LanguageSupport/dune
+++ b/src/Feature/LanguageSupport/dune
@@ -5,7 +5,7 @@
  (libraries Oni2.editor-core-types Oni2.component.vimTree Oni2.core
    Oni2.syntax Oni2.feature.commands Oni2.feature.configuration
    Oni2.feature.extensions Oni2.feature.diagnostics Oni2.feature.keywords
-   Oni2.feature.quickmenu Oni2.component.inputText Oni2.service.exthost Oni2.service.font
-   Oni2.service.snippets Oni2.service.vim Oni2.input uucp)
+   Oni2.feature.quickmenu Oni2.component.inputText Oni2.service.exthost
+   Oni2.service.font Oni2.service.snippets Oni2.service.vim Oni2.input uucp)
  (preprocess
   (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -10,6 +10,7 @@ module Schema: {
       ~onItemFocused: 'item => 'outmsg=?,
       ~onItemSelected: 'item => 'outmsg=?,
       ~onCancelled: unit => 'outmsg=?,
+      ~placeholderText: string=?,
       ~toString: 'item => string,
       list('item)
     ) =>

--- a/src/Feature/Quickmenu/Schema.re
+++ b/src/Feature/Quickmenu/Schema.re
@@ -5,6 +5,7 @@ type internal('item, 'outmsg) = {
   onItemFocused: option('item => 'outmsg),
   onItemSelected: option('item => 'outmsg),
   onCancelled: option(unit => 'outmsg),
+  placeholderText: string,
   toString: 'item => string,
   items: list('item),
 };
@@ -16,6 +17,7 @@ let menu:
     ~onItemFocused: 'item => 'outmsg=?,
     ~onItemSelected: 'item => 'outmsg=?,
     ~onCancelled: unit => 'outmsg=?,
+    ~placeholderText: string=?,
     ~toString: 'item => string,
     list('item)
   ) =>
@@ -24,6 +26,7 @@ let menu:
     ~onItemFocused=?,
     ~onItemSelected=?,
     ~onCancelled=?,
+    ~placeholderText="type to search...",
     ~toString,
     initialItems,
   ) =>
@@ -31,6 +34,7 @@ let menu:
       onItemFocused,
       onItemSelected,
       onCancelled,
+      placeholderText,
       toString,
       items: initialItems,
     });
@@ -43,13 +47,12 @@ let mapFunction: ('a => 'b, 'item => 'a, 'item) => 'b =
 let map: ('a => 'b, menu('a)) => menu('b) =
   (f, model) => {
     switch (model) {
-    | Menu({onItemFocused, onItemSelected, onCancelled, toString, items}) =>
+    | Menu({onItemFocused, onItemSelected, onCancelled, _} as orig) =>
       Menu({
+        ...orig,
         onItemFocused: onItemFocused |> Option.map(mapFunction(f)),
         onItemSelected: onItemSelected |> Option.map(mapFunction(f)),
         onCancelled: onCancelled |> Option.map(mapFunction(f)),
-        toString,
-        items,
       })
     };
   };
@@ -194,7 +197,7 @@ let instantiate: menu('outmsg) => Instance.t('outmsg) =
       text:
         Component_InputText.empty
         |> Component_InputText.setPlaceholder(
-             ~placeholder="type to search...",
+             ~placeholder=internal.placeholderText,
            ),
       allItems: internal.items,
       filteredItems: [||],

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -734,6 +734,14 @@ let update =
         |> Feature_Quickmenu.Schema.map(msg => Actions.LanguageSupport(msg));
         let quickmenu' = Feature_Quickmenu.show(~menu=menu', state.newQuickmenu);
         ({...state, newQuickmenu: quickmenu'}, Isolinear.Effect.none)
+
+      | TransformConfiguration(transformer) =>
+        let config' =
+              Feature_Configuration.queueTransform(
+                ~transformer,
+                state.config,
+              );
+        ({...state, config: config'}, Isolinear.Effect.none);
       }
     );
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -730,17 +730,16 @@ let update =
         ({...state, layout: layout'}, Isolinear.Effect.none);
 
       | ShowMenu(menu) =>
-        let menu' = menu
-        |> Feature_Quickmenu.Schema.map(msg => Actions.LanguageSupport(msg));
-        let quickmenu' = Feature_Quickmenu.show(~menu=menu', state.newQuickmenu);
-        ({...state, newQuickmenu: quickmenu'}, Isolinear.Effect.none)
+        let menu' =
+          menu
+          |> Feature_Quickmenu.Schema.map(msg => Actions.LanguageSupport(msg));
+        let quickmenu' =
+          Feature_Quickmenu.show(~menu=menu', state.newQuickmenu);
+        ({...state, newQuickmenu: quickmenu'}, Isolinear.Effect.none);
 
       | TransformConfiguration(transformer) =>
         let config' =
-              Feature_Configuration.queueTransform(
-                ~transformer,
-                state.config,
-              );
+          Feature_Configuration.queueTransform(~transformer, state.config);
         ({...state, config: config'}, Isolinear.Effect.none);
       }
     );

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -728,6 +728,12 @@ let update =
                )
              );
         ({...state, layout: layout'}, Isolinear.Effect.none);
+
+      | ShowMenu(menu) =>
+        let menu' = menu
+        |> Feature_Quickmenu.Schema.map(msg => Actions.LanguageSupport(msg));
+        let quickmenu' = Feature_Quickmenu.show(~menu=menu', state.newQuickmenu);
+        ({...state, newQuickmenu: quickmenu'}, Isolinear.Effect.none)
       }
     );
 


### PR DESCRIPTION
__Issue:__ When formatting a JavaScript file, or other file without a formatter installed by default, and formatting (either via the 'Format Document' command, or key sequences like `gg=G`) - there'd be a confusing 'Invalid range specified' error.

__Defect:__ There were actually several issues:
1) When falling back to the default format provider, there was an off-by-one bug that caused that error to be displayed when the whole document was requested to be formatted.
2) In the case of #3014 , there actually is a default format provider - the type script language feature provides a formatter, but it is a range formatter (not a document formatter). However, in the case where there is a range formatter but no document formatter, we can fall back to using the range formatter.
3) The case of multiple format providers wasn't handled in a robust way

__Fix:__
1) Fix the issues with the ranges in the default and language server range formatters
2) Implement logic to fall back to the range formatter in the case where there is no document formatter available
3) Implement proper resolution of format providers. When there are multiple, prompt the user to pick a default formatter. Use the `"editor.defaultFormatter": "publisher.extension-id"` configuration setting to disambiguate, for example:
```
"[javascript]": {
   "editor.defaultFormatter": "esbenp.prettier-vscode"
}
```
When the user selects a default, automatically update the configuration.