### PR TITLE
fix(exthost/#2380): Haskell files at root do not get language integration

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -18,6 +18,7 @@
 - #3310 - Snippets: Fix parse error for printf/sprintf snippets
 - #3287 - Search: Initiate search automatically when text is selected (fixes #3277)
 - #3308 - Completion: Allow case-insensitive matches in scoring (fixes #3136)
+- #3317 - Extensions: Fix haskell files at root not loading language integration (related #2380)
 
 ### Performance
 

--- a/src/Core/Glob.re
+++ b/src/Core/Glob.re
@@ -1,0 +1,31 @@
+type t = {
+  globWithDoubleAsterisks: Re.re,
+  globWithoutDoubleAsterisks: Re.re,
+  globString: string,
+};
+
+let parse = str => {
+  let original = str |> Utility.Path.normalizeBackSlashes;
+  let noDoubleAsterisks =
+    original |> StringEx.replace(~match="/**/", ~replace="/");
+
+  try({
+    let globWithDoubleAsterisks =
+      original |> Re.Glob.glob(~expand_braces=true) |> Re.compile;
+
+    let globWithoutDoubleAsterisks =
+      noDoubleAsterisks |> Re.Glob.glob(~expand_braces=true) |> Re.compile;
+    Ok({
+      globWithDoubleAsterisks,
+      globWithoutDoubleAsterisks,
+      globString: original,
+    });
+  }) {
+  | exn => Error(Printexc.to_string(exn))
+  };
+};
+
+let matches = ({globWithDoubleAsterisks, globWithoutDoubleAsterisks, _}) => {
+  true;
+};
+

--- a/src/Core/Glob.re
+++ b/src/Core/Glob.re
@@ -1,13 +1,16 @@
+[@deriving show]
 type t = {
-  globWithDoubleAsterisks: Re.re,
-  globWithoutDoubleAsterisks: Re.re,
+  globWithDoubleAsterisks: [@opaque] Re.re,
+  globWithoutDoubleAsterisks: [@opaque] Re.re,
   globString: string,
 };
+
+let toDebugString = ({globString, _}) => globString;
 
 let parse = str => {
   let original = str |> Utility.Path.normalizeBackSlashes;
   let noDoubleAsterisks =
-    original |> StringEx.replace(~match="/**/", ~replace="/");
+    original |> Utility.StringEx.replace(~match="/**/", ~replace="/");
 
   try({
     let globWithDoubleAsterisks =
@@ -25,7 +28,37 @@ let parse = str => {
   };
 };
 
-let matches = ({globWithDoubleAsterisks, globWithoutDoubleAsterisks, _}) => {
-  true;
+let matches =
+    ({globWithDoubleAsterisks, globWithoutDoubleAsterisks, _}, path) => {
+  Re.matches(globWithDoubleAsterisks, path) != []
+  || Re.matches(globWithoutDoubleAsterisks, path) != [];
 };
 
+let decode =
+  Json.Decode.(
+    {
+      string
+      |> map(parse)
+      |> and_then(
+           fun
+           | Ok(glob) => succeed(glob)
+           | Error(msg) => fail(msg),
+         );
+    }
+  );
+
+let%test_module "Glob" =
+  (module
+   {
+     let%test "double asterisk matches directory" = {
+       let glob = parse("/abc/**/*.hs") |> Result.get_ok;
+
+       matches(glob, "/abc/src/file.hs");
+     };
+
+     let%test "double asterisk matches file at root, too" = {
+       let glob = parse("/abc/**/*.hs") |> Result.get_ok;
+
+       matches(glob, "/abc/file.hs");
+     };
+   });

--- a/src/Core/Glob.rei
+++ b/src/Core/Glob.rei
@@ -1,3 +1,4 @@
+[@deriving show]
 type t;
 
 let parse: string => result(t, string);
@@ -7,4 +8,3 @@ let matches: (t, string) => bool;
 let toDebugString: t => string;
 
 let decode: Json.decoder(t);
-

--- a/src/Core/Glob.rei
+++ b/src/Core/Glob.rei
@@ -1,0 +1,10 @@
+type t;
+
+let parse: string => result(t, string);
+
+let matches: (t, string) => bool;
+
+let toDebugString: t => string;
+
+let decode: Json.decoder(t);
+

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -29,6 +29,7 @@ module Font = Font;
 module FontLigatures = FontLigatures;
 module FontSmoothing = FontSmoothing;
 module FontMeasurementCache = FontMeasurementCache;
+module Glob = Glob;
 module IconTheme = IconTheme;
 module Indentation = Indentation;
 module IndentationSettings = IndentationSettings;

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -491,3 +491,8 @@ let escapeSpaces: string => string =
     List.init(String.length(s), String.get(s))
     |> List.map(c => (c == ' ' ? "\\" : "") ++ String.make(1, c))
     |> String.concat("");
+
+let replace = (~match, ~replace, str) => {
+  Str.global_replace(Str.regexp_string(match), replace, str);
+};
+

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -495,4 +495,3 @@ let escapeSpaces: string => string =
 let replace = (~match, ~replace, str) => {
   Str.global_replace(Str.regexp_string(match), replace, str);
 };
-

--- a/src/Exthost/DocumentFilter.re
+++ b/src/Exthost/DocumentFilter.re
@@ -3,28 +3,9 @@ open Oni_Core;
 [@deriving show]
 type t = {
   language: option(string),
-  pattern: option(Re.re),
-  patternString: option(string),
+  pattern: option(Glob.t),
   scheme: option(string),
   exclusive: bool,
-};
-
-module CustomDecoders = {
-  let glob =
-    Json.Decode.(
-      string
-      |> and_then(str =>
-           try(
-             str
-             |> Utility.Path.normalizeBackSlashes
-             |> Re.Glob.glob(~expand_braces=true)
-             |> Re.compile
-             |> succeed
-           ) {
-           | exn => fail(Printexc.to_string(exn))
-           }
-         )
-    );
 };
 
 let decode = {
@@ -34,8 +15,7 @@ let decode = {
         language: field.optional("language", string),
         scheme: field.optional("scheme", string),
         exclusive: field.withDefault("exclusive", true, bool),
-        pattern: field.optional("pattern", CustomDecoders.glob),
-        patternString: field.optional("pattern", string),
+        pattern: field.optional("pattern", Glob.decode),
       }
     )
   );
@@ -52,7 +32,7 @@ let matches = (~filetype: string, ~filepath: string, filter) => {
     switch (filter.pattern) {
     | None => true
     | Some(glob) =>
-      Re.matches(glob, Utility.Path.normalizeBackSlashes(filepath)) != []
+      Glob.matches(glob, Utility.Path.normalizeBackSlashes(filepath))
     };
 
   fileTypeMatches && patternMatches;
@@ -62,8 +42,9 @@ let toString = filter =>
   Printf.sprintf(
     "DocumentFilter : language=%s, pattern=%s, scheme=%s, exclusive=%b",
     filter.language |> Option.value(~default="(none)"),
-    filter.patternString |> Option.value(~default="(none)"),
+    filter.pattern
+    |> Option.map(Glob.toDebugString)
+    |> Option.value(~default="(none)"),
     filter.scheme |> Option.value(~default="(none)"),
     filter.exclusive,
   );
-

--- a/src/Exthost/DocumentFilter.re
+++ b/src/Exthost/DocumentFilter.re
@@ -4,6 +4,7 @@ open Oni_Core;
 type t = {
   language: option(string),
   pattern: option(Re.re),
+  patternString: option(string),
   scheme: option(string),
   exclusive: bool,
 };
@@ -34,6 +35,7 @@ let decode = {
         scheme: field.optional("scheme", string),
         exclusive: field.withDefault("exclusive", true, bool),
         pattern: field.optional("pattern", CustomDecoders.glob),
+        patternString: field.optional("pattern", string),
       }
     )
   );
@@ -58,8 +60,10 @@ let matches = (~filetype: string, ~filepath: string, filter) => {
 
 let toString = filter =>
   Printf.sprintf(
-    "DocumentFilter : language = %s, scheme = %s, exclusive = %b",
+    "DocumentFilter : language=%s, pattern=%s, scheme=%s, exclusive=%b",
     filter.language |> Option.value(~default="(none)"),
+    filter.patternString |> Option.value(~default="(none)"),
     filter.scheme |> Option.value(~default="(none)"),
     filter.exclusive,
   );
+

--- a/src/Exthost/DocumentSelector.re
+++ b/src/Exthost/DocumentSelector.re
@@ -22,22 +22,10 @@ let matchesBuffer = (~buffer: Oni_Core.Buffer.t, filter) => {
 
   let maybeFilePath = buffer |> Buffer.getFilePath;
 
-  let ret =
-    OptionEx.map2(
-      (filetype, filepath) => {matches(~filetype, ~filepath, filter)},
-      maybeFileType,
-      maybeFilePath,
-    )
-    |> Option.value(~default=false);
-
-  prerr_endline(
-    Printf.sprintf(
-      "Matches buffer: %s - %s (%s)",
-      Buffer.getFilePath(buffer) |> Option.value(~default="(none)"),
-      ret |> string_of_bool,
-      toDebugString(filter),
-    ),
-  );
-  ret;
+  OptionEx.map2(
+    (filetype, filepath) => {matches(~filetype, ~filepath, filter)},
+    maybeFileType,
+    maybeFilePath,
+  )
+  |> Option.value(~default=false);
 };
-

--- a/src/Exthost/DocumentSelector.re
+++ b/src/Exthost/DocumentSelector.re
@@ -10,15 +10,34 @@ let matches = (~filetype: string, ~filepath: string, filter) => {
   filter |> List.exists(DocumentFilter.matches(~filetype, ~filepath));
 };
 
+let toDebugString = filter => {
+  let filterString =
+    filter |> List.map(DocumentFilter.toString) |> String.concat("\n");
+
+  Printf.sprintf("DocumentSelector - filters:\n %s", filterString);
+};
+
 let matchesBuffer = (~buffer: Oni_Core.Buffer.t, filter) => {
   let maybeFileType = buffer |> Buffer.getFileType |> Buffer.FileType.toOption;
 
   let maybeFilePath = buffer |> Buffer.getFilePath;
 
-  OptionEx.map2(
-    (filetype, filepath) => {matches(~filetype, ~filepath, filter)},
-    maybeFileType,
-    maybeFilePath,
-  )
-  |> Option.value(~default=false);
+  let ret =
+    OptionEx.map2(
+      (filetype, filepath) => {matches(~filetype, ~filepath, filter)},
+      maybeFileType,
+      maybeFilePath,
+    )
+    |> Option.value(~default=false);
+
+  prerr_endline(
+    Printf.sprintf(
+      "Matches buffer: %s - %s (%s)",
+      Buffer.getFilePath(buffer) |> Option.value(~default="(none)"),
+      ret |> string_of_bool,
+      toDebugString(filter),
+    ),
+  );
+  ret;
 };
+


### PR DESCRIPTION
__Issue:__  I wanted to test the state of #2380 w/ the latest exthost fixes - and I found when opening a Haskell project (ie, `oni2 my-haskell-project`), and then opening a Haskell file at the root, no language integration is provided. Curiously, Haskell files in sub-folders would get language integrations:

![2021-03-22 15 01 17](https://user-images.githubusercontent.com/13532591/112064093-a9908580-8b1f-11eb-9e9e-06e0dd9373cc.gif)

(The [haskell extension from Open-VSX](https://open-vsx.org/extension/haskell/haskell) is required)

This seems to also impact elixir files - they had the exact same issue - files at the root of the project did not get language integration, but files in subfolders did.

__Defect:__ The glob module we were leveraging was treating double-asterisks as a required folders - so, for example, `/my-haskell-project/**/*.hs` would match `/my-haskell-project/src/some-file.hs` but NOT `/my-haskell-project/some-file.hs`

__Fix:__ Refactor glob module, and allow 'empty' double asterisk paths. The fix isn't perfect; as if there are more intricate globs (like `/my-haskell-project/**/src/**/*.hs`), there could still be cases that may not match. However, the new behavior handles the document selector cases better, and doesn't regress functionality.

Related #2380 