### PR TITLE
fix(diagnostics): Fix out-of-range index after processing minimal updates

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -7,6 +7,7 @@
 - #3289 - Extensions: Fix logs location path provided to extension (related #3268)
 - #3290 - Symbols: Fix issues focusing nodes in symbol outline view (fixes #2002)
 - #3292 - Vim: Fix control+d/control+u behavior in explorer
+- #3297 - Diagnostics: Fix potential crash when deleting lines with diagnostics
 
 ### Performance
 

--- a/src/Feature/Diagnostics/Diagnostic.re
+++ b/src/Feature/Diagnostics/Diagnostic.re
@@ -25,7 +25,7 @@ let explode = (buffer, diagnostic) => {
   let lineCount = Buffer.getNumberOfLines(buffer);
   let measure = n => {
     let lineIdx = EditorCoreTypes.LineNumber.toZeroBased(n);
-    lineIdx >= 0 && lineIdx < lineCount 
+    lineIdx >= 0 && lineIdx < lineCount
       ? buffer
         |> Buffer.getLine(lineIdx)
         // TODO: Is this correct, for a character range?

--- a/src/Feature/Diagnostics/Diagnostic.re
+++ b/src/Feature/Diagnostics/Diagnostic.re
@@ -24,9 +24,10 @@ let create = (~range, ~message, ~severity) => {range, message, severity};
 let explode = (buffer, diagnostic) => {
   let lineCount = Buffer.getNumberOfLines(buffer);
   let measure = n => {
-    EditorCoreTypes.LineNumber.toZeroBased(n) < lineCount
+    let lineIdx = EditorCoreTypes.LineNumber.toZeroBased(n);
+    lineIdx >= 0 && lineIdx < lineCount 
       ? buffer
-        |> Buffer.getLine(EditorCoreTypes.LineNumber.toZeroBased(n))
+        |> Buffer.getLine(lineIdx)
         // TODO: Is this correct, for a character range?
         |> BufferLine.lengthInBytes
       : 0;


### PR DESCRIPTION
__Issue:__ There was a potential crash when deleting lines, after processing minimal updates

__Defect:__ After shifting the diagnostics, the diagnostic line could potentially be out of range (less than 0), and when the buffer line is looked up - an exception is thrown

__Fix:__ Clamp the diagnostic line to a valid range when expanding