### PR TITLE
fix(input): Add context key for currently active sidebar panel

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -32,6 +32,7 @@
 - #3326 - Lifecycle: Delay process termination until cleanup actions have run (fixes #3270, thanks @timbertson !)
 - #3359 - SCM: Don't show diffs for untracked or ignored files (fixes #3355)
 - #3361 - Clipboard: Add command+v binding for paste in normal mode (fixes #3353)
+- #3364 - Input: Add context key to differentiate sidebar panels
 
 ### Performance
 

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -117,9 +117,16 @@ Common contexts with VSCode:
 | --- | --- |
 | `editorTextFocus` | An editor has focus |
 | `inSnippetMode` | A snippet session is currently active |
+| `renameInputVisible` | The rename input is visible |
+| `suggestWidgetVisible` | The suggest widget (auto-completion) is visible |
 | `textInputFocus` | A text input area has focus |
 | `terminalFocus` | A terminal has focus |
-| `suggestWidgetVisible` | The suggest widget (auto-completion) is visible |
+
+The `activeViewlet` context key corresponds to the id of the open sidebar pane:
+- `workbench.view.explorer` - File Explorer
+- `workbench.view.extensions` - Extensions
+- `workbench.view.scm` - SCM
+- `workbench.view.search` - Search
 
 Onivim-specific contexts:
 
@@ -131,6 +138,9 @@ Onivim-specific contexts:
 | `sneakMode` | Sneak mode is active |
 | `commandLineFocus` | The Vim commandline is open |
 | `listFocus` | A list of items (like a pop-up menu) is focused |
+| `sideBarFocus` | The sidebar has focus visible |
+| `sideBarVisible` | The sidebar is visible |
+| `paneFocus` | The bottom pane has focus |
 | `vimListNavigation` | Inside a Vim-navigable list |
 | `vimTreeNavigation` | Inside the file explorer |
 

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -325,6 +325,16 @@ module ContextKeys = {
   module Focused = {
     let sideBarFocus = bool("sideBarFocus", _ => true);
   };
+
+  let activeViewlet =
+    string("activeViewlet", model => {
+      switch (model.selected) {
+      | FileExplorer => "workbench.view.explorer"
+      | Search => "workbench.view.search"
+      | SCM => "workbench.view.scm"
+      | Extensions => "workbench.view.extensions"
+      }
+    });
 };
 
 module Configuration = {
@@ -440,7 +450,7 @@ module Contributions = {
   MenuBar.Schema.group(~parent=Feature_MenuBar.Global.view, menuItems);
 
   let contextKeys = (~isFocused) => {
-    let common = ContextKeys.[sideBarVisible];
+    let common = ContextKeys.[sideBarVisible, activeViewlet];
 
     let focused = ContextKeys.Focused.[sideBarFocus];
 


### PR DESCRIPTION
This PR allows setting keybindings based on the currently active sidebar panel, for example:


```
[
  // See the onivim documentation for details on the format:
  // https://onivim.github.io/docs/configuration/key-bindings
  {
    "key": "<ESC>",
    "command": "workbench.action.findInFiles",
    "when": "sideBarFocus && textInputFocus && activeViewlet == 'workbench.view.search'"
  },
  {
    "key": "<DOWN>",
    "command": "vim.window.moveDown",
    "when": "sideBarFocus && textInputFocus && activeViewlet == 'workbench.view.search'"
  },
  {
    "key": "<UP>",
    "command": "vim.window.moveUp",
    "when": "sideBarFocus && !textInputFocus && activeViewlet == 'workbench.view.search'"
  }
]
```

From question here: https://discord.com/channels/417774914645262338/424012160696582144/827583796835909642