### PR TITLE
fix(auto-indent/#3288): Implement $setLanguageConfiguration model + parser

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -10,6 +10,7 @@
 - #3295 - Formatting: Make formatting notifications ephemeral
 - #3297 - Diagnostics: Fix potential crash when deleting lines with diagnostics
 - #3298 - Completion: Sort ordering improvements (related #3283)
+- #3302 - Auto-Indent: Implement $setLanguageConfiguration handler (related to #3288)
 
 ### Performance
 

--- a/src/Core/Json.re
+++ b/src/Core/Json.re
@@ -191,17 +191,15 @@ module Decode = {
   };
 
   let%test "decode valid regexp" = {
-    json({|"abc"|})
+    Yojson.Safe.from_string({|"abc"|})
     |> decode_value(regexp)
-    |> Result.get_ok
-    |> Option.is_some;
+    |> Result.is_ok;
   };
 
   let%test "decode invalid regexp" = {
-    json({|"(invalid"|})
+    Yojson.Safe.from_string({|"(invalid"|})
     |> decode_value(regexp)
-    |> Result.get_ok
-    |> Option.is_none;
+    |> Result.is_error;
   };
 
   let default = default => map(Option.value(~default));

--- a/src/Core/Json.re
+++ b/src/Core/Json.re
@@ -1,4 +1,5 @@
 open EditorCoreTypes;
+open Oniguruma;
 
 type t = Yojson.Safe.json;
 
@@ -164,6 +165,44 @@ module Decode = {
         };
       },
     };
+
+  let regexp = {
+    let str =
+      string
+      |> map(OnigRegExp.create)
+      |> and_then(
+           fun
+           | Ok(regexp) => succeed(regexp)
+           | Error(msg) => {
+               fail(Printf.sprintf("Error %s parsing regex", msg));
+             },
+         );
+
+    let dto =
+      obj(({field, _}) => {
+        field.required(
+          "pattern",
+          str,
+          // TODO: Flags field?
+        )
+      });
+
+    one_of([("string", str), ("dto", dto)]);
+  };
+
+  let%test "decode valid regexp" = {
+    json({|"abc"|})
+    |> decode_value(regexp)
+    |> Result.get_ok
+    |> Option.is_some;
+  };
+
+  let%test "decode invalid regexp" = {
+    json({|"(invalid"|})
+    |> decode_value(regexp)
+    |> Result.get_ok
+    |> Option.is_none;
+  };
 
   let default = default => map(Option.value(~default));
 };

--- a/src/Core/Json.rei
+++ b/src/Core/Json.rei
@@ -20,6 +20,7 @@ module Decode: {
   };
 
   let obj: (objGetters => 'a) => decoder('a);
+  let regexp: decoder(Oniguruma.OnigRegExp.t);
   let default: ('a, decoder(option('a))) => decoder('a);
 };
 

