### PR TITLE
fix(quickmenu): Fix quick menu smart case

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -44,6 +44,7 @@
 - #3251 - QuickOpen: Show filename first in Control+P/Command+P menu (fixes #2259, #3165)
 - #3249 - Extensions: Send 'onCommand' activation event (related #3215)
 - #3252 - UX: Remove glitchy pane animation (fixes #3245)
+- #3259 - Quickmenu: Implement smart case (thanks @amiralies!)
 
 ### Performance
 

--- a/src/Feature/Quickmenu/Schema.re
+++ b/src/Feature/Quickmenu/Schema.re
@@ -170,11 +170,12 @@ module Instance = {
           shouldLower ? String.lowercase_ascii(str) : str;
         };
         let queryStr = Component_InputText.value(text);
+        let shouldLower = queryStr == String.lowercase_ascii(queryStr);
         let query = Zed_utf8.explode(queryStr);
         let filteredItems =
           allItems
           |> List.filter(item =>
-               Filter.fuzzyMatches(query, schema.toString(item))
+               Filter.fuzzyMatches(query, format(item, ~shouldLower))
              )
           |> Filter.rank(queryStr, format)
           |> Array.of_list;


### PR DESCRIPTION
This fixes issue with smart casing while filtering items in quickmenu (theme picker, formatter picker, snippets..).