### PR TITLE
fix(snippets): Parse error with sprintf snippet

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -14,6 +14,7 @@
 - #3302 - Auto-Indent: Implement $setLanguageConfiguration handler (related to #3288)
 - #3300 - Formatting: Fix format edits containing a trailing newline (related to #3288)
 - #3307 - UX: Bring back 'workbench.tree.indent' configuration setting (fixes #3305)
+- #3310 - Snippets: Fix parse error for printf/sprintf snippets
 
 ### Performance
 

--- a/src/Core/Snippet/Snippet.re
+++ b/src/Core/Snippet/Snippet.re
@@ -161,4 +161,8 @@ let%test_module "parse" =
        )
        |> Result.is_ok;
      };
+
+     let%test "sprintf parse bug (comma in placeholder)" = {
+       parse("sprintf(${1:char *,})") |> Result.is_ok;
+     };
    });

--- a/src/Core/Snippet/Snippet_parser.mly
+++ b/src/Core/Snippet/Snippet_parser.mly
@@ -24,7 +24,6 @@ expr:
 | e = expr_nested; { e }
 | LB; { Text("{") } 
 | RB; { Text("}") }
-| COMMA; { Text(",") }
 | PIPE; { Text("|") }
 | COLON; { Text(":") }
 
@@ -38,9 +37,9 @@ additionalChoices }) }
 | DOLLAR; LB; var = VARIABLE; COLON; default = string; RB { Variable({name = var; default = Some(default) }) }
 | DOLLAR; LB; text = TEXT; { Text("${" ^ text) }
 | text = TEXT { Text(text) }
+| COMMA; { Text(",") }
 | numberAsText = NUMBER { Text(string_of_int(numberAsText)) }
 | variableAsText = VARIABLE { Snippet_internal.Text(variableAsText) }
-
 
 additional_choice:
 | COMMA; choice = string; { choice }


### PR DESCRIPTION
__Issue:__ When testing the `clangd` extension, I observed some snippet parse failures for some completions:

<img width="328" alt="Screen Shot 2021-03-19 at 5 08 29 PM" src="https://user-images.githubusercontent.com/13532591/111854301-b91f8c80-88db-11eb-932d-42977c630c34.png">

__Defect:__ The `,` character wasn't being parsed correctly, and wasn't treated as valid text

__Fix:__ Allow commas in placeholder / text blocks; add test case