### PR TITLE
fix(formatting): Compute minimal updates for buffer updates / shifting

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -50,6 +50,7 @@
 
 - #3148 - Large Files: Improve performance & fix crash when opening large files (related #1670)
 - #3139 - Large Files: Fix hang when using `/` search (fixes #1670)
+- #3260 - Editor: Compute minimal updates, fix flash when reloading file
 
 ### Documentation
 

--- a/src/Core/MarkerUpdate.re
+++ b/src/Core/MarkerUpdate.re
@@ -1,7 +1,11 @@
 open EditorCoreTypes;
 
 type movement =
-  | ClearLine({line: LineNumber.t})
+  | Noop
+  | DeleteLines({
+      startLine: LineNumber.t,
+      stopLine: LineNumber.t,
+    })
   | ShiftLines({
       afterLine: LineNumber.t,
       delta: int,
@@ -16,87 +20,76 @@ type movement =
 
 type t = list(movement);
 
-let none = [];
+module Internal = {
+  let minimalUpdateToMovement: MinimalUpdate.update => movement =
+    update => {
+      MinimalUpdate.(
+        switch (update) {
+        | Added({beforeLine, lines}) =>
+          ShiftLines({afterLine: beforeLine, delta: Array.length(lines)})
+
+        | Deleted({startLine, stopLine}) =>
+          DeleteLines({startLine, stopLine})
+
+        | Modified({line, original, updated}) =>
+          let deltaBytes = String.length(updated) - String.length(original);
+
+          // For now, we'll only handle insertions / deletions
+          if (deltaBytes == 0) {
+            Noop;
+          } else {
+            Utility.StringEx.firstDifference(original, updated)
+            |> Option.map(firstDifferentByte => {
+                 let characterCount =
+                   Utility.StringEx.characterCount(
+                     ~startByte=0,
+                     ~endByte=firstDifferentByte,
+                     original,
+                   );
+
+                 // If delta bytes is less than 0 - ie, bytes were removed,
+                 // need to look at the original line
+                 let deltaCharacterCount =
+                   if (deltaBytes < 0) {
+                     Utility.StringEx.characterCount(
+                       ~startByte=firstDifferentByte,
+                       ~endByte=firstDifferentByte + abs(deltaBytes),
+                       original,
+                     )
+                     * (-1);
+                   } else {
+                     Utility.StringEx.characterCount(
+                       ~startByte=firstDifferentByte,
+                       ~endByte=firstDifferentByte + deltaBytes,
+                       updated,
+                     );
+                   };
+
+                 ShiftCharacters({
+                   line,
+                   afterByte: ByteIndex.ofInt(firstDifferentByte),
+                   deltaBytes,
+                   afterCharacter: CharacterIndex.ofInt(characterCount),
+                   deltaCharacters: deltaCharacterCount,
+                 });
+               })
+            |> Option.value(~default=Noop);
+          };
+        }
+      );
+    };
+};
 
 let create = (~update: BufferUpdate.t, ~original, ~updated) =>
   if (update.isFull) {
-    none;
+    let minimalUpdate = MinimalUpdate.fromBuffers(~original, ~updated);
+
+    MinimalUpdate.map(Internal.minimalUpdateToMovement, minimalUpdate);
   } else {
-    let startPos = update.startLine |> EditorCoreTypes.LineNumber.toZeroBased;
-    let endPos = update.endLine |> EditorCoreTypes.LineNumber.toZeroBased;
-    let len = Array.length(update.lines);
-    let delta = Array.length(update.lines) - (endPos - startPos);
-    if (delta == 0
-        && len == 1
-        && Buffer.getNumberOfLines(original) > startPos
-        && Buffer.getNumberOfLines(updated) > startPos) {
-      // Single line was updated - we can adjust the bytes / characters in the line
-      let originalLine =
-        original |> Buffer.getLine(startPos) |> BufferLine.raw;
+    let minimalUpdate =
+      MinimalUpdate.fromBufferUpdate(~buffer=original, ~update);
 
-      let newLine = updated |> Buffer.getLine(startPos) |> BufferLine.raw;
-
-      let deltaBytes = String.length(newLine) - String.length(originalLine);
-
-      // For now, we'll only handle insertions / deletions
-      if (deltaBytes == 0) {
-        none;
-      } else {
-        Utility.StringEx.firstDifference(originalLine, newLine)
-        |> Option.map(firstDifferentByte => {
-             let characterCount =
-               Utility.StringEx.characterCount(
-                 ~startByte=0,
-                 ~endByte=firstDifferentByte,
-                 originalLine,
-               );
-
-             // If delta bytes is less than 0 - ie, bytes were removed,
-             // need to look at the original line
-             let deltaCharacterCount =
-               if (deltaBytes < 0) {
-                 Utility.StringEx.characterCount(
-                   ~startByte=firstDifferentByte,
-                   ~endByte=firstDifferentByte + abs(deltaBytes),
-                   originalLine,
-                 )
-                 * (-1);
-               } else {
-                 Utility.StringEx.characterCount(
-                   ~startByte=firstDifferentByte,
-                   ~endByte=firstDifferentByte + deltaBytes,
-                   newLine,
-                 );
-               };
-
-             ShiftCharacters({
-               line: update.startLine,
-               afterByte: ByteIndex.ofInt(firstDifferentByte),
-               deltaBytes,
-               afterCharacter: CharacterIndex.ofInt(characterCount),
-               deltaCharacters: deltaCharacterCount,
-             });
-           })
-        |> Option.to_list;
-      };
-    } else if (delta != 0) {
-      let afterLine = delta < 0 ? update.startLine : update.endLine;
-      let candidate = ShiftLines({afterLine, delta});
-
-      // Pure delete - let's clear out the lines in the update
-      if (delta < 0 && Array.length(update.lines) == 0) {
-        let linesToClear =
-          List.init(abs(delta), i =>
-            ClearLine({line: LineNumber.(update.startLine + i)})
-          );
-
-        [candidate, ...linesToClear] |> List.rev;
-      } else {
-        [candidate];
-      };
-    } else {
-      none;
-    };
+    MinimalUpdate.map(Internal.minimalUpdateToMovement, minimalUpdate);
   };
 
 let apply = (~clearLine, ~shiftLines, ~shiftCharacters, markerUpdate, target) => {
@@ -104,10 +97,26 @@ let apply = (~clearLine, ~shiftLines, ~shiftCharacters, markerUpdate, target) =>
   |> List.fold_left(
        (acc, movement) => {
          switch (movement) {
-         | ClearLine({line}) => clearLine(~line, acc)
+         | Noop => acc
 
          | ShiftLines({afterLine, delta}) =>
            shiftLines(~afterLine, ~delta, acc)
+
+         | DeleteLines({startLine, stopLine}) =>
+           let delta =
+             LineNumber.toZeroBased(stopLine)
+             - LineNumber.toZeroBased(startLine);
+
+           let rec clear = (acc, idx) =>
+             if (idx >= delta) {
+               acc;
+             } else {
+               let acc' = clearLine(~line=LineNumber.(startLine + idx), acc);
+               clear(acc', idx + 1);
+             };
+
+           let acc' = clear(acc, 0);
+           shiftLines(~afterLine=startLine, ~delta=- delta, acc');
 
          | ShiftCharacters({
              line,

--- a/src/Core/MinimalUpdate.re
+++ b/src/Core/MinimalUpdate.re
@@ -1,0 +1,330 @@
+open EditorCoreTypes;
+
+[@deriving show]
+type update =
+  | Added({
+      beforeLine: LineNumber.t,
+      lines: array(string),
+    })
+  | Deleted({
+      startLine: LineNumber.t,
+      stopLine: LineNumber.t,
+    })
+  | Modified({
+      line: LineNumber.t,
+      original: string,
+      updated: string,
+    });
+
+let shift = (startLine: LineNumber.t, update) => {
+  let idx = LineNumber.toZeroBased(startLine);
+  LineNumber.(
+    switch (update) {
+    | Added({beforeLine, lines}) =>
+      Added({beforeLine: beforeLine + idx, lines})
+    | Deleted({startLine, stopLine}) =>
+      Deleted({startLine: startLine + idx, stopLine: stopLine + idx})
+    | Modified({line, original, updated}) =>
+      Modified({line: line + idx, original, updated})
+    }
+  );
+};
+
+[@deriving show]
+type t = list(update);
+
+let map = List.map;
+
+let toDebugString = show;
+
+module Internal = {
+  let compute = (~original, ~updated) => {
+    let originalLineCount = Array.length(original);
+    let updatedLineCount = Array.length(updated);
+
+    let (deletes, adds) = Diff.f(original, updated);
+
+    let isAdded = i => {
+      i < updatedLineCount && adds[i];
+    };
+
+    let isDeleted = i => {
+      i < originalLineCount && deletes[i];
+    };
+
+    // Return the number of 'true' lines, after `idx`
+    let numberOfTrue = (idx, array) => {
+      let len = Array.length(array);
+
+      let rec loop = (acc, curr) =>
+        if (curr >= len) {
+          acc;
+        } else if (array[curr]) {
+          loop(acc + 1, curr + 1);
+        } else {
+          acc;
+        };
+
+      loop(0, idx);
+    };
+
+    // TODO: Fix recursion
+    // Maybe track index for original and udpated separately?
+    let rec loop = (acc, originalIdx, updatedIdx) =>
+      if (updatedIdx >= updatedLineCount && originalIdx >= originalLineCount) {
+        // Reached end of both arrays, at the same time
+        acc;
+        // } else if (originalIdx >= originalLineCount && updatedIdx < updatedLineCount) {
+        // TODO: Reached end of original lines, but still adds
+        //   acc;
+        // } else if (updatedIdx >= updatedLineCount
+        //            && originalIdx < originalLineCount) {
+        // TODO: Reached end up of updated lines, but still deletes
+        //   acc;
+      } else {
+        switch (isDeleted(originalIdx), isAdded(updatedIdx)) {
+        // Modified line
+        | (true, true) =>
+          let lineIdx = LineNumber.ofZeroBased(originalIdx);
+          loop(
+            [
+              Modified({
+                line: lineIdx,
+                original: original[originalIdx],
+                updated: updated[updatedIdx],
+              }),
+              ...acc,
+            ],
+            originalIdx + 1,
+            updatedIdx + 1,
+          );
+
+        // Deleted line
+        | (true, false) =>
+          let lineIdx = LineNumber.ofZeroBased(originalIdx);
+          let additionalDeletes = numberOfTrue(originalIdx, deletes);
+          loop(
+            [
+              Deleted({
+                startLine: lineIdx,
+                stopLine: LineNumber.(lineIdx + additionalDeletes),
+              }),
+              ...acc,
+            ],
+            originalIdx + additionalDeletes,
+            updatedIdx,
+          );
+
+        | (false, true) =>
+          let additionalAdds = numberOfTrue(updatedIdx, adds);
+          let lines = Array.sub(updated, updatedIdx, additionalAdds);
+
+          let lineIdx = LineNumber.ofZeroBased(originalIdx);
+          loop(
+            [Added({beforeLine: lineIdx, lines}), ...acc],
+            originalIdx,
+            updatedIdx + additionalAdds,
+          );
+
+        | (false, false) => loop(acc, originalIdx + 1, updatedIdx + 1)
+        };
+      };
+
+    loop([], 0, 0);
+  };
+
+  let%test_module "compute" =
+    (module
+     {
+       let%test "empty arrays result in no updates" = {
+         let original = [||];
+         let updated = [||];
+         compute(~original, ~updated) == [];
+       };
+
+       let%test "modification gives an edit" = {
+         let original = [|"a"|];
+         let updated = [|"b"|];
+         compute(~original, ~updated)
+         == [Modified({line: LineNumber.zero, original: "a", updated: "b"})];
+       };
+
+       let%test "delete line in middle of array" = {
+         let original = [|"a", "b", "c"|];
+         let updated = [|"a", "c"|];
+         compute(~original, ~updated)
+         == [
+              Deleted({
+                startLine: LineNumber.(zero + 1),
+                stopLine: LineNumber.(zero + 2),
+              }),
+            ];
+       };
+
+       let%test "delete multiple lines in middle of array" = {
+         let original = [|"a", "b", "c", "d"|];
+         let updated = [|"a", "d"|];
+         compute(~original, ~updated)
+         == [
+              Deleted({
+                startLine: LineNumber.(zero + 1),
+                stopLine: LineNumber.(zero + 3),
+              }),
+            ];
+       };
+
+       let%test "add line in middle of array" = {
+         let original = [|"a", "c"|];
+         let updated = [|"a", "b", "c"|];
+         compute(~original, ~updated)
+         == [Added({beforeLine: LineNumber.(zero + 1), lines: [|"b"|]})];
+       };
+
+       let%test "add multiple lines in middle of array" = {
+         let original = [|"a", "d"|];
+         let updated = [|"a", "b", "c", "d"|];
+         compute(~original, ~updated)
+         == [
+              Added({beforeLine: LineNumber.(zero + 1), lines: [|"b", "c"|]}),
+            ];
+       };
+
+       let%test "add single line to empty array" = {
+         let original = [||];
+         let updated = [|"a"|];
+         compute(~original, ~updated)
+         == [Added({beforeLine: LineNumber.(zero), lines: [|"a"|]})];
+       };
+
+       let%test "add multiple lines to empty array" = {
+         let original = [||];
+         let updated = [|"a", "b"|];
+         compute(~original, ~updated)
+         == [Added({beforeLine: LineNumber.(zero), lines: [|"a", "b"|]})];
+       };
+
+       let%test "remove single line to empty array" = {
+         let original = [|"a"|];
+         let updated = [||];
+         compute(~original, ~updated)
+         == [
+              Deleted({
+                startLine: LineNumber.(zero),
+                stopLine: LineNumber.(zero + 1),
+              }),
+            ];
+       };
+
+       let%test "remove multiple lines to empty array" = {
+         let original = [|"a", "b"|];
+         let updated = [||];
+         compute(~original, ~updated)
+         == [
+              Deleted({
+                startLine: LineNumber.(zero),
+                stopLine: LineNumber.(zero + 2),
+              }),
+            ];
+       };
+
+       let%test "remove separate lines" = {
+         let original = [|"a", "b", "c", "d", "e"|];
+         let updated = [|"a", "c", "e"|];
+         compute(~original, ~updated)
+         == [
+              Deleted({
+                startLine: LineNumber.(zero + 3),
+                stopLine: LineNumber.(zero + 4),
+              }),
+              Deleted({
+                startLine: LineNumber.(zero + 1),
+                stopLine: LineNumber.(zero + 2),
+              }),
+            ];
+       };
+
+       let%test "add separate lines" = {
+         let original = [|"a", "c", "e"|];
+         let updated = [|"a", "b", "c", "d", "e"|];
+         let ret = compute(~original, ~updated);
+         ret
+         == [
+              Added({beforeLine: LineNumber.(zero + 2), lines: [|"d"|]}),
+              Added({beforeLine: LineNumber.(zero + 1), lines: [|"b"|]}),
+            ];
+       };
+
+       let%test "add separate, multiple lines" = {
+         let original = [|"a", "c", "e"|];
+         let updated = [|"a", "b0", "b1", "c", "d0", "d1", "e"|];
+         let ret = compute(~original, ~updated);
+         ret
+         == [
+              Added({
+                beforeLine: LineNumber.(zero + 2),
+                lines: [|"d0", "d1"|],
+              }),
+              Added({
+                beforeLine: LineNumber.(zero + 1),
+                lines: [|"b0", "b1"|],
+              }),
+            ];
+       };
+
+       let%test "delete some, add some" = {
+         let original = [|"a", "b0", "b1", "c", "e"|];
+         let updated = [|"a", "c", "d0", "d1", "e"|];
+         let ret = compute(~original, ~updated);
+         ret
+         == [
+              Added({
+                beforeLine: LineNumber.(zero + 4),
+                lines: [|"d0", "d1"|],
+              }),
+              Deleted({
+                startLine: LineNumber.(zero + 1),
+                stopLine: LineNumber.(zero + 3),
+              }),
+            ];
+       };
+
+       let%test "add some, delete some" = {
+         let original = [|"a", "c", "d0", "d1", "e"|];
+         let updated = [|"a", "b0", "b1", "c", "e"|];
+         let ret = compute(~original, ~updated);
+         ret
+         == [
+              Deleted({
+                startLine: LineNumber.(zero + 2),
+                stopLine: LineNumber.(zero + 4),
+              }),
+              Added({
+                beforeLine: LineNumber.(zero + 1),
+                lines: [|"b0", "b1"|],
+              }),
+            ];
+       };
+     });
+};
+
+let fromBuffers = (~original, ~updated) => {
+  let originalLines = Buffer.getLines(original);
+  let updatedLines = Buffer.getLines(updated);
+
+  Internal.compute(~original=originalLines, ~updated=updatedLines);
+};
+
+let fromBufferUpdate = (~buffer: Buffer.t, ~update: BufferUpdate.t) => {
+  let original =
+    if (update.startLine == update.endLine) {
+      [||];
+    } else {
+      let startIdx = EditorCoreTypes.LineNumber.toZeroBased(update.startLine);
+      let stopIdx = EditorCoreTypes.LineNumber.toZeroBased(update.endLine);
+      let allOriginalLines = Buffer.getLines(buffer);
+      Array.sub(allOriginalLines, startIdx, stopIdx - startIdx);
+    };
+  let updated = update.lines;
+
+  Internal.compute(~original, ~updated) |> List.map(shift(update.startLine));
+};

--- a/src/Core/MinimalUpdate.re
+++ b/src/Core/MinimalUpdate.re
@@ -321,9 +321,15 @@ let fromBufferUpdate = (~buffer: Buffer.t, ~update: BufferUpdate.t) => {
     } else {
       let startIdx = EditorCoreTypes.LineNumber.toZeroBased(update.startLine);
       let stopIdx = EditorCoreTypes.LineNumber.toZeroBased(update.endLine);
-      let allOriginalLines = Buffer.getLines(buffer);
-      Array.sub(allOriginalLines, startIdx, stopIdx - startIdx);
+      let lines = Buffer.getLines(buffer);
+      Utility.ArrayEx.slice(
+        ~lines,
+        ~start=startIdx,
+        ~length=stopIdx - startIdx,
+        (),
+      );
     };
+
   let updated = update.lines;
 
   Internal.compute(~original, ~updated) |> List.map(shift(update.startLine));

--- a/src/Core/MinimalUpdate.rei
+++ b/src/Core/MinimalUpdate.rei
@@ -1,0 +1,26 @@
+open EditorCoreTypes;
+
+type update =
+  | Added({
+      beforeLine: LineNumber.t,
+      lines: array(string),
+    })
+  | Deleted({
+      startLine: LineNumber.t,
+      stopLine: LineNumber.t,
+    })
+  | Modified({
+      line: LineNumber.t,
+      original: string,
+      updated: string,
+    });
+
+type t;
+
+let toDebugString: t => string;
+
+let map: (update => 'a, t) => list('a);
+
+let fromBuffers: (~original: Buffer.t, ~updated: Buffer.t) => t;
+
+let fromBufferUpdate: (~buffer: Buffer.t, ~update: BufferUpdate.t) => t;

--- a/src/Feature/Syntax/Feature_Syntax.re
+++ b/src/Feature/Syntax/Feature_Syntax.re
@@ -266,7 +266,7 @@ let handleUpdate =
         );
     };
     newHighlights^;
-  } else if (!bufferUpdate.isFull) {
+  } else {
     // Otherwise, if not a full update, we'll pre-emptively shift highlights
     // to give immediate feedback.
     let highlights =
@@ -328,8 +328,6 @@ let handleUpdate =
         bufferHighlights.highlights,
       );
     {...bufferHighlights, highlights};
-  } else {
-    bufferHighlights;
   };
 
 let update: (t, msg) => (t, outmsg) =


### PR DESCRIPTION
In cases where there is a scoped buffer update, like a few lines, Onivim is smart enough to shift 'markers' (syntax highlighting, codelens in #3255 , search highlights).

However, there are some cases where we get a full update - the entire buffer contents is flagged as updated. A couple of these cases are:
- Running `:e!` to re-load the file from disk - this comes through as a refresh of the entire buffer
- Some format providers provide scoped updates (ie, line-by-line). Others, however, like `ocamllsp` just send the whole buffer contents.

The problem with processing the full update is that, today, those don't shift markers - we just clear out syntax highlighting, codelens, etc. This is a poor user experience, because it causes 'flashes' of syntax highlighting disappearing, or codelens disappearing and then re-appearing.

In order to have a better experience - this PR adds the computation of a set of minimal updates from these full updates. After computing minimal updates, Onivim can then properly shift markers, codelens, syntax highlighting, etc.

This is important for #3246 , as this same logic will be used to shift and preserve the cursor position.