### PR TITLE
fix(completion/#3258): Rescript identifiers not completing with opened module

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -52,6 +52,7 @@
 - #3274 - Completion: Fix race condition between completion subscription and buffer updates (fixes #3274)
 - #3263 - Formatting: Update cursor position based on formatting edits
 - #3272 - Snippets: Fix error parsing '@media' sass snippet
+- #3279 - Completion: Fix issue completing ReScript identifiers (fixes #3258)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -158,7 +158,11 @@ module Session = {
           filteredItems
           |> List.fold_left(
                (acc, item: Filter.result(CompletionItem.t)) => {
-                 StringMap.add(item.item.label, (meet.insertLocation, item), acc)
+                 StringMap.add(
+                   item.item.label,
+                   (meet.insertLocation, item),
+                   acc,
+                 )
                },
                StringMap.empty,
              )

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -158,7 +158,7 @@ module Session = {
           filteredItems
           |> List.fold_left(
                (acc, item: Filter.result(CompletionItem.t)) => {
-                 StringMap.add(item.item.label, (meet.location, item), acc)
+                 StringMap.add(item.item.label, (meet.insertLocation, item), acc)
                },
                StringMap.empty,
              )
@@ -884,7 +884,7 @@ let update =
       | None => default
       | Some(focusedIndex) =>
         let (
-          location: CharacterPosition.t,
+          insertLocation: CharacterPosition.t,
           result: Filter.result(CompletionItem.t),
         ) = allItems[focusedIndex];
 
@@ -897,7 +897,7 @@ let update =
               Exthost.OneBasedRange.(
                 insert.startColumn - 1 |> CharacterIndex.ofInt
               )
-            | None => location.character
+            | None => insertLocation.character
             }
           );
 

--- a/src/Feature/LanguageSupport/CompletionMeet.rei
+++ b/src/Feature/LanguageSupport/CompletionMeet.rei
@@ -10,8 +10,11 @@ type t = {
   bufferId: int,
   // Base is the prefix string
   base: string,
-  // Meet is the location where we request completions
+  // `location` is the location where we request completions
   location: CharacterPosition.t,
+  // `insertLocation` is the location where snippets are keywords should begin insertion
+  // Often, this will be overridden by the completion provider
+  insertLocation: CharacterPosition.t,
 };
 
 let matches: (t, t) => bool;

--- a/test/Feature/LanguageSupport/CompletionMeetTests.re
+++ b/test/Feature/LanguageSupport/CompletionMeetTests.re
@@ -50,7 +50,12 @@ describe("CompletionMeet", ({describe, _}) => {
         );
 
       let expected =
-        CompletionMeet.{location: line0column0, base: "a", bufferId: 0};
+        CompletionMeet.{
+          location: line0column1,
+          insertLocation: line0column0,
+          base: "a",
+          bufferId: 0,
+        };
 
       expect.equal(result, Some(expected));
     });
@@ -65,7 +70,12 @@ describe("CompletionMeet", ({describe, _}) => {
         );
 
       let expected =
-        CompletionMeet.{location: line0column1, base: "a", bufferId: 0};
+        CompletionMeet.{
+          location: line0column2,
+          insertLocation: line0column1,
+          base: "a",
+          bufferId: 0,
+        };
       expect.equal(result, Some(expected));
     });
 
@@ -79,7 +89,12 @@ describe("CompletionMeet", ({describe, _}) => {
         );
 
       let expected =
-        CompletionMeet.{location: line0column2, base: "a", bufferId: 0};
+        CompletionMeet.{
+          location: line0column2,
+          insertLocation: line0column2,
+          base: "a",
+          bufferId: 0,
+        };
       expect.equal(result, Some(expected));
     });
 
@@ -92,7 +107,12 @@ describe("CompletionMeet", ({describe, _}) => {
           " abc" |> makeLine,
         );
       let expected =
-        CompletionMeet.{location: line0column1, base: "abc", bufferId: 0};
+        CompletionMeet.{
+          location: line0column2,
+          insertLocation: line0column1,
+          base: "abc",
+          bufferId: 0,
+        };
       expect.equal(result, Some(expected));
     });
 
@@ -105,7 +125,12 @@ describe("CompletionMeet", ({describe, _}) => {
           " ." |> makeLine,
         );
       let expected =
-        CompletionMeet.{location: line0column2, base: "", bufferId: 0};
+        CompletionMeet.{
+          location: line0column2,
+          insertLocation: line0column2,
+          base: "",
+          bufferId: 0,
+        };
       expect.equal(result, Some(expected));
     });
 
@@ -118,7 +143,12 @@ describe("CompletionMeet", ({describe, _}) => {
           "console.lo" |> makeLine,
         );
       let expected =
-        CompletionMeet.{location: line0column8, base: "lo", bufferId: 0};
+        CompletionMeet.{
+          location: line0column8,
+          insertLocation: line0column8,
+          base: "lo",
+          bufferId: 0,
+        };
       expect.equal(result, Some(expected));
     });
   })


### PR DESCRIPTION
__Issue:__ After opening a module (ie, `open Array`), functions that are now exposed, like `max` wouldn't show up in completion.

__Defect:__ When typing (ie, `m|`), the completion meet would be at position 0 - and querying the completions at position 0 for the rescript provider wouldn't return anything.

__Fix:__ In the case where a token is at the beginning of a line, or after a space, query after the first character - this gives better results and mimics the behavior of Code. In addition,  keep track of a separate `insertLocation` which built-in keywords and snippets can use to pick up the correct insertion range.

Fixes #3258 