### PR TITLE
feat(definition/#3261): Add support for 'editor.definition'

### DIFF
--- a/integration_test/ClipboardxpTest.re
+++ b/integration_test/ClipboardxpTest.re
@@ -30,7 +30,7 @@ runTest(~name="ClipboardyypTest", ({dispatch, wait, runEffects, _}) => {
   });
 
   let testFile = getAssetPath("some-test-file.txt");
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   wait(~name="Verify buffer is loaded", (state: State.t) => {
     state

--- a/integration_test/ClipboardyypTest.re
+++ b/integration_test/ClipboardyypTest.re
@@ -30,7 +30,7 @@ runTest(~name="ClipboardyypTest", ({dispatch, wait, runEffects, _}) => {
   });
 
   let testFile = getAssetPath("some-test-file.txt");
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   wait(~name="Verify buffer is loaded", (state: State.t) => {
     state

--- a/integration_test/ConfigurationPerFileTypeTest.re
+++ b/integration_test/ConfigurationPerFileTypeTest.re
@@ -38,7 +38,9 @@ runTest(
       );
 
     // Create a plaintext file
-    dispatch(Actions.OpenFileByPath("test.txt", None, None));
+    dispatch(
+      Actions.OpenFileByPath("test.txt", SplitDirection.Current, None),
+    );
 
     // Verify plaintext buffer matches the default settings:
     waitForBuffer(~name="Plaintext buffer should pick up defaults", buffer => {
@@ -51,7 +53,9 @@ runTest(
     });
 
     // Open a new buffer, that should pick up the per-filetype settings
-    dispatch(Actions.OpenFileByPath("test.js", None, None));
+    dispatch(
+      Actions.OpenFileByPath("test.js", SplitDirection.Current, None),
+    );
 
     waitForBuffer(
       ~name="Wait for active buffer to pick up javascript filetype", buffer => {

--- a/integration_test/EditorUtf8Test.re
+++ b/integration_test/EditorUtf8Test.re
@@ -11,7 +11,7 @@ runTest(~name="EditorUtf8Test", ({input, dispatch, wait, _}) => {
   );
 
   let testFile = getAssetPath("utf8.txt");
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   wait(~name="Verify buffer is loaded", (state: State.t) => {
     state

--- a/integration_test/ExCommandKeybindingNormTest.re
+++ b/integration_test/ExCommandKeybindingNormTest.re
@@ -13,7 +13,9 @@ runTest(
   ~name="ExCommandKeybindingNormTest",
   ({dispatch, wait, input, _}) => {
     let testFile = getAssetPath("some-test-file.txt");
-    dispatch(Actions.OpenFileByPath(testFile, None, None));
+    dispatch(
+      Actions.OpenFileByPath(testFile, Oni_Core.SplitDirection.Current, None),
+    );
 
     wait(~name="Verify buffer is loaded", (state: State.t) => {
       state

--- a/integration_test/ExCommandKeybindingWithArgsTest.re
+++ b/integration_test/ExCommandKeybindingWithArgsTest.re
@@ -16,7 +16,7 @@ runTest(
   ~name="ExCommandKeybindingTest",
   ({dispatch, wait, input, _}) => {
     let testFile = getAssetPath("some-test-file.txt");
-    dispatch(Actions.OpenFileByPath(testFile, None, None));
+    dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
     wait(~name="Verify buffer is loaded", (state: State.t) =>
       switch (Selectors.getActiveBuffer(state)) {

--- a/integration_test/ExtHostBufferOpenTest.re
+++ b/integration_test/ExtHostBufferOpenTest.re
@@ -27,7 +27,9 @@ runTest(~name="ExtHostBufferOpen", ({dispatch, wait, _}) => {
   let testFile = getAssetPath("some-test-file.txt");
 
   // Open an erroneous CSS file - verify we get some diagnostics
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(
+    Actions.OpenFileByPath(testFile, Oni_Core.SplitDirection.Current, None),
+  );
 
   let () =
     TS.validateTextIsSynchronized(

--- a/integration_test/ExtHostBufferUpdatesTest.re
+++ b/integration_test/ExtHostBufferUpdatesTest.re
@@ -26,7 +26,9 @@ runTest(~name="ExtHostBufferUpdates", ({input, dispatch, wait, key, _}) => {
   );
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath("test.oni-dev", None, None));
+  dispatch(
+    Actions.OpenFileByPath("test.oni-dev", SplitDirection.Current, None),
+  );
 
   // Wait for the oni-dev filetype
   wait(

--- a/integration_test/ExtHostCompletionTest.re
+++ b/integration_test/ExtHostCompletionTest.re
@@ -23,7 +23,9 @@ runTest(~name="ExtHostCompletionTest", ({input, dispatch, wait, _}) => {
   );
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath("test.oni-dev", None, None));
+  dispatch(
+    Actions.OpenFileByPath("test.oni-dev", SplitDirection.Current, None),
+  );
 
   // Wait for the oni-dev filetype
   wait(

--- a/integration_test/ExtHostDefinitionTest.re
+++ b/integration_test/ExtHostDefinitionTest.re
@@ -24,7 +24,9 @@ runTest(~name="ExtHostDefinitionTest", ({input, dispatch, wait, key, _}) => {
   );
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath("test.oni-dev", None, None));
+  dispatch(
+    Actions.OpenFileByPath("test.oni-dev", SplitDirection.Current, None),
+  );
 
   // Wait for the oni-dev filetype
   wait(

--- a/integration_test/FormatOnSaveTest.re
+++ b/integration_test/FormatOnSaveTest.re
@@ -33,7 +33,13 @@ runTest(
     let unformattedFilePath = getAssetPath("test.unformatted.js");
 
     // Create a buffer
-    dispatch(Actions.OpenFileByPath(unformattedFilePath, None, None));
+    dispatch(
+      Actions.OpenFileByPath(
+        unformattedFilePath,
+        SplitDirection.Current,
+        None,
+      ),
+    );
 
     wait(
       ~timeout=30.0,

--- a/integration_test/InputRemapMotionTest.re
+++ b/integration_test/InputRemapMotionTest.re
@@ -11,7 +11,9 @@ runTest(
 
   let testFile = getAssetPath("some-test-file.txt");
   // Open an erroneous CSS file - verify we get some diagnostics
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(
+    Actions.OpenFileByPath(testFile, Oni_Core.SplitDirection.Current, None),
+  );
 
   wait(~name="buffer load", (state: State.t) => {
     switch (Selectors.getActiveBuffer(state)) {

--- a/integration_test/LanguageCssTest.re
+++ b/integration_test/LanguageCssTest.re
@@ -19,7 +19,9 @@ runTest(~name="LanguageCssTest", ({input, dispatch, wait, _}) => {
     ~description="css completion",
     () => {
       // Create a buffer
-      dispatch(Actions.OpenFileByPath("test.css", None, None));
+      dispatch(
+        Actions.OpenFileByPath("test.css", SplitDirection.Current, None),
+      );
 
       // Wait for the CSS filetype
       wait(

--- a/integration_test/LanguageTypeScriptTest.re
+++ b/integration_test/LanguageTypeScriptTest.re
@@ -16,7 +16,9 @@ runTest(~name="LanguageTypeScriptTest", ({input, dispatch, wait, _}) => {
     ~description="typescript completion",
     () => {
       // Create a buffer
-      dispatch(Actions.OpenFileByPath("test.ts", None, None));
+      dispatch(
+        Actions.OpenFileByPath("test.ts", SplitDirection.Current, None),
+      );
 
       wait(
         ~timeout=30.0,

--- a/integration_test/LineEndingsCRLFTest.re
+++ b/integration_test/LineEndingsCRLFTest.re
@@ -11,7 +11,7 @@ runTest(~name="LineEndingsCRLFTest", ({dispatch, wait, _}) => {
   let testFile = getAssetPath("test.crlf");
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   // Wait for highlights to show up
   wait(

--- a/integration_test/LineEndingsLFTest.re
+++ b/integration_test/LineEndingsLFTest.re
@@ -11,7 +11,7 @@ runTest(~name="LineEndingsLFTest", ({dispatch, wait, _}) => {
   let testFile = getAssetPath("test.lf");
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   wait(~name="Verify buffer is loaded", (state: State.t) => {
     state

--- a/integration_test/RegressionFileModifiedIndicationTest.re
+++ b/integration_test/RegressionFileModifiedIndicationTest.re
@@ -18,7 +18,7 @@ runTest(
   dispatch(
     Actions.OpenFileByPath(
       "regression-file-modified-indication.txt",
-      None,
+      SplitDirection.Current,
       None,
     ),
   );

--- a/integration_test/RegressionFontFallbackTest.re
+++ b/integration_test/RegressionFontFallbackTest.re
@@ -17,7 +17,9 @@ runTest(~name="RegressionFontFallback", ({input, dispatch, wait, _}) => {
   let testFile = getAssetPath("utf8-test-file.htm");
 
   // Open test file
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(
+    Actions.OpenFileByPath(testFile, Oni_Core.SplitDirection.Current, None),
+  );
 
   wait(~name="Wait for cursor to be ready", (state: State.t) => {
     let location: CharacterPosition.t =

--- a/integration_test/SyntaxHighlightPhpTest.re
+++ b/integration_test/SyntaxHighlightPhpTest.re
@@ -37,7 +37,7 @@ runTest(~name="SyntaxHighlightPhpTest", ({dispatch, wait, _}) => {
   let testFile = getAssetPath("test-syntax.php");
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   // Wait for highlights to show up
   wait(~name="Verify we get syntax highlights", (state: State.t) => {

--- a/integration_test/SyntaxHighlightTextMateTest.re
+++ b/integration_test/SyntaxHighlightTextMateTest.re
@@ -14,7 +14,7 @@ runTest(~name="SyntaxHighlightTextMateTest", ({dispatch, wait, _}) => {
   let testFile = getAssetPath("large-c-file.c");
 
   // Create a buffer
-  dispatch(Actions.OpenFileByPath(testFile, None, None));
+  dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
   // Wait for highlights to show up
   wait(

--- a/integration_test/SyntaxHighlightTreesitterTest.re
+++ b/integration_test/SyntaxHighlightTreesitterTest.re
@@ -22,7 +22,7 @@ runTest(
     let testFile = getAssetPath("some-test-file.json");
 
     // Create a buffer
-    dispatch(Actions.OpenFileByPath(testFile, None, None));
+    dispatch(Actions.OpenFileByPath(testFile, SplitDirection.Current, None));
 
     // Wait for highlights to show up
     wait(

--- a/integration_test/VimIncsearchScrollTest.re
+++ b/integration_test/VimIncsearchScrollTest.re
@@ -8,7 +8,7 @@ runTest(~name="VimIncsearchScrollTest", ({dispatch, wait, input, key, _}) => {
   );
 
   let largeCFile = getAssetPath("large-c-file.c");
-  dispatch(Actions.OpenFileByPath(largeCFile, None, None));
+  dispatch(Actions.OpenFileByPath(largeCFile, SplitDirection.Current, None));
 
   // Wait for file to load
   wait(

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -53,6 +53,7 @@ module Decoration = Decoration;
 module Persistence = Persistence;
 module Setup = Setup;
 module ShellUtility = ShellUtility;
+module SplitDirection = SplitDirection;
 module StringMap = Kernel.StringMap;
 module StringSet = Kernel.StringSet;
 module SubEx = SubEx;

--- a/src/Core/SplitDirection.re
+++ b/src/Core/SplitDirection.re
@@ -2,5 +2,10 @@
 type t =
   | Current
   | Horizontal
-  | Vertical({shouldReuse: bool})
+  | Vertical
+      // `shouldReuse` specifies the behavior in case there is an existing
+      // vertical split. If `shouldReuse` is `false`, a new split will always
+      // be created. If `shouldReuse` is `true`, the available existing
+      // split will be used.
+      ({shouldReuse: bool})
   | NewTab;

--- a/src/Core/SplitDirection.re
+++ b/src/Core/SplitDirection.re
@@ -2,5 +2,5 @@
 type t =
   | Current
   | Horizontal
-  | Vertical
+  | Vertical({shouldReuse: bool})
   | NewTab;

--- a/src/Core/SplitDirection.re
+++ b/src/Core/SplitDirection.re
@@ -1,0 +1,6 @@
+[@deriving show]
+type t =
+  | Current
+  | Horizontal
+  | Vertical
+  | NewTab;

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -152,14 +152,14 @@ type msg =
   | Command(command)
   | EditorRequested({
       buffer: [@opaque] Oni_Core.Buffer.t,
-      split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      split: SplitDirection.t,
       position: option(CharacterPosition.t),
       grabFocus: bool,
       preview: bool,
     })
   | NewBufferAndEditorRequested({
       buffer: [@opaque] Oni_Core.Buffer.t,
-      split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      split: SplitDirection.t,
       position: option(CharacterPosition.t),
       grabFocus: bool,
       preview: bool,
@@ -241,7 +241,7 @@ type outmsg =
   | BufferSaved(Oni_Core.Buffer.t)
   | CreateEditor({
       buffer: Oni_Core.Buffer.t,
-      split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      split: SplitDirection.t,
       position: option(BytePosition.t),
       grabFocus: bool,
       preview: bool,
@@ -538,7 +538,7 @@ module Effects = {
       (
         ~font: Service_Font.font,
         ~languageInfo: Exthost.LanguageInfo.t,
-        ~split=`Current,
+        ~split=SplitDirection.Current,
         ~position=None,
         ~grabFocus=true,
         ~filePath,

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -76,7 +76,7 @@ type outmsg =
   | BufferSaved(Oni_Core.Buffer.t)
   | CreateEditor({
       buffer: Oni_Core.Buffer.t,
-      split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      split: SplitDirection.t,
       position: option(BytePosition.t),
       grabFocus: bool,
       preview: bool,
@@ -113,7 +113,7 @@ module Effects: {
     (
       ~font: Service_Font.font,
       ~languageInfo: Exthost.LanguageInfo.t,
-      ~split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      ~split: SplitDirection.t,
       model
     ) =>
     Isolinear.Effect.t(msg);
@@ -122,7 +122,7 @@ module Effects: {
     (
       ~font: Service_Font.font,
       ~languageInfo: Exthost.LanguageInfo.t,
-      ~split: [ | `Current | `Horizontal | `Vertical | `NewTab]=?,
+      ~split: SplitDirection.t=?,
       ~position: option(CharacterPosition.t)=?,
       ~grabFocus: bool=?,
       ~filePath: string,
@@ -135,7 +135,7 @@ module Effects: {
     (
       ~font: Service_Font.font,
       ~languageInfo: Exthost.LanguageInfo.t,
-      ~split: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      ~split: SplitDirection.t,
       ~bufferId: int,
       model
     ) =>

--- a/src/Feature/LanguageSupport/Definition.re
+++ b/src/Feature/LanguageSupport/Definition.re
@@ -179,6 +179,6 @@ module Contributions = {
 
   let keybindings = [
     Keybindings.gotoDefinition,
-    Keybindings.gotoDefinitionAside,
+    //Keybindings.gotoDefinitionAside,
   ];
 };

--- a/src/Feature/LanguageSupport/Definition.re
+++ b/src/Feature/LanguageSupport/Definition.re
@@ -26,7 +26,7 @@ type model = {
 
 [@deriving show]
 type command =
-  | GotoDefinition;
+  | GotoDefinition(SplitDirection.t);
 
 [@deriving show]
 type msg =
@@ -46,7 +46,7 @@ let update = (msg, model) =>
       {...model, maybeDefinition: Some(definition)},
       Outmsg.Nothing,
     )
-  | Command(GotoDefinition) =>
+  | Command(GotoDefinition(direction)) =>
     let outmsg =
       switch (model.maybeDefinition) {
       | None => Outmsg.Nothing
@@ -62,6 +62,7 @@ let update = (msg, model) =>
         Outmsg.OpenFile({
           filePath: definition.uri |> Oni_Core.Uri.toFileSystemPath,
           location: Some(position),
+          direction,
         });
       };
     (model, outmsg);
@@ -145,7 +146,15 @@ module Commands = {
       ~category="Language",
       ~title="Go-to Definition",
       "editor.action.revealDefinition",
-      Command(GotoDefinition),
+      Command(GotoDefinition(SplitDirection.Current)),
+    );
+
+  let gotoDefinitionAside =
+    define(
+      ~category="Language",
+      ~title="Go-to Definition Aside",
+      "editor.action.revealDefinitionAside",
+      Command(GotoDefinition(SplitDirection.Horizontal)),
     );
 };
 
@@ -154,12 +163,22 @@ module Keybindings = {
 
   let condition = "normalMode" |> WhenExpr.parse;
 
-  let goToDefinition =
+  let gotoDefinition =
     bind(~key="<F12>", ~command=Commands.gotoDefinition.id, ~condition);
+
+  let gotoDefinitionAside =
+    bind(
+      ~key="<C-K>F12",
+      ~command=Commands.gotoDefinitionAside.id,
+      ~condition,
+    );
 };
 
 module Contributions = {
-  let commands = [Commands.gotoDefinition];
+  let commands = [Commands.gotoDefinition, Commands.gotoDefinitionAside];
 
-  let keybindings = [Keybindings.goToDefinition];
+  let keybindings = [
+    Keybindings.gotoDefinition,
+    Keybindings.gotoDefinitionAside,
+  ];
 };

--- a/src/Feature/LanguageSupport/Definition.re
+++ b/src/Feature/LanguageSupport/Definition.re
@@ -154,7 +154,7 @@ module Commands = {
       ~category="Language",
       ~title="Go-to Definition Aside",
       "editor.action.revealDefinitionAside",
-      Command(GotoDefinition(SplitDirection.Vertical)),
+      Command(GotoDefinition(SplitDirection.Vertical({shouldReuse: true}))),
     );
 };
 

--- a/src/Feature/LanguageSupport/Definition.re
+++ b/src/Feature/LanguageSupport/Definition.re
@@ -154,7 +154,7 @@ module Commands = {
       ~category="Language",
       ~title="Go-to Definition Aside",
       "editor.action.revealDefinitionAside",
-      Command(GotoDefinition(SplitDirection.Horizontal)),
+      Command(GotoDefinition(SplitDirection.Vertical)),
     );
 };
 
@@ -165,13 +165,13 @@ module Keybindings = {
 
   let gotoDefinition =
     bind(~key="<F12>", ~command=Commands.gotoDefinition.id, ~condition);
-
-  let gotoDefinitionAside =
-    bind(
-      ~key="<C-K>F12",
-      ~command=Commands.gotoDefinitionAside.id,
-      ~condition,
-    );
+  // TODO:
+  // let gotoDefinitionAside =
+  //   bind(
+  //     ~key="<C-K>F12",
+  //     ~command=Commands.gotoDefinitionAside.id,
+  //     ~condition,
+  //   );
 };
 
 module Contributions = {

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -67,6 +67,7 @@ type outmsg =
   | OpenFile({
       filePath: string,
       location: option(CharacterPosition.t),
+      direction: Oni_Core.SplitDirection.t,
     })
   | ReferencesAvailable
   | NotifySuccess(string)
@@ -99,7 +100,8 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
     | Outmsg.NotifySuccess(msg) => NotifySuccess(msg)
     | Outmsg.NotifyFailure(msg) => NotifyFailure(msg)
     | Outmsg.ReferencesAvailable => ReferencesAvailable
-    | Outmsg.OpenFile({filePath, location}) => OpenFile({filePath, location})
+    | Outmsg.OpenFile({filePath, location, direction}) =>
+      OpenFile({filePath, location, direction})
     | Outmsg.Effect(eff) => Effect(eff |> Isolinear.Effect.map(f))
     | Outmsg.CodeLensesChanged({
         handle,

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -70,6 +70,7 @@ type outmsg =
   | OpenFile({
       filePath: string,
       location: option(CharacterPosition.t),
+      direction: SplitDirection.t,
     })
   | ReferencesAvailable
   | NotifySuccess(string)

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -1,3 +1,4 @@
+open Oni_Core;
 open EditorCoreTypes;
 
 type internalMsg('a) =
@@ -20,6 +21,7 @@ type internalMsg('a) =
   | OpenFile({
       filePath: string,
       location: option(CharacterPosition.t),
+      direction: SplitDirection.t,
     })
   | ReferencesAvailable
   | NotifySuccess(string)

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -170,11 +170,11 @@ let update = (~focus, model, msg) => {
 
   | Command(SplitVertical) =>
     let editor = Feature_Editor.Editor.copy(activeEditor(model));
-    (split(~editor, `Vertical, model), SplitAdded);
+    (split(~shouldReuse=false, ~editor, `Vertical, model), SplitAdded);
 
   | Command(SplitHorizontal) =>
     let editor = Feature_Editor.Editor.copy(activeEditor(model));
-    (split(~editor, `Horizontal, model), SplitAdded);
+    (split(~shouldReuse=false, ~editor, `Horizontal, model), SplitAdded);
 
   | Command(CloseActiveEditor) =>
     switch (removeActiveEditor(model)) {

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -26,7 +26,14 @@ let visibleEditors: model => list(Editor.t);
 let editorById: (int, model) => option(Editor.t);
 let removeEditor: (int, model) => option(model);
 
-let split: (~editor: Editor.t, [ | `Horizontal | `Vertical], model) => model;
+let split:
+  (
+    ~shouldReuse: bool,
+    ~editor: Editor.t,
+    [ | `Horizontal | `Vertical],
+    model
+  ) =>
+  model;
 
 let activeEditor: model => Editor.t;
 let activeGroupEditors: model => list(Editor.t);

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -253,7 +253,7 @@ let insertWindow = (target, direction, focus) =>
   updateTree(Layout.insertWindow(target, direction, focus));
 let removeWindow = target => updateTree(Layout.removeWindow(target));
 
-let split = (~editor, direction, model) => {
+let split = (~shouldReuse as _, ~editor, direction, model) => {
   let newGroup = Group.create([editor]);
 
   updateActiveLayout(

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -253,27 +253,6 @@ let insertWindow = (target, direction, focus) =>
   updateTree(Layout.insertWindow(target, direction, focus));
 let removeWindow = target => updateTree(Layout.removeWindow(target));
 
-let split = (~shouldReuse as _, ~editor, direction, model) => {
-  let newGroup = Group.create([editor]);
-
-  updateActiveLayout(
-    layout =>
-      {
-        groups: [newGroup, ...layout.groups],
-        activeGroupId: newGroup.id,
-        tree:
-          Layout.insertWindow(
-            `After(layout.activeGroupId),
-            direction,
-            newGroup.id,
-            activeTree(layout),
-          ),
-        uncommittedTree: `None,
-      },
-    model,
-  );
-};
-
 let move = (focus, dirX, dirY, layout) => {
   let positioned = Positioned.fromLayout(0, 0, 200, 200, layout);
 
@@ -285,6 +264,46 @@ let moveLeft = current => move(current, -1, 0);
 let moveRight = current => move(current, 1, 0);
 let moveUp = current => move(current, 0, -1);
 let moveDown = current => move(current, 0, 1);
+
+let hasSplitToRight = model => {
+  let layout = model |> activeLayout;
+  let newActiveGroupId =
+    layout |> activeTree |> moveRight(layout.activeGroupId);
+
+  layout.activeGroupId != newActiveGroupId;
+};
+
+let split = (~shouldReuse, ~editor, direction, model) =>
+  if (shouldReuse && direction == `Vertical && hasSplitToRight(model)) {
+    // TODO: Consider split open direction?
+    let layout = model |> activeLayout;
+    let newActiveGroupId =
+      layout |> activeTree |> moveRight(layout.activeGroupId);
+    model
+    |> updateActiveLayout(layout =>
+         {...layout, activeGroupId: newActiveGroupId}
+       )
+    |> updateActiveGroup(Group.openEditor(editor));
+  } else {
+    let newGroup = Group.create([editor]);
+
+    updateActiveLayout(
+      layout =>
+        {
+          groups: [newGroup, ...layout.groups],
+          activeGroupId: newGroup.id,
+          tree:
+            Layout.insertWindow(
+              `After(layout.activeGroupId),
+              direction,
+              newGroup.id,
+              activeTree(layout),
+            ),
+          uncommittedTree: `None,
+        },
+      model,
+    );
+  };
 
 let nextEditor = updateActiveGroup(Group.nextEditor);
 

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -95,21 +95,13 @@ type t =
   | ListFocusDown
   | ListSelect
   | ListSelectBackground
-  | NewBuffer({direction: [ | `Current | `Horizontal | `Vertical | `NewTab]})
+  | NewBuffer({direction: SplitDirection.t})
   | OpenBufferById({
       bufferId: int,
-      direction: [ | `Current | `Horizontal | `Vertical | `NewTab],
+      direction: SplitDirection.t,
     })
-  | OpenFileByPath(
-      string,
-      option([ | `Current | `Horizontal | `Vertical | `NewTab]),
-      option(CharacterPosition.t),
-    )
-  | PreviewFileByPath(
-      string,
-      option([ | `Horizontal | `Vertical | `NewTab]),
-      option(CharacterPosition.t),
-    )
+  | OpenFileByPath(string, SplitDirection.t, option(CharacterPosition.t))
+  | PreviewFileByPath(string, SplitDirection.t, option(CharacterPosition.t))
   | Pasted({
       rawText: string,
       isMultiLine: bool,

--- a/src/Store/CommandStoreConnector.re
+++ b/src/Store/CommandStoreConnector.re
@@ -19,7 +19,9 @@ let start = () => {
 
   let openChangelogEffect = _ =>
     Isolinear.Effect.createWithDispatch(~name="oni.changelog", dispatch => {
-      dispatch(OpenFileByPath(BufferPath.changelog, None, None))
+      dispatch(
+        OpenFileByPath(BufferPath.changelog, SplitDirection.Current, None),
+      )
     });
 
   let commands = [

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1248,7 +1248,7 @@ let update =
 
             // However, if we're splitting, we need to clone the editor
             | SplitDirection.Horizontal
-            | SplitDirection.Vertical
+            | SplitDirection.Vertical(_)
             | SplitDirection.NewTab => Editor.copy(ed)
             };
 
@@ -1268,9 +1268,14 @@ let update =
         switch (split) {
         | SplitDirection.Current => state.layout
         | SplitDirection.Horizontal =>
-          Feature_Layout.split(~editor, `Horizontal, state.layout)
-        | SplitDirection.Vertical =>
-          Feature_Layout.split(~editor, `Vertical, state.layout)
+          Feature_Layout.split(
+            ~shouldReuse=false,
+            ~editor,
+            `Horizontal,
+            state.layout,
+          )
+        | SplitDirection.Vertical({shouldReuse}) =>
+          Feature_Layout.split(~shouldReuse, ~editor, `Vertical, state.layout)
         | SplitDirection.NewTab => Feature_Layout.addLayoutTab(state.layout)
         };
 
@@ -1686,7 +1691,7 @@ let update =
         let windowTreeDirection =
           switch (splitDirection) {
           | Horizontal => SplitDirection.Horizontal
-          | Vertical => SplitDirection.Vertical
+          | Vertical => SplitDirection.Vertical({shouldReuse: false})
           | Current => SplitDirection.Current
           };
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -11,10 +11,11 @@ module Internal = {
     |> Isolinear.Effect.map(msg => Actions.Notification(msg));
   };
 
-  let openFileEffect = (~position=None, filePath) => {
+  let openFileEffect =
+      (~direction=SplitDirection.Current, ~position=None, filePath) => {
     Isolinear.Effect.createWithDispatch(
       ~name="features.openFileByPath", dispatch =>
-      dispatch(OpenFileByPath(filePath, SplitDirection.Current, position))
+      dispatch(OpenFileByPath(filePath, direction, position))
     );
   };
 
@@ -731,9 +732,9 @@ let update =
           )
           |> Isolinear.Effect.map(msg => Snippets(msg)),
         );
-      | OpenFile({filePath, location}) => (
+      | OpenFile({filePath, location, direction}) => (
           state,
-          Internal.openFileEffect(~position=location, filePath),
+          Internal.openFileEffect(~direction, ~position=location, filePath),
         )
       | NotifySuccess(msg) => (
           state,

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -131,7 +131,7 @@ let start = () => {
                category: None,
                name,
                command: () => {
-                 Actions.OpenFileByPath(path, None, None);
+                 Actions.OpenFileByPath(path, SplitDirection.Current, None);
                },
                icon:
                  Component_FileExplorer.getFileIcon(
@@ -540,7 +540,8 @@ let subscriptions = (ripgrep, dispatch) => {
         Actions.{
           category: None,
           name: Path.toRelative(~base=directory, fullPath),
-          command: () => Actions.OpenFileByPath(fullPath, None, None),
+          command: () =>
+            Actions.OpenFileByPath(fullPath, SplitDirection.Current, None),
           icon:
             Component_FileExplorer.getFileIcon(
               ~languageInfo,

--- a/src/Store/Reducer.re
+++ b/src/Store/Reducer.re
@@ -17,15 +17,6 @@ let reduce: (State.t, Actions.t) => State.t =
       };
 
       switch (a) {
-      // Turn off zenMode with :vsp/:sp
-      | OpenFileByPath(_, Some(_), _) => {
-          ...s,
-          zen: Feature_Zen.exitZenMode(s.zen),
-        }
-      | PreviewFileByPath(_, Some(_), _) => {
-          ...s,
-          zen: Feature_Zen.exitZenMode(s.zen),
-        }
       | SetLanguageInfo(languageInfo) => {...s, languageInfo}
       | SetGrammarRepository(grammarRepository) => {...s, grammarRepository}
       | SetIconTheme(iconTheme) => {...s, iconTheme}

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -111,11 +111,16 @@ let start =
       | NewHorizontal =>
         Actions.NewBuffer({direction: Core.SplitDirection.Horizontal})
       | NewVertical =>
-        Actions.NewBuffer({direction: Core.SplitDirection.Vertical})
+        Actions.NewBuffer({
+          direction: Core.SplitDirection.Vertical({shouldReuse: false}),
+        })
       | NewTabPage =>
         Actions.NewBuffer({direction: Core.SplitDirection.NewTab})
       | Vertical({filePath}) =>
-        actionForFilePath(filePath, Core.SplitDirection.Vertical)
+        actionForFilePath(
+          filePath,
+          Core.SplitDirection.Vertical({shouldReuse: false}),
+        )
       | Horizontal({filePath}) =>
         actionForFilePath(filePath, Core.SplitDirection.Horizontal)
       | TabPage({filePath}) =>

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -61,7 +61,12 @@ let start =
 
   let _: unit => unit =
     Vim.onVersion(() => {
-      Actions.OpenFileByPath("oni://Version", None, None) |> dispatch
+      Actions.OpenFileByPath(
+        "oni://Version",
+        Core.SplitDirection.Current,
+        None,
+      )
+      |> dispatch
     });
 
   let _: unit => unit =
@@ -96,19 +101,25 @@ let start =
 
     let actionForFilePath = (filePath, direction) => {
       switch (filePath) {
-      | Some(fp) => Actions.OpenFileByPath(fp, Some(direction), None)
+      | Some(fp) => Actions.OpenFileByPath(fp, direction, None)
       // No file path specified, so let's use the current buffer
       | None => Actions.OpenBufferById({bufferId: currentBufferId, direction})
       };
     };
     Vim.Split.(
       switch (split) {
-      | NewHorizontal => Actions.NewBuffer({direction: `Horizontal})
-      | NewVertical => Actions.NewBuffer({direction: `Vertical})
-      | NewTabPage => Actions.NewBuffer({direction: `NewTab})
-      | Vertical({filePath}) => actionForFilePath(filePath, `Vertical)
-      | Horizontal({filePath}) => actionForFilePath(filePath, `Horizontal)
-      | TabPage({filePath}) => actionForFilePath(filePath, `NewTab)
+      | NewHorizontal =>
+        Actions.NewBuffer({direction: Core.SplitDirection.Horizontal})
+      | NewVertical =>
+        Actions.NewBuffer({direction: Core.SplitDirection.Vertical})
+      | NewTabPage =>
+        Actions.NewBuffer({direction: Core.SplitDirection.NewTab})
+      | Vertical({filePath}) =>
+        actionForFilePath(filePath, Core.SplitDirection.Vertical)
+      | Horizontal({filePath}) =>
+        actionForFilePath(filePath, Core.SplitDirection.Horizontal)
+      | TabPage({filePath}) =>
+        actionForFilePath(filePath, Core.SplitDirection.NewTab)
       }
     );
   };
@@ -151,7 +162,7 @@ let start =
 
              Actions.OpenFileByPath(
                definitionResult.uri |> Core.Uri.toFileSystemPath,
-               None,
+               Core.SplitDirection.Current,
                Some(position),
              );
            });
@@ -551,7 +562,11 @@ let start =
       if (showUpdateChangelog
           && Core.BuildInfo.commitId != Persistence.Global.version()) {
         dispatch(
-          Actions.OpenFileByPath(Core.BufferPath.updateChangelog, None, None),
+          Actions.OpenFileByPath(
+            Core.BufferPath.updateChangelog,
+            Core.SplitDirection.Current,
+            None,
+          ),
         );
       };
       libvimHasInitialized := true;
@@ -589,7 +604,7 @@ let start =
         dispatch(
           Actions.OpenBufferById({
             bufferId: newContext.bufferId,
-            direction: `Current,
+            direction: Core.SplitDirection.Current,
           }),
         );
       } else {
@@ -621,7 +636,12 @@ let start =
 
         // If we switched buffer, open it in current editor
         if (previousBufferId != bufferId) {
-          dispatch(Actions.OpenBufferById({bufferId, direction: `Current}));
+          dispatch(
+            Actions.OpenBufferById({
+              bufferId,
+              direction: Core.SplitDirection.Current,
+            }),
+          );
         };
 
         updateActiveEditorMode(subMode, mode, effects);

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -515,7 +515,14 @@ switch (eff) {
     |> (ignore: Revery.App.unsubscribe => unit);
 
     List.iter(
-      v => dispatch(Model.Actions.OpenFileByPath(v, None, None)),
+      v =>
+        dispatch(
+          Model.Actions.OpenFileByPath(
+            v,
+            Oni_Core.SplitDirection.Current,
+            None,
+          ),
+        ),
       cliOptions.filesToOpen,
     );
 


### PR DESCRIPTION
This adds support for the `"editor.action.revealDefinitionAside"` command - which opens in a vertical split (reusing the current split, if available).

This PR doesn't add a default keybinding, at the moment - the equivalent key-binding for VSCode is `Control+K`, `F12` on Windows/Linux, which conflicts with the `Control+K` vim key. I need to consider a holistic approach for this - there are several VSCode keybindings that are prefixed by `Control+K`/`Command+K`.

However, with this PR, a key can be bound - for example, this binding would override the default `gd` behavior:
```json
{
  {
    "key": "gd",
    "command": "editor.action.revealDefinitionAside",
    "when": "editorTextFocus && normalMode"
  }
}
```

Fixes #3261 