### PR TITLE
fix(extensions/#3215): Part 1 - Implement max count parameter for findFiles API

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -39,6 +39,7 @@
 - #3233 - Formatting: Fix buffer de-sync when applying formatting edits (fixes #2196, #2820)
 - #3239 - Buffers: Fix filetype picker not working as expected without an active workspace
 - #3240 - Formatting: Fix 'Invalid Range Specified' error (fixes #3014)
+- #3241 - Extensions: Handle `maxCount` and FS errors in `vscode.workspace.findFiles` (related #3215)
 
 ### Performance
 

--- a/development_extensions/oni-dev-extension/extension.js
+++ b/development_extensions/oni-dev-extension/extension.js
@@ -28,7 +28,18 @@ function activate(context) {
             vscode.window.showWarningMessage("You clicked developer", [])
         }),
     )
-    
+
+    cleanup(
+        vscode.commands.registerCommand("_test.findFiles", (count) => {
+            vscode.workspace.findFiles(
+                "*.json", undefined, count
+            ).then((results) => {
+                vscode.window.showInformationMessage("success:" + results.length);
+                // vscode.window.showInformationMessage("success:1");
+            })
+        }),
+    )
+
     cleanup(
         vscode.commands.registerCommand("developer.oni.hideStatusBar", () => {
             item.hide();
@@ -37,31 +48,31 @@ function activate(context) {
 
     cleanup(
         vscode.commands.registerCommand("developer.oni.logBufferUpdates", () => {
-                vscode.window.showInformationMessage("Logging buffer updates!");
-                vscode.workspace.onDidChangeTextDocument((e) => {
-                    console.log({
-                        type: "workspace.onDidChangeTextDocument",
-                        filename: e.document.fileName,
-                        version: e.document.version,
-                        contentChanges: e.contentChanges,
-                        fullText: e.document.getText(),
-                    });
+            vscode.window.showInformationMessage("Logging buffer updates!");
+            vscode.workspace.onDidChangeTextDocument((e) => {
+                console.log({
+                    type: "workspace.onDidChangeTextDocument",
+                    filename: e.document.fileName,
+                    version: e.document.version,
+                    contentChanges: e.contentChanges,
+                    fullText: e.document.getText(),
                 });
+            });
         }),
     )
 
     cleanup(
         vscode.commands.registerCommand("developer.oni.tryOpenDocument", () => {
             vscode.workspace.openTextDocument(vscode.Uri.file("package.json"))
-            .then((document) => {
-                let text = document.getText();
-                vscode.window.showInformationMessage("Got text document: " + text);
-            }, err => {
-                vscode.window.showErrorMessage("Failed to get text document: " + err.toString());
-            })
+                .then((document) => {
+                    let text = document.getText();
+                    vscode.window.showInformationMessage("Got text document: " + text);
+                }, err => {
+                    vscode.window.showErrorMessage("Failed to get text document: " + err.toString());
+                })
         }),
     )
-    
+
     cleanup(
         vscode.commands.registerCommand("developer.oni.showStatusBar", () => {
             item.show();
@@ -83,7 +94,7 @@ function activate(context) {
                 return [vscode.CompletionItem("HelloWorld"), vscode.CompletionItem("HelloAgain")]
             },
             resolveCompletionItem: (completionItem, token) => {
-                completionItem.documentation = "RESOLVED documentation:  "+ completionItem.label;
+                completionItem.documentation = "RESOLVED documentation:  " + completionItem.label;
                 completionItem.detail = "RESOLVED detail: " + completionItem.label;
                 return completionItem;
             }
@@ -120,10 +131,10 @@ function activate(context) {
                 return new Promise((resolve) => {
                     setTimeout(() => {
                         resolve([
-                        vscode.CompletionItem("ReasonML0"),
-                        vscode.CompletionItem("OCaml0"),
-                        vscode.CompletionItem("ReasonML2"),
-                        vscode.CompletionItem("OCaml2"),
+                            vscode.CompletionItem("ReasonML0"),
+                            vscode.CompletionItem("OCaml0"),
+                            vscode.CompletionItem("ReasonML2"),
+                            vscode.CompletionItem("OCaml2"),
                         ])
                     }, 500);
                 });
@@ -135,15 +146,15 @@ function activate(context) {
     cleanup(
         vscode.languages.registerCompletionItemProvider("oni-dev", {
             provideCompletionItems: (document, position, token, context) => {
-                        const items = [
-                            vscode.CompletionItem("Incomplete" + Date.now().toString()),
-                        ];
-                        return {
-                            isIncomplete: true,
-                            items,
-                        };
-                },
-            }),
+                const items = [
+                    vscode.CompletionItem("Incomplete" + Date.now().toString()),
+                ];
+                return {
+                    isIncomplete: true,
+                    items,
+                };
+            },
+        }),
     )
 
     const output = vscode.window.createOutputChannel("oni-dev")
@@ -153,7 +164,7 @@ function activate(context) {
     output2.append("Hello output channel!")
 
     const collection = vscode.languages.createDiagnosticCollection("test")
-    
+
     let latestText = ""
 
     cleanup(
@@ -209,16 +220,16 @@ function activate(context) {
     cleanup(
         vscode.commands.registerCommand("developer.oni.showChoiceMessage", () => {
             vscode.window.showInformationMessage(
-//`Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?`
-"Hello!"
-    , "Option 1", "Option 2", "Option 3").then(
-                (result) => {
-                    vscode.window.showInformationMessage("You picked: " + result)
-                },
-                (err) => {
-                    vscode.window.showInformationMessage("Cancelled: " + err)
-                },
-            )
+                //`Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?`
+                "Hello!"
+                , "Option 1", "Option 2", "Option 3").then(
+                    (result) => {
+                        vscode.window.showInformationMessage("You picked: " + result)
+                    },
+                    (err) => {
+                        vscode.window.showInformationMessage("Cancelled: " + err)
+                    },
+                )
         }),
     )
 
@@ -392,7 +403,7 @@ function activate(context) {
 }
 
 // this method is called when your extension is deactivated
-function deactivate() {}
+function deactivate() { }
 
 module.exports = {
     activate,

--- a/integration_test/ExtHostWorkspaceSearchTest.re
+++ b/integration_test/ExtHostWorkspaceSearchTest.re
@@ -39,8 +39,7 @@ runTest(~name="ExtHostWorkspaceSearchTest", ({dispatch, wait, _}) => {
       let notifications = Feature_Notification.all(state.notifications);
       notifications
       |> List.exists((notification: Feature_Notification.notification) => {
-           prerr_endline("Messages: " ++ notification.message);
-           notification.message == "success:1";
+           notification.message == "success:1"
          });
     },
   );
@@ -63,8 +62,7 @@ runTest(~name="ExtHostWorkspaceSearchTest", ({dispatch, wait, _}) => {
       let notifications = Feature_Notification.all(state.notifications);
       notifications
       |> List.exists((notification: Feature_Notification.notification) => {
-           prerr_endline("Messages: " ++ notification.message);
-           notification.message == "success:5";
+           notification.message == "success:5"
          });
     },
   );

--- a/integration_test/ExtHostWorkspaceSearchTest.re
+++ b/integration_test/ExtHostWorkspaceSearchTest.re
@@ -1,0 +1,95 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// This test validates:
+// - The 'oni-dev' extension gets activated
+// - When typing in an 'oni-dev' buffer, we get some completion results
+runTest(~name="ExtHostWorkspaceSearchTest", ({input, dispatch, wait, _}) => {
+  wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
+    Feature_Exthost.isInitialized(state.exthost)
+  );
+
+  // Wait until the extension is activated
+  // Give some time for the exthost to start
+  wait(
+    ~timeout=30.0,
+    ~name="Validate the 'oni-dev' extension gets activated",
+    (state: State.t) =>
+    List.exists(
+      id => id == "oni-dev-extension",
+      state.extensions |> Feature_Extensions.activatedIds,
+    )
+  );
+
+  // Search for 1 match
+  dispatch(
+    Actions.Extensions(
+      Feature_Extensions.Msg.command(
+        ~command="_test.findFiles",
+        ~arguments=[`Int(1)],
+      ),
+    ),
+  );
+
+  // Wait for a notification
+  wait(
+    ~timeout=30.,
+    ~name="Got success notification for 1 result",
+    (state: State.t) => {
+      let notifications = Feature_Notification.all(state.notifications);
+      notifications
+      |> List.exists((notification: Feature_Notification.notification) => {
+           prerr_endline("Messages: " ++ notification.message);
+           notification.message == "success:1";
+         });
+    },
+  );
+
+  // Search for multiple matches
+  dispatch(
+    Actions.Extensions(
+      Feature_Extensions.Msg.command(
+        ~command="_test.findFiles",
+        ~arguments=[`Int(5)],
+      ),
+    ),
+  );
+
+  // Wait for a notification
+  wait(
+    ~timeout=60.,
+    ~name="Got success notification for 5 results",
+    (state: State.t) => {
+      let notifications = Feature_Notification.all(state.notifications);
+      notifications
+      |> List.exists((notification: Feature_Notification.notification) => {
+           prerr_endline("Messages: " ++ notification.message);
+           notification.message == "success:5";
+         });
+    },
+  );
+  // Wait for the oni-dev filetype
+  // wait(
+  //   ~timeout=30.0,
+  //   ~name="Wait for oni-dev filetype to show up",
+  //   (state: State.t) => {
+  //     let fileType =
+  //       Selectors.getActiveBuffer(state)
+  //       |> Option.map(Buffer.getFileType)
+  //       |> Option.map(Buffer.FileType.toString);
+  //     fileType == Some("oni-dev");
+  //   },
+  // );
+  // Enter some text
+  // input("i");
+  // input("R");
+  // Should get completions
+  // wait(
+  //   ~timeout=30.0,
+  //   ~name="Validate we get some completions from the 'oni-dev' extension",
+  //   (state: State.t) =>
+  //   state.languageSupport
+  //   |> Feature_LanguageSupport.Completion.availableCompletionCount > 0
+  // );
+});

--- a/integration_test/ExtHostWorkspaceSearchTest.re
+++ b/integration_test/ExtHostWorkspaceSearchTest.re
@@ -68,27 +68,4 @@ runTest(~name="ExtHostWorkspaceSearchTest", ({dispatch, wait, _}) => {
          });
     },
   );
-  // Wait for the oni-dev filetype
-  // wait(
-  //   ~timeout=30.0,
-  //   ~name="Wait for oni-dev filetype to show up",
-  //   (state: State.t) => {
-  //     let fileType =
-  //       Selectors.getActiveBuffer(state)
-  //       |> Option.map(Buffer.getFileType)
-  //       |> Option.map(Buffer.FileType.toString);
-  //     fileType == Some("oni-dev");
-  //   },
-  // );
-  // Enter some text
-  // input("i");
-  // input("R");
-  // Should get completions
-  // wait(
-  //   ~timeout=30.0,
-  //   ~name="Validate we get some completions from the 'oni-dev' extension",
-  //   (state: State.t) =>
-  //   state.languageSupport
-  //   |> Feature_LanguageSupport.Completion.availableCompletionCount > 0
-  // );
 });

--- a/integration_test/ExtHostWorkspaceSearchTest.re
+++ b/integration_test/ExtHostWorkspaceSearchTest.re
@@ -49,7 +49,7 @@ runTest(~name="ExtHostWorkspaceSearchTest", ({dispatch, wait, _}) => {
     Actions.Extensions(
       Feature_Extensions.Msg.command(
         ~command="_test.findFiles",
-        ~arguments=[`Int(5)],
+        ~arguments=[`Int(3)],
       ),
     ),
   );
@@ -62,7 +62,7 @@ runTest(~name="ExtHostWorkspaceSearchTest", ({dispatch, wait, _}) => {
       let notifications = Feature_Notification.all(state.notifications);
       notifications
       |> List.exists((notification: Feature_Notification.notification) => {
-           notification.message == "success:5"
+           notification.message == "success:3"
          });
     },
   );

--- a/integration_test/ExtHostWorkspaceSearchTest.re
+++ b/integration_test/ExtHostWorkspaceSearchTest.re
@@ -1,11 +1,10 @@
-open Oni_Core;
 open Oni_Model;
 open Oni_IntegrationTestLib;
 
 // This test validates:
 // - The 'oni-dev' extension gets activated
 // - When typing in an 'oni-dev' buffer, we get some completion results
-runTest(~name="ExtHostWorkspaceSearchTest", ({input, dispatch, wait, _}) => {
+runTest(~name="ExtHostWorkspaceSearchTest", ({dispatch, wait, _}) => {
   wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
     Feature_Exthost.isInitialized(state.exthost)
   );

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,11 +1,70 @@
 (executables
- (names InsertModeTest ExtHostWorkspaceSearchTest)
+ (names InsertModeTest ClipboardInsertModePasteMultiLineTest
+   ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
+   ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
+   ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
+   ConfigurationInvalidThemeTest ConfigurationPerFileTypeTest
+   EditorFontFromPathTest EditorFontValidTest EditorSplitFileTest
+   EditorUtf8Test ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
+   ExCommandKeybindingNormTest ExtConfigurationChangedTest
+   ExtHostBufferOpenTest ExtHostBufferUpdatesTest ExtHostCompletionTest
+   ExtHostDefinitionTest ExtHostWorkspaceSearchTest FileWatcherTest
+   KeybindingsInvalidJsonTest KeySequenceJJTest InputIgnoreTest
+   InputContextKeysTest InputRemapMotionTest LanguageCssTest
+   LanguageTypeScriptTest LineEndingsLFTest LineEndingsCRLFTest
+   QuickOpenEventuallyCompletesTest SearchShowClearHighlightsTest
+   SyntaxServer SyntaxServerCloseTest SyntaxServerMessageExceptionTest
+   SyntaxServerParentPidTest SyntaxServerParentPidCorrectTest
+   SyntaxServerReadExceptionTest Regression1671Test Regression2349EnewTest
+   Regression2988SwitchEditorTest Regression3084CommandLoopTest
+   RegressionCommandLineNoCompletionTest RegressionFontFallbackTest
+   RegressionFileModifiedIndicationTest RegressionNonExistentDirectory
+   RegressionVspEmptyInitialBufferTest RegressionVspEmptyExistingBufferTest
+   SCMGitTest SyntaxHighlightPhpTest SyntaxHighlightTextMateTest
+   SyntaxHighlightTreesitterTest AddRemoveSplitTest TerminalSetPidTitleTest
+   TerminalConfigurationTest TypingBatchedTest TypingUnbatchedTest
+   VimIncsearchScrollTest VimExperimentalVimlTest VimRemapTimeoutTest
+   VimSimpleRemapTest VimlRemapCmdlineTest ClipboardChangeTest
+   VimScriptLocalFunctionTest ZenModeSingleFileModeTest ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
  (section bin)
  (package OniIntegrationTests)
- (files run-tests.sh InsertModeTest.exe ExtHostWorkspaceSearchTest.exe
+ (files run-tests.sh InsertModeTest.exe
+   ClipboardInsertModePasteMultiLineTest.exe
+   ClipboardInsertModePasteSingleLineTest.exe
+   ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
+   ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
+   ConfigurationInvalidThemeTest.exe ConfigurationPerFileTypeTest.exe
+   CopyActiveFilepathToClipboardTest.exe EchoNotificationTest.exe
+   EditorFontFromPathTest.exe EditorFontValidTest.exe EditorSplitFileTest.exe
+   EditorUtf8Test.exe ExCommandKeybindingTest.exe
+   ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
+   ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
+   ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
+   ExtHostDefinitionTest.exe ExtHostWorkspaceSearchTest FileWatcherTest.exe
+   KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
+   InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
+   LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
+   QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
+   Regression2349EnewTest.exe Regression2988SwitchEditorTest.exe
+   Regression3084CommandLoopTest.exe
+   RegressionCommandLineNoCompletionTest.exe
+   RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
+   RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe
+   RegressionVspEmptyExistingBufferTest.exe SCMGitTest.exe
+   SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
+   SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
+   SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
+   SyntaxHighlightPhpTest.exe SyntaxServerParentPidTest.exe
+   SyntaxServerParentPidCorrectTest.exe SyntaxServerReadExceptionTest.exe
+   TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
+   AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
+   VimExperimentalVimlTest.exe VimIncsearchScrollTest.exe
+   VimScriptLocalFunctionTest.exe VimRemapTimeoutTest.exe
+   VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
+   ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe ClipboardChangeTest.exe
    large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
    test.lf test-syntax.php utf8.txt utf8-test-file.htm
    Inconsolata-Regular.ttf PlugScriptLocal.vim))

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -43,7 +43,7 @@
    ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
    ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
    ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
-   ExtHostDefinitionTest.exe ExtHostWorkspaceSearchTest FileWatcherTest.exe
+   ExtHostDefinitionTest.exe ExtHostWorkspaceSearchTest.exe FileWatcherTest.exe
    KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
    InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
    LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -43,13 +43,13 @@
    ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
    ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
    ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
-   ExtHostDefinitionTest.exe ExtHostWorkspaceSearchTest.exe FileWatcherTest.exe
-   KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
-   InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
-   LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
-   QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
-   Regression2349EnewTest.exe Regression2988SwitchEditorTest.exe
-   Regression3084CommandLoopTest.exe
+   ExtHostDefinitionTest.exe ExtHostWorkspaceSearchTest.exe
+   FileWatcherTest.exe KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe
+   InputIgnoreTest.exe InputContextKeysTest.exe InputRemapMotionTest.exe
+   LanguageCssTest.exe LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe
+   LineEndingsLFTest.exe QuickOpenEventuallyCompletesTest.exe
+   Regression1671Test.exe Regression2349EnewTest.exe
+   Regression2988SwitchEditorTest.exe Regression3084CommandLoopTest.exe
    RegressionCommandLineNoCompletionTest.exe
    RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
    RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,70 +1,11 @@
 (executables
- (names InsertModeTest ClipboardInsertModePasteMultiLineTest
-   ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
-   ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
-   ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
-   ConfigurationInvalidThemeTest ConfigurationPerFileTypeTest
-   EditorFontFromPathTest EditorFontValidTest EditorSplitFileTest
-   EditorUtf8Test ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
-   ExCommandKeybindingNormTest ExtConfigurationChangedTest
-   ExtHostBufferOpenTest ExtHostBufferUpdatesTest ExtHostCompletionTest
-   ExtHostDefinitionTest FileWatcherTest KeybindingsInvalidJsonTest
-   KeySequenceJJTest InputIgnoreTest InputContextKeysTest
-   InputRemapMotionTest LanguageCssTest LanguageTypeScriptTest
-   LineEndingsLFTest LineEndingsCRLFTest QuickOpenEventuallyCompletesTest
-   SearchShowClearHighlightsTest SyntaxServer SyntaxServerCloseTest
-   SyntaxServerMessageExceptionTest SyntaxServerParentPidTest
-   SyntaxServerParentPidCorrectTest SyntaxServerReadExceptionTest
-   Regression1671Test Regression2349EnewTest Regression2988SwitchEditorTest
-   Regression3084CommandLoopTest RegressionCommandLineNoCompletionTest
-   RegressionFontFallbackTest RegressionFileModifiedIndicationTest
-   RegressionNonExistentDirectory RegressionVspEmptyInitialBufferTest
-   RegressionVspEmptyExistingBufferTest SCMGitTest SyntaxHighlightPhpTest
-   SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
-   AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
-   TypingBatchedTest TypingUnbatchedTest VimIncsearchScrollTest
-   VimExperimentalVimlTest VimRemapTimeoutTest VimSimpleRemapTest
-   VimlRemapCmdlineTest ClipboardChangeTest VimScriptLocalFunctionTest
-   ZenModeSingleFileModeTest ZenModeSplitTest)
+ (names InsertModeTest ExtHostWorkspaceSearchTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
  (section bin)
  (package OniIntegrationTests)
- (files run-tests.sh InsertModeTest.exe
-   ClipboardInsertModePasteMultiLineTest.exe
-   ClipboardInsertModePasteSingleLineTest.exe
-   ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
-   ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
-   ConfigurationInvalidThemeTest.exe ConfigurationPerFileTypeTest.exe
-   CopyActiveFilepathToClipboardTest.exe EchoNotificationTest.exe
-   EditorFontFromPathTest.exe EditorFontValidTest.exe EditorSplitFileTest.exe
-   EditorUtf8Test.exe ExCommandKeybindingTest.exe
-   ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
-   ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
-   ExtHostBufferUpdatesTest.exe ExtHostCompletionTest.exe
-   ExtHostDefinitionTest.exe FileWatcherTest.exe
-   KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
-   InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
-   LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
-   QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
-   Regression2349EnewTest.exe Regression2988SwitchEditorTest.exe
-   Regression3084CommandLoopTest.exe
-   RegressionCommandLineNoCompletionTest.exe
-   RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
-   RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe
-   RegressionVspEmptyExistingBufferTest.exe SCMGitTest.exe
-   SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
-   SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
-   SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
-   SyntaxHighlightPhpTest.exe SyntaxServerParentPidTest.exe
-   SyntaxServerParentPidCorrectTest.exe SyntaxServerReadExceptionTest.exe
-   TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
-   AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
-   VimExperimentalVimlTest.exe VimIncsearchScrollTest.exe
-   VimScriptLocalFunctionTest.exe VimRemapTimeoutTest.exe
-   VimSimpleRemapTest.exe VimlRemapCmdlineTest.exe
-   ZenModeSingleFileModeTest.exe ZenModeSplitTest.exe ClipboardChangeTest.exe
+ (files run-tests.sh InsertModeTest.exe ExtHostWorkspaceSearchTest.exe
    large-c-file.c lsan.supp some-test-file.json some-test-file.txt test.crlf
    test.lf test-syntax.php utf8.txt utf8-test-file.htm
    Inconsolata-Regular.ttf PlugScriptLocal.vim))

--- a/src/Service/OS/Service_OS.re
+++ b/src/Service/OS/Service_OS.re
@@ -70,6 +70,8 @@ module Api = {
         if (!shouldContinue(initial)) {
           Lwt.return(initial)
         } else {
+        Lwt.catch(() => {
+          
     readdir(rootPath)
     |> LwtEx.flatMap(entries => {
          entries
@@ -103,7 +105,11 @@ module Api = {
               },
               Lwt.return(initial),
             )
-       });
+       })
+      } , exn => {
+        Log.warnf(m => m("Error while running Service_OS.fold on %s: %s", rootPath, Printexc.to_string(exn)));
+        Lwt.return(initial)
+       })
        };
   };
 

--- a/src/Service/OS/Service_OS.re
+++ b/src/Service/OS/Service_OS.re
@@ -142,7 +142,7 @@ module Api = {
     let shouldContinue =
       switch (maxCount) {
       | None => (_ => true)
-      | Some(max) => (list => ListEx.boundedLength(~max, list) >= max)
+      | Some(max) => (list => ListEx.boundedLength(~max, list) < max)
       };
 
     fold(
@@ -152,7 +152,13 @@ module Api = {
       ~initial=[],
       (acc, curr) => [curr, ...acc],
       path,
-    );
+    )
+    |> Lwt.map(items => {
+         switch (maxCount) {
+         | None => items
+         | Some(count) => items |> ListEx.firstk(count)
+         }
+       });
   };
 
   let readFile = (~chunkSize=4096, path) => {

--- a/src/Service/OS/Service_OS.rei
+++ b/src/Service/OS/Service_OS.rei
@@ -1,18 +1,8 @@
 open Oni_Core;
 
 module Api: {
-  let fold:
-    (
-      ~includeFiles: string => bool,
-      ~excludeDirectory: string => bool,
-      ~initial: 'a,
-      ('a, string) => 'a,
-      string
-    ) =>
-    Lwt.t('a);
-
   let glob:
-    (~includeFiles: string=?, ~excludeDirectories: string=?, string) =>
+    (~maxCount: int=?, ~includeFiles: string=?, ~excludeDirectories: string=?, string) =>
     Lwt.t(list(string));
 
   let rmdir: (~recursive: bool=?, string) => Lwt.t(unit);

--- a/src/Service/OS/Service_OS.rei
+++ b/src/Service/OS/Service_OS.rei
@@ -2,7 +2,12 @@ open Oni_Core;
 
 module Api: {
   let glob:
-    (~maxCount: int=?, ~includeFiles: string=?, ~excludeDirectories: string=?, string) =>
+    (
+      ~maxCount: int=?,
+      ~includeFiles: string=?,
+      ~excludeDirectories: string=?,
+      string
+    ) =>
     Lwt.t(list(string));
 
   let rmdir: (~recursive: bool=?, string) => Lwt.t(unit);

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -204,8 +204,11 @@ let create =
           : Lwt.return(Reply.error("Unable to open URI"))
       | Window(GetWindowVisibility) =>
         Lwt.return(Reply.okJson(`Bool(true)))
-      | Workspace(StartFileSearch({includePattern, excludePattern, _})) =>
+      | Workspace(
+          StartFileSearch({includePattern, excludePattern, maxResults}),
+        ) =>
         Service_OS.Api.glob(
+          ~maxCount=?maxResults,
           ~includeFiles=?includePattern,
           ~excludeDirectories=?excludePattern,
           // TODO: Pull from store


### PR DESCRIPTION
__Issue:__ Some extensions that use the `vscode.workspace.findFiles` API wouldn't work as expected - like the [Live Server](https://open-vsx.org/extension/ritwickdey/LiveServer) extension.

__Defect:__ The `maxCount` argument wasn't being used by Onivim - so for a very large folder, we might not finish traversing for a while. In addition, the `readdir` call could fail, in which case no result would be returned at at all.
 
__Fix:__ Implement handling of `maxCount`, and short-circuit the find-in-files once the limit is reached. This fixes the first blocking issue for #3215 