### PR TITLE
refactor(auto-indent/#3288): Move languageInfo into Feature_LanguageSupport

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -20,4 +20,6 @@
 
 ### Refactoring
 
+- #3303 - Language Support: Move language metadata into Feature_LanguageSupport (related #3288)
+
 ### Infrastructure

--- a/src/Exthost/LanguageInfo.re
+++ b/src/Exthost/LanguageInfo.re
@@ -267,7 +267,7 @@ let getListOfLanguages = (extensions: list(Scanner.ScanResult.t)) => {
   extensions |> List.map(v => v.manifest.contributes.languages) |> List.flatten;
 };
 
-let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
+let addExtensions = (extensions: list(Scanner.ScanResult.t), model: t) => {
   let grammars = getListOfGrammars(extensions);
   let languages = getListOfLanguages(extensions);
 
@@ -280,7 +280,7 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
            let (extension, language) = v;
            StringMap.add(extension, language, prev);
          },
-         StringMap.empty,
+         model.extToLanguage,
        );
 
   let fileNameToLanguage =
@@ -292,7 +292,7 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
            let (fileName, language) = v;
            StringMap.add(fileName, language, prev);
          },
-         StringMap.empty,
+         model.fileNameToLanguage,
        );
 
   let fileNamePatternToLanguage =
@@ -307,7 +307,7 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
            | Ok(pattern) => [{pattern, language}, ...prev]
            };
          },
-         [],
+         model.fileNamePatternToLanguage,
        );
 
   let firstLineToLanguage =
@@ -326,7 +326,7 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
              }
            )
          },
-         [],
+         model.firstLineToLanguage,
        );
   open Contributions.Grammar;
   let languageToScope =
@@ -337,7 +337,7 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
            | None => prev
            | Some(v) => StringMap.add(v, curr.scopeName, prev)
            },
-         StringMap.empty,
+         model.languageToScope,
        );
 
   let languageToConfigurationPath =
@@ -349,11 +349,11 @@ let ofExtensions = (extensions: list(Scanner.ScanResult.t)) => {
            | Some(configPath) => StringMap.add(id, configPath, prev)
            }
          },
