### PR TITLE
fix(symbols/#2002): Fix focusing symbol in outline via keyboard

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -54,6 +54,7 @@
 - #3272 - Snippets: Fix error parsing '@media' sass snippet
 - #3276 - Completion: Handle replace range after cursor position (related #2583)
 - #3280 - Quickmenu: Fix delay in processing Control+W key (fixes #3262)
+- #3290 - Symbols: Fix issues focusing nodes in symbol outline view (fixes #2002)
 
 ### Performance
 

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -293,6 +293,7 @@ let update = (~config, ~configuration, msg, model) => {
         model |> setActive(Some(node.path)),
         OpenFile(FpExp.toString(node.path)),
       )
+    | Component_VimTree.SelectedNode(_) => (model, Nothing)
     | Component_VimTree.Nothing => (model, Nothing)
     };
   };

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -36,7 +36,8 @@ type outmsg('node, 'leaf) =
   | Expanded('node)
   | Collapsed('node)
   | Touched('leaf)
-  | Selected('leaf);
+  | Selected('leaf)
+  | SelectedNode('node);
 
 let update:
   (msg, model('node, 'leaf)) => (model('node, 'leaf), outmsg('node, 'leaf));

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -235,7 +235,7 @@ let update = (~config, ~configuration, msg, model) => {
       | Component_VimTree.Expanded(_)
       | Component_VimTree.Collapsed(_) => Nothing
       | Component_VimTree.Touched(symbol) => SymbolSelected(symbol)
-      | Component_VimTree.Selected(_) => Nothing
+      | Component_VimTree.Selected(symbol) => SymbolSelected(symbol)
       };
 
     ({...model, symbolOutline}, outmsg');

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -234,8 +234,10 @@ let update = (~config, ~configuration, msg, model) => {
       | Component_VimTree.Nothing
       | Component_VimTree.Expanded(_)
       | Component_VimTree.Collapsed(_) => Nothing
-      | Component_VimTree.Touched(symbol) => SymbolSelected(symbol)
-      | Component_VimTree.Selected(symbol) => SymbolSelected(symbol)
+
+      | Component_VimTree.Touched(symbol)
+      | Component_VimTree.Selected(symbol)
+      | Component_VimTree.SelectedNode(symbol) => SymbolSelected(symbol)
       };
 
     ({...model, symbolOutline}, outmsg');

--- a/src/Feature/LanguageSupport/DocumentSymbols.re
+++ b/src/Feature/LanguageSupport/DocumentSymbols.re
@@ -22,7 +22,7 @@ let extHostSymbolToTree: Exthost.DocumentSymbol.t => Tree.t(symbol, symbol) =
     let rec loop = (~uniqueIdPrefix, extSymbol: Exthost.DocumentSymbol.t) => {
       let newUniqueId = uniqueIdPrefix ++ "." ++ extSymbol.name;
       let children =
-        extSymbol.children |> List.map(loop(~uniqueIdPrefix=newUniqueId));
+        extSymbol.children |> List.rev_map(loop(~uniqueIdPrefix=newUniqueId));
 
       let symbol = {
         uniqueId: newUniqueId,
@@ -60,7 +60,7 @@ type msg =
 let update = (msg, model) => {
   switch (msg) {
   | DocumentSymbolsAvailable({bufferId, symbols}) =>
-    let symbolTrees = symbols |> List.map(extHostSymbolToTree);
+    let symbolTrees = symbols |> List.rev_map(extHostSymbolToTree);
     let bufferToSymbols =
       IntMap.add(bufferId, symbolTrees, model.bufferToSymbols);
     {...model, bufferToSymbols};

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -454,6 +454,7 @@ let update = (~buffers, ~font, ~languageInfo, ~previewEnabled, msg, model) =>
           : OpenFile({filePath: item.file, position: item.location})
       | Component_VimTree.Selected(item) =>
         OpenFile({filePath: item.file, position: item.location})
+      | Component_VimTree.SelectedNode(_) => Nothing
       | Component_VimTree.Collapsed(_) => Nothing
       | Component_VimTree.Expanded({path, _}) =>
         Effect(
@@ -497,6 +498,7 @@ let update = (~buffers, ~font, ~languageInfo, ~previewEnabled, msg, model) =>
         previewEnabled
           ? PreviewFile({filePath: item.file, position: item.location})
           : OpenFile({filePath: item.file, position: item.location})
+      | Component_VimTree.SelectedNode(_) => Nothing
       | Component_VimTree.Selected(item) =>
         OpenFile({filePath: item.file, position: item.location})
       | Component_VimTree.Collapsed(_) => Nothing

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -201,6 +201,7 @@ let update = (~previewEnabled, model, msg) => {
       | Component_VimTree.Selected(item) =>
         Some(OpenFile({filePath: item.file, location: item.location}))
       // TODO
+      | Component_VimTree.SelectedNode(_) => None
       | Component_VimTree.Collapsed(_) => None
       | Component_VimTree.Expanded(_) => None
       };


### PR DESCRIPTION
This fixes a few issues called out in #2002 -
1) Pressing 'enter' on symbols in the symbol outline view did not focus them
2) Symbols were in reverse order
3) Nodes with children were not focusable - added <kbd>Space</kbd> as a key that focuses w/o expanding

Fixes #2002 