### PR TITLE
fix(scm/#3315): Show staged changes in dock

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -23,6 +23,7 @@
 - #3329 - Formatting: Fix trailing newline being introduced by some providers (fixes #3320)
 - #3331 - Editor: Fix crash when manipulating Unicode characters
 - #3327, #3329 - Formatting: Fix trailing newline being introduced by some providers (fixes #3320)
+- #3338 - SCM: Show changes badge in dock (fixes #3315)
 
 ### Performance
 

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -221,10 +221,11 @@ type model = {
 
 let count = ({providers, _}) => {
   providers
-  |> List.fold_left((count, provider: Provider.t) => {
-    count + provider.count
-  }, 0)
-}
+  |> List.fold_left(
+       (count, provider: Provider.t) => {count + provider.count},
+       0,
+     );
+};
 
 let resetFocus = model => {...model, focus: Focus.initial};
 

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -219,6 +219,13 @@ type model = {
   focus: Focus.t,
 };
 
+let count = ({providers, _}) => {
+  providers
+  |> List.fold_left((count, provider: Provider.t) => {
+    count + provider.count
+  }, 0)
+}
+
 let resetFocus = model => {...model, focus: Focus.initial};
 
 let initial = {

--- a/src/Feature/SCM/Feature_SCM.rei
+++ b/src/Feature/SCM/Feature_SCM.rei
@@ -20,13 +20,6 @@ module Resource: {
 module ResourceGroup: {
   [@deriving show]
   type t;
-  //  type t = {
-  //    handle: int,
-  //    id: string,
-  //    label: string,
-  //    hideWhenEmpty: bool,
-  //    resources: list(Resource.t),
-  //  };
 };
 
 module Provider: {
@@ -51,6 +44,8 @@ module Provider: {
 type model;
 
 let resetFocus: model => model;
+
+let count: model => int;
 
 let initial: model;
 

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -48,17 +48,19 @@ module Styles = {
     ];
   };
 
-  let notification = (~scale, ~theme, ~padding) => [
+  let notification = (~theme, ~padding) => [
     position(`Absolute),
     bottom(4),
     right(4),
-    width(15),
+    minWidth(15),
+    //width(15),
     height(15),
+    flexDirection(`Row),
+    justifyContent(`Center),
     paddingTop(padding),
-    paddingLeft(padding),
+    paddingHorizontal(padding),
     borderRadius(8.),
     backgroundColor(BadgeColors.background.from(theme)),
-    transform([Revery.UI.Transform.Scale(scale)]),
   ];
 };
 module Animations = {
@@ -71,19 +73,19 @@ module Animations = {
 };
 
 module Notification = {
-  let%component make = (~notification, ~theme, ~font: UiFont.t, ()) => {
+  let make = (~notification, ~theme, ~font: UiFont.t, ()) => {
     let foregroundColor = BadgeColors.foreground.from(theme);
     let (padding, inner) =
       switch (notification) {
       | Count(count) =>
-        let text = count > 9 ? "9+" : string_of_int(count);
+        let text = count > 999 ? "999+" : string_of_int(count);
         (
           2,
           <Text
             text
             fontFamily={font.family}
             fontSize=10.
-            style=[Style.color(foregroundColor)]
+            style=[Style.marginTop(-1), Style.color(foregroundColor)]
           />,
         );
       | InProgress => (
@@ -92,13 +94,7 @@ module Notification = {
         )
       };
 
-    let%hook (scale, _state, _reset) =
-      Hooks.animation(
-        ~name="Notification Appear",
-        Animations.appear,
-        ~active=true,
-      );
-    <View style={Styles.notification(~scale, ~theme, ~padding)}>
+    <View style={Styles.notification(~theme, ~padding)}>
       inner
     </View>;
   };
@@ -167,6 +163,7 @@ let onExtensionsClick = _ => {
 let make =
     (
       ~theme: ColorTheme.Colors.t,
+      ~scm: Feature_SCM.model,
       ~sideBar: Feature_SideBar.model,
       ~extensions: Feature_Extensions.model,
       ~font: UiFont.t,
@@ -176,6 +173,11 @@ let make =
 
   let extensionNotification =
     Feature_Extensions.isBusy(extensions) ? Some(InProgress) : None;
+
+  let scmCount =
+    Feature_SCM.count(scm);
+
+  let scmNotification = scmCount > 0 ? Some(Count(scmCount)) : None;
 
   <View style={Styles.container(~theme)}>
     <item
@@ -202,6 +204,7 @@ let make =
       theme
       isActive={isSidebarVisible(SCM)}
       icon=FontAwesome.codeBranch
+      notification=?scmNotification
     />
     <item
       font

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -52,7 +52,7 @@ module Styles = {
     position(`Absolute),
     bottom(4),
     right(4),
-    minWidth(16),
+    minWidth(15),
     height(16),
     flexDirection(`Row),
     justifyContent(`Center),

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -48,17 +48,15 @@ module Styles = {
     ];
   };
 
-  let notification = (~theme, ~padding) => [
+  let notification = (~theme, ~padding as p) => [
     position(`Absolute),
     bottom(4),
     right(4),
-    minWidth(15),
-    //width(15),
-    height(15),
+    minWidth(16),
+    height(16),
     flexDirection(`Row),
     justifyContent(`Center),
-    paddingTop(padding),
-    paddingHorizontal(padding),
+    padding(p),
     borderRadius(8.),
     backgroundColor(BadgeColors.background.from(theme)),
   ];
@@ -85,18 +83,18 @@ module Notification = {
             text
             fontFamily={font.family}
             fontSize=10.
-            style=[Style.marginTop(-1), Style.color(foregroundColor)]
+            style=[Style.color(foregroundColor)]
           />,
         );
       | InProgress => (
-          3,
-          <Codicon icon=Codicon.clock fontSize=10. color=foregroundColor />,
+          2,
+          <View style=Style.[marginTop(1), marginLeft(1)]>
+            <Codicon icon=Codicon.clock fontSize=10. color=foregroundColor />
+          </View>,
         )
       };
 
-    <View style={Styles.notification(~theme, ~padding)}>
-      inner
-    </View>;
+    <View style={Styles.notification(~theme, ~padding)}> inner </View>;
   };
 };
 
@@ -174,8 +172,7 @@ let make =
   let extensionNotification =
     Feature_Extensions.isBusy(extensions) ? Some(InProgress) : None;
 
-  let scmCount =
-    Feature_SCM.count(scm);
+  let scmCount = Feature_SCM.count(scm);
 
   let scmNotification = scmCount > 0 ? Some(Count(scmCount)) : None;
 

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -119,7 +119,13 @@ let make = (~dispatch, ~state: State.t, ()) => {
           config,
         )
         && !zenMode) {
-      <Dock font={state.uiFont} scm={state.scm} theme sideBar extensions={state.extensions} />;
+      <Dock
+        font={state.uiFont}
+        scm={state.scm}
+        theme
+        sideBar
+        extensions={state.extensions}
+      />;
     } else {
       React.empty;
     };

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -119,7 +119,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
           config,
         )
         && !zenMode) {
-      <Dock font={state.uiFont} theme sideBar extensions={state.extensions} />;
+      <Dock font={state.uiFont} scm={state.scm} theme sideBar extensions={state.extensions} />;
     } else {
       React.empty;
     };


### PR DESCRIPTION
Fix #3315 - add a badge to show current staged changes in dock:

![image](https://user-images.githubusercontent.com/13532591/112704198-eb3e6a80-8e56-11eb-8171-f5507d02be38.png)

