### PR TITLE
fix(formatting): Crash on trying to apply negative indentation level

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -10,6 +10,7 @@
 - #3295 - Formatting: Make formatting notifications ephemeral
 - #3297 - Diagnostics: Fix potential crash when deleting lines with diagnostics
 - #3298 - Completion: Sort ordering improvements (related #3283)
+- #3301 - Formatting: Fix crash in default formatter with negative indentation levels
 
 ### Performance
 

--- a/src/Core/Indentation.re
+++ b/src/Core/Indentation.re
@@ -57,6 +57,9 @@ let getLevel = (settings: IndentationSettings.t, text: string) => {
 
 let applyLevel =
     (~indentation: IndentationSettings.t, ~level: int, str: string) => {
+  // Negative levels should not be allowed
+  let level = level < 0 ? 0 : level;
+
   str
   |> StringEx.findNonWhitespace
   |> Option.map(idx => {
@@ -70,3 +73,21 @@ let applyLevel =
      })
   |> Option.value(~default=str);
 };
+
+let%test_module "applyLevel" =
+  (module
+   {
+     let indentation = IndentationSettings.default; // 4 spaces
+
+     let%test "remove whitespace, level 0" = {
+       applyLevel(~indentation, ~level=0, "  ab") == "ab";
+     };
+
+     let%test "add whitespace, level 0" = {
+       applyLevel(~indentation, ~level=1, "ab") == "    ab";
+     };
+
+     let%test "remove whitespace, negative level" = {
+       applyLevel(~indentation, ~level=-1, "  ab") == "ab";
+     };
+   });


### PR DESCRIPTION
__Issue:__ The default formatter - our fallback when there is no language provider - could crash on a negative indent level with a `Bytes.create` exception

__Fix:__ Clamp to indentation level of 0, add test case