### PR TITLE
fix(completion): Keyword completion insertion is off-by-one in some cases

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -13,6 +13,7 @@
 - #3301 - Formatting: Fix crash in default formatter with negative indentation levels
 - #3302 - Auto-Indent: Implement $setLanguageConfiguration handler (related to #3288)
 - #3300 - Formatting: Fix format edits containing a trailing newline (related to #3288)
+- #3309 - Completion: Fix off-by-one keyword / snippet completion 
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -324,7 +324,7 @@ module Session = {
                ~base=meet.base,
                ~trigger,
                ~buffer,
-               ~location=meet.location,
+               ~location=meet.insertLocation,
              )
              |> Option.map(model => (meet, model))
            })

--- a/src/Feature/LanguageSupport/CompletionItem.re
+++ b/src/Feature/LanguageSupport/CompletionItem.re
@@ -44,10 +44,10 @@ let suggestRangeFromMeet = (~meet: CharacterPosition.t, ~base: string) => {
   let characters = Zed_utf8.length(base);
   Exthost.SuggestItem.SuggestRange.Single({
     startLineNumber: meet.line |> EditorCoreTypes.LineNumber.toOneBased,
-    startColumn: meet.character |> EditorCoreTypes.CharacterIndex.toInt,
+    startColumn: (meet.character |> EditorCoreTypes.CharacterIndex.toInt) + 1,
     endLineNumber: meet.line |> EditorCoreTypes.LineNumber.toOneBased,
     endColumn:
-      (meet.character |> EditorCoreTypes.CharacterIndex.toInt) + characters,
+      (meet.character |> EditorCoreTypes.CharacterIndex.toInt) + characters + 1,
   });
 };
 


### PR DESCRIPTION
__Issue:__ A combination of #3279 and #3298 caused a regression in keyword / snippet completion.

In some cases, the keyword completion would work fine - but if there was a non-word trigger character in front, that character would be consumed by the insertion.

__Defect:__ In #3279 , an `insertLocation` was added to the meet. This `insertLocation` is used for positioning the insertion. In #3298, the keywords/ snippets bake in an insert range - but from the `meet.location` instead of `meet.insertLocation`. The `meet.location` is incorrect in the situation described above, so it causes an incorrect insertion position.

__Fix:__ Pass `meet.insertLocation` to the snippet / keyword providers.
