### PR TITLE
fix(extensions/#3215): Part 2 - Implement 'vscode.workspace.saveAll' API

### DIFF
--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1588,6 +1588,7 @@ module Msg: {
   module Workspace: {
     [@deriving show]
     type msg =
+      | SaveAll({includeUntitled: bool})
       | StartFileSearch({
           includePattern: option(string),
           //        includeFolder: option(Oni_Core.Uri.t),

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -1699,6 +1699,7 @@ module Window = {
 module Workspace = {
   [@deriving show]
   type msg =
+    | SaveAll({includeUntitled: bool})
     | StartFileSearch({
         includePattern: option(string),
         //        includeFolder: option(Oni_Core.Uri.t),
@@ -1709,6 +1710,26 @@ module Workspace = {
   let handle = (method, args: Yojson.Safe.t) => {
     Base.Result.Let_syntax.(
       switch (method) {
+      | "$saveAll" =>
+        switch (args) {
+        | `List([]) => Ok(SaveAll({includeUntitled: false}))
+        | `List([includeUntitledJson]) =>
+          let%bind includeUntitled =
+            includeUntitledJson
+            |> Internal.decode_value(Json.Decode.nullable(Decode.bool));
+          Ok(
+            SaveAll({
+              includeUntitled:
+                includeUntitled |> Option.value(~default=false),
+            }),
+          );
+        | _ =>
+          Error(
+            "Unexpected arguments for $saveAll: "
+            ++ Yojson.Safe.to_string(args),
+          )
+        }
+
       | "$startFileSearch" =>
         switch (args) {
         | `List([

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -204,6 +204,15 @@ let create =
           : Lwt.return(Reply.error("Unable to open URI"))
       | Window(GetWindowVisibility) =>
         Lwt.return(Reply.okJson(`Bool(true)))
+
+      | Workspace(SaveAll({includeUntitled})) =>
+        ignore(includeUntitled);
+
+        dispatch(
+          Actions.VimExecuteCommand({command: "wa!", allowAnimation: false}),
+        );
+        Lwt.return(Reply.okEmpty);
+
       | Workspace(
           StartFileSearch({includePattern, excludePattern, maxResults}),
         ) =>


### PR DESCRIPTION
This fixes part 2 of #3215 - the live-server extension has an `await vscode.workspace.saveAll()` call, which Onivim was currently not handling - since this promise never returned, the extension would not start the session.

