### PR TITLE
fix(notifications/#3245): Remove glitchy animation

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -42,6 +42,7 @@
 - #3241 - Extensions: Handle `maxCount` and FS errors in `vscode.workspace.findFiles` (related #3215)
 - #3248 - Extension - Windows: Fix path normalization issue in document selector (fixes #3238)
 - #3251 - QuickOpen: Show filename first in Control+P/Command+P menu (fixes #2259, #3165)
+- #3252 - UX: Fix glitchy pane animation (fixes #3245)
 
 ### Performance
 

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -784,20 +784,20 @@ module View = {
       </Sneakable>
     | _ => React.empty
     };
-  let%component make =
-                (
-                  ~config,
-                  ~isFocused,
-                  ~theme,
-                  ~iconTheme,
-                  ~languageInfo,
-                  ~editorFont: Service_Font.font,
-                  ~uiFont,
-                  ~dispatch: msg => unit,
-                  ~pane: model,
-                  ~workingDirectory: string,
-                  (),
-                ) => {
+  let make =
+      (
+        ~config,
+        ~isFocused,
+        ~theme,
+        ~iconTheme,
+        ~languageInfo,
+        ~editorFont: Service_Font.font,
+        ~uiFont,
+        ~dispatch: msg => unit,
+        ~pane: model,
+        ~workingDirectory: string,
+        (),
+      ) => {
     let problemsTabClicked = () => {
       dispatch(TabClicked(Diagnostics));
     };
@@ -812,21 +812,7 @@ module View = {
     };
 
     let desiredHeight = height(pane);
-    let targetHeight = !isOpen(pane) && !isFocused ? 0 : desiredHeight;
-
-    let animationEnabled =
-      pane.allowAnimation
-      && Feature_Configuration.GlobalConfiguration.animation.get(config);
-    let%hook (springHeight, _setHeightImmediately) =
-      Hooks.spring(
-        ~name="Pane Open Spring",
-        ~target=float(targetHeight),
-        ~restThreshold=10.,
-        ~enabled=animationEnabled,
-        Animation.openSpring,
-      );
-
-    let height = springHeight < 20. ? 0 : int_of_float(springHeight);
+    let height = !isOpen(pane) && !isFocused ? 0 : desiredHeight;
 
     let opacity =
       isFocused

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -747,10 +747,6 @@ module View = {
       |> Option.value(~default=React.empty)
     };
 
-  module Animation = {
-    let openSpring = Spring.Options.create(~stiffness=600., ~damping=50., ());
-  };
-
   let closeButton = (~theme, ~dispatch, ()) => {
     <Sneakable
       sneakId="close"

--- a/src/Feature/Pane/Feature_Pane.rei
+++ b/src/Feature/Pane/Feature_Pane.rei
@@ -84,7 +84,6 @@ let setOutput: (string, option(string), model) => model;
 module View: {
   let make:
     (
-      ~key: Brisk_reconciler.Key.t=?,
       ~config: Config.resolver,
       ~isFocused: bool,
       ~theme: Oni_Core.ColorTheme.Colors.t,


### PR DESCRIPTION
This removes a potentially buggy animation when the notifications / references pane opens - the animation gets glitched because it is bouncing between a view-based (the pane) and a model-based (the layout) animations. A more robust approach would be to use a model-based animation for the pane, as well.

Fixes #3245 