### PR TITLE
fix(exthost/#3268): Part 1 - Fix activation error for dendron extension

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -55,6 +55,7 @@
 - #3276 - Completion: Handle replace range after cursor position (related #2583)
 - #3280 - Quickmenu: Fix delay in processing Control+W key (fixes #3262)
 - #3279 - Completion: Fix issue completing ReScript identifiers (fixes #3258)
+- #3286 - Quickmenu: Scope control+tab to visible editor (fixes #3275, #2009)
 
 ### Performance
 

--- a/development_extensions/oni-test-extension/extension.js
+++ b/development_extensions/oni-test-extension/extension.js
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require("vscode")
+const path = require("path");
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -11,6 +12,33 @@ function activate(context) {
     cleanup(
         vscode.commands.registerCommand("oni-test.showMessage", (message) => {
             vscode.window.showInformationMessage(message, [])
+        }),
+    );
+
+
+    const pass = () => {
+        vscode.window.showInformationMessage("PASS", [])
+    };
+
+    const fail = (msg) => {
+        vscode.window.showInformationMessage("FAIL: " + msg, [])
+    };
+
+    cleanup(
+        vscode.commands.registerCommand("oni-test.exthost.validateLogPathIsDirectory", () => {
+            (async () => {
+                // From docs: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext
+                // Given path might not exist - but parent directory will exist.
+                const logPath = path.dirname(context.logUri.path);
+                const logParentUri = vscode.Uri.file(logPath);
+                const statResult = await vscode.workspace.fs.stat(logParentUri);
+
+                if ((statResult.type & vscode.FileType.Directory) == vscode.FileType.Directory) {
+                    pass()
+                } else {
+                    fail("Filetype was: " + statResult.type.toString());
+                }
+            })();
         }),
     );
 }

--- a/development_extensions/oni-test-extension/package.json
+++ b/development_extensions/oni-test-extension/package.json
@@ -7,7 +7,8 @@
 		"vscode": "^1.25.0"
 	},
 	"activationEvents": [
-		"onCommand:oni-test.showMessage"
+		"onCommand:oni-test.showMessage",
+		"onCommand:oni-test.exthost.validateLogPathIsDirectory"
 	],
 	"main": "./extension.js",
 	"contributes": {},

--- a/integration_test/ExtHostContextTest.re
+++ b/integration_test/ExtHostContextTest.re
@@ -1,0 +1,47 @@
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+
+// This test validates:
+// - The 'oni-dev' extension gets activated
+// - When typing in an 'oni-dev' buffer, we get some completion results
+runTest(~name="ExtHostContextTest", ({dispatch, wait, _}) => {
+  wait(~timeout=30.0, ~name="Exthost is initialized", (state: State.t) =>
+    Feature_Exthost.isInitialized(state.exthost)
+  );
+
+  // Wait until the extension is activated
+  // Give some time for the exthost to start
+  wait(
+    ~timeout=30.0,
+    ~name="Validate the 'oni-dev' extension gets activated",
+    (state: State.t) =>
+    List.exists(
+      id => id == "oni-dev-extension",
+      state.extensions |> Feature_Extensions.activatedIds,
+    )
+  );
+
+  // Kick off an oni-test command that should activate the oni-test-extension:
+  dispatch(
+    Actions.Extensions(
+      Feature_Extensions.Msg.command(
+        ~command="oni-test.exthost.validateLogPathIsDirectory",
+        ~arguments=[],
+      ),
+    ),
+  );
+
+  // Validate test passes
+  wait(
+    ~timeout=30.0,
+    ~name="Validate test passes",
+    (state: State.t) => {
+      let notifications = Feature_Notification.all(state.notifications);
+      notifications
+      |> List.exists((notification: Feature_Notification.notification) => {
+           notification.message == "PASS"
+         });
+    },
+  );
+});

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -7,6 +7,7 @@
    EditorFontFromPathTest EditorFontValidTest EditorSplitFileTest
    EditorUtf8Test ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
    ExCommandKeybindingNormTest ExtConfigurationChangedTest
+   ExtHostContextTest
    ExtHostBufferOpenTest ExtHostBufferUpdatesTest
    ExtHostCommandActivationTest ExtHostCompletionTest ExtHostDefinitionTest
    ExtHostWorkspaceSearchTest FileWatcherTest FormatOnSaveTest
@@ -44,6 +45,7 @@
    ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
    ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
    ExtHostBufferUpdatesTest.exe ExtHostCommandActivationTest.exe
+   ExtHostContextTest.exe
    ExtHostCompletionTest.exe ExtHostDefinitionTest.exe
    ExtHostWorkspaceSearchTest.exe FileWatcherTest.exe FormatOnSaveTest.exe
    KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe

--- a/src/Store/ExtensionClient.re
+++ b/src/Store/ExtensionClient.re
@@ -248,8 +248,8 @@ let create =
 
   let tempDir = Filename.get_temp_dir_name();
 
-  let logFile = tempDir |> Uri.fromPath;
-  let logsLocation =
+  let logsLocation = tempDir |> Uri.fromPath;
+  let logFile =
     Filename.temp_file(~temp_dir=tempDir, "onivim2", "exthost.log")
     |> Uri.fromPath;
 


### PR DESCRIPTION
__Issue:__ The dendron extension is failing with an activation error:

![image](https://user-images.githubusercontent.com/13532591/111376942-56b95880-865d-11eb-9369-2e21a6378990.png)

__Defect:__ The path being supplied to the extension client via InitData is not a valid folder

__Fix:__ Fix up the `logsLocation` and `logFile` initialization logic. Add a test case covering the guarantee in the VSCode API docs - that the parent directory must exist and be a valid directory.