### PR TITLE
fix(codelens): CodeLens disappear when pressing 'enter' in insert mode

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -44,6 +44,7 @@
 - #3251 - QuickOpen: Show filename first in Control+P/Command+P menu (fixes #2259, #3165)
 - #3249 - Extensions: Send 'onCommand' activation event (related #3215)
 - #3252 - UX: Remove glitchy pane animation (fixes #3245)
+- #3255 - CodeLens: Fix disappearing lens when pressing enter in insert mode
 
 ### Performance
 

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1677,12 +1677,13 @@ let unprojectToPixel =
 
 let getBufferId = ({buffer, _}) => EditorBuffer.id(buffer);
 
-let updateBuffer = (~update, ~buffer, editor) => {
+let updateBuffer = (~update, ~markerUpdate, ~buffer, editor) => {
   {
     ...editor,
     buffer,
     wrapState: WrapState.update(~update, ~buffer, editor.wrapState),
-    inlineElements: InlineElements.shift(update, editor.inlineElements),
+    inlineElements:
+      InlineElements.moveMarkers(markerUpdate, editor.inlineElements),
   };
 };
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -263,7 +263,13 @@ let unprojectToPixel:
 let setSize: (~pixelWidth: int, ~pixelHeight: int, t) => t;
 
 let updateBuffer:
-  (~update: Oni_Core.BufferUpdate.t, ~buffer: EditorBuffer.t, t) => t;
+  (
+    ~update: Oni_Core.BufferUpdate.t,
+    ~markerUpdate: Oni_Core.MarkerUpdate.t,
+    ~buffer: EditorBuffer.t,
+    t
+  ) =>
+  t;
 let setBuffer: (~buffer: EditorBuffer.t, t) => t;
 
 let configurationChanged:

--- a/src/Feature/Editor/InlineElements.re
+++ b/src/Feature/Editor/InlineElements.re
@@ -483,26 +483,44 @@ let getAllReservedSpace = ({cache, _}) => {
 };
 
 // When there is a buffer update, shift elements as needed
-let shift = (update: Oni_Core.BufferUpdate.t, model) => {
-  let startLineIdx = update.startLine |> LineNumber.toZeroBased;
-  let endLineIdx = update.endLine |> LineNumber.toZeroBased;
+let moveMarkers = (markerUpdate: Oni_Core.MarkerUpdate.t, model) => {
+  // let startLineIdx = update.startLine |> LineNumber.toZeroBased;
+  // let endLineIdx = update.endLine |> LineNumber.toZeroBased;
 
-  let delta = Array.length(update.lines) - (endLineIdx - startLineIdx);
+  // let delta = Array.length(update.lines) - (endLineIdx - startLineIdx);
 
-  if (update.isFull || delta == 0) {
-    model;
-  } else {
-    let keyToElements' =
-      model.keyToElements
-      |> IntMap.shift(
-           ~default=_ => None,
-           ~startPos=startLineIdx,
-           ~endPos=endLineIdx,
-           ~delta,
-         );
-
-    keyToElements' |> makeConsistent;
+  let shiftLines = (~afterLine, ~delta, keyToElements) => {
+    let line = EditorCoreTypes.LineNumber.toZeroBased(afterLine);
+    keyToElements |> IntMap.shift(~startPos=line, ~endPos=line, ~delta);
   };
+
+  let clearLine = (~line, keyToElements) => {
+    keyToElements
+    |> IntMap.remove(line |> EditorCoreTypes.LineNumber.toZeroBased);
+  };
+
+  let shiftCharacters =
+      (
+        ~line as _,
+        ~afterByte as _,
+        ~deltaBytes as _,
+        ~afterCharacter as _,
+        ~deltaCharacters as _,
+        keyToElements,
+      ) => {
+    keyToElements;
+  };
+
+  let keyToElements' =
+    MarkerUpdate.apply(
+      ~clearLine,
+      ~shiftLines,
+      ~shiftCharacters,
+      markerUpdate,
+      model.keyToElements,
+    );
+
+  keyToElements' |> makeConsistent;
 };
 
 let animate = (msg, model) => {

--- a/src/Feature/Editor/InlineElements.re
+++ b/src/Feature/Editor/InlineElements.re
@@ -484,11 +484,6 @@ let getAllReservedSpace = ({cache, _}) => {
 
 // When there is a buffer update, shift elements as needed
 let moveMarkers = (markerUpdate: Oni_Core.MarkerUpdate.t, model) => {
-  // let startLineIdx = update.startLine |> LineNumber.toZeroBased;
-  // let endLineIdx = update.endLine |> LineNumber.toZeroBased;
-
-  // let delta = Array.length(update.lines) - (endLineIdx - startLineIdx);
-
   let shiftLines = (~afterLine, ~delta, keyToElements) => {
     let line = EditorCoreTypes.LineNumber.toZeroBased(afterLine);
     keyToElements |> IntMap.shift(~startPos=line, ~endPos=line, ~delta);

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1439,7 +1439,12 @@ let update =
             Feature_Layout.map(
               editor =>
                 if (Editor.getBufferId(editor) == bufferId) {
-                  Editor.updateBuffer(~update=bufferUpdate, ~buffer, editor);
+                  Editor.updateBuffer(
+                    ~update=bufferUpdate,
+                    ~markerUpdate,
+                    ~buffer,
+                    editor,
+                  );
                 } else {
                   editor;
                 },


### PR DESCRIPTION
__Issue:__ When editing in insert mode, codelens disappear from the current line when pressing enter.

__Defect:__ The `BufferUpdate.t` is including the current line in the update, which causes the codelens to refresh, even though the line isn't changed.

__Fix:__ Use the `MarkerUpdate.t` instead, which is more minimal and does not adjust markers for the originating line.

This is actually needed for #3246 as well, because one issue with that format-on-save implementation is that it causes all code lenses to be refreshed. 