### PR TITLE
fix(formatting): Ephemeral notifications

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -7,6 +7,7 @@
 - #3289 - Extensions: Fix logs location path provided to extension (related #3268)
 - #3290 - Symbols: Fix issues focusing nodes in symbol outline view (fixes #2002)
 - #3292 - Vim: Fix control+d/control+u behavior in explorer
+- #3295 - Formatting: Make formatting notifications ephemeral
 
 ### Performance
 

--- a/src/Feature/Notification/Feature_Notification.rei
+++ b/src/Feature/Notification/Feature_Notification.rei
@@ -15,6 +15,7 @@ type notification = {
   message: string,
   source: option(string),
   yOffset: float,
+  ephemeral: bool,
 };
 
 type model;
@@ -24,6 +25,8 @@ let initial: model;
 let active: model => list(notification);
 
 let all: model => list(notification);
+
+let count: model => int;
 
 let statusBarBackground:
   (~theme: ColorTheme.Colors.t, model) => Revery.Color.t;
@@ -58,7 +61,8 @@ let changeTheme:
 
 module Effects: {
   let create:
-    (~kind: kind=?, ~source: string=?, string) => Isolinear.Effect.t(msg);
+    (~ephemeral: bool=?, ~kind: kind=?, ~source: string=?, string) =>
+    Isolinear.Effect.t(msg);
   let dismiss: notification => Isolinear.Effect.t(msg);
   let clear: unit => Isolinear.Effect.t(msg);
 };

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -277,8 +277,7 @@ let notificationCount =
       ~dispatch,
       (),
     ) => {
-  let text =
-    Feature_Notification.all(notifications) |> List.length |> string_of_int;
+  let text = Feature_Notification.count(notifications) |> string_of_int;
 
   let onClick = () => dispatch(NotificationCountClicked);
   let onRightClick = () => dispatch(NotificationsCountRightClicked);

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -6,8 +6,8 @@ open Oni_Model;
 open Actions;
 
 module Internal = {
-  let notificationEffect = (~kind, message) => {
-    Feature_Notification.Effects.create(~kind, message)
+  let notificationEffect = (~ephemeral=false, ~kind, message) => {
+    Feature_Notification.Effects.create(~ephemeral, ~kind, message)
     |> Isolinear.Effect.map(msg => Actions.Notification(msg));
   };
 
@@ -698,7 +698,10 @@ let update =
           };
 
         let eff =
-          [formatEffect, Internal.notificationEffect(~kind=Info, msg)]
+          [
+            formatEffect,
+            Internal.notificationEffect(~ephemeral=true, ~kind=Info, msg),
+          ]
           |> Isolinear.Effect.batch;
         (state, eff);
       | ReferencesAvailable =>


### PR DESCRIPTION
__Issue:__ After using format-on-save for some time, the notifications get quite cluttered:

![image](https://user-images.githubusercontent.com/13532591/111553734-3616fe80-8742-11eb-9893-43319a8cb346.png)

This isn't really adding an user value

__Fix:__ Add a concept of ephemeral notifications, which disappear once they show - so we still show format notifications, but don't save them in the notifications pane or add them into the notification count.