### PR TITLE
fix(completion): Fix snippet sorting in presence of snippet completions

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -24,6 +24,7 @@
 - #3331 - Editor: Fix crash when manipulating Unicode characters
 - #3327, #3329 - Formatting: Fix trailing newline being introduced by some providers (fixes #3320)
 - #3338 - SCM: Show changes badge in dock (fixes #3315)
+- #3342 - Completion: Use completion kind instead of insert text rules for sorting
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/CompletionItemSorter.re
+++ b/src/Feature/LanguageSupport/CompletionItemSorter.re
@@ -2,10 +2,7 @@ open Oni_Core;
 open Utility;
 
 let isSnippet = (item: CompletionItem.t) => {
-  item.insertTextRules
-  |> Exthost.SuggestItem.InsertTextRules.matches(
-       ~rule=Exthost.SuggestItem.InsertTextRules.InsertAsSnippet,
-     );
+  item.kind == Exthost.CompletionKind.Snippet;
 };
 
 module Compare = {


### PR DESCRIPTION
__Issue:__ While investigating some issues around snippets in C, I saw that the `"editor.snippetSuggestions"` configuration setting wasn't quite behaving as expected. In particular, if `"editor.snippetSuggestions": "top"` is set, I'd expect user-created snippets to be at the top of the completion context menu.

__Defect:__ Some language extensions, like clangd, are really good about providing almost every completion as a snippet, even though they might not be categorized as a 'snippet' completion type. There's a difference between the completion kind being a snippet and the insert text rules being a snippet. We were using the latter to sort, but we should've been using the former.

__Fix:__ Use the completion item kind instead of the insert text rules to decide if an item is a snippet.