### PR TITLE
fix(vim): Fix control+d/control+u behavior in explorer

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -56,6 +56,7 @@
 - #3280 - Quickmenu: Fix delay in processing Control+W key (fixes #3262)
 - #3279 - Completion: Fix issue completing ReScript identifiers (fixes #3258)
 - #3286 - Quickmenu: Scope control+tab to visible editor (fixes #3275, #2009)
+- #3292 - Vim: Fix control+d/control+u behavior in explorer
 
 ### Performance
 


### PR DESCRIPTION
__Issue:__ Pressing `control+d` or `control+u` in the explorer would scroll the viewport, but not move the cursor. 

__Fix:__ Move the cursor when scrolling, like `control+d`/`control+u` do in the editor surface.