### PR TITLE
fix(ux/#3305): Re-implement 'workbench.tree.indent' setting

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -12,6 +12,7 @@
 - #3298 - Completion: Sort ordering improvements (related #3283)
 - #3301 - Formatting: Fix crash in default formatter with negative indentation levels
 - #3302 - Auto-Indent: Implement $setLanguageConfiguration handler (related to #3288)
+- #3307 - UX: Bring back 'workbench.tree.indent' configuration setting (fixes #3305)
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -118,7 +118,7 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `workbench.iconTheme` __(_string_ default: `"vs-seti"`)__ - Icon theme to use.
 
-- `workbench.tree.indent` __(_int_ default: `2`)__ - Indentation of the tree explorer.
+- `workbench.tree.indent` __(_int_ default: `5`)__ - Indentation of the tree explorer.
 
 - `vim.highlightedyank.enable` __(_bool_ default: `true`)__ - When `true`, briefly highlight yanks on the editor surface.
 

--- a/src/Components/Accordion/Component_Accordion.re
+++ b/src/Components/Accordion/Component_Accordion.re
@@ -176,6 +176,7 @@ module VimList = {
 module VimTree = {
   let make =
       (
+        ~config,
         ~showCount=true,
         ~focusedIndex=None,
         ~title,
@@ -194,6 +195,7 @@ module VimTree = {
     let contents =
       count > 0
         ? <Component_VimTree.View
+            config
             isActive=isFocused
             font=uiFont
             focusedIndex

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -50,6 +50,7 @@ let sub:
 module View: {
   let make:
     (
+      ~config: Config.resolver,
       ~isFocused: bool,
       ~iconTheme: IconTheme.t,
       ~languageInfo: Exthost.LanguageInfo.t,

--- a/src/Components/FileExplorer/FileTreeView.re
+++ b/src/Components/FileExplorer/FileTreeView.re
@@ -93,6 +93,7 @@ let getFileIcon = Model.getFileIcon;
 
 let make =
     (
+      ~config,
       ~rootName,
       ~isFocused,
       ~iconTheme,
@@ -110,6 +111,7 @@ let make =
       (),
     ) => {
   <Component_Accordion.VimTree
+    config
     title=rootName
     showCount=false
     isFocused

--- a/src/Components/FileExplorer/View.re
+++ b/src/Components/FileExplorer/View.re
@@ -2,6 +2,7 @@ open Revery.UI;
 
 let make =
     (
+      ~config,
       ~isFocused: bool,
       ~iconTheme,
       ~languageInfo,
@@ -18,6 +19,7 @@ let make =
   | {tree: Some(_), treeView, active, rootName, _} =>
     let focusedIndex = Model.getFocusedIndex(model);
     <FileTreeView
+      config
       rootName
       isFocused
       iconTheme

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -157,7 +157,7 @@ let create = (~rowHeight) => {
 
 module Constants = {
   let arrowSize = 15.;
-  let indentSize = 12;
+  let indentCaretSize = 7;
 };
 
 // UPDATE
@@ -450,10 +450,11 @@ module View = {
   };
 
   let indentGuide = (~horizontalSize, ~verticalSize, ~strokeColor) => {
+    let offset = max(0, horizontalSize);
     <View
       style=Style.[
-        marginLeft(horizontalSize / 2 + 1),
-        width(horizontalSize / 2 - 1),
+        marginLeft(Constants.indentCaretSize),
+        width(offset),
         height(verticalSize),
         borderLeft(~color=strokeColor, ~width=1),
       ]
@@ -481,6 +482,7 @@ module View = {
     </View>;
   let make =
       (
+        ~config,
         ~isActive,
         ~font,
         ~focusedIndex,
@@ -491,7 +493,10 @@ module View = {
         (),
       ) => {
     let indentHeight = model.rowHeight;
-    let indentWidth = Constants.indentSize;
+    let indentWidth =
+      Feature_Configuration.GlobalConfiguration.Workbench.treeIndent.get(
+        config,
+      );
     let activeIndentColor = Colors.List.activeIndentGuide.from(theme);
     let inactiveIndentColor = Colors.List.inactiveIndentGuide.from(theme);
 

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -79,6 +79,7 @@ module Contributions: {
 module View: {
   let make:
     (
+      ~config: Config.resolver,
       ~isActive: bool,
       ~font: UiFont.t,
       ~focusedIndex: option(int),

--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -272,6 +272,8 @@ module Workbench = {
 
   let editorEnablePreview =
     setting("workbench.editor.enablePreview", bool, ~default=true);
+
+  let treeIndent = setting("workbench.tree.indent", int, ~default=5);
 };
 
 let contributions = [
@@ -286,4 +288,5 @@ let contributions = [
   Workbench.activityBarVisible.spec,
   Workbench.editorShowTabs.spec,
   Workbench.editorEnablePreview.spec,
+  Workbench.treeIndent.spec,
 ];

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -317,6 +317,7 @@ module View = {
   open Revery.UI;
   let%component make =
                 (
+                  ~config,
                   ~isFocused,
                   ~iconTheme,
                   ~languageInfo,
@@ -468,6 +469,7 @@ module View = {
 
       | Some(explorer) =>
         <Component_FileExplorer.View
+          config
           isFocused={isFocused && model.focus == FileExplorer}
           expanded={ExpandedState.isOpen(model.isFileExplorerExpanded)}
           iconTheme
@@ -484,6 +486,7 @@ module View = {
     <View style=Style.[flexDirection(`Column), flexGrow(1)]>
       explorerComponent
       <Component_Accordion.VimTree
+        config
         showCount=false
         title="Outline"
         expanded={ExpandedState.isOpen(model.isSymbolOutlineExpanded)}

--- a/src/Feature/Explorer/Feature_Explorer.rei
+++ b/src/Feature/Explorer/Feature_Explorer.rei
@@ -52,6 +52,7 @@ module View: {
   let make:
     (
       ~key: Brisk_reconciler.Key.t=?,
+      ~config: Config.resolver,
       ~isFocused: bool,
       ~iconTheme: IconTheme.t,
       ~languageInfo: Exthost.LanguageInfo.t,

--- a/src/Feature/Pane/DiagnosticsPaneView.re
+++ b/src/Feature/Pane/DiagnosticsPaneView.re
@@ -32,6 +32,7 @@ module Styles = {
 
 let make =
     (
+      ~config,
       ~isFocused: bool,
       ~diagnosticsList: Component_VimTree.model(string, LocationListItem.t),
       ~theme,
@@ -54,6 +55,7 @@ let make =
       </View>;
     } else {
       <Component_VimTree.View
+        config
         font=uiFont
         isActive=isFocused
         focusedIndex=None

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -679,6 +679,7 @@ module View = {
   };
   let content =
       (
+        ~config,
         ~isFocused,
         ~selected,
         ~theme,
@@ -702,6 +703,7 @@ module View = {
     switch (selected) {
     | Locations =>
       <LocationsPaneView
+        config
         isFocused
         locationsList
         iconTheme
@@ -714,6 +716,7 @@ module View = {
 
     | Diagnostics =>
       <DiagnosticsPaneView
+        config
         isFocused
         diagnosticsList
         iconTheme
@@ -867,6 +870,7 @@ module View = {
           </View>
           <View style=Styles.content>
             <content
+              config
               isFocused
               iconTheme
               languageInfo

--- a/src/Feature/Pane/LocationsPaneView.re
+++ b/src/Feature/Pane/LocationsPaneView.re
@@ -38,6 +38,7 @@ module Styles = {
 
 let make =
     (
+      ~config,
       ~isFocused: bool,
       ~locationsList:
          Component_VimTree.model(location, Oni_Components.LocationListItem.t),
@@ -61,6 +62,7 @@ let make =
       </View>;
     } else {
       <Component_VimTree.View
+        config
         font=uiFont
         isActive=isFocused
         focusedIndex=None

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -283,6 +283,7 @@ module Styles = {
 
 let make =
     (
+      ~config,
       ~theme,
       ~uiFont: UiFont.t,
       ~iconTheme,
@@ -328,6 +329,7 @@ let make =
         text={Printf.sprintf("%n results", List.length(model.hits))}
       />
       <Component_VimTree.View
+        config
         isActive={isFocused && model.focus == ResultsPane}
         font=uiFont
         focusedIndex=None

--- a/src/Feature/Search/Feature_Search.rei
+++ b/src/Feature/Search/Feature_Search.rei
@@ -42,6 +42,7 @@ let subscriptions:
 
 let make:
   (
+    ~config: Oni_Core.Config.resolver,
     ~theme: ColorTheme.Colors.t,
     ~uiFont: UiFont.t,
     ~iconTheme: IconTheme.t,

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -83,6 +83,7 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
         | FileExplorer =>
           let dispatch = msg => dispatch(Actions.FileExplorer(msg));
           <Feature_Explorer.View
+            config
             isFocused={FocusManager.current(state) == Focus.FileExplorer}
             languageInfo={state.languageInfo}
             iconTheme={state.iconTheme}
@@ -114,6 +115,7 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
             GlobalContext.current().dispatch(Actions.Search(msg));
 
           <Feature_Search
+            config
             isFocused={FocusManager.current(state) == Focus.Search}
             theme
             languageInfo={state.languageInfo}


### PR DESCRIPTION
This brings back the `workbench.tree.indent` setting:

![2021-03-19 13 51 41](https://user-images.githubusercontent.com/13532591/111841015-887b2b00-88ba-11eb-9588-73d962b9f2ce.gif)

Fixes #3305 

