### PR TITLE
fix(snippets): Fix error parsing @media sass snippet

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -47,6 +47,7 @@
 - #3255 - CodeLens: Fix disappearing lens when pressing enter in insert mode
 - #3259 - Quickmenu: Implement smart case (thanks @amiralies!)
 - #3264 - Formatting: Add 'Format Document' to menu
+- #3272 - Snippets: Fix error parsing '@media' sass snippet
 
 ### Performance
 

--- a/src/Core/Snippet/Snippet.re
+++ b/src/Core/Snippet/Snippet.re
@@ -7,7 +7,8 @@ let parse: string => result(t, string) =
       switch (Snippet_parser.main(Snippet_lexer.token, lexbuf)) {
       | exception Snippet_lexer.Error =>
         Error("Error parsing binding: " ++ str)
-      | exception Snippet_parser.Error => Error("Error parsing snippet: " ++ str)
+      | exception Snippet_parser.Error =>
+        Error("Error parsing snippet: " ++ str)
       | v => Ok(v)
       };
 
@@ -155,7 +156,9 @@ let%test_module "parse" =
      };
 
      let%test "sass snippet bug" = {
-      parse("@media ${1:screen} ${2:and} ( ${3|max-width: ,min-width: ,height: |} )")
-      |> Result.is_ok;
-     }
+       parse(
+         "@media ${1:screen} ${2:and} ( ${3|max-width: ,min-width: ,height: |} )",
+       )
+       |> Result.is_ok;
+     };
    });

--- a/src/Core/Snippet/Snippet.re
+++ b/src/Core/Snippet/Snippet.re
@@ -7,7 +7,7 @@ let parse: string => result(t, string) =
       switch (Snippet_parser.main(Snippet_lexer.token, lexbuf)) {
       | exception Snippet_lexer.Error =>
         Error("Error parsing binding: " ++ str)
-      | exception Snippet_parser.Error => Error("Error parsing")
+      | exception Snippet_parser.Error => Error("Error parsing snippet: " ++ str)
       | v => Ok(v)
       };
 
@@ -153,4 +153,9 @@ let%test_module "parse" =
      let%test "non-placeholder special case" = {
        parse("${ data }") == Ok([[Text("${ data }")]]);
      };
+
+     let%test "sass snippet bug" = {
+      parse("@media ${1:screen} ${2:and} ( ${3|max-width: ,min-width: ,height: |} )")
+      |> Result.is_ok;
+     }
    });

--- a/src/Core/Snippet/Snippet_parser.mly
+++ b/src/Core/Snippet/Snippet_parser.mly
@@ -47,8 +47,9 @@ additional_choice:
 
 string:
 | str = list(character) { String.concat "" str }
-| numberAsText = NUMBER { string_of_int(numberAsText) }
-| variableAsText = VARIABLE { variableAsText }
 
 character:
 | char = TEXT { char }
+| COLON; { ":" }
+| numberAsText = NUMBER { string_of_int(numberAsText) }
+| variableAsText = VARIABLE { variableAsText }


### PR DESCRIPTION
__Issue:__ The `@media` sass snippet failed to expand

__Defect:__ The parser for choice snippets would fail if certain characters were part of the choices (in the case of `@media` - the `:` character in the choice was causing the snippet parse to fail). The choice parser wasn't handling concatenation of multiple tokens, and the `:` character would make it through the lexer, but would cause multiple tokens to be produced, which wasn't handled by our parser rules.

__Fix:__ Fix the string parser to concatenate multiple tokens; add test case