--- a/src/Core/LanguageConfiguration.re
+++ b/src/Core/LanguageConfiguration.re
@@ -203,32 +203,6 @@ let default: t = {
 module CustomDecoders = {
   open Json.Decode;
   let autoCloseBeforeDecode = string |> map(StringEx.explode);
-
-  let regexp =
-    string
-    |> map(OnigRegExp.create)
-    |> and_then(
-         fun
-         | Ok(regexp) => succeed(Some(regexp))
-         | Error(msg) => {
-             Log.errorf(m => m("Error %s parsing regex", msg));
-             succeed(None);
-           },
-       );
-
-  let%test "decode valid regexp" = {
-    json({|"abc"|})
-    |> decode_value(regexp)
-    |> Result.get_ok
-    |> Option.is_some;
-  };
-
-  let%test "decode invalid regexp" = {
-    json({|"(invalid"|})
-    |> decode_value(regexp)
-    |> Result.get_ok
-    |> Option.is_none;
-  };
 };
 
 module Decode = {
@@ -272,20 +246,20 @@ module Decode = {
           at.withDefault(
             ["indentationRules", "increaseIndentPattern"],
             None,
-            regexp,
+            regexp |> map(Option.some),
           ),
         decreaseIndentPattern:
           at.withDefault(
             ["indentationRules", "decreaseIndentPattern"],
             None,
-            regexp,
+            regexp |> map(Option.some),
           ),
 
         wordPattern:
           field.withDefault(
             "wordPattern",
             _defaultConfig.wordPattern,
-            regexp,
+            regexp |> map(Option.some),
           ),
       }
     );

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -27,6 +27,7 @@ module FormattingOptions = FormattingOptions;
 module Hover = Hover;
 module InputBoxOptions = InputBoxOptions;
 module Label = Label;
+module LanguageConfiguration = LanguageConfiguration;
 module Location = Location;
 module MarkdownString = MarkdownString;
 module Message = Message;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -1,5 +1,6 @@
 open EditorCoreTypes;
 open Oni_Core;
+open Oniguruma;
 
 module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
@@ -23,6 +24,36 @@ module Label: {
 
   let ofString: string => t;
   let toString: t => string;
+
+  let decode: Json.decoder(t);
+};
+
+module LanguageConfiguration: {
+  module IndentAction: {
+    type t =
+      | Indent
+      | IndentOutdent
+      | Outdent;
+  };
+
+  module EnterAction: {
+    type t = {
+      indentAction: IndentAction.t,
+      appendText: option(string),
+      removeText: option(int),
+    };
+  };
+
+  module OnEnterRule: {
+    type t = {
+      beforeText: OnigRegExp.t,
+      afterText: option(OnigRegExp.t),
+      previousLineText: option(OnigRegExp.t),
+      action: EnterAction.t,
+    };
+  };
+
+  type t = {onEnterRules: list(OnEnterRule.t)};
 
   let decode: Json.decoder(t);
 };

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -30,6 +30,7 @@ module Label: {
 
 module LanguageConfiguration: {
   module IndentAction: {
+    [@deriving show]
     type t =
       | Indent
       | IndentOutdent
@@ -37,6 +38,7 @@ module LanguageConfiguration: {
   };
 
   module EnterAction: {
+    [@deriving show]
     type t = {
       indentAction: IndentAction.t,
       appendText: option(string),
@@ -45,6 +47,7 @@ module LanguageConfiguration: {
   };
 
   module OnEnterRule: {
+    [@deriving show]
     type t = {
       beforeText: OnigRegExp.t,
       afterText: option(OnigRegExp.t),
@@ -53,6 +56,7 @@ module LanguageConfiguration: {
     };
   };
 
+  [@deriving show]
   type t = {onEnterRules: list(OnEnterRule.t)};
 
   let decode: Json.decoder(t);
@@ -1399,6 +1403,11 @@ module Msg: {
           selector: DocumentSelector.t,
           autoFormatTriggerCharacters: list(string),
           extensionId: ExtensionId.t,
+        })
+      | SetLanguageConfiguration({
+          handle: int,
+          languageId: string,
+          configuration: LanguageConfiguration.t,
         })
       | Unregister({handle: int});
   };

--- a/src/Exthost/LanguageConfiguration.re
+++ b/src/Exthost/LanguageConfiguration.re
@@ -1,0 +1,9 @@
+
+module OnEnterRule = {
+   type t = { 
+    beforeText: OnigRegExp.t,
+    afterText: option(OnigRegExp.t),
+    previousLineText: option(OnigRegExp.t),
+    action
+   }
+}

--- a/src/Exthost/LanguageConfiguration.re
+++ b/src/Exthost/LanguageConfiguration.re
@@ -5,6 +5,7 @@ open Oniguruma;
 open Oni_Core;
 
 module IndentAction = {
+  [@deriving show]
   type t =
     | Indent
     | IndentOutdent
@@ -32,6 +33,7 @@ module IndentAction = {
 };
 
 module EnterAction = {
+  [@deriving show]
   type t = {
     indentAction: IndentAction.t,
     appendText: option(string),
@@ -51,10 +53,11 @@ module EnterAction = {
 };
 
 module OnEnterRule = {
+  [@deriving show]
   type t = {
-    beforeText: OnigRegExp.t,
-    afterText: option(OnigRegExp.t),
-    previousLineText: option(OnigRegExp.t),
+    beforeText: [@opaque] OnigRegExp.t,
+    afterText: [@opaque] option(OnigRegExp.t),
+    previousLineText: [@opaque] option(OnigRegExp.t),
     action: EnterAction.t,
   };
 
@@ -72,6 +75,7 @@ module OnEnterRule = {
   };
 };
 
+[@deriving show]
 type t = {onEnterRules: list(OnEnterRule.t)};
 
 let decode =

--- a/src/Exthost/LanguageConfiguration.re
+++ b/src/Exthost/LanguageConfiguration.re
@@ -1,9 +1,85 @@
+// LanguageConfiguration.re models the extension-provided language configuration:
+// https://github.com/onivim/vscode-exthost/blob/0d6b39803352369daaa97a444ff76352d8452be2/src/vs/workbench/api/common/extHost.protocol.ts#L341
+
+open Oniguruma;
+open Oni_Core;
+
+module IndentAction = {
+  type t =
+    | Indent
+    | IndentOutdent
+    | Outdent;
+
+  // Must be in sync with: https://github.com/microsoft/vscode/blob/39ea9cac052a2e5e05f7d6c0911078415f506e29/src/vs/editor/common/modes/languageConfiguration.ts#L192
+  let ofInt =
+    fun
+    | 1 => Some(Indent)
+    | 2 => Some(IndentOutdent)
+
+    | 3 => Some(Outdent)
+    | _ => None;
+
+  let decode =
+    Json.Decode.(
+      int
+      |> map(ofInt)
+      |> and_then(
+           fun
+           | None => fail("Unable to parse IndentAction")
+           | Some(action) => succeed(action),
+         )
+    );
+};
+
+module EnterAction = {
+  type t = {
+    indentAction: IndentAction.t,
+    appendText: option(string),
+    removeText: option(int),
+  };
+
+  let decode =
+    Json.Decode.(
+      obj(({field, _}) =>
+        {
+          indentAction: field.required("indentAction", IndentAction.decode),
+          appendText: field.optional("appendText", string),
+          removeText: field.optional("removeText", int),
+        }
+      )
+    );
+};
 
 module OnEnterRule = {
-   type t = { 
+  type t = {
     beforeText: OnigRegExp.t,
     afterText: option(OnigRegExp.t),
     previousLineText: option(OnigRegExp.t),
-    action
-   }
-}
+    action: EnterAction.t,
+  };
+
+  let decode = {
+    Json.Decode.(
+      obj(({field, _}) =>
+        {
+          beforeText: field.required("beforeText", regexp),
+          afterText: field.optional("afterText", regexp),
+          previousLineText: field.optional("previousLineText", regexp),
+          action: field.required("action", EnterAction.decode),
+        }
+      )
+    );
+  };
+};
+
+type t = {onEnterRules: list(OnEnterRule.t)};
+
+let decode =
+  Json.Decode.(
+    obj(({field, _}) =>
+      {
+        onEnterRules:
+          field.withDefault("onEnterRules", [], list(OnEnterRule.decode)),
+      }
+    )
+  );

--- a/src/Exthost/dune
+++ b/src/Exthost/dune
@@ -3,7 +3,7 @@
  (inline_tests)
  (libraries timber base Oni2.core Oni2.core.kernel Oni2.exthost.extension
    Oni2.exthost.protocol Oni2.exthost.transport luv Oni2.service.os
-   Oni2.service.net yojson decoders-yojson semver2)
+   Oni2.service.net yojson decoders-yojson semver2 oniguruma)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving_yojson ppx_inline_test))
  (public_name Oni2.exthost))

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -288,6 +288,14 @@ let update =
       Nothing,
     )
 
+  | Exthost(SetLanguageConfiguration({handle, languageId, configuration})) =>
+    // TODO - Wire up to language info pipeline, and use the onEnterRules:
+    ignore(handle);
+    ignore(languageId);
+    ignore(configuration);
+
+    (model, Nothing);
+
   | Exthost(_) =>
     // TODO:
     (model, Nothing)


### PR DESCRIPTION
This is work on Part 2 of #3288 - this implements a parser for `$setLanguageConfiguration` and a model for the onEnterRules.

This doesn't fix the auto-indent behavior, yet - the remaining work is:
- Merge the `$setLanguageConfiguration` configuration with the extension metadata configuration
- Use the `onEnter` rules when adding new lines in insert mode (as well as `o`/`O`)