### PR TITLE
fix(search/#3277): Search selected text

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -54,6 +54,7 @@
 - #3272 - Snippets: Fix error parsing '@media' sass snippet
 - #3276 - Completion: Handle replace range after cursor position (related #2583)
 - #3280 - Quickmenu: Fix delay in processing Control+W key (fixes #3262)
+- #3287 - Search: Initiate search automatically when text is selected (fixes #3277)
 
 ### Performance
 

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -17,7 +17,17 @@ type model = {
   resultsTree: Component_VimTree.model(string, LocationListItem.t),
 };
 
-let resetFocus = model => {...model, focus: FindInput};
+let resetFocus = (~query: option(string), model) => {
+  switch (query) {
+  | None => {...model, focus: FindInput}
+  | Some(query) => {
+      ...model,
+      query,
+      focus: FindInput,
+      findInput: Component_InputText.set(~text=query, model.findInput),
+    }
+  };
+};
 
 let initial = {
   findInput: Component_InputText.create(~placeholder="Search"),

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -25,6 +25,7 @@ let resetFocus = (~query: option(string), model) => {
       query,
       focus: FindInput,
       findInput: Component_InputText.set(~text=query, model.findInput),
+      hits: query != model.query ? [] : model.hits,
     }
   };
 };

--- a/src/Feature/Search/Feature_Search.rei
+++ b/src/Feature/Search/Feature_Search.rei
@@ -28,7 +28,7 @@ type outmsg =
 
 let update: (~previewEnabled: bool, model, msg) => (model, option(outmsg));
 
-let resetFocus: model => model;
+let resetFocus: (~query: option(string), model) => model;
 
 let subscriptions:
   (

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1072,7 +1072,11 @@ let update =
           | Search =>
             {
               ...state,
-              searchPane: Feature_Search.resetFocus(state.searchPane),
+              searchPane:
+                Feature_Search.resetFocus(
+                  ~query=Some("test"),
+                  state.searchPane,
+                ),
             }
             |> FocusManager.push(Focus.Search)
           | Extensions =>

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1070,15 +1070,17 @@ let update =
             {...state, scm: Feature_SCM.resetFocus(state.scm)}
             |> FocusManager.push(Focus.SCM)
           | Search =>
+            let query =
+              FocusManager.current(state) == Focus.Editor
+                ? state.layout
+                  |> Feature_Layout.activeEditor
+                  |> Feature_Editor.Editor.singleLineSelectedText
+                : None;
             {
               ...state,
-              searchPane:
-                Feature_Search.resetFocus(
-                  ~query=Some("test"),
-                  state.searchPane,
-                ),
+              searchPane: Feature_Search.resetFocus(~query, state.searchPane),
             }
-            |> FocusManager.push(Focus.Search)
+            |> FocusManager.push(Focus.Search);
           | Extensions =>
             {
               ...state,


### PR DESCRIPTION
This PR augments the functionality of the existing search hot key (Control+Shift+F/Command+Shift+F) - if there is a selection in the active editor, seed the input component and start a search with it.

Related #3277 