### PR TITLE
perf(buffers): Skip applying full updates if nothing changed

### DIFF
--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -292,9 +292,22 @@ let setIndentation = (indentation, buf) => {
 
 let getIndentation = buf => buf.indentation |> Inferred.value;
 
-let shouldApplyUpdate = (update: BufferUpdate.t, buf: t) => {
-  update.version > getVersion(buf);
-};
+let shouldApplyUpdate = (update: BufferUpdate.t, buf: t) =>
+  // First, make sure the version check passes...
+  if (update.version > getVersion(buf)) {
+    // Then, if this is a full update, do a pass to see if there actually is an update.
+    // There are some cases - like undo - where a full update may come through, but actually
+    // is just bumping the change tick.
+    if (update.isFull) {
+      let bufferLines = getLines(buf);
+
+      !ArrayEx.equals(String.equal, bufferLines, update.lines);
+    } else {
+      true;
+    };
+  } else {
+    false;
+  };
 
 let update = (buf: t, update: BufferUpdate.t) =>
   if (shouldApplyUpdate(update, buf)) {

--- a/src/Core/Utility/ArrayEx.re
+++ b/src/Core/Utility/ArrayEx.re
@@ -14,6 +14,25 @@ let findIndex = (predicate, array) =>
   | Found(i) => Some(i)
   };
 
+let equals = (f, a1, a2) => {
+  let len1 = Array.length(a1);
+  let len2 = Array.length(a2);
+
+  if (len1 != len2) {
+    false;
+  } else {
+    let rec loop = idx =>
+      if (idx >= len1) {
+        true;
+      } else if (!f(a1[idx], a2[idx])) {
+        false;
+      } else {
+        loop(idx + 1);
+      };
+    loop(0);
+  };
+};
+
 let slice = (~lines: array(_), ~start, ~length, ()) => {
   let len = Array.length(lines);
   if (start >= len) {


### PR DESCRIPTION
Processing full-buffer updates are expensive - we recompute syntax highlighting for the entire buffer, we recompute minimal updates in the case of formatting, and it requires a full sync with the extension host - all expensive operations!

In some cases, this is necessary - for example, reading new data from the file system might mean the entire buffer has changed. However, in some cases, Onivim is processing full updates when it is not strictly necessary (like 'undo').

This PR does a check to see if the full update actually changes the buffer, and if not, skips applying it.