### PR TITLE
feat(code-actions): Implement extension host protocol

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -2,6 +2,7 @@
 
 - #3284 - Definition: Add 'editor.action.revealDefinitionAside' command (fixes #3261)
 - #2881 - Extensions: Initial rename support
+- #3348 - Code Actions: Implement extension host protocol for quick fix / code actions
 
 ### Bug Fixes
 

--- a/src/Exthost/CacheId.re
+++ b/src/Exthost/CacheId.re
@@ -1,0 +1,8 @@
+open Oni_Core;
+
+[@deriving show]
+type t = int;
+
+let decode = Json.Decode.int;
+
+let encode = Json.Encode.int;

--- a/src/Exthost/CodeAction.re
+++ b/src/Exthost/CodeAction.re
@@ -11,6 +11,27 @@ type t = {
   disabled: option(string),
 };
 
+module Decode = {
+  let decode = {
+    Oni_Core.Json.Decode.(
+      obj(({field, _}) =>
+        {
+          chainedCacheId:
+            field.optional("chainedCacheId", ChainedCacheId.decode),
+          title: field.required("title", string),
+          edit: field.optional("edit", WorkspaceEdit.decode),
+          diagnostics:
+            field.withDefault("diagnostics", [], list(Diagnostic.decode)),
+          command: field.optional("command", Command.decode),
+          kind: field.optional("kind", string),
+          isPreferred: field.withDefault("isPreferred", false, bool),
+          disabled: field.optional("disabled", string),
+        }
+      )
+    );
+  };
+};
+
 module TriggerType = {
   type t =
     | Auto
@@ -92,8 +113,19 @@ module ProviderMetadata = {
 };
 
 module List = {
-  type t = {
+  type nonrec t = {
     cacheId: CacheId.t,
     actions: list(t),
+  };
+
+  let decode = {
+    Oni_Core.Json.Decode.(
+      obj(({field, _}) =>
+        {
+          cacheId: field.required("cacheId", CacheId.decode),
+          actions: field.withDefault("actions", [], list(Decode.decode)),
+        }
+      )
+    );
   };
 };

--- a/src/Exthost/CodeAction.re
+++ b/src/Exthost/CodeAction.re
@@ -1,3 +1,5 @@
+module StringMap = Oni_Core.StringMap;
+
 type t = {
   chainedCacheId: option(ChainedCacheId.t),
   title: string,
@@ -9,16 +11,89 @@ type t = {
   disabled: option(string),
 };
 
+module TriggerType = {
+  type t =
+    | Auto
+    | Manual;
+
+  // Must be kept in sync with:
+  // https://github.com/onivim/vscode-exthost/blob/0d6b39803352369daaa97a444ff76352d8452be2/src/vs/editor/common/modes.ts#L641
+  let toInt =
+    fun
+    | Auto => 1
+    | Manual => 2;
+
+  let encode = triggerType => triggerType |> toInt |> Oni_Core.Json.Encode.int;
+};
+
+module Context = {
+  type t = {
+    // TODO: What is this for?
+    only: option(string),
+    trigger: TriggerType.t,
+  };
+
+  let encode = {
+    Oni_Core.Json.Encode.(
+      context =>
+        obj([
+          ("only", context.only |> nullable(string)),
+          ("trigger", context.trigger |> TriggerType.encode),
+        ])
+    );
+  };
+};
+
 module ProviderMetadata = {
+  [@deriving show]
   type t = {
     providedKinds: list(string),
-    providedDocumentation: Oni_Core.StringMap.t(Command.t),
+    providedDocumentation: [@opaque] Oni_Core.StringMap.t(Command.t),
+  };
+
+  module Documentation = {
+    type t = {
+      kind: string,
+      command: Command.t,
+    };
+
+    let decode = {
+      Oni_Core.Json.Decode.(
+        obj(({field, _}) => {
+          let kind = field.required("kind", string);
+          let command = field.required("command", Command.decode);
+          {kind, command};
+        })
+      );
+    };
+  };
+
+  let decode = {
+    Oni_Core.Json.Decode.(
+      obj(({field, _}) => {
+        let providedKinds =
+          field.withDefault("providedKinds", [], list(string));
+        let documentationList =
+          field.withDefault("documentation", [], list(Documentation.decode));
+
+        let providedDocumentation =
+          documentationList
+          |> List.fold_left(
+               (acc, curr: Documentation.t) => {
+                 StringMap.add(curr.kind, curr.command, acc)
+               },
+               StringMap.empty,
+             );
+
+        {providedKinds, providedDocumentation};
+      })
+    );
   };
 };
 
 module List = {
   type t = {
-    cacheId: int,
+    cacheId: CacheId.t,
     actions: list(t),
   };
 };

--- a/src/Exthost/CodeAction.re
+++ b/src/Exthost/CodeAction.re
@@ -1,0 +1,24 @@
+type t = {
+  chainedCacheId: option(ChainedCacheId.t),
+  title: string,
+  edit: option(WorkspaceEdit.t),
+  diagnostics: list(Diagnostic.t),
+  command: option(Command.t),
+  kind: option(string),
+  isPreferred: bool,
+  disabled: option(string),
+};
+
+module ProviderMetadata = {
+  type t = {
+    providedKinds: list(string),
+    providedDocumentation: Oni_Core.StringMap.t(Command.t),
+  };
+};
+
+module List = {
+  type t = {
+    cacheId: int,
+    actions: list(t),
+  };
+};

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -5,6 +5,7 @@ module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
 module ChainedCacheId = ChainedCacheId;
+module CodeAction = CodeAction;
 module CodeLens = CodeLens;
 module Color = Color;
 module Command = Command;

--- a/src/Exthost/Exthost.re
+++ b/src/Exthost/Exthost.re
@@ -4,6 +4,7 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module CacheId = CacheId;
 module ChainedCacheId = ChainedCacheId;
 module CodeAction = CodeAction;
 module CodeLens = CodeLens;
@@ -44,7 +45,9 @@ module ReferenceContext = ReferenceContext;
 module RenameLocation = RenameLocation;
 module Reply = Reply;
 module SCM = SCM;
+module Selection = Selection;
 module SignatureHelp = SignatureHelp;
+module Span = Span;
 module SuggestItem = SuggestItem;
 module SuggestResult = SuggestResult;
 module SymbolKind = SymbolKind;

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -6,6 +6,11 @@ module Extension = Exthost_Extension;
 module Protocol = Exthost_Protocol;
 module Transport = Exthost_Transport;
 
+module CacheId: {
+  [@deriving show]
+  type t;
+};
+
 module ChainedCacheId: {
   [@deriving show]
   type t;
@@ -84,6 +89,26 @@ module CodeAction: {
     disabled: option(string),
   };
 
+  module TriggerType: {
+    type t =
+      | Auto
+      | Manual;
+
+    let toInt: t => int;
+
+    let encode: Json.Encode.encoder(t);
+  };
+
+  module Context: {
+    type t = {
+      // TODO: What is this for?
+      only: option(string),
+      trigger: TriggerType.t,
+    };
+
+    let encode: Json.Encode.encoder(t);
+  };
+
   module ProviderMetadata: {
     type t = {
       providedKinds: list(string),
@@ -158,6 +183,28 @@ module OneBasedRange: {
 
   let ofRange: CharacterRange.t => t;
   let toRange: t => CharacterRange.t;
+};
+
+// Implementation of 'IRange':
+// https://github.com/onivim/vscode-exthost/blob/0d6b39803352369daaa97a444ff76352d8452be2/src/vs/base/browser/ui/inputbox/inputBox.ts#L74
+module Span: {
+  type t = {
+    start: int,
+    stop: int,
+  };
+
+  let encode: Json.Encode.encoder(t);
+};
+
+module Selection: {
+  type t = {
+    selectionStartLineNumber: int,
+    selectionStartColumn: int,
+    positionLineNumber: int,
+    positionColumn: int,
+  };
+
+  let encode: Json.Encode.encoder(t);
 };
 
 module CodeLens: {
@@ -1443,6 +1490,13 @@ module Msg: {
           supportsResolveDetails: bool,
           extensionId: string,
         })
+      | RegisterQuickFixSupport({
+          handle: int,
+          selector: DocumentSelector.t,
+          metadata: CodeAction.ProviderMetadata.t,
+          displayName: string,
+          supportsResolve: bool,
+        })
       | RegisterReferenceSupport({
           handle: int,
           selector: DocumentSelector.t,
@@ -1883,6 +1937,33 @@ module Request: {
   };
 
   module LanguageFeatures: {
+    let provideCodeActionsBySpan:
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~span: Span.t,
+        ~context: CodeAction.Context.t,
+        Client.t
+      ) =>
+      Lwt.t(option(CodeAction.List.t));
+
+    let provideCodeActionsBySelection:
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~selection: Selection.t,
+        ~context: CodeAction.Context.t,
+        Client.t
+      ) =>
+      Lwt.t(option(CodeAction.List.t));
+
+    let resolveCodeAction:
+      (~handle: int, ~id: ChainedCacheId.t, Client.t) =>
+      Lwt.t(option(WorkspaceEdit.t));
+
+    let releaseCodeActions:
+      (~handle: int, ~cacheId: CacheId.t, Client.t) => unit;
+
     let provideCodeLenses:
       (~handle: int, ~resource: Uri.t, Client.t) =>
       Lwt.t(option(CodeLens.List.t));

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -117,8 +117,8 @@ module CodeAction: {
   };
 
   module List: {
-    type t = {
-      cacheId: int,
+    type nonrec t = {
+      cacheId: CacheId.t,
       actions: list(t),
     };
   };

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -72,6 +72,33 @@ module Command: {
   let decode: Json.decoder(t);
 };
 
+module CodeAction: {
+  type t = {
+    chainedCacheId: option(ChainedCacheId.t),
+    title: string,
+    edit: option(WorkspaceEdit.t),
+    diagnostics: list(Diagnostic.t),
+    command: option(Command.t),
+    kind: option(string),
+    isPreferred: bool,
+    disabled: option(string),
+  };
+
+  module ProviderMetadata: {
+    type t = {
+      providedKinds: list(string),
+      providedDocumentation: StringMap.t(Command.t),
+    };
+  };
+
+  module List: {
+    type t = {
+      cacheId: int,
+      actions: list(t),
+    };
+  };
+};
+
 module CompletionContext: {
   [@deriving show]
   type triggerKind =

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -239,6 +239,34 @@ module FileSystemEventService = {
 };
 
 module LanguageFeatures = {
+  let provideCodeActionsBySpan =
+      (
+        ~handle: int,
+        ~resource: Uri.t,
+        ~span: Span.t,
+        ~context: CodeAction.Context.t,
+        client,
+      ) => {
+    // TODO
+    Lwt.return(None);
+  };
+
+  let provideCodeActionsBySelection =
+      (~handle, ~resource, ~selection, ~context, client) => {
+    // TODO:
+    Lwt.return(None);
+  };
+
+  let resolveCodeAction = (~handle, ~id, client) => {
+    // TODO:
+    Lwt.return(None);
+  };
+
+  let releaseCodeActions = (~handle, ~cacheId, client) => {
+    ();
+      // TODO
+  };
+
   let provideCodeLenses = (~handle: int, ~resource: Uri.t, client) => {
     let decoder = Json.Decode.(nullable(CodeLens.List.decode));
 

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -247,24 +247,70 @@ module LanguageFeatures = {
         ~context: CodeAction.Context.t,
         client,
       ) => {
-    // TODO
-    Lwt.return(None);
+    let decoder = Json.Decode.(nullable(CodeAction.List.decode));
+    Client.request(
+      ~decoder,
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$provideCodeActions",
+      ~args=
+        `List([
+          `Int(handle),
+          Uri.to_yojson(resource),
+          span |> Json.Encode.encode_value(Span.encode),
+          context |> Json.Encode.encode_value(CodeAction.Context.encode),
+        ]),
+      client,
+    );
   };
 
   let provideCodeActionsBySelection =
       (~handle, ~resource, ~selection, ~context, client) => {
-    // TODO:
-    Lwt.return(None);
+    let decoder = Json.Decode.(nullable(CodeAction.List.decode));
+    Client.request(
+      ~decoder,
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$provideCodeActions",
+      ~args=
+        `List([
+          `Int(handle),
+          Uri.to_yojson(resource),
+          selection |> Json.Encode.encode_value(Selection.encode),
+          context |> Json.Encode.encode_value(CodeAction.Context.encode),
+        ]),
+      client,
+    );
   };
 
   let resolveCodeAction = (~handle, ~id, client) => {
-    // TODO:
-    Lwt.return(None);
+    let decoder = Json.Decode.(nullable(WorkspaceEdit.decode));
+    Client.request(
+      ~decoder,
+      ~usesCancellationToken=true,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$resolveCodeAction",
+      ~args=
+        `List([
+          `Int(handle),
+          id |> Json.Encode.encode_value(ChainedCacheId.encode),
+        ]),
+      client,
+    );
   };
 
   let releaseCodeActions = (~handle, ~cacheId, client) => {
-    ();
-      // TODO
+    Client.notify(
+      ~usesCancellationToken=false,
+      ~rpcName="ExtHostLanguageFeatures",
+      ~method="$releaseCodeActions",
+      ~args=
+        `List([
+          `Int(handle),
+          cacheId |> Json.Encode.encode_value(CacheId.encode),
+        ]),
+      client,
+    );
   };
 
   let provideCodeLenses = (~handle: int, ~resource: Uri.t, client) => {

--- a/src/Exthost/Selection.re
+++ b/src/Exthost/Selection.re
@@ -1,0 +1,18 @@
+open Oni_Core;
+type t = {
+  selectionStartLineNumber: int,
+  selectionStartColumn: int,
+  positionLineNumber: int,
+  positionColumn: int,
+};
+
+let encode = selection => {
+  Json.Encode.(
+    obj([
+      ("selectionStartLineNumber", selection.selectionStartLineNumber |> int),
+      ("selectionStartColumn", selection.selectionStartColumn |> int),
+      ("positionLineNumber", selection.positionLineNumber |> int),
+      ("positionColumn", selection.positionColumn |> int),
+    ])
+  );
+};

--- a/src/Exthost/Span.re
+++ b/src/Exthost/Span.re
@@ -1,0 +1,11 @@
+open Oni_Core;
+type t = {
+  start: int,
+  stop: int,
+};
+
+let encode = span => {
+  Json.Encode.(
+    obj([("start", span.start |> int), ("end", span.stop |> int)])
+  );
+};

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -163,7 +163,6 @@ module Sub: {
     Isolinear.Sub.t('a);
 
   let completionItems:
-    // TODO: ~base: option(string),
     (
       ~handle: int,
       ~context: Exthost.CompletionContext.t,

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -25,6 +25,14 @@ function activate(context) {
         },
     }
 
+    const codeActionProvider = {
+        provideCodeActions: (document, range, context, token) => {
+            const codeAction1 = new vscode.CodeAction("Code Action 1");
+            const codeAction2 = new vscode.CodeAction("Code Action 2");
+            return [codeAction1, codeAction2]
+        }
+    };
+
     const completionProvider = {
         provideCompletionItems: (document, position, token, context) => {
             return [
@@ -146,41 +154,42 @@ function activate(context) {
         },
     }
 
-    ;[
-        vscode.languages.registerCodeLensProvider("plaintext", codeLensProvider),
-        vscode.languages.registerCompletionItemProvider("plaintext", completionProvider, ["."]),
-        vscode.languages.registerDefinitionProvider("plaintext", definitionProvider),
-        vscode.languages.registerDeclarationProvider("plaintext", declarationProvider),
-        vscode.languages.registerTypeDefinitionProvider("plaintext", typeDefinitionProvider),
-        vscode.languages.registerImplementationProvider("plaintext", implementationProvider),
-        vscode.languages.registerDocumentHighlightProvider("plaintext", documentHighlightProvider),
-        vscode.languages.registerReferenceProvider("plaintext", referenceProvider),
-        vscode.languages.registerDocumentSymbolProvider("plaintext", documentSymbolProvider),
-        vscode.languages.registerSignatureHelpProvider("plaintext", signatureHelpProvider, {
-            triggerCharacters: ["("],
-            retriggerCharacters: [","],
-        }),
-        vscode.languages.registerHoverProvider("plaintext", hoverProvider),
-        vscode.languages.registerOnTypeFormattingEditProvider(
-            "plaintext",
-            documentFormattingProvider,
-            "{",
-        ),
-        vscode.languages.registerDocumentFormattingEditProvider(
-            "plaintext",
-            documentFormattingProvider,
-            "{",
-        ),
-        vscode.languages.registerDocumentRangeFormattingEditProvider(
-            "plaintext",
-            documentFormattingProvider,
-            "{",
-        ),
-    ].forEach((subscription) => context.subscriptions.push(subscription))
+        ;[
+            vscode.languages.registerCodeActionProvider("plaintext", codeActionProvider),
+            vscode.languages.registerCodeLensProvider("plaintext", codeLensProvider),
+            vscode.languages.registerCompletionItemProvider("plaintext", completionProvider, ["."]),
+            vscode.languages.registerDefinitionProvider("plaintext", definitionProvider),
+            vscode.languages.registerDeclarationProvider("plaintext", declarationProvider),
+            vscode.languages.registerTypeDefinitionProvider("plaintext", typeDefinitionProvider),
+            vscode.languages.registerImplementationProvider("plaintext", implementationProvider),
+            vscode.languages.registerDocumentHighlightProvider("plaintext", documentHighlightProvider),
+            vscode.languages.registerReferenceProvider("plaintext", referenceProvider),
+            vscode.languages.registerDocumentSymbolProvider("plaintext", documentSymbolProvider),
+            vscode.languages.registerSignatureHelpProvider("plaintext", signatureHelpProvider, {
+                triggerCharacters: ["("],
+                retriggerCharacters: [","],
+            }),
+            vscode.languages.registerHoverProvider("plaintext", hoverProvider),
+            vscode.languages.registerOnTypeFormattingEditProvider(
+                "plaintext",
+                documentFormattingProvider,
+                "{",
+            ),
+            vscode.languages.registerDocumentFormattingEditProvider(
+                "plaintext",
+                documentFormattingProvider,
+                "{",
+            ),
+            vscode.languages.registerDocumentRangeFormattingEditProvider(
+                "plaintext",
+                documentFormattingProvider,
+                "{",
+            ),
+        ].forEach((subscription) => context.subscriptions.push(subscription))
 }
 
 // this method is called when your extension is deactivated
-function deactivate() {}
+function deactivate() { }
 
 module.exports = {
     activate,

--- a/test/collateral/extensions/oni-language-features/extension.js
+++ b/test/collateral/extensions/oni-language-features/extension.js
@@ -155,7 +155,7 @@ function activate(context) {
     }
 
         ;[
-            vscode.languages.registerCodeActionProvider("plaintext", codeActionProvider),
+            vscode.languages.registerCodeActionsProvider("plaintext", codeActionProvider),
             vscode.languages.registerCodeLensProvider("plaintext", codeLensProvider),
             vscode.languages.registerCompletionItemProvider("plaintext", completionProvider, ["."]),
             vscode.languages.registerDefinitionProvider("plaintext", definitionProvider),


### PR DESCRIPTION
This is the first part of implementing code-actions - wiring up the various extension host protocol APIs:

- `$registerQuickFixSupport` - registration of code action providers, including documentation
- `$provideCodeActions` - querying the available code actions, based on a line span or a selection
- `$resolveCodeAction` - get the workspace edit associated with a code action
- `$releaseCodeActions` - clean up code actions when the session is complete

This also implements a simple integration test, as a sanity check that parsing basic code actions work as expected.