### PR TITLE
fix(quickmenu/#3262): Fix delay in processing control+w in quick menu / command line

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -52,6 +52,7 @@
 - #3274 - Completion: Fix race condition between completion subscription and buffer updates (fixes #3274)
 - #3263 - Formatting: Update cursor position based on formatting edits
 - #3272 - Snippets: Fix error parsing '@media' sass snippet
+- #3280 - Quickmenu: Fix delay in processing Control+W key (fixes #3262)
 
 ### Performance
 

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -7,7 +7,9 @@
 open Oni_Core;
 
 module Commands = GlobalCommands;
-let windowCommandCondition = "!insertMode || terminalFocus" |> WhenExpr.parse;
+let windowCommandCondition =
+  "!commandLineFocus && !insertMode && !inQuickOpen || terminalFocus"
+  |> WhenExpr.parse;
 
 let isMacCondition = "isMac" |> WhenExpr.parse;
 let defaultKeyBindings =


### PR DESCRIPTION
__Issue:__ When using `control+w` to delete a word in the quick open / command palette / command line, there would be a delay before the command is executed.

__Defect:__ The window commands were active in this context, and the input state machine was waiting for the next key in the binding.

__Fix:__ Update the window command condition to exclude the quick menu and vim command line.

Fixes #3262 