### PR TITLE
chore(ci): Fix Java path for removal

### DIFF
--- a/.ci/clean-windows-deps.yml
+++ b/.ci/clean-windows-deps.yml
@@ -27,7 +27,7 @@ steps:
     displayName: "Remove Android SDK"
   - script: rd /s /q "C:\Program Files\MongoDB"
     displayName: "Remove MongoDB"
-  - script: rd /s /q "C:\Program Files\Java"
+  - script: rd /s /q "%JAVA_HOME%"
     displayName: "Remove Java"
   - script: rd /s /q "C:\Program Files\Internet Explorer"
     displayName: "Remove Internet Explorer"


### PR DESCRIPTION
__Issue:__ CI is failing on Windows at the 'Remove Java' step

__Defect:__ VM images were updated: https://github.com/actions/virtual-environments/commit/0cf21e451224281a74a004ae22fd456b5bad0f2b

__Fix:__ Use `JAVA_HOME` environment variable