### PR TITLE
fix(formatting/#3288) - Part 1: Fix format edits containing a trailing newline

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -12,6 +12,7 @@
 - #3298 - Completion: Sort ordering improvements (related #3283)
 - #3301 - Formatting: Fix crash in default formatter with negative indentation levels
 - #3302 - Auto-Indent: Implement $setLanguageConfiguration handler (related to #3288)
+- #3300 - Formatting: Fix format edits containing a trailing newline (related to #3288)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Formatting.re
+++ b/src/Feature/LanguageSupport/Formatting.re
@@ -145,7 +145,6 @@ module Internal = {
     | Some(text) =>
       text
       |> Utility.StringEx.removeWindowsNewLines
-      |> Utility.StringEx.removeTrailingNewLine
       |> Utility.StringEx.splitNewLines;
 
   let extHostEditToVimEdit: Exthost.Edit.SingleEditOperation.t => Vim.Edit.t =

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -161,9 +161,7 @@ module Effects = {
 
         Lwt.on_success(
           promise,
-          Option.iter(edits => {
-            edits |> List.iter(edit => dispatch(toMsg(Ok(edits))))
-          }),
+          Option.iter(edits => {dispatch(toMsg(Ok(edits)))}),
         );
         Lwt.on_failure(promise, err =>
           dispatch(toMsg(Error(Printexc.to_string(err))))

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -161,7 +161,9 @@ module Effects = {
 
         Lwt.on_success(
           promise,
-          Option.iter(edits => dispatch(toMsg(Ok(edits)))),
+          Option.iter(edits => {
+            edits |> List.iter(edit => dispatch(toMsg(Ok(edits))))
+          }),
         );
         Lwt.on_failure(promise, err =>
           dispatch(toMsg(Error(Printexc.to_string(err))))


### PR DESCRIPTION
__Issue:__ There were certain formatting edits, as described in the first part of #3288 , that were not handled correctly by Onivim. This impacted the Python extension, as well as the `clangd` extension.

__Defect:__ When receiving formatting edits, if there was a trailing newline, it would be incorrectly removed - and the formatter would end up merging lines that shouldn't be merged.

__Fix:__ Preserve trailing newlines - fixes the first part of #3288 