### PR TITLE
fix(completion/#2583): Handle replace range after cursor

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -48,7 +48,8 @@
 - #3259 - Quickmenu: Implement smart case (thanks @amiralies!)
 - #3264 - Formatting: Add 'Format Document' to menu
 - #3273 - Completion: Use the default insert/replace range when provided (fixes #2388)
-- #3274 - Completion: Fix race condition between completion subscription and buffer updates (fixes #3274)
+- #3274 - Completion: Fix race condition between completion subscription and buffer updates (related #2583)
+- #3276 - Completion: Handle replace range after cursor position (related #2583)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -891,19 +891,29 @@ let update =
         let replaceSpan =
           Exthost.SuggestItem.(
             switch (result.item.suggestRange) {
-            | Some(SuggestRange.Single({startColumn, _})) =>
+            | Some(SuggestRange.Single({startColumn, endColumn, _})) =>
+              let stop =
+                max(
+                  endColumn - 1 |> CharacterIndex.ofInt,
+                  activeCursor.character,
+                );
               CharacterSpan.{
                 start: startColumn - 1 |> CharacterIndex.ofInt,
-                stop: activeCursor.character,
-              }
+                stop,
+              };
             | Some(SuggestRange.Combo({insert, _})) =>
+              let stop =
+                max(
+                  insert.endColumn - 1 |> CharacterIndex.ofInt,
+                  activeCursor.character,
+                );
               CharacterSpan.{
                 start:
                   Exthost.OneBasedRange.(
                     insert.startColumn - 1 |> CharacterIndex.ofInt
                   ),
-                stop: activeCursor.character,
-              }
+                stop,
+              };
             | None =>
               CharacterSpan.{
                 start: location.character,

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -50,12 +50,12 @@ type msg =
 type outmsg =
   | Nothing
   | ApplyCompletion({
-      meetColumn: CharacterIndex.t,
+      replaceSpan: CharacterSpan.t,
       insertText: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
   | InsertSnippet({
-      meetColumn: CharacterIndex.t,
+      replaceSpan: CharacterSpan.t,
       snippet: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
@@ -84,10 +84,10 @@ type outmsg =
 let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
   f =>
     fun
-    | Outmsg.ApplyCompletion({meetColumn, insertText, additionalEdits}) =>
-      ApplyCompletion({meetColumn, insertText, additionalEdits})
-    | Outmsg.InsertSnippet({meetColumn, snippet, additionalEdits}) =>
-      InsertSnippet({meetColumn, snippet, additionalEdits})
+    | Outmsg.ApplyCompletion({replaceSpan, insertText, additionalEdits}) =>
+      ApplyCompletion({replaceSpan, insertText, additionalEdits})
+    | Outmsg.InsertSnippet({replaceSpan, snippet, additionalEdits}) =>
+      InsertSnippet({replaceSpan, snippet, additionalEdits})
     | Outmsg.Nothing => Nothing
     | Outmsg.NotifySuccess(msg) => NotifySuccess(msg)
     | Outmsg.NotifyFailure(msg) => NotifyFailure(msg)

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -53,12 +53,12 @@ module CodeLens: {
 type outmsg =
   | Nothing
   | ApplyCompletion({
-      meetColumn: CharacterIndex.t,
+      replaceSpan: CharacterSpan.t,
       insertText: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
   | InsertSnippet({
-      meetColumn: CharacterIndex.t,
+      replaceSpan: CharacterSpan.t,
       snippet: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -3,12 +3,12 @@ open EditorCoreTypes;
 type internalMsg('a) =
   | Nothing
   | ApplyCompletion({
-      meetColumn: CharacterIndex.t,
+      replaceSpan: CharacterSpan.t,
       insertText: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
   | InsertSnippet({
-      meetColumn: CharacterIndex.t,
+      replaceSpan: CharacterSpan.t,
       snippet: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -120,7 +120,7 @@ let handleEffects = (effects, model) => {
 };
 
 module Effects = {
-  let applyCompletion = (~meetColumn, ~insertText, ~additionalEdits) => {
+  let applyCompletion = (~cursor, ~meetColumn, ~insertText, ~additionalEdits) => {
     let toMsg = mode =>
       ModeChanged({
         allowAnimation: true,
@@ -129,6 +129,7 @@ module Effects = {
         effects: [],
       });
     Service_Vim.Effects.applyCompletion(
+      ~cursor,
       ~meetColumn,
       ~insertText,
       ~additionalEdits,

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -120,7 +120,7 @@ let handleEffects = (effects, model) => {
 };
 
 module Effects = {
-  let applyCompletion = (~cursor, ~meetColumn, ~insertText, ~additionalEdits) => {
+  let applyCompletion = (~cursor, ~replaceSpan, ~insertText, ~additionalEdits) => {
     let toMsg = mode =>
       ModeChanged({
         allowAnimation: true,
@@ -130,7 +130,7 @@ module Effects = {
       });
     Service_Vim.Effects.applyCompletion(
       ~cursor,
-      ~meetColumn,
+      ~replaceSpan,
       ~insertText,
       ~additionalEdits,
       ~toMsg,

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -83,7 +83,7 @@ module Effects: {
   let applyCompletion:
     (
       ~cursor: EditorCoreTypes.CharacterPosition.t,
-      ~meetColumn: EditorCoreTypes.CharacterIndex.t,
+      ~replaceSpan: EditorCoreTypes.CharacterSpan.t,
       ~insertText: string,
       ~additionalEdits: list(Vim.Edit.t)
     ) =>

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -82,6 +82,7 @@ module CommandLine: {let getCompletionMeet: string => option(int);};
 module Effects: {
   let applyCompletion:
     (
+      ~cursor: EditorCoreTypes.CharacterPosition.t,
       ~meetColumn: EditorCoreTypes.CharacterIndex.t,
       ~insertText: string,
       ~additionalEdits: list(Vim.Edit.t)

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -184,8 +184,13 @@ module Effects = {
       let overwriteBefore =
         CharacterIndex.toInt(cursor.character)
         - CharacterIndex.toInt(replaceSpan.start);
-      // TODO: Handle full replace range
-      let overwriteAfter = 0;
+
+      let overwriteAfter =
+        max(
+          0,
+          CharacterIndex.toInt(replaceSpan.stop)
+          - CharacterIndex.toInt(cursor.character),
+        );
 
       let _: Vim.Context.t = VimEx.repeatKey(overwriteAfter, "<DEL>");
       let _: Vim.Context.t = VimEx.repeatKey(overwriteBefore, "<BS>");

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -172,12 +172,10 @@ module Effects = {
     List.fold_left(adjustModeForEdit, mode, edits);
   };
 
-  let applyCompletion = (~meetColumn, ~insertText, ~toMsg, ~additionalEdits) =>
+  let applyCompletion = (~cursor: CharacterPosition.t, ~meetColumn, ~insertText, ~toMsg, ~additionalEdits) =>
     Isolinear.Effect.createWithDispatch(~name="applyCompletion", dispatch => {
-      let cursor = Vim.Cursor.get();
-      // TODO: Does this logic correctly handle unicode characters?
       let delta =
-        ByteIndex.toInt(cursor.byte) - CharacterIndex.toInt(meetColumn);
+        CharacterIndex.toInt(cursor.character) - CharacterIndex.toInt(meetColumn);
 
       let _: Vim.Context.t = VimEx.repeatKey(delta, "<BS>");
       let ({mode, _}: Vim.Context.t, _effects) =

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -172,10 +172,18 @@ module Effects = {
     List.fold_left(adjustModeForEdit, mode, edits);
   };
 
-  let applyCompletion = (~cursor: CharacterPosition.t, ~meetColumn, ~insertText, ~toMsg, ~additionalEdits) =>
+  let applyCompletion =
+      (
+        ~cursor: CharacterPosition.t,
+        ~replaceSpan: CharacterSpan.t,
+        ~insertText,
+        ~toMsg,
+        ~additionalEdits,
+      ) =>
     Isolinear.Effect.createWithDispatch(~name="applyCompletion", dispatch => {
       let overwriteBefore =
-        CharacterIndex.toInt(cursor.character) - CharacterIndex.toInt(meetColumn);
+        CharacterIndex.toInt(cursor.character)
+        - CharacterIndex.toInt(replaceSpan.start);
       // TODO: Handle full replace range
       let overwriteAfter = 0;
 

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -174,10 +174,10 @@ module Effects = {
 
   let applyCompletion = (~cursor: CharacterPosition.t, ~meetColumn, ~insertText, ~toMsg, ~additionalEdits) =>
     Isolinear.Effect.createWithDispatch(~name="applyCompletion", dispatch => {
-      let delta =
+      let overwriteBefore =
         CharacterIndex.toInt(cursor.character) - CharacterIndex.toInt(meetColumn);
 
-      let _: Vim.Context.t = VimEx.repeatKey(delta, "<BS>");
+      let _: Vim.Context.t = VimEx.repeatKey(overwriteBefore, "<BS>");
       let ({mode, _}: Vim.Context.t, _effects) =
         VimEx.inputString(insertText);
 

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -176,7 +176,10 @@ module Effects = {
     Isolinear.Effect.createWithDispatch(~name="applyCompletion", dispatch => {
       let overwriteBefore =
         CharacterIndex.toInt(cursor.character) - CharacterIndex.toInt(meetColumn);
+      // TODO: Handle full replace range
+      let overwriteAfter = 0;
 
+      let _: Vim.Context.t = VimEx.repeatKey(overwriteAfter, "<DEL>");
       let _: Vim.Context.t = VimEx.repeatKey(overwriteBefore, "<BS>");
       let ({mode, _}: Vim.Context.t, _effects) =
         VimEx.inputString(insertText);

--- a/src/Service/Vim/Service_Vim.rei
+++ b/src/Service/Vim/Service_Vim.rei
@@ -38,7 +38,7 @@ module Effects: {
   let applyCompletion:
     (
       ~cursor: CharacterPosition.t,
-      ~meetColumn: CharacterIndex.t,
+      ~replaceSpan: CharacterSpan.t,
       ~insertText: string,
       ~toMsg: Vim.Mode.t => 'msg,
       ~additionalEdits: list(Vim.Edit.t)

--- a/src/Service/Vim/Service_Vim.rei
+++ b/src/Service/Vim/Service_Vim.rei
@@ -37,6 +37,7 @@ module Effects: {
 
   let applyCompletion:
     (
+      ~cursor: CharacterPosition.t,
       ~meetColumn: CharacterIndex.t,
       ~insertText: string,
       ~toMsg: Vim.Mode.t => 'msg,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -654,6 +654,7 @@ let update =
         (
           state,
           Feature_Vim.Effects.applyCompletion(
+            ~cursor=cursorLocation,
             ~additionalEdits,
             ~meetColumn,
             ~insertText,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -648,7 +648,7 @@ let update =
     Feature_LanguageSupport.(
       switch (outmsg) {
       | Nothing => (state, Isolinear.Effect.none)
-      | ApplyCompletion({insertText, meetColumn, additionalEdits}) =>
+      | ApplyCompletion({insertText, replaceSpan, additionalEdits}) =>
         let additionalEdits =
           additionalEdits |> List.map(exthostEditToVimEdit);
         (
@@ -656,7 +656,7 @@ let update =
           Feature_Vim.Effects.applyCompletion(
             ~cursor=cursorLocation,
             ~additionalEdits,
-            ~meetColumn,
+            ~replaceSpan,
             ~insertText,
           )
           |> Isolinear.Effect.map(msg => Vim(msg)),
@@ -673,16 +673,19 @@ let update =
           |> Feature_Pane.show(~pane=Locations);
         let state' = {...state, pane} |> FocusManager.push(Focus.Pane);
         (state', Isolinear.Effect.none);
-      | InsertSnippet({meetColumn, snippet, _}) =>
+      | InsertSnippet({replaceSpan, snippet, _}) =>
         let editor = Feature_Layout.activeEditor(state.layout);
-        let cursor = Feature_Editor.Editor.getPrimaryCursor(editor);
-        let characterPosition =
-          CharacterPosition.{line: cursor.line, character: meetColumn};
-        let rangeToReplace =
-          CharacterRange.{start: characterPosition, stop: cursor};
+        // let cursor = Feature_Editor.Editor.getPrimaryCursor(editor);
+        // let characterPosition =
+        //   CharacterPosition.{line: cursor.line, character: meetColumn};
+        // let rangeToReplace =
+        //   CharacterRange.{start: characterPosition, stop: cursor};
         let maybeReplaceRange =
           Feature_Editor.Editor.characterRangeToByteRange(
-            rangeToReplace,
+            EditorCoreTypes.CharacterSpan.toRange(
+              ~line=cursorLocation.line,
+              replaceSpan,
+            ),
             editor,
           );
         (

--- a/src/editor-core-types/CharacterIndex.re
+++ b/src/editor-core-types/CharacterIndex.re
@@ -14,3 +14,5 @@ let (<) = (a, b) => a < b;
 let (>) = (a, b) => a > b;
 let (<=) = (a, b) => a <= b;
 let (>=) = (a, b) => a >= b;
+
+let max = max;

--- a/src/editor-core-types/CharacterIndex.rei
+++ b/src/editor-core-types/CharacterIndex.rei
@@ -15,3 +15,5 @@ let (<): (t, t) => bool;
 let (>): (t, t) => bool;
 let (<=): (t, t) => bool;
 let (>=): (t, t) => bool;
+
+let max: (t, t) => t;

--- a/src/editor-core-types/CharacterSpan.re
+++ b/src/editor-core-types/CharacterSpan.re
@@ -1,0 +1,14 @@
+[@deriving show]
+type t = {
+  start: CharacterIndex.t,
+  stop: CharacterIndex.t,
+};
+
+let zero = {start: CharacterIndex.zero, stop: CharacterIndex.zero};
+
+let toRange = (~line, span: t) => {
+  CharacterRange.{
+    start: CharacterPosition.{line, character: span.start},
+    stop: CharacterPosition.{line, character: span.stop},
+  };
+};

--- a/src/editor-core-types/CharacterSpan.rei
+++ b/src/editor-core-types/CharacterSpan.rei
@@ -1,0 +1,9 @@
+[@deriving show]
+type t = {
+  start: CharacterIndex.t,
+  stop: CharacterIndex.t,
+};
+
+let zero: t;
+
+let toRange: (~line: LineNumber.t, t) => CharacterRange.t;


### PR DESCRIPTION
__Issue:__ Some completion providers, like TabNine, will give a replace range past the cursor, as well.

For example, in the completion case (where `|` is the cursor)
`app.get('/|')`

Selecting a completion like `', (req, res) => {` would result in an extra `'` at the end of the completion.

__Defect:__ We weren't utilizing the 'end' part of the insert / replace range

__Fix:__ Use the end column of the insert/replace range to decide how many characters _after_ the cursor to delete.

Related #2583 