### PR TITLE
fix(formatting): Adjust cursor position based on formatting edits

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -45,6 +45,7 @@
 - #3249 - Extensions: Send 'onCommand' activation event (related #3215)
 - #3252 - UX: Remove glitchy pane animation (fixes #3245)
 - #3255 - CodeLens: Fix disappearing lens when pressing enter in insert mode
+- #3263 - Formatting: Update cursor position based on formatting edits
 
 ### Performance
 

--- a/bench/lib/BufferBench.re
+++ b/bench/lib/BufferBench.re
@@ -30,6 +30,7 @@ let hundredThousandLines = Array.make(100000, "Another big buffer update");
 let addLinesToEmptyBuffer = () => {
   let _ =
     BufferUpdate.create(
+      ~shouldAdjustCursorPosition=false,
       ~id=emptyBufferId,
       ~startLine=LineNumber.zero,
       ~endLine=LineNumber.ofZeroBased(-1),
@@ -44,6 +45,7 @@ let addLinesToEmptyBuffer = () => {
 let clearLargeBuffer = () => {
   let _ =
     BufferUpdate.create(
+      ~shouldAdjustCursorPosition=false,
       ~id=hundredThousandLineBufferId,
       ~startLine=LineNumber.zero,
       ~endLine=LineNumber.ofZeroBased(-1),
@@ -58,6 +60,7 @@ let clearLargeBuffer = () => {
 let insertInMiddleOfSmallBuffer = () => {
   let _ =
     BufferUpdate.create(
+      ~shouldAdjustCursorPosition=false,
       ~id=smallBufferId,
       ~startLine=LineNumber.ofZeroBased(50),
       ~endLine=LineNumber.ofZeroBased(51),
@@ -72,6 +75,7 @@ let insertInMiddleOfSmallBuffer = () => {
 let insertInMiddleOfLargeBuffer = () => {
   let _ =
     BufferUpdate.create(
+      ~shouldAdjustCursorPosition=false,
       ~id=hundredThousandLineBufferId,
       ~startLine=LineNumber.ofZeroBased(5000),
       ~endLine=LineNumber.ofZeroBased(50001),

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -142,6 +142,7 @@ let thousandLineStateWithIndents =
     createUpdateAction(
       thousandLineBuffer,
       BufferUpdate.create(
+        ~shouldAdjustCursorPosition=false,
         ~startLine=LineNumber.zero,
         ~endLine=LineNumber.ofZeroBased(1),
         ~lines=thousandLinesWithIndents,
@@ -160,6 +161,7 @@ let hundredThousandLineState =
     createUpdateAction(
       Buffer.ofLines(~font=Font.default(), [||]),
       BufferUpdate.create(
+        ~shouldAdjustCursorPosition=false,
         ~startLine=LineNumber.zero,
         ~endLine=LineNumber.ofZeroBased(1),
         ~lines=hundredThousandLines,

--- a/bench/lib/Helpers.re
+++ b/bench/lib/Helpers.re
@@ -115,6 +115,7 @@ let thousandLineState =
     createUpdateAction(
       thousandLineBuffer,
       BufferUpdate.create(
+        ~shouldAdjustCursorPosition=false,
         ~startLine=LineNumber.zero,
         ~endLine=LineNumber.ofZeroBased(1),
         ~lines=thousandLines,

--- a/src/Core/BufferUpdate.re
+++ b/src/Core/BufferUpdate.re
@@ -9,12 +9,20 @@ type t = {
   endLine: LineNumber.t,
   lines: [@opaque] array(string),
   version: int,
-
   shouldAdjustCursorPosition: bool,
 };
 
 let create =
-    (~id=0, ~isFull=false, ~startLine, ~endLine, ~lines, ~version, ~shouldAdjustCursorPosition, ()) => {
+    (
+      ~id=0,
+      ~isFull=false,
+      ~startLine,
+      ~endLine,
+      ~lines,
+      ~version,
+      ~shouldAdjustCursorPosition,
+      (),
+    ) => {
   id,
   startLine,
   endLine,
@@ -24,7 +32,18 @@ let create =
   shouldAdjustCursorPosition,
 };
 
-let toDebugString = ({isFull, version, startLine, endLine, lines, shouldAdjustCursorPosition, _}) => {
+let toDebugString =
+    (
+      {
+        isFull,
+        version,
+        startLine,
+        endLine,
+        lines,
+        shouldAdjustCursorPosition,
+        _,
+      },
+    ) => {
   let lineStr =
     lines
     |> Array.to_list

--- a/src/Core/BufferUpdate.re
+++ b/src/Core/BufferUpdate.re
@@ -9,28 +9,32 @@ type t = {
   endLine: LineNumber.t,
   lines: [@opaque] array(string),
   version: int,
+
+  shouldAdjustCursorPosition: bool,
 };
 
 let create =
-    (~id=0, ~isFull=false, ~startLine, ~endLine, ~lines, ~version, ()) => {
+    (~id=0, ~isFull=false, ~startLine, ~endLine, ~lines, ~version, ~shouldAdjustCursorPosition, ()) => {
   id,
   startLine,
   endLine,
   lines,
   version,
   isFull,
+  shouldAdjustCursorPosition,
 };
 
-let toDebugString = ({isFull, version, startLine, endLine, lines, _}) => {
+let toDebugString = ({isFull, version, startLine, endLine, lines, shouldAdjustCursorPosition, _}) => {
   let lineStr =
     lines
     |> Array.to_list
     |> List.mapi((idx, str) => Printf.sprintf("Line %d: |%s|", idx, str))
     |> String.concat("\n");
   Printf.sprintf(
-    "Core.BufferUpdate - version %d (full: %b) - startLine: %d endLine:%d\nLines:\n---\n%s\n---\n\n",
+    "Core.BufferUpdate - version %d (full: %b adjustCursor: %b) - startLine: %d endLine:%d\nLines:\n---\n%s\n---\n\n",
     version,
     isFull,
+    shouldAdjustCursorPosition,
     startLine |> LineNumber.toZeroBased,
     endLine |> LineNumber.toZeroBased,
     lineStr,

--- a/src/Core/BufferUpdate.rei
+++ b/src/Core/BufferUpdate.rei
@@ -9,7 +9,6 @@ type t = {
   endLine: LineNumber.t,
   lines: array(string),
   version: int,
-
   // [shouldAdjustCursorPosition] describes if the client should calculate a new cursor position based on the update.
   // For some updates, the cursor position has already been updated (ie, insert mode edits), so `shouldAdjustCursorPosition` would be `false`.
   // Other edits, like formatting, may not have adjusted the cursor position, and are relying on the client to make adjustments in the `true` case.

--- a/src/Core/BufferUpdate.rei
+++ b/src/Core/BufferUpdate.rei
@@ -9,6 +9,11 @@ type t = {
   endLine: LineNumber.t,
   lines: array(string),
   version: int,
+
+  // [shouldAdjustCursorPosition] describes if the client should calculate a new cursor position based on the update.
+  // For some updates, the cursor position has already been updated (ie, insert mode edits), so `shouldAdjustCursorPosition` would be `false`.
+  // Other edits, like formatting, may not have adjusted the cursor position, and are relying on the client to make adjustments in the `true` case.
+  shouldAdjustCursorPosition: bool,
 };
 
 let create:
@@ -19,6 +24,7 @@ let create:
     ~endLine: LineNumber.t,
     ~lines: array(string),
     ~version: int,
+    ~shouldAdjustCursorPosition: bool,
     unit
   ) =>
   t;

--- a/src/Core/MarkerUpdate.re
+++ b/src/Core/MarkerUpdate.re
@@ -1,5 +1,6 @@
 open EditorCoreTypes;
 
+[@deriving show]
 type movement =
   | Noop
   | DeleteLines({
@@ -18,6 +19,7 @@ type movement =
       deltaCharacters: int,
     });
 
+[@deriving show]
 type t = list(movement);
 
 module Internal = {
@@ -138,3 +140,5 @@ let apply = (~clearLine, ~shiftLines, ~shiftCharacters, markerUpdate, target) =>
        target,
      );
 };
+
+let toDebugString = show;

--- a/src/Core/MarkerUpdate.rei
+++ b/src/Core/MarkerUpdate.rei
@@ -22,3 +22,5 @@ let apply:
     'a
   ) =>
   'a;
+
+let toDebugString: t => string;

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1678,73 +1678,79 @@ let unprojectToPixel =
 let getBufferId = ({buffer, _}) => EditorBuffer.id(buffer);
 
 let updateBuffer = (~update, ~markerUpdate, ~buffer, editor) => {
-  let shiftCursor = (~f, mode) => {
-      switch (mode: Vim.Mode.t) {
-      // Don't touch command-line mode
-      | CommandLine(orig) => Vim.Mode.CommandLine(orig)
+  let shiftCursor = (f, mode) => {
+    switch ((mode: Vim.Mode.t)) {
+    // Don't touch command-line mode
+    | CommandLine(orig) => Vim.Mode.CommandLine(orig)
 
-      // Cancel pending operator, if we have a shift
-      | Operator({cursor, _}) => Vim.Mode.Normal({cursor: f(cursor)})
-      | Normal({cursor}) => Normal({cursor: f(cursor)})
-      | Visual(curr) =>
-        Visual(Vim.VisualRange.{...curr, anchor: f(curr.anchor), cursor: f(curr.cursor)})
-      | Select({ranges}) => 
+    // Cancel pending operator, if we have a shift
+    | Operator({cursor, _}) => Vim.Mode.Normal({cursor: f(cursor)})
+    | Normal({cursor}) => Normal({cursor: f(cursor)})
+    | Visual(curr) =>
+      Visual(
+        Vim.VisualRange.{
+          ...curr,
+          anchor: f(curr.anchor),
+          cursor: f(curr.cursor),
+        },
+      )
+    | Select({ranges}) =>
       // TODO: Properly shift ranges
       Select({ranges: ranges})
-      | Replace({cursor}) => Replace({cursor: f(cursor)})
-      | Insert({cursors}) => Insert({cursors: List.map(f, cursors)})
-      };
+    | Replace({cursor}) => Replace({cursor: f(cursor)})
+    | Insert({cursors}) => Insert({cursors: List.map(f, cursors)})
+    };
   };
 
   // Check if we _should_ shift cursor
   let shiftLines = (~afterLine, ~delta: int, mode) => {
-    let moveByte = (bytePosition: BytePosition.t) => {
+    let moveByte = (bytePosition: BytePosition.t) =>
       if (bytePosition.line >= afterLine) {
         BytePosition.{
           ...bytePosition,
           line: EditorCoreTypes.LineNumber.(bytePosition.line + delta),
-        }
+        };
       } else {
-        bytePosition
-      }
-    };
+        bytePosition;
+      };
     shiftCursor(moveByte, mode);
   };
 
   let clearLine = (~line as _, mode) => mode;
 
-  let shiftCharacters = (
-    ~line,
-    ~afterByte,
-    ~deltaBytes,
-    ~afterCharacter as _,
-    ~deltaCharacters as _,
-    mode,
-  ) => {
-    let moveByte = (bytePosition: BytePosition.t) => {
+  let shiftCharacters =
+      (
+        ~line,
+        ~afterByte,
+        ~deltaBytes,
+        ~afterCharacter as _,
+        ~deltaCharacters as _,
+        mode,
+      ) => {
+    let moveByte = (bytePosition: BytePosition.t) =>
       if (bytePosition.line == line && bytePosition.byte >= afterByte) {
         BytePosition.{
           ...bytePosition,
-          byte: ByteIndex.(bytePosition.byte + deltaBytes)
-        }
+          byte: ByteIndex.(bytePosition.byte + deltaBytes),
+        };
       } else {
-        bytePosition
-      }
-    };
+        bytePosition;
+      };
     shiftCursor(moveByte, mode);
   };
 
-  let mode' = if (true) {
-    MarkerUpdate.apply(
-      ~clearLine,
-      ~shiftLines,
-      ~shiftCharacters,
-      markerUpdate,
-      editor.mode
-    )
-  } else {
-    editor.mode
-  };
+  let mode' =
+    if (BufferUpdate.(update.shouldAdjustCursorPosition)) {
+      MarkerUpdate.apply(
+        ~clearLine,
+        ~shiftLines,
+        ~shiftCharacters,
+        markerUpdate,
+        editor.mode,
+      );
+    } else {
+      editor.mode;
+    };
 
   {
     ...editor,

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1678,8 +1678,77 @@ let unprojectToPixel =
 let getBufferId = ({buffer, _}) => EditorBuffer.id(buffer);
 
 let updateBuffer = (~update, ~markerUpdate, ~buffer, editor) => {
+  let shiftCursor = (~f, mode) => {
+      switch (mode: Vim.Mode.t) {
+      // Don't touch command-line mode
+      | CommandLine(orig) => Vim.Mode.CommandLine(orig)
+
+      // Cancel pending operator, if we have a shift
+      | Operator({cursor, _}) => Vim.Mode.Normal({cursor: f(cursor)})
+      | Normal({cursor}) => Normal({cursor: f(cursor)})
+      | Visual(curr) =>
+        Visual(Vim.VisualRange.{...curr, anchor: f(curr.anchor), cursor: f(curr.cursor)})
+      | Select({ranges}) => 
+      // TODO: Properly shift ranges
+      Select({ranges: ranges})
+      | Replace({cursor}) => Replace({cursor: f(cursor)})
+      | Insert({cursors}) => Insert({cursors: List.map(f, cursors)})
+      };
+  };
+
+  // Check if we _should_ shift cursor
+  let shiftLines = (~afterLine, ~delta: int, mode) => {
+    let moveByte = (bytePosition: BytePosition.t) => {
+      if (bytePosition.line >= afterLine) {
+        BytePosition.{
+          ...bytePosition,
+          line: EditorCoreTypes.LineNumber.(bytePosition.line + delta),
+        }
+      } else {
+        bytePosition
+      }
+    };
+    shiftCursor(moveByte, mode);
+  };
+
+  let clearLine = (~line as _, mode) => mode;
+
+  let shiftCharacters = (
+    ~line,
+    ~afterByte,
+    ~deltaBytes,
+    ~afterCharacter as _,
+    ~deltaCharacters as _,
+    mode,
+  ) => {
+    let moveByte = (bytePosition: BytePosition.t) => {
+      if (bytePosition.line == line && bytePosition.byte >= afterByte) {
+        BytePosition.{
+          ...bytePosition,
+          byte: ByteIndex.(bytePosition.byte + deltaBytes)
+        }
+      } else {
+        bytePosition
+      }
+    };
+    shiftCursor(moveByte, mode);
+  };
+
+  let mode' = if (true) {
+    MarkerUpdate.apply(
+      ~clearLine,
+      ~shiftLines,
+      ~shiftCharacters,
+      markerUpdate,
+      editor.mode
+    )
+  } else {
+    editor.mode
+  };
+
   {
     ...editor,
+    mode: mode',
     buffer,
     wrapState: WrapState.update(~update, ~buffer, editor.wrapState),
     inlineElements:

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -163,6 +163,7 @@ module Internal = {
       } else {
         let effect =
           Service_Vim.Effects.applyEdits(
+            ~shouldAdjustCursors=true, // Make sure the cursor ends up in the right place, due to the formatting edits
             ~bufferId=buffer |> Oni_Core.Buffer.getId,
             ~version=buffer |> Oni_Core.Buffer.getVersion,
             ~edits,
@@ -503,6 +504,7 @@ let update =
       } else {
         let effect =
           Service_Vim.Effects.applyEdits(
+            ~shouldAdjustCursors=true,
             ~bufferId=activeSession.bufferId,
             ~version=activeSession.bufferVersion,
             ~edits,

--- a/src/Feature/Snippets/Feature_Snippets.re
+++ b/src/Feature/Snippets/Feature_Snippets.re
@@ -484,6 +484,7 @@ module Effects = {
         | Error(msg) => SnippetInsertionError(msg);
 
       Service_Vim.Effects.setLines(
+        ~shouldAdjustCursors=false, // We're going to be manually adjusting the cursor for snippet placeholders
         ~bufferId,
         ~start=replaceStartLine,
         ~stop=LineNumber.(position.line + 1),

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -59,7 +59,7 @@ module Effects = {
 
   let applyEdits =
       (
-        ~shouldAdjustCursors, 
+        ~shouldAdjustCursors,
         ~bufferId: int,
         ~version: int,
         ~edits: list(Vim.Edit.t),
@@ -157,8 +157,14 @@ module Effects = {
       let buffer = Vim.Buffer.getCurrent();
 
       if (additionalEdits != []) {
-        let _: result(unit, string) = Vim.Buffer.applyEdits(~shouldAdjustCursors=true, ~edits=additionalEdits, buffer)
-      }
+        let _: result(unit, string) =
+          Vim.Buffer.applyEdits(
+            ~shouldAdjustCursors=true,
+            ~edits=additionalEdits,
+            buffer,
+          );
+        ();
+      };
 
       dispatch(toMsg(mode));
     });

--- a/src/Service/Vim/Service_Vim.rei
+++ b/src/Service/Vim/Service_Vim.rei
@@ -15,6 +15,7 @@ module Effects: {
 
   let applyEdits:
     (
+      ~shouldAdjustCursors: bool,
       ~bufferId: int,
       ~version: int,
       ~edits: list(Vim.Edit.t),
@@ -24,6 +25,7 @@ module Effects: {
 
   let setLines:
     (
+      ~shouldAdjustCursors: bool,
       ~bufferId: int,
       ~start: LineNumber.t=?,
       ~stop: LineNumber.t=?,

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -422,6 +422,7 @@ let start =
           ~endLine=EditorCoreTypes.LineNumber.ofOneBased(endLine),
           ~lines=update.lines,
           ~version=update.version,
+          ~shouldAdjustCursorPosition=update.shouldAdjustCursorPosition,
           (),
         );
 

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -751,7 +751,7 @@ let start =
         |> Vim.Buffer.getById
         |> Option.iter(buf => {
              Vim.Buffer.setModifiable(~modifiable=true, buf);
-             Vim.Buffer.setLines(~lines, buf);
+             Vim.Buffer.setLines(~shouldAdjustCursors=false, ~lines, buf);
              Vim.Buffer.setModifiable(~modifiable=false, buf);
              Vim.Buffer.setReadOnly(~readOnly=true, buf);
            });

--- a/src/reason-libvim/Buffer.re
+++ b/src/reason-libvim/Buffer.re
@@ -82,27 +82,29 @@ let setLineEndings = (buffer, lineEnding) => {
      );
 };
 
-let setLines = (~undoable=false, ~start=?, ~stop=?, ~lines, buffer) => {
-  let startLine =
-    switch (start) {
-    | Some(v) => LineNumber.toOneBased(v) - 1
-    | None => 0
+let setLines = (~undoable=false, ~start=?, ~stop=?, ~shouldAdjustCursors, ~lines, buffer) => {
+  BufferUpdateTracker.watch(~shouldAdjustCursors, () => {
+    let startLine =
+      switch (start) {
+      | Some(v) => LineNumber.toOneBased(v) - 1
+      | None => 0
+      };
+
+    let endLine =
+      switch (stop) {
+      | Some(v) => LineNumber.toOneBased(v) - 1
+      | None => (-1)
+      };
+
+    if (undoable) {
+      Undo.saveRegion(startLine - 1, endLine + 1);
     };
 
-  let endLine =
-    switch (stop) {
-    | Some(v) => LineNumber.toOneBased(v) - 1
-    | None => (-1)
-    };
-
-  if (undoable) {
-    Undo.saveRegion(startLine - 1, endLine + 1);
-  };
-
-  Native.vimBufferSetLines(buffer, startLine, endLine, lines);
+    Native.vimBufferSetLines(buffer, startLine, endLine, lines);
+  });
 };
 
-let applyEdits = (~edits, buffer) => {
+let applyEdits = (~shouldAdjustCursors, ~edits, buffer) => {
   let provider = idx => {
     let lineCount = getLineCount(buffer);
     if (idx >= lineCount) {
@@ -153,7 +155,7 @@ let applyEdits = (~edits, buffer) => {
                   Some(LineNumber.(oldEndLine + 1));
                 };
 
-              setLines(~start=oldStartLine, ~stop?, ~lines=newLines, buffer);
+              setLines(~shouldAdjustCursors, ~start=oldStartLine, ~stop?, ~lines=newLines, buffer);
               loop(tail);
             }
           )

--- a/src/reason-libvim/BufferInternal.re
+++ b/src/reason-libvim/BufferInternal.re
@@ -33,7 +33,8 @@ let string_opt = s =>
   };
 
 let doFullUpdate = (buffer: t) => {
-  let bu = BufferUpdate.createFull(buffer);
+  let shouldAdjustCursorPosition = BufferUpdateTracker.shouldAdjustCursors();
+  let bu = BufferUpdate.createFull(~shouldAdjustCursorPosition, buffer);
   notifyUpdate(buffer);
   Event.dispatch(bu, Listeners.bufferUpdate);
 };

--- a/src/reason-libvim/BufferUpdate.re
+++ b/src/reason-libvim/BufferUpdate.re
@@ -4,6 +4,7 @@ type t = {
   endLine: int,
   lines: array(string),
   version: int,
+  shouldAdjustCursorPosition: bool,
 };
 
 let show = (v: t) => {
@@ -45,7 +46,7 @@ let createInitial = (buffer: Native.buffer) => {
   let version = Native.vimBufferGetChangedTick(buffer) - 1;
   let lines = getAllLines(buffer);
 
-  {id, startLine: 1, endLine: (-1), lines, version};
+  {id, startLine: 1, endLine: (-1), lines, version, shouldAdjustCursorPosition: false};
 };
 
 let createIncremental =
@@ -66,7 +67,7 @@ let createIncremental =
     incr(idx);
   };
 
-  {id, startLine, endLine, lines, version};
+  {id, startLine, endLine, lines, version, shouldAdjustCursorPosition: false};
 };
 
 let createFull = (buffer: Native.buffer) => {
@@ -75,5 +76,5 @@ let createFull = (buffer: Native.buffer) => {
 
   let lines = getAllLines(buffer);
 
-  {id, startLine: 1, endLine: (-1), lines, version};
+  {id, startLine: 1, endLine: (-1), lines, version, shouldAdjustCursorPosition: false};
 };

--- a/src/reason-libvim/BufferUpdate.re
+++ b/src/reason-libvim/BufferUpdate.re
@@ -46,11 +46,24 @@ let createInitial = (buffer: Native.buffer) => {
   let version = Native.vimBufferGetChangedTick(buffer) - 1;
   let lines = getAllLines(buffer);
 
-  {id, startLine: 1, endLine: (-1), lines, version, shouldAdjustCursorPosition: false};
+  {
+    id,
+    startLine: 1,
+    endLine: (-1),
+    lines,
+    version,
+    shouldAdjustCursorPosition: false,
+  };
 };
 
 let createIncremental =
-    (~buffer: Native.buffer, ~startLine, ~endLine, ~extra: int) => {
+    (
+      ~shouldAdjustCursorPosition,
+      ~buffer: Native.buffer,
+      ~startLine,
+      ~endLine,
+      ~extra: int,
+    ) => {
   let id = Native.vimBufferGetId(buffer);
   let version = Native.vimBufferGetChangedTick(buffer);
   let idx: ref(int) = ref(startLine);
@@ -67,14 +80,21 @@ let createIncremental =
     incr(idx);
   };
 
-  {id, startLine, endLine, lines, version, shouldAdjustCursorPosition: false};
+  {id, startLine, endLine, lines, version, shouldAdjustCursorPosition};
 };
 
-let createFull = (buffer: Native.buffer) => {
+let createFull = (~shouldAdjustCursorPosition, buffer: Native.buffer) => {
   let id = Native.vimBufferGetId(buffer);
   let version = Native.vimBufferGetChangedTick(buffer);
 
   let lines = getAllLines(buffer);
 
-  {id, startLine: 1, endLine: (-1), lines, version, shouldAdjustCursorPosition: false};
+  {
+    id,
+    startLine: 1,
+    endLine: (-1),
+    lines,
+    version,
+    shouldAdjustCursorPosition,
+  };
 };

--- a/src/reason-libvim/BufferUpdateTracker.re
+++ b/src/reason-libvim/BufferUpdateTracker.re
@@ -1,0 +1,11 @@
+module Internal = {
+  let shouldAdjustCursors = ref(false);
+};
+
+let watch = (~shouldAdjustCursors, f) => {
+  let prev = Internal.shouldAdjustCursors^;
+  Internal.shouldAdjustCursors := shouldAdjustCursors;
+  f();
+  Internal.shouldAdjustCursors := prev;
+  ();
+};

--- a/src/reason-libvim/BufferUpdateTracker.re
+++ b/src/reason-libvim/BufferUpdateTracker.re
@@ -2,6 +2,8 @@ module Internal = {
   let shouldAdjustCursors = ref(false);
 };
 
+let shouldAdjustCursors: unit => bool = () => Internal.shouldAdjustCursors^;
+
 let watch = (~shouldAdjustCursors, f) => {
   let prev = Internal.shouldAdjustCursors^;
   Internal.shouldAdjustCursors := shouldAdjustCursors;

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -273,8 +273,15 @@ let _onAutocommand = (autoCommand: Types.autocmd, buffer: Buffer.t) => {
 
 let _onBufferChanged =
     (buffer: Buffer.t, startLine: int, endLine: int, extra: int) => {
+  let shouldAdjustCursorPosition = BufferUpdateTracker.shouldAdjustCursors();
   let update =
-    BufferUpdate.createIncremental(~buffer, ~startLine, ~endLine, ~extra);
+    BufferUpdate.createIncremental(
+      ~shouldAdjustCursorPosition,
+      ~buffer,
+      ~startLine,
+      ~endLine,
+      ~extra,
+    );
 
   BufferInternal.notifyUpdate(buffer);
 

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -895,6 +895,7 @@ let inputCommon = (~inputFn, ~context=Context.current(), v: string) => {
                Undo.saveRegion(lineNumber - 1, lineNumber + 1);
                // Clear out range, and replace with current line
                Buffer.setLines(
+                 ~shouldAdjustCursors=false,
                  ~start=range.start.line,
                  ~stop=EditorCoreTypes.LineNumber.(range.start.line + 1),
                  ~lines=[|updatedLine|],

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -326,7 +326,9 @@ module Buffer: {
     ) =>
     unit;
 
-  let applyEdits: (~shouldAdjustCursors: bool, ~edits: list(Edit.t), t) => result(unit, string);
+  let applyEdits:
+    (~shouldAdjustCursors: bool, ~edits: list(Edit.t), t) =>
+    result(unit, string);
 
   let onLineEndingsChanged:
     Listeners.bufferLineEndingsChangedListener => Event.unsubscribe;

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -320,12 +320,13 @@ module Buffer: {
       ~undoable: bool=?,
       ~start: LineNumber.t=?,
       ~stop: LineNumber.t=?,
+      ~shouldAdjustCursors: bool,
       ~lines: array(string),
       t
     ) =>
     unit;
 
-  let applyEdits: (~edits: list(Edit.t), t) => result(unit, string);
+  let applyEdits: (~shouldAdjustCursors: bool, ~edits: list(Edit.t), t) => result(unit, string);
 
   let onLineEndingsChanged:
     Listeners.bufferLineEndingsChangedListener => Event.unsubscribe;

--- a/test/Core/BufferTests.re
+++ b/test/Core/BufferTests.re
@@ -14,6 +14,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([||]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.zero,
           ~endLine=LineNumber.ofZeroBased(1),
           ~lines=[|"a"|],
@@ -28,6 +29,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a", "d", "e", "f", "c"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~isFull=true,
           ~startLine=LineNumber.zero,
           ~endLine=LineNumber.ofZeroBased(-1),
@@ -45,6 +47,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a", "d", "e", "f", "c"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~isFull=true,
           ~startLine=LineNumber.ofZeroBased(1),
           ~endLine=LineNumber.ofZeroBased(-1),
@@ -60,6 +63,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.zero,
           ~endLine=LineNumber.ofZeroBased(1),
           ~lines=[|"abc"|],
@@ -74,6 +78,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.zero,
           ~endLine=LineNumber.ofZeroBased(1),
           ~lines=[||],
@@ -88,6 +93,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a", "b", "c"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.ofZeroBased(1),
           ~endLine=LineNumber.ofZeroBased(2),
           ~lines=[|"d", "e", "f"|],
@@ -102,6 +108,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a", "b", "c"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.ofZeroBased(3),
           ~endLine=LineNumber.ofZeroBased(3),
           ~lines=[|"d"|],
@@ -116,6 +123,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([|"a", "b", "c"|]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.ofZeroBased(3),
           ~endLine=LineNumber.ofZeroBased(3),
           ~lines=[|"d"|],
@@ -131,6 +139,7 @@ describe("Buffer", ({describe, _}) =>
       let buffer = makeBuffer([||]);
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.ofZeroBased(3),
           ~endLine=LineNumber.ofZeroBased(3),
           ~lines=[|"d"|],
@@ -141,6 +150,7 @@ describe("Buffer", ({describe, _}) =>
 
       let update =
         BufferUpdate.create(
+          ~shouldAdjustCursorPosition=false,
           ~startLine=LineNumber.ofZeroBased(3),
           ~endLine=LineNumber.ofZeroBased(3),
           ~lines=[|"e"|],

--- a/test/Feature/Editor/WrappingTests.re
+++ b/test/Feature/Editor/WrappingTests.re
@@ -64,6 +64,7 @@ describe("Wrapping", ({describe, _}) => {
         let update =
           BufferUpdate.{
             id: 0,
+            shouldAdjustCursorPosition: false,
             startLine: LineNumber.ofZeroBased(0),
             endLine: LineNumber.ofZeroBased(1),
             lines: [|"aaaa"|],
@@ -88,6 +89,7 @@ describe("Wrapping", ({describe, _}) => {
         let update =
           BufferUpdate.{
             id: 0,
+            shouldAdjustCursorPosition: false,
             startLine: LineNumber.ofZeroBased(0),
             endLine: LineNumber.ofZeroBased(1),
             lines: [|"aa"|],
@@ -156,6 +158,7 @@ describe("Wrapping", ({describe, _}) => {
       let update =
         BufferUpdate.{
           id: 0,
+          shouldAdjustCursorPosition: false,
           startLine: LineNumber.ofZeroBased(0),
           endLine: LineNumber.ofZeroBased(1),
           lines: [|"aaa"|],
@@ -183,6 +186,7 @@ describe("Wrapping", ({describe, _}) => {
       let update =
         BufferUpdate.{
           id: 0,
+          shouldAdjustCursorPosition: false,
           startLine: LineNumber.ofZeroBased(0),
           endLine: LineNumber.ofZeroBased(1),
           lines: [|"aaaa"|],
@@ -216,6 +220,7 @@ describe("Wrapping", ({describe, _}) => {
         BufferUpdate.{
           id: 0,
           startLine: LineNumber.ofZeroBased(0),
+          shouldAdjustCursorPosition: false,
           endLine: LineNumber.ofZeroBased(1),
           lines: [|"aaaa"|],
           isFull: false,

--- a/test/reason-libvim/AutoIndentTest.re
+++ b/test/reason-libvim/AutoIndentTest.re
@@ -137,6 +137,7 @@ describe("AutoIndent", ({test, _}) => {
 
     buffer
     |> Vim.Buffer.setLines(
+         ~shouldAdjustCursors=false,
          ~lines=[|
            "line 1",
            "", // Add a line with spaces

--- a/test/reason-libvim/BufferTest.re
+++ b/test/reason-libvim/BufferTest.re
@@ -80,7 +80,12 @@ describe("Buffer", ({describe, _}) => {
       let updates: ref(list(BufferUpdate.t)) = ref([]);
       let dispose = Buffer.onUpdate(upd => updates := [upd, ...updates^]);
 
-      Buffer.setLines(~stop=LineNumber.zero, ~lines=[|"abc"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~stop=LineNumber.zero,
+        ~lines=[|"abc"|],
+        buffer,
+      );
       let line0 = Buffer.getLine(buffer, LineNumber.zero);
       let line1 = Buffer.getLine(buffer, LineNumber.(zero + 1));
       let lineCount = Buffer.getLineCount(buffer);

--- a/test/reason-libvim/BufferTest.re
+++ b/test/reason-libvim/BufferTest.re
@@ -110,7 +110,13 @@ describe("Buffer", ({describe, _}) => {
       let line2Index = LineNumber.(zero + 2);
 
       let lines = [|"abc"|];
-      Buffer.setLines(~start=line1Index, ~stop=line2Index, ~lines, buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~start=line1Index,
+        ~stop=line2Index,
+        ~lines,
+        buffer,
+      );
       let lineCount = Buffer.getLineCount(buffer);
       let line0 = Buffer.getLine(buffer, LineNumber.zero);
       let line1 = Buffer.getLine(buffer, LineNumber.(zero + 1));
@@ -129,7 +135,13 @@ describe("Buffer", ({describe, _}) => {
       let startVersion = Buffer.getVersion(buffer);
 
       let lines = [|"abc"|];
-      Buffer.setLines(~start=line1Index, ~stop=line2Index, ~lines, buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~start=line1Index,
+        ~stop=line2Index,
+        ~lines,
+        buffer,
+      );
       let newVersion = Buffer.getVersion(buffer);
       expect.equal(newVersion > startVersion, true);
     });
@@ -142,13 +154,20 @@ describe("Buffer", ({describe, _}) => {
       let line2Index = LineNumber.(zero + 2);
 
       let lines = [|"abc"|];
-      Buffer.setLines(~start=line1Index, ~stop=line2Index, ~lines, buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~start=line1Index,
+        ~stop=line2Index,
+        ~lines,
+        buffer,
+      );
       expect.bool(Buffer.isModified(buffer)).toBe(true);
     });
     test("replace whole buffer - set both start / stop", ({expect, _}) => {
       let buffer = resetBuffer();
 
       Buffer.setLines(
+        ~shouldAdjustCursors=false,
         ~start=LineNumber.zero,
         ~stop=LineNumber.(zero + 4),
         ~lines=[|"abc"|],
@@ -162,7 +181,12 @@ describe("Buffer", ({describe, _}) => {
     test("replace whole buffer - set just start", ({expect, _}) => {
       let buffer = resetBuffer();
 
-      Buffer.setLines(~start=LineNumber.zero, ~lines=[|"abc"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~start=LineNumber.zero,
+        ~lines=[|"abc"|],
+        buffer,
+      );
       let lineCount = Buffer.getLineCount(buffer);
       let line0 = Buffer.getLine(buffer, LineNumber.zero);
       expect.int(lineCount).toBe(1);
@@ -174,7 +198,7 @@ describe("Buffer", ({describe, _}) => {
       let updates: ref(list(BufferUpdate.t)) = ref([]);
       let dispose = Buffer.onUpdate(upd => updates := [upd, ...updates^]);
 
-      Buffer.setLines(~lines=[|"abc"|], buffer);
+      Buffer.setLines(~shouldAdjustCursors=false, ~lines=[|"abc"|], buffer);
       let lineCount = Buffer.getLineCount(buffer);
       let line0 = Buffer.getLine(buffer, LineNumber.zero);
       expect.int(lineCount).toBe(1);
@@ -195,7 +219,12 @@ describe("Buffer", ({describe, _}) => {
 
       let endPoint = Buffer.getLineCount(buffer) |> LineNumber.ofZeroBased;
 
-      Buffer.setLines(~start=endPoint, ~lines=[|"abc"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~start=endPoint,
+        ~lines=[|"abc"|],
+        buffer,
+      );
       let line3 = Buffer.getLine(buffer, LineNumber.(zero + 2));
       let line4 = Buffer.getLine(buffer, LineNumber.(zero + 3));
       let lineCount = Buffer.getLineCount(buffer);
@@ -225,7 +254,9 @@ describe("Buffer", ({describe, _}) => {
 
       let edit = Edit.{range: range(0, 1, 0, 1), text: [|"a"|]};
 
-      let () = Buffer.applyEdits(~edits=[edit], buffer) |> Result.get_ok;
+      let () =
+        Buffer.applyEdits(~shouldAdjustCursors=false, ~edits=[edit], buffer)
+        |> Result.get_ok;
 
       let line = Buffer.getLine(buffer, LineNumber.ofOneBased(1));
       expect.string(line).toEqual("Tahis is the first line of a test file");
@@ -241,7 +272,9 @@ describe("Buffer", ({describe, _}) => {
           text: [|"his is a whole new line", "T"|],
         };
 
-      let () = Buffer.applyEdits(~edits=[edit], buffer) |> Result.get_ok;
+      let () =
+        Buffer.applyEdits(~shouldAdjustCursors=false, ~edits=[edit], buffer)
+        |> Result.get_ok;
 
       let line = Buffer.getLine(buffer, LineNumber.ofOneBased(1));
       expect.string(line).toEqual("This is a whole new line");
@@ -265,7 +298,9 @@ describe("Buffer", ({describe, _}) => {
           text: [|"his is a whole new line", "T"|],
         };
 
-      let () = Buffer.applyEdits(~edits=[edit], buffer) |> Result.get_ok;
+      let () =
+        Buffer.applyEdits(~shouldAdjustCursors=false, ~edits=[edit], buffer)
+        |> Result.get_ok;
 
       expect.int(modifiedEvents^ |> List.length).toBe(1);
 
@@ -277,7 +312,9 @@ describe("Buffer", ({describe, _}) => {
 
       let edit = Edit.{range: range(0, 0, 1, 0), text: [||]};
 
-      let () = Buffer.applyEdits(~edits=[edit], buffer) |> Result.get_ok;
+      let () =
+        Buffer.applyEdits(~shouldAdjustCursors=false, ~edits=[edit], buffer)
+        |> Result.get_ok;
 
       let line = Buffer.getLine(buffer, LineNumber.ofOneBased(1));
       expect.string(line).toEqual("This is the second line of a test file");
@@ -290,7 +327,9 @@ describe("Buffer", ({describe, _}) => {
 
       let edit = Edit.{range: range(0, 0, 2, 0), text: [||]};
 
-      let () = Buffer.applyEdits(~edits=[edit], buffer) |> Result.get_ok;
+      let () =
+        Buffer.applyEdits(~shouldAdjustCursors=false, ~edits=[edit], buffer)
+        |> Result.get_ok;
 
       let line = Buffer.getLine(buffer, LineNumber.ofOneBased(1));
       expect.string(line).toEqual("This is the third line of a test file");
@@ -303,7 +342,9 @@ describe("Buffer", ({describe, _}) => {
 
       let edit = Edit.{range: range(0, 14, 0, 15), text: [||]};
 
-      let () = Buffer.applyEdits(~edits=[edit], buffer) |> Result.get_ok;
+      let () =
+        Buffer.applyEdits(~shouldAdjustCursors=false, ~edits=[edit], buffer)
+        |> Result.get_ok;
 
       let line = Buffer.getLine(buffer, LineNumber.ofOneBased(1));
       expect.string(line).toEqual("import 'κόσμε'");

--- a/test/reason-libvim/MacroTest.re
+++ b/test/reason-libvim/MacroTest.re
@@ -99,6 +99,7 @@ describe("Macro", ({test, _}) => {
     let buf = reset();
 
     Vim.Buffer.setLines(
+      ~shouldAdjustCursors=false,
       ~lines=[|
         {|<meta name="”robots”" content="”noindex,nofollow,noarchive,nosnippet,noodp”">|},
         {|<meta name="apple-mobile-web-app-capable" content="yes">|},

--- a/test/reason-libvim/UndoTest.re
+++ b/test/reason-libvim/UndoTest.re
@@ -12,7 +12,11 @@ describe("Undo", ({describe, _}) => {
       let buffer = resetBuffer();
 
       Vim.Testing.Undo.saveRegion(0, 4);
-      Buffer.setLines(~lines=[|"a", "b", "c"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~lines=[|"a", "b", "c"|],
+        buffer,
+      );
 
       let index0 = LineNumber.zero;
       let index1 = LineNumber.(zero + 1);
@@ -40,10 +44,18 @@ describe("Undo", ({describe, _}) => {
 
     test("undo is clamped to buffer size", ({expect, _}) => {
       let buffer = resetBuffer();
-      Buffer.setLines(~lines=[|"d", "e", "f"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~lines=[|"d", "e", "f"|],
+        buffer,
+      );
 
       Vim.Testing.Undo.saveRegion(-1, 5);
-      Buffer.setLines(~lines=[|"a", "b", "c"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~lines=[|"a", "b", "c"|],
+        buffer,
+      );
 
       let index0 = LineNumber.zero;
       let index1 = LineNumber.(zero + 1);
@@ -63,9 +75,17 @@ describe("Undo", ({describe, _}) => {
     test("undo partial buffer", ({expect, _}) => {
       let buffer = resetBuffer();
 
-      Buffer.setLines(~lines=[|"0", "1", "2"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~lines=[|"0", "1", "2"|],
+        buffer,
+      );
       Vim.Testing.Undo.saveRegion(0, 2);
-      Buffer.setLines(~lines=[|"a", "b", "c"|], buffer);
+      Buffer.setLines(
+        ~shouldAdjustCursors=false,
+        ~lines=[|"a", "b", "c"|],
+        buffer,
+      );
 
       let index0 = LineNumber.zero;
       let index1 = LineNumber.(zero + 1);


### PR DESCRIPTION
__Issue:__ When formatting a document, the cursor doesn't move to stay in sync with the current position.

__Fix:__ Adjust the cursor position when applying formatting edits to match the previous position.