### PR TITLE
perf(luv): Re-use allocated buffer when possible

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -19,6 +19,8 @@
 
 ### Performance
 
+- #3316 - Transport: Re-use Luv.Buffer.t when possible for reads
+
 ### Documentation
 
 - #3293 - Formatting: Initial formatting documentation

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -189,7 +189,9 @@ let process = (rgPath, args, onUpdate, onComplete, onError) => {
       ();
     };
 
+    let allocator = Utility.LuvEx.allocator("Ripgrep");
     Luv.Stream.read_start(
+      ~allocate=allocator,
       pipe,
       fun
       | Error(`EOF) => {

--- a/src/Core/Utility/LuvEx.re
+++ b/src/Core/Utility/LuvEx.re
@@ -1,5 +1,7 @@
 exception LuvException(Luv.Error.t);
 
+module Log = (val Kernel.Log.withNamespace("LuvEx"));
+
 let wrapPromise = (f, arg) => {
   let (promise, resolver) = Lwt.task();
 
@@ -10,6 +12,29 @@ let wrapPromise = (f, arg) => {
     }
   });
   promise;
+};
+
+let allocator = name => {
+  let maybeAllocatedBuffer = ref(None);
+
+  let createNewBuffer = size => {
+    let newBuffer = Luv.Buffer.create(size);
+    Log.infof(m => m("Allocating new buffer of size %d", size));
+    maybeAllocatedBuffer := Some(newBuffer);
+    newBuffer;
+  };
+
+  size => {
+    switch (maybeAllocatedBuffer^) {
+    | Some(buffer) =>
+      if (Luv.Buffer.size(buffer) >= size) {
+        buffer;
+      } else {
+        createNewBuffer(size);
+      }
+    | None => createNewBuffer(size)
+    };
+  };
 };
 
 module Process = {

--- a/src/Core/Utility/LuvEx.re
+++ b/src/Core/Utility/LuvEx.re
@@ -19,7 +19,9 @@ let allocator = name => {
 
   let createNewBuffer = size => {
     let newBuffer = Luv.Buffer.create(size);
-    Log.infof(m => m("Allocating new buffer of size %d", size));
+    Log.infof(m =>
+      m("Allocating new buffer for %s with size %d", name, size)
+    );
     maybeAllocatedBuffer := Some(newBuffer);
     newBuffer;
   };

--- a/src/Exthost/Transport/Exthost_Transport.re
+++ b/src/Exthost/Transport/Exthost_Transport.re
@@ -64,8 +64,6 @@ let flushQueuedMessages = (~dispatch, queuedMessages, client) => {
   packets |> List.iter(send(~dispatch));
 };
 
-let buffer = ref(None);
-
 let read = (~dispatch, clientPipe) => {
   let parser = ref(Packet.Parser.initial);
 

--- a/src/Exthost/Transport/Exthost_Transport.re
+++ b/src/Exthost/Transport/Exthost_Transport.re
@@ -64,6 +64,8 @@ let flushQueuedMessages = (~dispatch, queuedMessages, client) => {
   packets |> List.iter(send(~dispatch));
 };
 
+let buffer = ref(None);
+
 let read = (~dispatch, clientPipe) => {
   let parser = ref(Packet.Parser.initial);
 
@@ -75,7 +77,10 @@ let read = (~dispatch, clientPipe) => {
 
   let handleError = handleError(~dispatch);
 
+  let allocator = Oni_Core.Utility.LuvEx.allocator("Exthost_Transport");
+
   Luv.Stream.read_start(
+    ~allocate=allocator,
     clientPipe,
     fun
     | Error(`EOF) => handleClosed()

--- a/src/Exthost/Transport/dune
+++ b/src/Exthost/Transport/dune
@@ -1,6 +1,6 @@
 (library
  (name Exthost_Transport)
  (public_name Oni2.exthost.transport)
- (libraries timber luv yojson decoders-yojson)
+ (libraries timber luv yojson decoders-yojson Oni2.core)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson)))


### PR DESCRIPTION
__Issue:__ We use `libuv` (via `luv`) to communicate with the extension host, syntax highlighting, and ripgrep. 

For each 'read' from the process pipe - we are allocating a large buffer (~65k bytes), and the reads can be quite high frequency, especially in the case of the extension host when there are several highlights / completion providers / codelens providers, etc.

__Fix:__ The `luv` API allows re-use of the allocated buffer - we can leverage that, as the buffer is used ephemerally anyway and copied to bytes when used. We can avoid extra allocations by writing into the same buffer as opposed to allocating a new one for every read.