### PR TITLE
fix(clipboard/#3353): Command-v should paste in normal mode

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -30,6 +30,7 @@
 - #3342 - Completion: Use completion kind instead of insert text rules for sorting
 - #3346 - Extensions: Fix parse errors for progress and updateConfigurationOption APIs (related #3321)
 - #3326 - Lifecycle: Delay process termination until cleanup actions have run (fixes #3270, thanks @timbertson !)
+- #3361 - Clipboard: Add command+v binding for paste in normal mode (fixes #3353)
 
 ### Performance
 

--- a/src/Feature/Clipboard/Feature_Clipboard.re
+++ b/src/Feature/Clipboard/Feature_Clipboard.re
@@ -66,6 +66,38 @@ module Commands = {
     );
 };
 
+module Keybindings = {
+  open Feature_Input.Schema;
+  let pasteNonMac =
+    bind(
+      ~key="<C-V>",
+      ~command=Commands.paste.id,
+      // The WhenExpr parser doesn't support precedence, so we manually construct it here...
+      // It'd be nice to bring back explicit precedence via '(' and ')'
+      // Alternatively, a manual construction could be done with separate bindings for !isMac OR each condition
+      ~condition=
+        WhenExpr.(
+          And([
+            Not(Defined("isMac")),
+            Or([
+              And([Defined("editorTextFocus"), Defined("insertMode")]),
+              Defined("textInputFocus"),
+              Defined("commandLineFocus"),
+            ]),
+          ])
+        ),
+    );
+
+  let pasteMac =
+    bind(
+      ~key="<D-V>",
+      ~command=Commands.paste.id,
+      ~condition="isMac" |> WhenExpr.parse,
+    );
+};
+
 module Contributions = {
   let commands = [Commands.paste];
+
+  let keybindings = Keybindings.[pasteMac, pasteNonMac];
 };

--- a/src/Feature/Clipboard/Feature_Clipboard.rei
+++ b/src/Feature/Clipboard/Feature_Clipboard.rei
@@ -21,4 +21,7 @@ let update: (msg, model) => (model, outmsg);
 
 module Commands: {let paste: Command.t(msg);};
 
-module Contributions: {let commands: list(Command.t(msg));};
+module Contributions: {
+  let commands: list(Command.t(msg));
+  let keybindings: list(Feature_Input.Schema.keybinding);
+};

--- a/src/Feature/Clipboard/dune
+++ b/src/Feature/Clipboard/dune
@@ -1,7 +1,7 @@
 (library
  (name Feature_Clipboard)
  (public_name Oni2.feature.clipboard)
- (libraries Oni2.core isolinear base Oni2.feature.commands
+ (libraries Oni2.core isolinear base Oni2.feature.commands Oni2.feature.input
    Oni2.service.clipboard)
  (preprocess
   (pps ppx_let ppx_deriving.show)))

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -156,7 +156,7 @@ module Effects = {
   };
 };
 
