### PR TITLE
fix(extension/#2583): Fix the last blocking issue for TabNine (sem/version commands)

### DIFF
--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -163,7 +163,7 @@ module Session = {
                    meet,
                    cursor,
                    currentItems: items,
-                   filteredItems: filter(~query=meet.base, items),
+                   filteredItems: items,
                    providerModel: providerModel',
                  })
                | (Complete, items) =>
@@ -273,11 +273,11 @@ module Session = {
                    ...prev,
                    meet: newMeet,
                    cursor: position,
-                   filteredItems:
-                     filter(
-                       ~query=CompletionMeet.(newMeet.base),
-                       currentItems,
-                     ),
+                   filteredItems: currentItems,
+                   // filter(
+                   //   ~query=CompletionMeet.(newMeet.base),
+                   //   currentItems,
+                   // ),
                  })
                | Completed({allItems, meet, _} as prev)
                    when CompletionMeet.matches(meet, newMeet) =>


### PR DESCRIPTION
__Issue:__ The `TabNine::sem` and `TabNine::version` commands weren't showing up as expected in the UI

__Defect:__ These options were being  filtered out because they didn't fuzzy-match any base string (for example, when the `version` autocomplete entry expands to the actual version number, Onivim would filter it out).

__Fix:__ When a completion provider says that the results list is incomplete, let it decide what should be shown.

Fixes the last blocking issue for #2583 