### PR TITLE
fix(diagnostics): Use one-based position in UI for diagnostics and locations

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -24,6 +24,7 @@
 - #3331 - Editor: Fix crash when manipulating Unicode characters
 - #3327, #3329 - Formatting: Fix trailing newline being introduced by some providers (fixes #3320)
 - #3338 - SCM: Show changes badge in dock (fixes #3315)
+- #3341 - Diagnostics: Use one-based positions in UI
 
 ### Performance
 

--- a/src/Components/LocationListItem.re
+++ b/src/Components/LocationListItem.re
@@ -84,8 +84,9 @@ module View = {
             <unstyled
               text={Printf.sprintf(
                 " [%d, %d]",
-                item.location.line |> EditorCoreTypes.LineNumber.toZeroBased,
-                item.location.character |> CharacterIndex.toInt,
+                // For UI: We should be showing one-based locations
+                item.location.line |> EditorCoreTypes.LineNumber.toOneBased,
+                (item.location.character |> CharacterIndex.toInt) + 1,
               )}
             />
           </Opacity>


### PR DESCRIPTION
__Issue:__ The lines and characters shown in the diagnostics view are off by one 

__Defect:__ We are using zero-based line and character indices in the rendering, but the user would expect one-based so it matches up with the line numbers and positions in the editor.

__Fix:__ Use one-based positions for rendering diagnostics and locations:

![image](https://user-images.githubusercontent.com/13532591/112734592-fac7bd00-8f03-11eb-86c2-45758939d82e.png)


