### PR TITLE
fix(completion/#2388): Use the default insert range from the suggest item list

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -47,6 +47,7 @@
 - #3255 - CodeLens: Fix disappearing lens when pressing enter in insert mode
 - #3259 - Quickmenu: Implement smart case (thanks @amiralies!)
 - #3264 - Formatting: Add 'Format Document' to menu
+- #3273 - Completion: Use the default insert/replace range when provided (fixes #2388)
 
 ### Performance
 

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -307,7 +307,7 @@ module SuggestItem: {
     filterText: option(string),
     insertText: option(string),
     insertTextRules: InsertTextRules.t,
-    suggestRange: option(SuggestRange.t),
+    suggestRange: SuggestRange.t,
     commitCharacters: list(string),
     additionalTextEdits: list(Edit.SingleEditOperation.t),
     command: option(Command.t),
@@ -1799,7 +1799,12 @@ module Request: {
       Lwt.t(SuggestResult.t);
 
     let resolveCompletionItem:
-      (~handle: int, ~chainedCacheId: ChainedCacheId.t, Client.t) =>
+      (
+        ~handle: int,
+        ~chainedCacheId: ChainedCacheId.t,
+        ~defaultRange: SuggestItem.SuggestRange.t,
+        Client.t
+      ) =>
       Lwt.t(SuggestItem.t);
 
     let releaseCompletionItems:

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -316,9 +316,14 @@ module LanguageFeatures = {
   };
 
   let resolveCompletionItem =
-      (~handle: int, ~chainedCacheId: ChainedCacheId.t, client) => {
+      (
+        ~handle: int,
+        ~chainedCacheId: ChainedCacheId.t,
+        ~defaultRange: SuggestItem.SuggestRange.t,
+        client,
+      ) => {
     Client.request(
-      ~decoder=SuggestItem.Dto.decode,
+      ~decoder=SuggestItem.Dto.decode(~defaultRange),
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$resolveCompletionItem",

--- a/src/Exthost/SuggestResult.re
+++ b/src/Exthost/SuggestResult.re
@@ -15,15 +15,21 @@ let empty = {completions: [], isIncomplete: false, cacheId: None};
 module Dto = {
   let decode = {
     Json.Decode.(
-      obj(({field, _}) =>
+      obj(({field, _}) => {
+        // These values come from `ISuggestResultDto`:
+        // https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L1129
+        let defaultRange =
+          field.required("a", SuggestItem.SuggestRange.decode);
         {
-          // These values come from `ISuggestResultDto`:
-          // https://github.com/onivim/vscode-exthost/blob/50bef147f7bbd250015361a4e3cad3305f65bc27/src/vs/workbench/api/common/extHost.protocol.ts#L1129
-          completions: field.required("b", list(SuggestItem.Dto.decode)),
+          completions:
+            field.required(
+              "b",
+              list(SuggestItem.Dto.decode(~defaultRange)),
+            ),
           isIncomplete: field.withDefault("c", false, bool),
           cacheId: field.optional("x", int),
-        }
-      )
+        };
+      })
     );
   };
 };

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -32,7 +32,7 @@ let create = (~isFuzzyMatching: bool, ~handle, item: SuggestItem.t) => {
   insertTextRules: item.insertTextRules,
   filterText: item |> SuggestItem.filterText,
   sortText: item |> SuggestItem.sortText,
-  suggestRange: item.suggestRange,
+  suggestRange: Some(item.suggestRange),
   commitCharacters: item.commitCharacters,
   additionalTextEdits: item.additionalTextEdits,
   command: item.command,

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -958,6 +958,7 @@ module Sub = {
     handle: int,
     chainedCacheId: Exthost.ChainedCacheId.t,
     client: Exthost.Client.t,
+    defaultRange: Exthost.SuggestItem.SuggestRange.t,
   };
 
   module CompletionItemSubscription =
@@ -976,6 +977,7 @@ module Sub = {
           Exthost.Request.LanguageFeatures.resolveCompletionItem(
             ~handle=params.handle,
             ~chainedCacheId=params.chainedCacheId,
+            ~defaultRange=params.defaultRange,
             params.client,
           );
 
@@ -1082,9 +1084,10 @@ module Sub = {
     |> Isolinear.Sub.map(toMsg);
   };
 
-  let completionItem = (~handle, ~chainedCacheId, ~toMsg, client) => {
+  let completionItem =
+      (~handle, ~chainedCacheId, ~defaultRange, ~toMsg, client) => {
     CompletionItemSubscription.create(
-      {handle, chainedCacheId, client}: completionItemParams,
+      {handle, chainedCacheId, client, defaultRange}: completionItemParams,
     )
     |> Isolinear.Sub.map(toMsg);
   };

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -156,6 +156,7 @@ module Sub: {
     (
       ~handle: int,
       ~chainedCacheId: Exthost.ChainedCacheId.t,
+      ~defaultRange: Exthost.SuggestItem.SuggestRange.t,
       ~toMsg: result(Exthost.SuggestItem.t, string) => 'a,
       Exthost.Client.t
     ) =>


### PR DESCRIPTION
__Issue:__ Some completions would add duplicate characters at the beginning, like the case in #2388

__Defect:__ The returned completion list from the extension host can send a default insert/replace range, which tells exactly what characters should be inserted or replaced from the completion. This can be sent per-item, or, to save bytes over the wire, a default can be sent for the list that should be used if it is not provided per-item. Onivim wasn't handling the default insert/replace range, which is provided in the case of #2388

__Fix:__ If a default insert/replace range is provided as part of the completion list, update completion items with that insert/replace range.

Fixes #2388