### PR TITLE
fix(formatting): Add 'Format Document' menu item

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -45,6 +45,7 @@
 - #3249 - Extensions: Send 'onCommand' activation event (related #3215)
 - #3252 - UX: Remove glitchy pane animation (fixes #3245)
 - #3255 - CodeLens: Fix disappearing lens when pressing enter in insert mode
+- #3264 - Formatting: Add 'Format Document' to menu
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -649,6 +649,7 @@ module Contributions = {
     @ Completion.Contributions.keybindings
     @ Definition.Contributions.keybindings
     @ DocumentHighlights.Contributions.keybindings
+    @ Formatting.Contributions.keybindings
     @ References.Contributions.keybindings
     @ SignatureHelp.Contributions.keybindings;
 };

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -652,6 +652,8 @@ module Contributions = {
     @ Formatting.Contributions.keybindings
     @ References.Contributions.keybindings
     @ SignatureHelp.Contributions.keybindings;
+
+  let menuGroups = Formatting.Contributions.menuGroups;
 };
 
 module OldCompletion = Completion;

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -243,6 +243,7 @@ module Contributions: {
   let configuration: list(Config.Schema.spec);
   let contextKeys: WhenExpr.ContextKeys.Schema.t(model);
   let keybindings: list(Feature_Input.Schema.keybinding);
+  let menuGroups: list(MenuBar.Schema.group);
 };
 
 module Definition: {

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -536,10 +536,52 @@ module Commands = {
     );
 };
 
+// KEYBINDINGS
+
+module Keybindings = {
+  open Feature_Input.Schema;
+
+  module Condition = {
+
+  let windows =
+    "editorTextFocus && isWin" |> WhenExpr.parse;
+
+  let linux =
+    "editorTextFocus && isLinux" |> WhenExpr.parse;
+
+  let mac =
+    "editorTextFocus && isMac" |> WhenExpr.parse;
+  };
+
+  let formatDocumentWindows = bind(
+    ~key="<A-S-F>",
+    ~command=Commands.formatDocument.id,
+    ~condition=Condition.windows,
+  );
+
+  let formatDocumentMac = bind(
+    ~key="<A-S-F>",
+    ~command=Commands.formatDocument.id,
+    ~condition=Condition.mac,
+  );
+
+  let formatDocumentLinux = bind(
+    ~key="<C-S-I>",
+    ~command=Commands.formatDocument.id,
+    ~condition=Condition.linux,
+  );
+};
+
 // CONTRIBUTIONS
 
 module Contributions = {
   let commands = [Commands.formatDocument];
 
   let configuration = [Configuration.defaultFormatter.spec];
+
+  let keybindings = Keybindings.[
+    formatDocumentWindows,
+    formatDocumentMac,
+    formatDocumentLinux,
+  ]
 };

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -542,34 +542,41 @@ module Keybindings = {
   open Feature_Input.Schema;
 
   module Condition = {
+    let windows = "editorTextFocus && isWin" |> WhenExpr.parse;
 
-  let windows =
-    "editorTextFocus && isWin" |> WhenExpr.parse;
+    let linux = "editorTextFocus && isLinux" |> WhenExpr.parse;
 
-  let linux =
-    "editorTextFocus && isLinux" |> WhenExpr.parse;
-
-  let mac =
-    "editorTextFocus && isMac" |> WhenExpr.parse;
+    let mac = "editorTextFocus && isMac" |> WhenExpr.parse;
   };
 
-  let formatDocumentWindows = bind(
-    ~key="<A-S-F>",
-    ~command=Commands.formatDocument.id,
-    ~condition=Condition.windows,
-  );
+  let formatDocumentWindows =
+    bind(
+      ~key="<A-S-F>",
+      ~command=Commands.formatDocument.id,
+      ~condition=Condition.windows,
+    );
 
-  let formatDocumentMac = bind(
-    ~key="<A-S-F>",
-    ~command=Commands.formatDocument.id,
-    ~condition=Condition.mac,
-  );
+  let formatDocumentMac =
+    bind(
+      ~key="<A-S-F>",
+      ~command=Commands.formatDocument.id,
+      ~condition=Condition.mac,
+    );
 
-  let formatDocumentLinux = bind(
-    ~key="<C-S-I>",
-    ~command=Commands.formatDocument.id,
-    ~condition=Condition.linux,
-  );
+  let formatDocumentLinux =
+    bind(
+      ~key="<C-S-I>",
+      ~command=Commands.formatDocument.id,
+      ~condition=Condition.linux,
+    );
+};
+
+module MenuItems = {
+  open MenuBar.Schema;
+  module Edit = {
+    let formatDocument =
+      command(~title="Format Document", Commands.formatDocument);
+  };
 };
 
 // CONTRIBUTIONS
@@ -579,9 +586,19 @@ module Contributions = {
 
   let configuration = [Configuration.defaultFormatter.spec];
 
-  let keybindings = Keybindings.[
-    formatDocumentWindows,
-    formatDocumentMac,
-    formatDocumentLinux,
-  ]
+  let keybindings =
+    Keybindings.[
+      formatDocumentWindows,
+      formatDocumentMac,
+      formatDocumentLinux,
+    ];
+
+  let menuGroups =
+    MenuBar.Schema.[
+      group(
+        ~order=200,
+        ~parent=Feature_MenuBar.Global.edit,
+        MenuItems.Edit.[formatDocument],
+      ),
+    ];
 };

--- a/src/Feature/LanguageSupport/dune
+++ b/src/Feature/LanguageSupport/dune
@@ -5,7 +5,8 @@
  (libraries Oni2.editor-core-types Oni2.component.vimTree Oni2.core
    Oni2.syntax Oni2.feature.commands Oni2.feature.configuration
    Oni2.feature.extensions Oni2.feature.diagnostics Oni2.feature.keywords
-   Oni2.feature.quickmenu Oni2.component.inputText Oni2.service.exthost
-   Oni2.service.font Oni2.service.snippets Oni2.service.vim Oni2.input uucp)
+   Oni2.feature.menubar Oni2.feature.quickmenu Oni2.component.inputText
+   Oni2.service.exthost Oni2.service.font Oni2.service.snippets
+   Oni2.service.vim Oni2.input uucp)
  (preprocess
   (pps ppx_deriving.show brisk-reconciler.ppx ppx_inline_test)))

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -540,6 +540,7 @@ let initial =
         ~menus=[],
         ~groups=
           [Feature_Workspace.Contributions.menuGroup]
+          @ Feature_LanguageSupport.Contributions.menuGroups
           @ Feature_SideBar.Contributions.menuGroups
           @ Feature_Help.Contributions.menuGroups,
       ),


### PR DESCRIPTION
This adds a `Format Document` command and shortcut key, visible in the 'Edit' menu