### PR TITLE
fix(ci): OSX - Notarization: Fix typo in awk usage

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -67,3 +67,4 @@
 - #3220 - Dependency: revery -> 26e8b73 (Unblock OCaml 4.11)
 - #3228 - Quickmenu: Initial feature implementation
 - #3250 - Quickmenu: Move theme menus to new Quickmenu feature
+- #3254 - Release: Fix notarization step

--- a/scripts/osx/notarize.sh
+++ b/scripts/osx/notarize.sh
@@ -4,8 +4,17 @@ SHORT_COMMIT_ID=$(git rev-parse --short HEAD)
 echo "Code signing certificate specified - notarizing zip"
 
 echo "Uploading to apple to notarize..."
-notarize_uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onivim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.app.zip" 2>&1 | grep RequestUUID | awk '{print $3'})
+notarize_output=$(xcrun altool --notarize-app --primary-bundle-id "com.outrunlabs.onivim2" --username $APPLE_DEVELOPER_ID --password $APPLE_NOTARIZE_PASSWORD --file "_release/Onivim2.app.zip" 2>&1)
+
+echo "$notarize_output" > notarize_output.tmp
+echo "xcrun altool output: $notarize_output"
+
+notarize_uuid=$(grep RequestUUID notarize_output.tmp | awk '{print $3}')
+
 # Load cert
+echo "notarize uuid: $notarize_uuid"
+
+rm notarize_output.tmp
 
 if  [ -z "$notarize_uuid" ]
 then
@@ -26,6 +35,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
 
 	if [ $? -ne 0 ] || [[ "${progress}" =~ "Invalid" ]]; then
 		echo "Error with notarization. Exiting"
+        exit 1
 	fi
 
 	if [[ "${progress}" =~ "success" ]]; then

--- a/scripts/osx/notarize.sh
+++ b/scripts/osx/notarize.sh
@@ -26,7 +26,6 @@ else
 	echo "Got notarization UUID: $notarize_uuid"
 fi
 
-
 success=0
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
 	echo "Checking progress..."


### PR DESCRIPTION
__Issue:__ The nightly builds were out-of-date, as the notarization step of the build process was failing

__Defect:__ There was a typo in our script that caused extraction of the notarization UUID to fail debugging on the output of the `xcrun altool` command

__Fix:__ Fix typo; add some more logging to assist in debugging future issues