### PR TITLE
fix(scm/#3355): Don't show diff markers on untracked or ignored files

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -30,6 +30,7 @@
 - #3342 - Completion: Use completion kind instead of insert text rules for sorting
 - #3346 - Extensions: Fix parse errors for progress and updateConfigurationOption APIs (related #3321)
 - #3326 - Lifecycle: Delay process termination until cleanup actions have run (fixes #3270, thanks @timbertson !)
+- #3359 - SCM: Don't show diffs for untracked or ignored files (fixes #3355)
 
 ### Performance
 

--- a/src/Feature/SCM/Feature_SCM.re
+++ b/src/Feature/SCM/Feature_SCM.re
@@ -412,7 +412,15 @@ module Effects = {
           resultLines =>
             switch (resultLines) {
             | Error(_) => GetOriginalContentFailed({bufferId: bufferId})
-            | Ok(lines) => GotOriginalContent({bufferId, lines})
+            | Ok(lines) =>
+              // If the file is empty, it's either untracked, ignored, or totally empty when adding -
+              // in any of these cases, we don't want to render diff markers.
+              // https://github.com/onivim/oni2/issues/3355
+              if (lines != [|""|]) {
+                GotOriginalContent({bufferId, lines});
+              } else {
+                GetOriginalContentFailed({bufferId: bufferId});
+              }
             },
         fileSystem,
         client,


### PR DESCRIPTION
__Issue:__ 

There were 3 scenarios where Onivim was showing diff markers incorrectly:
1) A file is untracked
2) A file is ignored by the .gitignore file
3) A file is tracked, but totally empty

In all of these cases - we shouldn't show the diff markers. They're just extra noise.

__Defect:__ In all of these cases, we query for the 'original' content, and get a result back - but a total empty string.

__Fix:__ When the 'original' content is empty, don't show diff markers.

Fixes #3355 