-let update = (msg, model: model) => {
+let update = (~vimContext, msg, model: model) => {
   switch (msg) {
   | ModeChanged({allowAnimation, mode, effects, subMode}) => (
       {...model, subMode} |> handleEffects(effects),
@@ -165,6 +165,7 @@ let update = (msg, model: model) => {
   | Pasted(text) =>
     let eff =
       Service_Vim.Effects.paste(
+        ~context=vimContext,
         ~toMsg=mode => PasteCompleted({mode: mode}),
         text,
       );

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -53,7 +53,7 @@ type outmsg =
 
 // UPDATE
 
-let update: (msg, model) => (model, outmsg);
+let update: (~vimContext: Vim.Context.t, msg, model) => (model, outmsg);
 
 let getSearchHighlightsByLine:
   (~bufferId: int, ~line: LineNumber.t, model) => list(ByteRange.t);

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -31,6 +31,7 @@ let defaultKeyBindings =
     ),
   ]
   @ Feature_SideBar.Contributions.keybindings
+  @ Feature_Clipboard.Contributions.keybindings
   @ Feature_Input.Schema.[
       bind(
         ~key="<C-TAB>",
@@ -57,29 +58,6 @@ let defaultKeyBindings =
         ~key="<D-S-P>",
         ~command=Commands.Workbench.Action.showCommands.id,
         ~condition="isMac" |> WhenExpr.parse,
-      ),
-      bind(
-        ~key="<C-V>",
-        ~command=Feature_Clipboard.Commands.paste.id,
-        // The WhenExpr parser doesn't support precedence, so we manually construct it here...
-        // It'd be nice to bring back explicit precedence via '(' and ')'
-        // Alternatively, a manual construction could be done with separate bindings for !isMac OR each condition
-        ~condition=
-          WhenExpr.(
-            And([
-              Not(Defined("isMac")),
-              Or([
-                And([Defined("editorTextFocus"), Defined("insertMode")]),
-                Defined("textInputFocus"),
-                Defined("commandLineFocus"),
-              ]),
-            ])
-          ),
-      ),
-      bind(
-        ~key="<D-V>",
-        ~command=Feature_Clipboard.Commands.paste.id,
-        ~condition=isMacCondition,
       ),
       bind(
         ~key="<ESC>",

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -31,10 +31,14 @@ let quitAll = () =>
 module Effects = {
   let paste = (~toMsg, text) => {
     Isolinear.Effect.createWithDispatch(~name="vim.clipboardPaste", dispatch => {
-      let isCmdLineMode = Vim.Mode.isCommandLine(Vim.Mode.current());
-      let isInsertMode = Vim.Mode.isInsert(Vim.Mode.current());
+      let mode = Vim.Mode.current();
+      let isCmdLineMode = Vim.Mode.isCommandLine(mode);
+      let isInsertMode = Vim.Mode.isInsert(mode);
+      let isSelectMode = Vim.Mode.isSelect(mode);
+      let isNormalMode = Vim.Mode.isNormal(mode);
+      let isVisualMode = Vim.Mode.isVisual(mode);
 
-      if (isInsertMode || isCmdLineMode) {
+      if (isInsertMode || isCmdLineMode || isSelectMode) {
         if (!isCmdLineMode) {
           Vim.command("set paste") |> ignore;
         };
@@ -47,6 +51,10 @@ module Effects = {
           Vim.command("set nopaste") |> ignore;
           dispatch(toMsg(latestContext.mode));
         };
+      } else if (isVisualMode || isNormalMode) {
+        let (latestContext: Vim.Context.t, _effects) =
+          Oni_Core.VimEx.inputString("\"*p");
+        dispatch(toMsg(latestContext.mode));
       };
     });
   };

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -29,9 +29,14 @@ let quitAll = () =>
   );
 
 module Effects = {
-  let paste = (~toMsg, text) => {
+  let paste = (~context=?, ~toMsg, text) => {
     Isolinear.Effect.createWithDispatch(~name="vim.clipboardPaste", dispatch => {
-      let mode = Vim.Mode.current();
+      let context =
+        switch (context) {
+        | None => Vim.Context.current()
+        | Some(ctx) => ctx
+        };
+      let mode = context.mode;
       let isCmdLineMode = Vim.Mode.isCommandLine(mode);
       let isInsertMode = Vim.Mode.isInsert(mode);
       let isSelectMode = Vim.Mode.isSelect(mode);
@@ -45,7 +50,7 @@ module Effects = {
 
         Log.infof(m => m("Pasting: %s", text));
         let (latestContext: Vim.Context.t, _effects) =
-          Oni_Core.VimEx.inputString(text);
+          Vim.input(~context, text);
 
         if (!isCmdLineMode) {
           Vim.command("set nopaste") |> ignore;

--- a/src/Service/Vim/Service_Vim.rei
+++ b/src/Service/Vim/Service_Vim.rei
@@ -7,7 +7,9 @@ let saveAllAndQuit: unit => Isolinear.Effect.t(_);
 let quitAll: unit => Isolinear.Effect.t(_);
 
 module Effects: {
-  let paste: (~toMsg: Vim.Mode.t => 'msg, string) => Isolinear.Effect.t('msg);
+  let paste:
+    (~context: Vim.Context.t=?, ~toMsg: Vim.Mode.t => 'msg, string) =>
+    Isolinear.Effect.t('msg);
 
   let getRegisterValue:
     (~toMsg: option(array(string)) => 'msg, char) =>

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -2251,7 +2251,8 @@ let update =
 
   | Vim(msg) =>
     let previousSubMode = state.vim |> Feature_Vim.subMode;
-    let (vim, outmsg) = Feature_Vim.update(msg, state.vim);
+    let vimContext = VimContext.current(state);
+    let (vim, outmsg) = Feature_Vim.update(~vimContext, msg, state.vim);
     let newSubMode = state.vim |> Feature_Vim.subMode;
 
     // If we've switched to, or from, insert literal,


### PR DESCRIPTION
__Issue:__ Command-v should paste in normal mode, since it doesn't conflict with a Vim binding, and is the intuitive behavior.

__Defect:__ The `"editor.clipboard.pasteAction"` the keybinding was bound to only ran in insert/command line modes.

__Fix:__ 
- Allow the command to run in select, normal, and visual modes
- Ensure we have the latest state by bringing in the current vim context
- Move bindings to `Feature_Clipboard`

Fixes #3353 