### PR TITLE
fix(editors/#3275): Scope control+tab to visible editors

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -54,6 +54,7 @@
 - #3272 - Snippets: Fix error parsing '@media' sass snippet
 - #3276 - Completion: Handle replace range after cursor position (related #2583)
 - #3280 - Quickmenu: Fix delay in processing Control+W key (fixes #3262)
+- #3286 - Quickmenu: Scope control+tab to visible editor (fixes #3275, #2009)
 
 ### Performance
 


### PR DESCRIPTION
__Issue:__ When using `Control+Tab`, closed editors / terminals can pop-up in the list, which is annoying

__Fix:__ Filter the buffer pickers to the set of visible buffers.

Fixes #2009
Fixes #3275 

Related to #3247 , but there are some additional fixes needed to prune the buffer list - properly handling `bdelete`, `bwipeout`, etc.