-         StringMap.empty,
+         model.languageToConfigurationPath,
        );
 
   {
-    ...initial,
+    ...model,
     languages,
     extToLanguage,
     fileNameToLanguage,

--- a/src/Exthost/LanguageInfo.rei
+++ b/src/Exthost/LanguageInfo.rei
@@ -23,4 +23,4 @@ let getScopeFromBuffer: (t, Buffer.t) => option(string);
 
 let getLanguageConfiguration: (t, string) => option(LanguageConfiguration.t);
 
-let ofExtensions: list(Scanner.ScanResult.t) => t;
+let addExtensions: (list(Scanner.ScanResult.t), t) => t;

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -1,7 +1,5 @@
 open EditorCoreTypes;
 
-let languageInfo = _ => Exthost.LanguageInfo.initial;
-
 type model = {
   codeLens: CodeLens.model,
   completion: Completion.model,
@@ -13,6 +11,7 @@ type model = {
   rename: Rename.model,
   references: References.model,
   signatureHelp: SignatureHelp.model,
+  languageInfo: Exthost.LanguageInfo.t,
 };
 
 let initial = {
@@ -26,7 +25,10 @@ let initial = {
   rename: Rename.initial,
   references: References.initial,
   signatureHelp: SignatureHelp.initial,
+  languageInfo: Exthost.LanguageInfo.initial,
 };
+
+let languageInfo = ({languageInfo, _}) => languageInfo;
 
 [@deriving show]
 type command =
@@ -274,6 +276,7 @@ let update =
 
   | Exthost(Unregister({handle})) => (
       {
+        ...model,
         codeLens: CodeLens.unregister(~handle, model.codeLens),
         completion: Completion.unregister(~handle, model.completion),
         definition: Definition.unregister(~handle, model.definition),
@@ -928,7 +931,10 @@ let sub =
   |> Isolinear.Sub.batch;
 };
 
-// TODO:
-let extensionsAdded = (_extensions, model) => model;
+let extensionsAdded = (extensions, model) => {
+  ...model,
+  languageInfo:
+    Exthost.LanguageInfo.addExtensions(extensions, model.languageInfo),
+};
 
 module CompletionMeet = CompletionMeet;

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -1,5 +1,7 @@
 open EditorCoreTypes;
 
+let languageInfo = _ => Exthost.LanguageInfo.initial;
+
 type model = {
   codeLens: CodeLens.model,
   completion: Completion.model,
@@ -925,5 +927,8 @@ let sub =
   ]
   |> Isolinear.Sub.batch;
 };
+
+// TODO:
+let extensionsAdded = (_extensions, model) => model;
 
 module CompletionMeet = CompletionMeet;

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -8,6 +8,8 @@ let initial: model;
 [@deriving show]
 type msg;
 
+let languageInfo: model => Exthost.LanguageInfo.t;
+
 module Msg: {
   let exthost: Exthost.Msg.LanguageFeatures.msg => msg;
   let keyPressed: string => msg;
@@ -139,6 +141,9 @@ let cursorMoved:
     model
   ) =>
   model;
+
+let extensionsAdded:
+  (list(Exthost.Extension.Scanner.ScanResult.t), model) => model;
 
 let moveMarkers:
   (~newBuffer: Buffer.t, ~markerUpdate: MarkerUpdate.t, model) => model;

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -116,7 +116,6 @@ type t =
   | ReallyQuitting
   | RegisterQuitCleanup(unit => unit)
   | SearchClearHighlights(int)
-  | SetLanguageInfo([@opaque] Exthost.LanguageInfo.t)
   | SetGrammarRepository([@opaque] Oni_Syntax.GrammarRepository.t)
   | SetIconTheme([@opaque] IconTheme.t)
   | StatusBar(Feature_StatusBar.msg)

--- a/src/Model/SnippetVariables.re
+++ b/src/Model/SnippetVariables.re
@@ -28,7 +28,7 @@ let current = (state: State.t, variable) => {
     maybeLanguage
     |> OptionEx.flatMap(language => {
          Exthost.LanguageInfo.getLanguageConfiguration(
-           state.languageInfo,
+           state.languageSupport |> Feature_LanguageSupport.languageInfo,
            language,
          )
        });

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -412,7 +412,6 @@ type t = {
   iconTheme: IconTheme.t,
   isQuitting: bool,
   languageSupport: Feature_LanguageSupport.model,
-  languageInfo: Exthost.LanguageInfo.t,
   grammarRepository: Oni_Syntax.GrammarRepository.t,
   lifecycle: Lifecycle.t,
   menuBar: Feature_MenuBar.model,
@@ -536,7 +535,6 @@ let initial =
     help: Feature_Help.initial,
     iconTheme: IconTheme.create(),
     isQuitting: false,
-    languageInfo: Exthost.LanguageInfo.initial,
     menuBar:
       Feature_MenuBar.initial(
         ~menus=[],

--- a/src/Model/VimContext.re
+++ b/src/Model/VimContext.re
@@ -117,7 +117,9 @@ let current = (state: State.t) => {
          Buffer.getFileType(buf) |> Buffer.FileType.toOption
        )
     |> OptionEx.flatMap(
-         Exthost.LanguageInfo.getLanguageConfiguration(state.languageInfo),
+         Exthost.LanguageInfo.getLanguageConfiguration(
+           state.languageSupport |> Feature_LanguageSupport.languageInfo,
+         ),
        );
 
   let maybeCursor =

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -453,10 +453,6 @@ let update =
           )
 
         | NewExtensions(extensions) =>
-          extensions
-          |> List.iter((ext: Exthost.Extension.Scanner.ScanResult.t) =>
-               prerr_endline(Exthost.Extension.Manifest.show(ext.manifest))
-             );
           let newExtensionConfigurations =
             extensions
             |> List.map((ext: Exthost.Extension.Scanner.ScanResult.t) => {

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -453,6 +453,10 @@ let update =
           )
 
         | NewExtensions(extensions) =>
+          extensions
+          |> List.iter((ext: Exthost.Extension.Scanner.ScanResult.t) =>
+               prerr_endline(Exthost.Extension.Manifest.show(ext.manifest))
+             );
           let newExtensionConfigurations =
             extensions
             |> List.map((ext: Exthost.Extension.Scanner.ScanResult.t) => {
@@ -461,13 +465,21 @@ let update =
                  )
                });
 
+          let languageInfo' =
+            Exthost.LanguageInfo.addExtensions(
+              extensions,
+              state.languageInfo,
+            );
           let config =
             Feature_Configuration.registerExtensionConfigurations(
               ~configurations=newExtensionConfigurations,
               state.config,
             );
 
-          ({...state, config}, Isolinear.Effect.none);
+          (
+            {...state, config, languageInfo: languageInfo'},
+            Isolinear.Effect.none,
+          );
 
         | InstallSucceeded({extensionId, contributions}) =>
           let notificationEffect =

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -283,6 +283,8 @@ module Internal = {
       |> Feature_Layout.activeEditor
       |> Feature_Editor.Editor.getPrimaryCursor;
 
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let languageSupport =
       if (prevCursor != newCursor) {
         maybeBuffer
@@ -291,9 +293,7 @@ module Internal = {
                buffer
                |> Oni_Core.Buffer.getFileType
                |> Oni_Core.Buffer.FileType.toString
-               |> Exthost.LanguageInfo.getLanguageConfiguration(
-                    state.languageInfo,
-                  )
+               |> Exthost.LanguageInfo.getLanguageConfiguration(languageInfo)
                |> Option.value(~default=LanguageConfiguration.default);
              Feature_LanguageSupport.cursorMoved(
                ~languageConfiguration,
@@ -465,10 +465,10 @@ let update =
                  )
                });
 
-          let languageInfo' =
-            Exthost.LanguageInfo.addExtensions(
+          let languageSupport' =
+            Feature_LanguageSupport.extensionsAdded(
               extensions,
-              state.languageInfo,
+              state.languageSupport,
             );
           let config =
             Feature_Configuration.registerExtensionConfigurations(
@@ -477,7 +477,7 @@ let update =
             );
 
           (
-            {...state, config, languageInfo: languageInfo'},
+            {...state, config, languageSupport: languageSupport'},
             Isolinear.Effect.none,
           );
 
@@ -613,12 +613,14 @@ let update =
 
     let editorId = editor |> Feature_Editor.Editor.getId;
 
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let languageConfiguration =
       maybeBuffer
       |> Option.map(Oni_Core.Buffer.getFileType)
       |> Option.map(Oni_Core.Buffer.FileType.toString)
       |> OptionEx.flatMap(
-           Exthost.LanguageInfo.getLanguageConfiguration(state.languageInfo),
+           Exthost.LanguageInfo.getLanguageConfiguration(languageInfo),
          )
       |> Option.value(~default=LanguageConfiguration.default);
 
@@ -872,10 +874,12 @@ let update =
 
   | Pane(msg) =>
     let config = Selectors.configResolver(state);
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let (model, outmsg) =
       Feature_Pane.update(
         ~font=state.editorFont,
-        ~languageInfo=state.languageInfo,
+        ~languageInfo,
         ~buffers=state.buffers,
         ~previewEnabled=
           Feature_Configuration.GlobalConfiguration.Workbench.editorEnablePreview.
@@ -1164,19 +1168,6 @@ let update =
           |> Feature_Layout.activeEditor
           |> Feature_Editor.Editor.getBufferId;
 
-        // TODO: Port to buffer filetype picker
-        // let languages =
-        //   state.languageInfo
-        //   |> Exthost.LanguageInfo.languages
-        //   |> List.map(language =>
-        //        (
-        //          language,
-        //          Oni_Core.IconTheme.getIconForLanguage(
-        //            state.iconTheme,
-        //            language,
-        //          ),
-        //        )
-        //      );
         (
           state',
           Isolinear.Effect.createWithDispatch(
@@ -1213,8 +1204,10 @@ let update =
     | Nothing => (state, Effect.none)
 
     | ShowMenu(menuFn) =>
+      let languageInfo =
+        state.languageSupport |> Feature_LanguageSupport.languageInfo;
       let menu =
-        menuFn(state.languageInfo, state.iconTheme)
+        menuFn(languageInfo, state.iconTheme)
         |> Feature_Quickmenu.Schema.map(msg => Buffers(msg));
       let quickmenu = Feature_Quickmenu.show(~menu, state.newQuickmenu);
       ({...state, newQuickmenu: quickmenu}, Isolinear.Effect.none);
@@ -1462,13 +1455,11 @@ let update =
 
       let bufferUpdate = update;
 
+      let languageInfo =
+        state.languageSupport |> Feature_LanguageSupport.languageInfo;
       let syntaxHighlights =
         Feature_Syntax.handleUpdate(
-          ~scope=
-            Internal.getScopeForBuffer(
-              ~languageInfo=state.languageInfo,
-              newBuffer,
-            ),
+          ~scope=Internal.getScopeForBuffer(~languageInfo, newBuffer),
           ~grammars=grammarRepository,
           ~config=
             Feature_Configuration.resolver(
@@ -1739,9 +1730,11 @@ let update =
     (state, effect);
 
   | OpenBufferById({bufferId, direction}) =>
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let effect =
       Feature_Buffers.Effects.openBufferInEditor(
-        ~languageInfo=state.languageInfo,
+        ~languageInfo,
         ~font=state.editorFont,
         ~bufferId,
         ~split=direction,
@@ -1751,10 +1744,12 @@ let update =
     (state, effect);
 
   | NewBuffer({direction}) =>
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let effect =
       Feature_Buffers.Effects.openNewBuffer(
         ~split=direction,
-        ~languageInfo=state.languageInfo,
+        ~languageInfo,
         ~font=state.editorFont,
         state.buffers,
       )
@@ -1762,9 +1757,11 @@ let update =
     (state, effect);
 
   | OpenFileByPath(filePath, split, position) =>
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let effect =
       Feature_Buffers.Effects.openFileInEditor(
-        ~languageInfo=state.languageInfo,
+        ~languageInfo,
         ~font=state.editorFont,
         ~split,
         ~position,
@@ -1775,9 +1772,11 @@ let update =
       |> Isolinear.Effect.map(msg => Actions.Buffers(msg));
     (state, effect);
   | PreviewFileByPath(filePath, split, position) =>
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
     let effect =
       Feature_Buffers.Effects.openFileInEditor(
-        ~languageInfo=state.languageInfo,
+        ~languageInfo,
         ~font=state.editorFont,
         ~split,
         ~position,
@@ -1953,10 +1952,12 @@ let update =
     let wasSnippetActive = Feature_Snippets.isActive(state.snippets);
 
     let selections = Feature_Editor.Editor.selections(editor);
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
 
     let (snippets', outmsg) =
       Feature_Snippets.update(
-        ~languageInfo=state.languageInfo,
+        ~languageInfo,
         ~resolverFactory,
         ~selections,
         ~maybeBuffer,
@@ -1981,6 +1982,8 @@ let update =
       let newCursor = newEditor |> Feature_Editor.Editor.getPrimaryCursor;
       let newMode = newEditor |> Feature_Editor.Editor.mode;
       let isInInsert = Vim.Mode.isInsertOrSelect(newMode);
+      let languageInfo =
+        state.languageSupport |> Feature_LanguageSupport.languageInfo;
 
       let languageSupport' =
         if (originalCursor != newCursor) {
@@ -1991,7 +1994,7 @@ let update =
                  |> Oni_Core.Buffer.getFileType
                  |> Oni_Core.Buffer.FileType.toString
                  |> Exthost.LanguageInfo.getLanguageConfiguration(
-                      state.languageInfo,
+                      languageInfo,
                     )
                  |> Option.value(~default=LanguageConfiguration.default);
                Feature_LanguageSupport.cursorMoved(
@@ -2134,6 +2137,8 @@ let update =
     let activeCursor = editor |> Feature_Editor.Editor.getPrimaryCursor;
     let activeCursorByte =
       editor |> Feature_Editor.Editor.getPrimaryCursorByte;
+    let languageInfo =
+      state.languageSupport |> Feature_LanguageSupport.languageInfo;
 
     let languageSupport' =
       maybeBuffer
@@ -2150,9 +2155,7 @@ let update =
              buffer
              |> Oni_Core.Buffer.getFileType
              |> Oni_Core.Buffer.FileType.toString
-             |> Exthost.LanguageInfo.getLanguageConfiguration(
-                  state.languageInfo,
-                )
+             |> Exthost.LanguageInfo.getLanguageConfiguration(languageInfo)
              |> Option.value(~default=LanguageConfiguration.default);
 
            let languageSupport =

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -510,7 +510,7 @@ let start = () => {
           state.quickmenu,
           action,
           state.buffers,
-          state.languageInfo,
+          state.languageSupport |> Feature_LanguageSupport.languageInfo,
           state.iconTheme,
           state.layout,
           state.workspace,
@@ -622,7 +622,7 @@ let subscriptions = (ripgrep, dispatch) => {
         [filter(query, quickmenu.items)]
         @ ripgrep(
             state.workspace,
-            state.languageInfo,
+            state.languageSupport |> Feature_LanguageSupport.languageInfo,
             state.iconTheme,
             state.config,
           )

--- a/src/Store/Reducer.re
+++ b/src/Store/Reducer.re
@@ -17,7 +17,6 @@ let reduce: (State.t, Actions.t) => State.t =
       };
 
       switch (a) {
-      | SetLanguageInfo(languageInfo) => {...s, languageInfo}
       | SetGrammarRepository(grammarRepository) => {...s, grammarRepository}
       | SetIconTheme(iconTheme) => {...s, iconTheme}
       | ReallyQuitting => {...s, isQuitting: true}

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -237,7 +237,8 @@ let start =
             ~buffers=state.buffers,
             ~config,
             ~grammarInfo,
-            ~languageInfo=state.languageInfo,
+            ~languageInfo=
+              state.languageSupport |> Feature_LanguageSupport.languageInfo,
             ~setup,
             ~tokenTheme=state.colorTheme |> Feature_Theme.tokenColors,
             ~bufferVisibility=visibleRanges,

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -111,7 +111,6 @@ let start =
       ~shouldLoadExtensions,
       ~overriddenExtensionsDir,
     );
-  let languageInfo = Exthost.LanguageInfo.ofExtensions(extensions);
   let grammarInfo = Exthost.GrammarInfo.ofExtensions(extensions);
   let grammarRepository = Oni_Syntax.GrammarRepository.create(grammarInfo);
 
@@ -119,7 +118,6 @@ let start =
   let (vimUpdater, vimStream) =
     VimStoreConnector.start(
       ~showUpdateChangelog,
-      languageInfo,
       getState,
       getClipboardText,
       setClipboardText,
@@ -239,7 +237,7 @@ let start =
             ~buffers=state.buffers,
             ~config,
             ~grammarInfo,
-            ~languageInfo,
+            ~languageInfo=state.languageInfo,
             ~setup,
             ~tokenTheme=state.colorTheme |> Feature_Theme.tokenColors,
             ~bufferVisibility=visibleRanges,
@@ -605,7 +603,6 @@ let start =
   let _: Isolinear.unsubscribe =
     Isolinear.Stream.connect(dispatch, extHostStream);
 
-  dispatch(Model.Actions.SetLanguageInfo(languageInfo));
   dispatch(Model.Actions.SetGrammarRepository(grammarRepository));
 
   /* Set icon theme */

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -339,6 +339,8 @@ let start =
   let _: unit => unit =
     Vim.Buffer.onFilenameChanged(meta => {
       Log.debugf(m => m("Buffer metadata changed: %n", meta.id));
+      let languageInfo =
+        getState().languageSupport |> Feature_LanguageSupport.languageInfo;
       // TODO: This isn't buffer aware, so it won't be able to deal with the
       // firstline way of getting syntax, which means if that is in use,
       // it will get wiped when renaming the file.
@@ -350,10 +352,7 @@ let start =
       let fileType =
         switch (meta.filePath) {
         | Some(v) =>
-          Exthost.LanguageInfo.getLanguageFromFilePath(
-            getState().languageInfo,
-            v,
-          )
+          Exthost.LanguageInfo.getLanguageFromFilePath(languageInfo, v)
           |> Oni_Core.Buffer.FileType.inferred
         | None => Oni_Core.Buffer.FileType.none
         };
@@ -457,6 +456,8 @@ let start =
         != Some(false);
 
       if (shouldApply) {
+        let languageInfo =
+          getState().languageSupport |> Feature_LanguageSupport.languageInfo;
         maybeBuffer
         |> Option.iter(oldBuffer => {
              let newBuffer = Core.Buffer.update(oldBuffer, bu);
@@ -472,7 +473,7 @@ let start =
                  let fileType =
                    Oni_Core.Buffer.FileType.inferred(
                      Exthost.LanguageInfo.getLanguageFromBuffer(
-                       getState().languageInfo,
+                       languageInfo,
                        newBuffer,
                      ),
                    );

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -20,7 +20,6 @@ module Log = (val Core.Log.withNamespace("Oni2.Store.Vim"));
 let start =
     (
       ~showUpdateChangelog: bool,
-      languageInfo: Exthost.LanguageInfo.t,
       getState: unit => State.t,
       getClipboardText,
       setClipboardText,
@@ -351,7 +350,10 @@ let start =
       let fileType =
         switch (meta.filePath) {
         | Some(v) =>
-          Exthost.LanguageInfo.getLanguageFromFilePath(languageInfo, v)
+          Exthost.LanguageInfo.getLanguageFromFilePath(
+            getState().languageInfo,
+            v,
+          )
           |> Oni_Core.Buffer.FileType.inferred
         | None => Oni_Core.Buffer.FileType.none
         };
@@ -470,7 +472,7 @@ let start =
                  let fileType =
                    Oni_Core.Buffer.FileType.inferred(
                      Exthost.LanguageInfo.getLanguageFromBuffer(
-                       languageInfo,
+                       getState().languageInfo,
                        newBuffer,
                      ),
                    );

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -31,11 +31,13 @@ module Parts = {
           ~renderOverlays,
           (),
         ) => {
+      let languageInfo =
+        state.languageSupport |> Feature_LanguageSupport.languageInfo;
       let languageConfiguration =
         buffer
         |> Oni_Core.Buffer.getFileType
         |> Oni_Core.Buffer.FileType.toString
-        |> Exthost.LanguageInfo.getLanguageConfiguration(state.languageInfo)
+        |> Exthost.LanguageInfo.getLanguageConfiguration(languageInfo)
         |> Option.value(~default=LanguageConfiguration.default);
 
       let editorDispatch = msg =>
@@ -56,7 +58,7 @@ module Parts = {
         buffer
         uiFont={state.uiFont}
         languageConfiguration
-        languageInfo={state.languageInfo}
+        languageInfo
         grammarRepository={state.grammarRepository}
         onEditorSizeChanged
         theme

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -217,7 +217,9 @@ let make = (~dispatch, ~state: State.t, ()) => {
         config
         isFocused={FocusManager.current(state) == Focus.Pane}
         iconTheme={state.iconTheme}
-        languageInfo={state.languageInfo}
+        languageInfo={
+          state.languageSupport |> Feature_LanguageSupport.languageInfo
+        }
         theme
         editorFont
         uiFont

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -65,6 +65,8 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
     | Search => "Search"
     };
 
+  let languageInfo =
+    state.languageSupport |> Feature_LanguageSupport.languageInfo;
   let maybeBuffer = Selectors.getActiveBuffer(state);
   let maybeSymbols =
     maybeBuffer
@@ -84,7 +86,7 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
           let dispatch = msg => dispatch(Actions.FileExplorer(msg));
           <Feature_Explorer.View
             isFocused={FocusManager.current(state) == Focus.FileExplorer}
-            languageInfo={state.languageInfo}
+            languageInfo
             iconTheme={state.iconTheme}
             decorations={state.decorations}
             documentSymbols=maybeSymbols
@@ -102,7 +104,7 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
               state.workspace,
             )}
             isFocused={FocusManager.current(state) == Focus.SCM}
-            languageInfo={state.languageInfo}
+            languageInfo
             iconTheme={state.iconTheme}
             theme
             font
@@ -116,7 +118,7 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
           <Feature_Search
             isFocused={FocusManager.current(state) == Focus.Search}
             theme
-            languageInfo={state.languageInfo}
+            languageInfo
             iconTheme={state.iconTheme}
             uiFont={state.uiFont}
             model={state.searchPane}

--- a/test/Exthost/LanguageInfoTest.re
+++ b/test/Exthost/LanguageInfoTest.re
@@ -23,7 +23,10 @@ let li =
        },
        [],
      )
-  |> Exthost.LanguageInfo.ofExtensions;
+  |> (
+    extensions =>
+      Exthost.(LanguageInfo.addExtensions(extensions, LanguageInfo.initial))
+  );
 
 let buf = Buffer.ofLines(~font=Font.default(), [|"#!/bin/bash", "ls *"|]);
 


### PR DESCRIPTION
This is some refactoring to move the language information state into `Feature_LanguageSupport`, so it can be merged with the information provided by the `$setLanguageConfiguration` in #3302 

Some prepatory work to wire up `onEnterAction`s for #3288 