### PR TITLE
fix(completion/#2583): Fix race condition between completion subscription & buffer updates

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -47,6 +47,7 @@
 - #3255 - CodeLens: Fix disappearing lens when pressing enter in insert mode
 - #3259 - Quickmenu: Implement smart case (thanks @amiralies!)
 - #3264 - Formatting: Add 'Format Document' to menu
+- #3274 - Completion: Fix race condition between completion subscription and buffer updates (fixes #3274)
 
 ### Performance
 

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -912,34 +912,45 @@ module Sub = {
         let isDisposed = ref(false);
         let cacheId = ref(None);
 
-        let dispose = Revery.Tick.timeout(
-          ~name="Completion",
-          () => {
-        let promise =
-          Exthost.Request.LanguageFeatures.provideCompletionItems(
-            ~handle=params.handle,
-            ~resource=Oni_Core.Buffer.getUri(params.buffer),
-            ~position=params.position,
-            ~context=params.context,
-            params.client,
+        // We debounce here to eliminate a race condition -
+        // if we request completion at a position before the buffer updates
+        // go through, completion providers that depend on up-to-buffer state
+        // could experience issues due to a race - like #2583.
+
+        // An idea to investigate further would be to have this subscription
+        // dependent on the latest 'sync'd' version - that could eliminate
+        // the need for a timeout.
+        let dispose =
+          Revery.Tick.timeout(
+            ~name="Completion",
+            () => {
+              let promise =
+                Exthost.Request.LanguageFeatures.provideCompletionItems(
+                  ~handle=params.handle,
+                  ~resource=Oni_Core.Buffer.getUri(params.buffer),
+                  ~position=params.position,
+                  ~context=params.context,
+                  params.client,
+                );
+
+              Lwt.on_success(
+                promise,
+                suggestResult => {
+                  cacheId := suggestResult.cacheId;
+                  if (isDisposed^) {
+                    cleanupCache(~params, ~cacheId);
+                  } else {
+                    dispatch(Ok(suggestResult));
+                  };
+                },
+              );
+
+              Lwt.on_failure(promise, exn =>
+                dispatch(Error(Printexc.to_string(exn)))
+              );
+            },
+            Revery.Time.milliseconds(10),
           );
-
-        Lwt.on_success(
-          promise,
-          suggestResult => {
-            cacheId := suggestResult.cacheId;
-            if (isDisposed^) {
-              cleanupCache(~params, ~cacheId);
-            } else {
-              dispatch(Ok(suggestResult));
-            };
-          },
-        );
-
-        Lwt.on_failure(promise, exn =>
-          dispatch(Error(Printexc.to_string(exn)))
-        );
-        }, Revery.Time.milliseconds(1));
 
         {isDisposed, cacheId, dispose};
       };


### PR DESCRIPTION
__Issue:__ When using TabNine (#2583), most completions are inserting an extra character at the beginning - this makes it much less useful.

__Defect:__ TabNine requires the latest buffer to give correct predictions and insert/replace ranges. There was a race condition where, when the user is typing a character, we could request completions at the _new_ character position before the buffer update reached the extension host - this would give us completions where the insert range is off, causing us to insert an extra when completing.

__Fix:__ Debouncing the completion sub is enough, because the buffer update effect is processed immediately after the first round of subscriptions. 

__Next steps:__ A better, more explicit fix would be to have the completion subscription take into account the last sync'd buffer version - and only start it if the last sync'd buffer version matches the current version. There'd be some additional plumbing and state management needed to accomodate this.

Related to #2583 , fixes the next round of issues blocking usage of TabNine