### PR TITLE
fix(completion/#3136): Case-insensitive completion filtering

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -13,6 +13,7 @@
 - #3301 - Formatting: Fix crash in default formatter with negative indentation levels
 - #3302 - Auto-Indent: Implement $setLanguageConfiguration handler (related to #3288)
 - #3300 - Formatting: Fix format edits containing a trailing newline (related to #3288)
+- #3308 - Completion: Allow case-insensitive matches in scoring (fixes #3136)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -111,13 +111,16 @@ module Session = {
   let filter:
     (~query: string, list(CompletionItem.t)) => list(CompletionItem.t) =
     (~query, items) => {
-      let explodedQuery = Zed_utf8.explode(query);
+      let explodedQuery = Zed_utf8.explode(query |> String.lowercase_ascii);
       items
       |> List.filter((item: CompletionItem.t) =>
            if (String.length(item.filterText) < String.length(query)) {
              false;
            } else {
-             Filter.fuzzyMatches(explodedQuery, item.filterText);
+             Filter.fuzzyMatches(
+               explodedQuery,
+               item.filterText |> String.lowercase_ascii,
+             );
            }
          );
     };


### PR DESCRIPTION
With the work done in #3298 (and #range , it's now easier to adjust the sort / scoring algorithm to fix issues like #3136 .

This PR implements case-insensitive completion filtering, ie for golang:

![2021-03-19 14 25 01](https://user-images.githubusercontent.com/13532591/111843805-09d4bc80-88bf-11eb-9fa0-b8eeea01c1ee.gif)

and other languages:

![image](https://user-images.githubusercontent.com/13532591/111843767-f9bcdd00-88be-11eb-9c17-6c8d5cb8b2db.png)

The scoring function allows inexact matches, but penalizes the score when the case doesn't match. This gets closer to parity with VSCode's matching, although there are some nice-to-haves that aren't implemented in Onivim yet - inexact matches and misspelling/typo resiliency. Incorporating edit distance into the scoring algorithm could help improve even further, as a next step. 

Fixes #3136 