### PR TITLE
fix(editor): Fix crash in marker update with UTF-8 characters

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -21,6 +21,7 @@
 - #3317 - Extensions: Fix haskell files at root not loading language integration (related #2380)
 - #3318 - Completion: Show full incomplete results list (fixes #2583)
 - #3329 - Formatting: Fix trailing newline being introduced by some providers (fixes #3320)
+- #3331 - Editor: Fix crash when manipulating Unicode characters
 
 ### Performance
 

--- a/src/Core/MarkerUpdate.re
+++ b/src/Core/MarkerUpdate.re
@@ -80,6 +80,31 @@ module Internal = {
         }
       );
     };
+
+  let%test_module "minimalUpdateToMovement" =
+    (module
+     {
+       let%test "unicode characters get shifted properly" = {
+         let update =
+           MinimalUpdate.(
+             Modified({
+               line: LineNumber.zero,
+               original: "κόσμε",
+               updated: "κόσε",
+             })
+           );
+         let actual = minimalUpdateToMovement(update);
+
+         actual
+         == ShiftCharacters({
+              line: LineNumber.zero,
+              afterByte: ByteIndex.ofInt(7),
+              deltaBytes: (-2),
+              afterCharacter: CharacterIndex.ofInt(3),
+              deltaCharacters: (-1),
+            });
+       };
+     });
 };
 
 let create = (~update: BufferUpdate.t, ~original, ~updated) =>

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -61,14 +61,35 @@ let firstDifference = (a, b) => {
       } else {
         Some(idx);
       };
-    } else if (a.[idx] != b.[idx]) {
-      Some(idx);
     } else {
-      loop(idx + 1);
+      let (charA, idxA) = Zed_utf8.extract_next(a, idx);
+      let (charB, _) = Zed_utf8.extract_next(b, idx);
+
+      if (!Uchar.equal(charA, charB)) {
+        Some(idx);
+      } else {
+        loop(idxA);
+      };
     };
 
   loop(0);
 };
+
+let%test_module "splitAt" =
+  (module
+   {
+     let%test "no difference" = {
+       firstDifference("", "") == None;
+     };
+
+     let%test "difference at first byte" = {
+       firstDifference("a", "b") == Some(0);
+     };
+
+     let%test "unicode-aware difference" = {
+       firstDifference("κόσμε", "κόσε") == Some(7);
+     };
+   });
 
 let splitAt = (~byte: int, str) => {
   let len = String.length(str);


### PR DESCRIPTION
__Issue:__ A crash can potentially occur when manipulating some Unicode characters

__Defect:__ The root exception is `Zed_utf8.Invalid("at position 8: invalid start of UTF-8 sequence", "\206\186\225\189\185\207\131\206\188\206\181").` - the logic we are using to calculate the offset for bytes / characters wasn't Unicode aware. Because the difference of the strings was only calculated at the byte level - if two subsequent unicode characters had the same prefix byte, we would compare the strings mid-character, which causes a zed crash further downstream.

__Fix:__ Make `firstDifference` unicode-aware; add tests 