### PR TITLE
fix(explorer/#3350): Implement Reload command + file system watcher for explorer

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -32,6 +32,7 @@
 - #3326 - Lifecycle: Delay process termination until cleanup actions have run (fixes #3270, thanks @timbertson !)
 - #3359 - SCM: Don't show diffs for untracked or ignored files (fixes #3355)
 - #3361 - Clipboard: Add command+v binding for paste in normal mode (fixes #3353)
+- #3365 - Explorer: Add manual refresh command and experimental `files.useExperimentalFileWatcher` setting (fixes #3350)
 
 ### Performance
 
@@ -51,4 +52,4 @@
 ### Infrastructure
 
 - #3319 - Dependency: esy-macdylibbundler -> 0.4.5001 to support Big Sur (thanks @brdoney !)
-- ##3313 - Packaging: Fix macOS Big Sur release bundling issues (fixes #2813, thanks @brdoney !)
+- #3313 - Packaging: Fix macOS Big Sur release bundling issues (fixes #2813, thanks @brdoney !)

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -100,8 +100,6 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.rulers` __(_list of int_ default: `[]`)__ - Render vertical rulers at given columns.
 
-- `explorer.autoReveal` __(_string|bool_ default: `true`)__  - When `true`, the file explorer will jump to highlight the file current focused. When `false` the file explorer will remain static. If a string is entered it must be `"focusNoScroll"` which will still highlight the currently focused file in the file explorer but the file explorer will not scroll to it. Any other string supplied will be treated as if `false` was entered and the file explorer will remain static and not highlight the currently focused file.
-
 - `editor.scrollShadow` __(_bool_ default: `true`)__ - When `true`, show a drop-shadow effect at the borders when there is additional content past the visible area.
 
 - `editor.smoothScroll` __(_bool_ default: `true`)__ - When `true`, smoothly scroll the editor when the viewport is adjusted due to a cursor motion.
@@ -131,6 +129,13 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 - `vim.leader` __(_string_)__ - Specify a custom [leader key](./key-bindings#leader-key).
 
 - `vim.timeout` __(_int_ default: `1000`)__ Sets the timeout, in milliseconds, when Onivim is waiting for a pending chord. When the timeout is reached, any pending keys that are partially mapped will be flushed. Equivalent to the `timeoutlen` Vim setting. Can be set to `0` to disable the timeout entirely.
+
+### Explorer
+
+- `explorer.autoReveal` __(_string|bool_ default: `true`)__  - When `true`, the file explorer will jump to highlight the file current focused. When `false` the file explorer will remain static. If a string is entered it must be `"focusNoScroll"` which will still highlight the currently focused file in the file explorer but the file explorer will not scroll to it. Any other string supplied will be treated as if `false` was entered and the file explorer will remain static and not highlight the currently focused file.
+
+- `files.useExperimentalFileWatcher` __(_bool_ default: `false`)__ When `true`, a file watcher will be used to monitor file system changes and update the explorer in the sidebar.
+
 
 ### Layout
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -136,7 +136,6 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `files.useExperimentalFileWatcher` __(_bool_ default: `false`)__ When `true`, a file watcher will be used to monitor file system changes and update the explorer in the sidebar.
 
-
 ### Layout
 
 - `workbench.editor.showTabs` __(_bool_ default: `true`)__ - When `false`, hides the editor tabs.

--- a/integration_test/FileWatcherTest.re
+++ b/integration_test/FileWatcherTest.re
@@ -1,3 +1,4 @@
+open Oni_Core;
 // Disable colors on windows to prevent hanging on CI
 
 Timber.App.enable(Timber.Reporter.console());
@@ -11,10 +12,13 @@ let oc = open_out(tempFilePath);
 Printf.fprintf(oc, "foo");
 close_out(oc);
 
+let key = Service_FileWatcher.Key.create(~friendlyName="FileWatcherTest");
+
 // System under test
 let sub =
   Service_FileWatcher.watch(
-    ~path=tempFilePath,
+    ~key,
+    ~path=FpExp.absoluteCurrentPlatform(tempFilePath) |> Option.get,
     ~onEvent=_ => {
       print_endline("Success!");
       Luv.Loop.stop(Luv.Loop.default());

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -257,10 +257,6 @@ let update = (~config, ~configuration, msg, model) => {
     | None => (model, Nothing)
     }
 
-  | KeyboardInput(_) =>
-    // Anything to be brought back here?
-    (model, Nothing)
-
   | Tree(treeMsg) =>
     let (treeView, outmsg) =
       Component_VimTree.update(treeMsg, model.treeView);

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -174,7 +174,7 @@ let replaceNode = (node, model: model) =>
   switch (model.tree) {
   | Some(tree) =>
     setTree(FsTreeNode.replace(~replacement=node, tree), model)
-  | None => model
+  | None => setTree(node, model)
   };
 
 let revealAndFocusPath = (~configuration, path, model: model) => {
@@ -241,9 +241,7 @@ let update = (~config, ~configuration, msg, model) => {
     | _ => (model, Nothing)
     }
 
-  | TreeLoaded(tree) => (setTree(tree, model), Nothing)
-
-  | TreeLoadError(_msg) => (model, Nothing)
+  | NodeLoadError(_msg) => (model, Nothing)
 
   | NodeLoaded(node) => (replaceNode(node, model), Nothing)
 
@@ -306,9 +304,9 @@ let sub = (~configuration, {rootPath, _}) => {
     | Ok(dirents) => {
         let children =
           dirents |> Internal.luvDirentsToFsTree(~ignored, ~cwd=rootPath);
-        TreeLoaded(FsTreeNode.directory(rootPath, ~children, ~isOpen=true));
+        NodeLoaded(FsTreeNode.directory(rootPath, ~children, ~isOpen=true));
       }
-    | Error(msg) => TreeLoadError(msg);
+    | Error(msg) => NodeLoadError(msg);
 
   Service_OS.Sub.dir(
     ~uniqueId="FileExplorerSideBar",

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -324,6 +324,8 @@ let update = (~config, ~configuration, msg, model) => {
     | None => (model, Nothing)
     }
 
+  | Command(Reload) => (reload(model), Nothing)
+
   | Tree(treeMsg) =>
     let (treeView, outmsg) =
       Component_VimTree.update(treeMsg, model.treeView);
@@ -406,12 +408,27 @@ let sub = (~configuration, {rootPath, expandedPaths, pathsToLoad, _}) => {
   expandedPathSubs @ watchers |> Isolinear.Sub.batch;
 };
 
+module Commands = {
+  open Feature_Commands.Schema;
+
+  let reload =
+    define(
+      ~category="Explorer",
+      ~title="Reload",
+      "workbench.todo.explorer-reload",
+      Command(Reload),
+    );
+};
+
 module Contributions = {
   let commands = (~isFocused) => {
     !isFocused
       ? []
-      : Component_VimTree.Contributions.commands
-        |> List.map(Oni_Core.Command.map(msg => Tree(msg)));
+      : [Commands.reload]
+        @ (
+          Component_VimTree.Contributions.commands
+          |> List.map(Oni_Core.Command.map(msg => Tree(msg)))
+        );
   };
 
   let contextKeys = (~isFocused, model) => {

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -13,11 +13,6 @@ module Configuration = {
     setting("files.useExperimentalFileWatcher", bool, ~default=false);
 };
 
-let configurationChanged = (~config, model) => {
-  ...model,
-  useFileWatcher: Configuration.useFileWatcher.get(config),
-};
-
 module Internal = {
   let sortByLoweredDisplayName = (a: FsTreeNode.t, b: FsTreeNode.t) => {
     switch (a, b) {
@@ -387,8 +382,9 @@ module View = View;
 
 let sub =
     (
+      ~config,
       ~configuration,
-      {useFileWatcher, fileWatcherKey, expandedPaths, pathsToLoad, _},
+      {fileWatcherKey, expandedPaths, pathsToLoad, _},
     ) => {
   let ignored =
     Feature_Configuration.Legacy.getValue(c => c.filesExclude, configuration);
@@ -420,9 +416,10 @@ let sub =
 
   let allPathsToWatch = expandedPaths;
 
+  let useFileWatcher = Configuration.useFileWatcher.get(config);
   let watchers =
     !useFileWatcher
-      ? Isolinear.Sub.none
+      ? [Isolinear.Sub.none]
       : allPathsToWatch
         |> List.map(path => {
              Service_FileWatcher.watch(
@@ -458,7 +455,7 @@ module Contributions = {
         );
   };
 
-  let configuration = Configuration.[useFileWatcher];
+  let configuration = Configuration.[useFileWatcher.spec];
 
   let contextKeys = (~isFocused, model) => {
     open WhenExpr.ContextKeys;

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -245,8 +245,8 @@ let reload = model => {...model, pathsToLoad: model.expandedPaths};
 // index is up to date in the inner tree. This is important
 // when a file is loaded or deleted, because the index would still
 // be in the previous location, if it would be shifted by the change.
-let ensureSelected = model => {
-  model.active
+let ensureSelected = (~maybeActivePath, model) => {
+  maybeActivePath
   |> Utility.OptionEx.flatMap(active => {
        let pred =
            (
@@ -307,10 +307,15 @@ let update = (~config, ~configuration, msg, model) => {
 
   | NodeLoadError(_msg) => (model, Nothing)
 
-  | NodeLoaded(node) => (
-      model |> replaceNode(node) |> markNodeAsLoaded(node) |> ensureSelected,
+  | NodeLoaded(node) =>
+    let maybeActivePath = model.active;
+    (
+      model
+      |> replaceNode(node)
+      |> markNodeAsLoaded(node)
+      |> ensureSelected(~maybeActivePath),
       Nothing,
-    )
+    );
 
   | FocusNodeLoaded(node) =>
     switch (model.active) {

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -324,13 +324,6 @@ let sub = (~configuration, {rootPath, expandedPaths, _}) => {
       }
     | Error(msg) => NodeLoadError(msg);
 
-  // let root =
-  //   Service_OS.Sub.dir(
-  //     ~uniqueId="FileExplorerSideBar",
-  //     ~toMsg=toMsg(rootPath),
-  //     FpExp.toString(rootPath),
-  //   );
-
   let allPathsToWatch = [rootPath, ...expandedPaths];
 
   let expandedPathSubs =

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -370,7 +370,11 @@ let update = (~config, ~configuration, msg, model) => {
 
 module View = View;
 
-let sub = (~configuration, {rootPath, expandedPaths, pathsToLoad, _}) => {
+let sub =
+    (
+      ~configuration,
+      {fileWatcherKey, rootPath, expandedPaths, pathsToLoad, _},
+    ) => {
   let ignored =
     Feature_Configuration.Legacy.getValue(c => c.filesExclude, configuration);
 
@@ -405,7 +409,8 @@ let sub = (~configuration, {rootPath, expandedPaths, pathsToLoad, _}) => {
     allPathsToWatch
     |> List.map(path => {
          Service_FileWatcher.watch(
-           ~path=FpExp.toString(path),
+           ~key=fileWatcherKey,
+           ~path,
            ~onEvent=onEvent(path),
          )
        });

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -15,6 +15,8 @@ let root: model => FpExp.t(FpExp.absolute);
 
 let keyPress: (string, model) => model;
 
+let reload: model => model;
+
 let getFileIcon:
   (~languageInfo: Exthost.LanguageInfo.t, ~iconTheme: IconTheme.t, string) =>
   option(IconTheme.IconDefinition.t);

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -9,6 +9,8 @@ module Msg: {let activeFileChanged: option(FpExp.t(FpExp.absolute)) => msg;};
 
 type model;
 
+let configurationChanged: (~config: Config.resolver, model) => model;
+
 let initial: (~rootPath: FpExp.t(FpExp.absolute)) => model;
 let setRoot: (~rootPath: FpExp.t(FpExp.absolute), model) => model;
 let root: model => FpExp.t(FpExp.absolute);
@@ -70,6 +72,7 @@ module View: {
 };
 
 module Contributions: {
+  let configuration: list(Config.Schema.spec);
   let commands: (~isFocused: bool) => list(Command.t(msg));
   let contextKeys: (~isFocused: bool, model) => WhenExpr.ContextKeys.t;
 };

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -9,8 +9,6 @@ module Msg: {let activeFileChanged: option(FpExp.t(FpExp.absolute)) => msg;};
 
 type model;
 
-let configurationChanged: (~config: Config.resolver, model) => model;
-
 let initial: (~rootPath: FpExp.t(FpExp.absolute)) => model;
 let setRoot: (~rootPath: FpExp.t(FpExp.absolute), model) => model;
 let root: model => FpExp.t(FpExp.absolute);
@@ -48,7 +46,12 @@ let update:
 // SUBSCRIPTION
 
 let sub:
-  (~configuration: Feature_Configuration.model, model) => Isolinear.Sub.t(msg);
+  (
+    ~config: Config.resolver,
+    ~configuration: Feature_Configuration.model,
+    model
+  ) =>
+  Isolinear.Sub.t(msg);
 
 // VIEW
 

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -5,10 +5,7 @@ open Oni_Core;
 [@deriving show]
 type msg;
 
-module Msg: {
-  let keyPressed: string => msg;
-  let activeFileChanged: option(FpExp.t(FpExp.absolute)) => msg;
-};
+module Msg: {let activeFileChanged: option(FpExp.t(FpExp.absolute)) => msg;};
 
 type model;
 

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -28,7 +28,11 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | OpenFile(string)
   | PreviewFile(string)
-  | GrabFocus;
+  | GrabFocus
+  | WatchedPathChanged({
+      path: FpExp.t(FpExp.absolute),
+      stat: option(Luv.File.Stat.t),
+    });
 
 let update:
   (

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -123,9 +123,52 @@ let findByPath = (path, tree) => {
 };
 
 let replace = (~replacement, tree) => {
+  let merge = (originalNode, newNode) =>
+    switch (originalNode, newNode) {
+    | (Tree.Leaf(_), _) => newNode
+    | (_, Tree.Leaf(_)) => newNode
+    // TODO: Merge old children with new children, so we don't to recursively refresh
+    | (
+        Tree.Node({children: oldChildren, expanded, data}),
+        Tree.Node({children: newChildren, _}),
+      ) =>
+      // Grab a map of previous children. For any that were existing, use the old metadata - some children might be expanded, for example.
+      let previousMap =
+        oldChildren
+        |> List.fold_left(
+             (
+               acc: IntMap.t(Tree.t(metadata, metadata)),
+               child: Tree.t(metadata, metadata),
+             ) => {
+               switch (child) {
+               | Tree.Leaf(_) => acc
+               | Tree.Node({expanded, data, children}) =>
+                 IntMap.add(data.hash, child, acc)
+               }
+             },
+             IntMap.empty,
+           );
+
+      // Now, go through the new children - see if any were around previously.
+      // If so, use the previous tree.
+
+      let children =
+        newChildren
+        |> List.map(child => {
+             switch (child) {
+             | Tree.Leaf(_) => child
+             | Tree.Node({data, _}) =>
+               IntMap.find_opt(data.hash, previousMap)
+               |> Option.value(~default=child)
+             }
+           });
+
+      Tree.Node({children, expanded, data});
+    };
+
   let rec loop = (pathHashes, node) =>
     switch (pathHashes) {
-    | [hash] when hash == getHash(node) => replacement
+    | [hash] when hash == getHash(node) => merge(node, replacement)
 
     | [hash, ...rest] when hash == getHash(node) =>
       switch (node) {

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -143,8 +143,7 @@ let replace = (~replacement, tree) => {
              ) => {
                switch (child) {
                | Tree.Leaf(_) => acc
-               | Tree.Node({expanded, data, children}) =>
-                 IntMap.add(data.hash, child, acc)
+               | Tree.Node(_) => IntMap.add(data.hash, child, acc)
                }
              },
              IntMap.empty,

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -130,8 +130,8 @@ let replace = (~replacement, tree) => {
     // Merge the 'old' children with the 'new' children, so that we don't have to recursively
     // refresh if we don't have to.
     | (
-        Tree.Node({children: oldChildren, _}),
-        Tree.Node({children: newChildren, expanded, data}),
+        Tree.Node({children: oldChildren, expanded, _}),
+        Tree.Node({children: newChildren, data, _}),
       ) =>
       // Grab a map of previous children. For any that were existing, use the old metadata - some children might be expanded, for example.
       let previousMap =
@@ -143,7 +143,7 @@ let replace = (~replacement, tree) => {
              ) => {
                switch (child) {
                | Tree.Leaf(_) => acc
-               | Tree.Node(_) => IntMap.add(data.hash, child, acc)
+               | Tree.Node({data, _}) => IntMap.add(data.hash, child, acc)
                }
              },
              IntMap.empty,

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -127,10 +127,11 @@ let replace = (~replacement, tree) => {
     switch (originalNode, newNode) {
     | (Tree.Leaf(_), _) => newNode
     | (_, Tree.Leaf(_)) => newNode
-    // TODO: Merge old children with new children, so we don't to recursively refresh
+    // Merge the 'old' children with the 'new' children, so that we don't have to recursively
+    // refresh if we don't have to.
     | (
-        Tree.Node({children: oldChildren, expanded, data}),
-        Tree.Node({children: newChildren, _}),
+        Tree.Node({children: oldChildren, _}),
+        Tree.Node({children: newChildren, expanded, data}),
       ) =>
       // Grab a map of previous children. For any that were existing, use the old metadata - some children might be expanded, for example.
       let previousMap =

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -4,8 +4,7 @@ open Oni_Core;
 [@deriving show]
 type msg =
   | ActiveFilePathChanged([@opaque] option(FpExp.t(FpExp.absolute)))
-  | TreeLoaded(FsTreeNode.t)
-  | TreeLoadError(string)
+  | NodeLoadError(string)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)
   | Tree(Component_VimTree.msg);

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -33,7 +33,8 @@ type model = {
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(FpExp.t(FpExp.absolute)),
-  focus: option(FpExp.t(FpExp.absolute)) // path
+  focus: option(FpExp.t(FpExp.absolute)), // path
+  useFileWatcher: bool,
 };
 
 let initial = (~rootPath) => {
@@ -51,6 +52,7 @@ let initial = (~rootPath) => {
   scrollOffset: `Start(0.),
   active: None,
   focus: None,
+  useFileWatcher: false,
 };
 
 let setRoot = (~rootPath, model) => {

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -23,6 +23,7 @@ module Msg = {
 };
 
 type model = {
+  fileWatcherKey: Service_FileWatcher.Key.t,
   rootPath: FpExp.t(FpExp.absolute),
   rootName: string,
   expandedPaths: list(FpExp.t(FpExp.absolute)),
@@ -36,6 +37,8 @@ type model = {
 };
 
 let initial = (~rootPath) => {
+  fileWatcherKey:
+    Service_FileWatcher.Key.create("Explorer:" ++ FpExp.toString(rootPath)),
   rootPath,
   rootName: "",
   expandedPaths: [rootPath],

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -33,26 +33,26 @@ type model = {
   isOpen: bool,
   scrollOffset: [ | `Start(float) | `Middle(float) | `Reveal(int)],
   active: option(FpExp.t(FpExp.absolute)),
-  focus: option(FpExp.t(FpExp.absolute)), // path
-  useFileWatcher: bool,
+  focus: option(FpExp.t(FpExp.absolute)) // path
 };
 
 let initial = (~rootPath) => {
-  fileWatcherKey:
-    Service_FileWatcher.Key.create(
-      ~friendlyName="Explorer:" ++ FpExp.toString(rootPath),
-    ),
-  rootPath,
-  rootName: "",
-  expandedPaths: [rootPath],
-  pathsToLoad: [rootPath],
-  tree: None,
-  treeView: Component_VimTree.create(~rowHeight=20),
-  isOpen: true,
-  scrollOffset: `Start(0.),
-  active: None,
-  focus: None,
-  useFileWatcher: false,
+  {
+    fileWatcherKey:
+      Service_FileWatcher.Key.create(
+        ~friendlyName="Explorer:" ++ FpExp.toString(rootPath),
+      ),
+    rootPath,
+    rootName: "",
+    expandedPaths: [rootPath],
+    pathsToLoad: [rootPath],
+    tree: None,
+    treeView: Component_VimTree.create(~rowHeight=20),
+    isOpen: true,
+    scrollOffset: `Start(0.),
+    active: None,
+    focus: None,
+  };
 };
 
 let setRoot = (~rootPath, model) => {

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -8,11 +8,9 @@ type msg =
   | TreeLoadError(string)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)
-  | KeyboardInput(string)
   | Tree(Component_VimTree.msg);
 
 module Msg = {
-  let keyPressed = key => KeyboardInput(key);
   let activeFileChanged = maybePath => ActiveFilePathChanged(maybePath);
 };
 

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -21,6 +21,7 @@ type model = {
   rootPath: FpExp.t(FpExp.absolute),
   rootName: string,
   expandedPaths: list(FpExp.t(FpExp.absolute)),
+  pathsToLoad: list(FpExp.t(FpExp.absolute)),
   tree: option(FsTreeNode.t),
   treeView: Component_VimTree.model(FsTreeNode.metadata, FsTreeNode.metadata),
   isOpen: bool,
@@ -32,7 +33,8 @@ type model = {
 let initial = (~rootPath) => {
   rootPath,
   rootName: "",
-  expandedPaths: [],
+  expandedPaths: [rootPath],
+  pathsToLoad: [rootPath],
   tree: None,
   treeView: Component_VimTree.create(~rowHeight=20),
   isOpen: true,
@@ -47,6 +49,8 @@ let setRoot = (~rootPath, model) => {
   tree: None,
   active: None,
   focus: None,
+  expandedPaths: [rootPath],
+  pathsToLoad: [rootPath],
 };
 
 let root = ({rootPath, _}) => rootPath;

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -38,7 +38,9 @@ type model = {
 
 let initial = (~rootPath) => {
   fileWatcherKey:
-    Service_FileWatcher.Key.create("Explorer:" ++ FpExp.toString(rootPath)),
+    Service_FileWatcher.Key.create(
+      ~friendlyName="Explorer:" ++ FpExp.toString(rootPath),
+    ),
   rootPath,
   rootName: "",
   expandedPaths: [rootPath],

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -2,8 +2,13 @@ open Oni_Core;
 // MODEL
 
 [@deriving show]
+type command =
+  | Reload;
+
+[@deriving show]
 type msg =
   | ActiveFilePathChanged([@opaque] option(FpExp.t(FpExp.absolute)))
+  | Command(command)
   | NodeLoadError(string)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)

--- a/src/Components/FileExplorer/Model.re
+++ b/src/Components/FileExplorer/Model.re
@@ -7,6 +7,10 @@ type msg =
   | NodeLoadError(string)
   | NodeLoaded(FsTreeNode.t)
   | FocusNodeLoaded(FsTreeNode.t)
+  | FileWatcherEvent({
+      path: [@opaque] FpExp.t(FpExp.absolute),
+      event: Service_FileWatcher.event,
+    })
   | Tree(Component_VimTree.msg);
 
 module Msg = {
@@ -16,6 +20,7 @@ module Msg = {
 type model = {
   rootPath: FpExp.t(FpExp.absolute),
   rootName: string,
+  expandedPaths: list(FpExp.t(FpExp.absolute)),
   tree: option(FsTreeNode.t),
   treeView: Component_VimTree.model(FsTreeNode.metadata, FsTreeNode.metadata),
   isOpen: bool,
@@ -27,6 +32,7 @@ type model = {
 let initial = (~rootPath) => {
   rootPath,
   rootName: "",
+  expandedPaths: [],
   tree: None,
   treeView: Component_VimTree.create(~rowHeight=20),
   isOpen: true,

--- a/src/Components/FileExplorer/dune
+++ b/src/Components/FileExplorer/dune
@@ -3,6 +3,7 @@
  (public_name Oni2.component.fileExplorer)
  (inline_tests)
  (libraries Oni2.component.vimTree Oni2.component.accordion Oni2.core
+   Oni2.service.file-watcher
    Oni2.exthost Oni2.feature.configuration Oni2.feature.decorations
    Oni2.feature.theme Oni2.components Revery isolinear)
  (preprocess

--- a/src/Components/FileExplorer/dune
+++ b/src/Components/FileExplorer/dune
@@ -3,8 +3,8 @@
  (public_name Oni2.component.fileExplorer)
  (inline_tests)
  (libraries Oni2.component.vimTree Oni2.component.accordion Oni2.core
-   Oni2.service.file-watcher
-   Oni2.exthost Oni2.feature.configuration Oni2.feature.decorations
-   Oni2.feature.theme Oni2.components Revery isolinear)
+   Oni2.service.file-watcher Oni2.exthost Oni2.feature.configuration
+   Oni2.feature.decorations Oni2.feature.theme Oni2.components Revery
+   isolinear)
  (preprocess
   (pps ppx_inline_test ppx_let lwt_ppx ppx_deriving.show brisk-reconciler.ppx)))

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -129,6 +129,11 @@ let findIndex = (f, {treeAsList, _}) => {
   Component_VimList.findIndex(pred, treeAsList);
 };
 
+let setSelected = (~selected, {treeAsList, _} as model) => {
+  let treeAsList' = treeAsList |> Component_VimList.setSelected(~selected);
+  {...model, treeAsList: treeAsList'};
+};
+
 let keyPress = (key, {treeAsList, _} as model) => {
   ...model,
   treeAsList: Component_VimList.keyPress(key, treeAsList),

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -56,6 +56,9 @@ let keyPress: (string, model('node, 'leaf)) => model('node, 'leaf);
 let findIndex:
   (nodeOrLeaf('node, 'leaf) => bool, model('node, 'leaf)) => option(int);
 
+let setSelected:
+  (~selected: int, model('node, 'leaf)) => model('node, 'leaf);
+
 let scrollTo:
   (
     ~index: int,

--- a/src/Core/FpExp.re
+++ b/src/Core/FpExp.re
@@ -201,3 +201,5 @@ let hasParentDir =
 let append = At.(/);
 
 let compare = (a, b) => String.compare(toString(a), toString(b));
+
+let pp = toString;

--- a/src/Core/FpExp.re
+++ b/src/Core/FpExp.re
@@ -199,3 +199,5 @@ let hasParentDir =
   | Path(path) => Fp.hasParentDir(path);
 
 let append = At.(/);
+
+let compare = (a, b) => String.compare(toString(a), toString(b));

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -69,6 +69,7 @@ module TreeList = TreeList;
 module Tokenizer = Tokenizer;
 module TrustedDomains = TrustedDomains;
 module UiFont = UiFont;
+module UniqueId = UniqueId;
 module Uri = Uri;
 module Utility = Utility;
 module Views = Views;

--- a/src/Core/UniqueId.re
+++ b/src/Core/UniqueId.re
@@ -1,0 +1,28 @@
+module Make:
+  () =>
+   {
+    type t;
+
+    let create: (~friendlyName: string) => t;
+
+    let compare: (t, t) => int;
+    let toString: t => string;
+  } =
+  (()) => {
+    let nextId: ref(Int64.t) = ref(Int64.zero);
+
+    type t = (string, Int64.t);
+
+    let create = (~friendlyName) => {
+      let id = nextId^;
+      nextId := Int64.add(id, Int64.one);
+
+      (friendlyName ++ Int64.to_string(id), id);
+    };
+
+    let compare = (a, b) => {
+      Int64.compare(snd(a), snd(b));
+    };
+
+    let toString = fst;
+  };

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -86,7 +86,6 @@ let initial = (~rootPath) => {
   symbolOutline: Component_VimTree.create(~rowHeight=20),
   vimWindowNavigation: Component_VimWindows.initial,
 };
-
 let focusOutline = model => {
   ...model,
   focus: Outline,
@@ -509,10 +508,10 @@ module View = {
   };
 };
 
-let sub = (~configuration, model) => {
+let sub = (~config, ~configuration, model) => {
   model.fileExplorer
   |> Option.map(explorer => {
-       Component_FileExplorer.sub(~configuration, explorer)
+       Component_FileExplorer.sub(~config, ~configuration, explorer)
        |> Isolinear.Sub.map(msg => FileExplorer(msg))
      })
   |> Option.value(~default=Isolinear.Sub.none);

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -58,12 +58,7 @@ type model = {
 };
 
 [@deriving show]
-type command =
-  | Reload;
-
-[@deriving show]
 type msg =
-  | Command(command)
   | KeyboardInput(string)
   | FileExplorer(Component_FileExplorer.msg)
   | SymbolOutline(Component_VimTree.msg)
@@ -139,14 +134,6 @@ type outmsg =
 
 let update = (~config, ~configuration, msg, model) => {
   switch (msg) {
-  | Command(Reload) =>
-    let model' = {
-      ...model,
-      fileExplorer:
-        model.fileExplorer |> Option.map(Component_FileExplorer.reload),
-    };
-    (model', Nothing);
-
   | KeyboardInput(key) =>
     if (model.focus == FileExplorer) {
       if (model.fileExplorer == None) {
@@ -525,18 +512,6 @@ let sub = (~configuration, model) => {
   |> Option.value(~default=Isolinear.Sub.none);
 };
 
-module Commands = {
-  open Feature_Commands.Schema;
-
-  let reload =
-    define(
-      ~category="Explorer",
-      ~title="Reload",
-      "workbench.todo.explorer-reload",
-      Command(Reload),
-    );
-};
-
 module Contributions = {
   let commands = (~isFocused, model) => {
     let explorerCommands =
@@ -557,7 +532,7 @@ module Contributions = {
           |> List.map(Oni_Core.Command.map(msg => VimWindowNav(msg)))
         : [];
 
-    explorerCommands @ vimNavCommands @ outlineCommands @ Commands.[reload];
+    explorerCommands @ vimNavCommands @ outlineCommands;
   };
 
   let contextKeys = (~isFocused, model) => {

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -127,6 +127,10 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | OpenFile(string)
   | PreviewFile(string)
+  | WatchedPathChanged({
+      path: FpExp.t(FpExp.absolute),
+      stat: option(Luv.File.Stat.t),
+    })
   | GrabFocus
   | UnhandledWindowMovement(Component_VimWindows.outmsg)
   | SymbolSelected(Feature_LanguageSupport.DocumentSymbols.symbol)
@@ -186,6 +190,8 @@ let update = (~config, ~configuration, msg, model) => {
            | Component_FileExplorer.PreviewFile(filePath) =>
              PreviewFile(filePath)
            | GrabFocus => GrabFocus
+           | Component_FileExplorer.WatchedPathChanged({path, stat}) =>
+             WatchedPathChanged({path, stat})
            };
 
          ({...model, fileExplorer: Some(fileExplorer)}, outmsg');

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -58,7 +58,12 @@ type model = {
 };
 
 [@deriving show]
+type command =
+  | Reload;
+
+[@deriving show]
 type msg =
+  | Command(command)
   | KeyboardInput(string)
   | FileExplorer(Component_FileExplorer.msg)
   | SymbolOutline(Component_VimTree.msg)
@@ -134,6 +139,14 @@ type outmsg =
 
 let update = (~config, ~configuration, msg, model) => {
   switch (msg) {
+  | Command(Reload) =>
+    let model' = {
+      ...model,
+      fileExplorer:
+        model.fileExplorer |> Option.map(Component_FileExplorer.reload),
+    };
+    (model', Nothing);
+
   | KeyboardInput(key) =>
     if (model.focus == FileExplorer) {
       if (model.fileExplorer == None) {
@@ -512,6 +525,18 @@ let sub = (~configuration, model) => {
   |> Option.value(~default=Isolinear.Sub.none);
 };
 
+module Commands = {
+  open Feature_Commands.Schema;
+
+  let reload =
+    define(
+      ~category="Explorer",
+      ~title="Reload",
+      "workbench.todo.explorer-reload",
+      Command(Reload),
+    );
+};
+
 module Contributions = {
   let commands = (~isFocused, model) => {
     let explorerCommands =
@@ -532,7 +557,7 @@ module Contributions = {
           |> List.map(Oni_Core.Command.map(msg => VimWindowNav(msg)))
         : [];
 
-    explorerCommands @ vimNavCommands @ outlineCommands;
+    explorerCommands @ vimNavCommands @ outlineCommands @ Commands.[reload];
   };
 
   let contextKeys = (~isFocused, model) => {

--- a/src/Feature/Explorer/Feature_Explorer.rei
+++ b/src/Feature/Explorer/Feature_Explorer.rei
@@ -27,6 +27,10 @@ type outmsg =
   | Effect(Isolinear.Effect.t(msg))
   | OpenFile(string)
   | PreviewFile(string)
+  | WatchedPathChanged({
+      path: FpExp.t(FpExp.absolute),
+      stat: option(Luv.File.Stat.t),
+    })
   | GrabFocus
   | UnhandledWindowMovement(Component_VimWindows.outmsg)
   | SymbolSelected(Feature_LanguageSupport.DocumentSymbols.symbol)

--- a/src/Feature/Explorer/Feature_Explorer.rei
+++ b/src/Feature/Explorer/Feature_Explorer.rei
@@ -48,7 +48,12 @@ let update:
 // SUBSCRIPTION
 
 let sub:
-  (~configuration: Feature_Configuration.model, model) => Isolinear.Sub.t(msg);
+  (
+    ~config: Config.resolver,
+    ~configuration: Feature_Configuration.model,
+    model
+  ) =>
+  Isolinear.Sub.t(msg);
 
 // VIEW
 

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -442,6 +442,7 @@ let initial =
     Feature_Configuration.initial(
       ~loader=configurationLoader,
       [
+        Component_FileExplorer.Contributions.configuration,
         Feature_AutoUpdate.Contributions.configuration,
         Feature_Buffers.Contributions.configuration,
         Feature_Editor.Contributions.configuration,

--- a/src/Service/Exthost/Service_Exthost.rei
+++ b/src/Service/Exthost/Service_Exthost.rei
@@ -1,4 +1,6 @@
 open EditorCoreTypes;
+open Oni_Core;
+
 // EFFECTS
 module Effects: {
   module Commands: {
@@ -41,8 +43,15 @@ module Effects: {
   };
 
   module FileSystemEventService: {
-    let onFileEvent:
-      (~events: Exthost.Files.FileSystemEvents.t, Exthost.Client.t) =>
+    let onBufferChanged:
+      (~buffer: Oni_Core.Buffer.t, Exthost.Client.t) => Isolinear.Effect.t(_);
+
+    let onPathChanged:
+      (
+        ~path: FpExp.t(FpExp.absolute),
+        ~maybeStat: option(Luv.File.Stat.t),
+        Exthost.Client.t
+      ) =>
       Isolinear.Effect.t(_);
   };
 

--- a/src/Service/FileWatcher/Service_FileWatcher.re
+++ b/src/Service/FileWatcher/Service_FileWatcher.re
@@ -30,7 +30,6 @@ module WatchSubscription =
         let onEvent = (
           fun
           | Ok((_file, events)) => {
-              prerr_endline("FILE: " ++ _file);
               dispatch({
                 path,
                 hasRenamed: List.mem(`RENAME, events),

--- a/src/Service/FileWatcher/Service_FileWatcher.re
+++ b/src/Service/FileWatcher/Service_FileWatcher.re
@@ -29,12 +29,14 @@ module WatchSubscription =
       | Ok(watcher) =>
         let onEvent = (
           fun
-          | Ok((_file, events)) =>
-            dispatch({
-              path,
-              hasRenamed: List.mem(`RENAME, events),
-              hasChanged: List.mem(`CHANGE, events),
-            })
+          | Ok((_file, events)) => {
+              prerr_endline("FILE: " ++ _file);
+              dispatch({
+                path,
+                hasRenamed: List.mem(`RENAME, events),
+                hasChanged: List.mem(`CHANGE, events),
+              });
+            }
           | Error(error) =>
             Log.errorf(m => m("'%s': %s", path, Luv.Error.strerror(error)))
         );

--- a/src/Service/FileWatcher/Service_FileWatcher.re
+++ b/src/Service/FileWatcher/Service_FileWatcher.re
@@ -2,53 +2,73 @@ open Oni_Core;
 
 module Log = (val Log.withNamespace("Oni2.Service.FileWatcher"));
 
+module Key =
+  Oni_Core.UniqueId.Make({});
+
 [@deriving show({with_path: false})]
 type event = {
-  path: string,
+  watchedPath: [@opaque] FpExp.t(FpExp.absolute),
+  changedPath: [@opaque] FpExp.t(FpExp.absolute),
   hasRenamed: bool,
   hasChanged: bool,
+};
+
+type params = {
+  path: FpExp.t(FpExp.absolute),
+  key: Key.t,
 };
 
 module WatchSubscription =
   Isolinear.Sub.Make({
     type state = {
-      path: string,
+      path: FpExp.t(FpExp.absolute),
       watcher: option(Luv.FS_event.t),
     };
 
     type nonrec msg = event;
-    type nonrec params = string;
+    type nonrec params = params;
 
     let name = "FileWatcher";
-    let id = Fun.id;
+    let id = params => {
+      String.concat(
+        ":",
+        [params.key |> Key.toString, FpExp.toString(params.path)],
+      );
+    };
 
-    let init = (~params as path, ~dispatch) => {
-      Log.tracef(m => m("Starting file watcher for %s", path));
+    let init = (~params: params, ~dispatch) => {
+      Log.tracef(m =>
+        m("Starting file watcher for %s", FpExp.toString(params.path))
+      );
 
+      let pathStr = FpExp.toString(params.path);
       switch (Luv.FS_event.init()) {
       | Ok(watcher) =>
         let onEvent = (
           fun
-          | Ok((_file, events)) => {
+          | Ok((file, events)) => {
               dispatch({
-                path,
+                watchedPath: params.path,
+                changedPath: FpExp.At.(params.path / file),
                 hasRenamed: List.mem(`RENAME, events),
                 hasChanged: List.mem(`CHANGE, events),
               });
             }
           | Error(error) =>
-            Log.errorf(m => m("'%s': %s", path, Luv.Error.strerror(error)))
+            Log.errorf(m =>
+              m("'%s': %s", pathStr, Luv.Error.strerror(error))
+            )
         );
 
-        Luv.FS_event.start(watcher, path, onEvent);
+        Luv.FS_event.start(watcher, pathStr, onEvent);
 
-        {path, watcher: Some(watcher)};
+        {path: params.path, watcher: Some(watcher)};
 
       | Error(error) =>
         let message = Luv.Error.strerror(error);
-        Log.errorf(m => m("init failed for '%s': %s", path, message));
+        Log.errorf(m => m("init failed for '%s': %s", pathStr, message));
 
-        {path, watcher: None};
+        {path: params.path, watcher: None};
       };
     };
 
@@ -56,8 +76,10 @@ module WatchSubscription =
       // Since the path is the id, there's nothing to change
       state;
 
-    let dispose = (~params as path, ~state) => {
-      Log.tracef(m => m("Disposing file watcher for %s", path));
+    let dispose = (~params: params, ~state) => {
+      Log.tracef(m =>
+        m("Disposing file watcher for %s", FpExp.toString(params.path))
+      );
 
       switch (state.watcher) {
       | Some(watcher) => ignore(Luv__FS_event.stop(watcher): result(_))
@@ -66,6 +88,6 @@ module WatchSubscription =
     };
   });
 
-let watch = (~path, ~onEvent) =>
-  WatchSubscription.create(path)
+let watch = (~key, ~path, ~onEvent) =>
+  WatchSubscription.create({key, path})
   |> Isolinear.Sub.map(event => onEvent(event));

--- a/src/Service/FileWatcher/Service_FileWatcher.rei
+++ b/src/Service/FileWatcher/Service_FileWatcher.rei
@@ -12,6 +12,7 @@ type event = {
   changedPath: FpExp.t(FpExp.absolute),
   hasRenamed: bool,
   hasChanged: bool,
+  stat: option(Luv.File.Stat.t),
 };
 
 let watch:

--- a/src/Service/FileWatcher/Service_FileWatcher.rei
+++ b/src/Service/FileWatcher/Service_FileWatcher.rei
@@ -1,8 +1,19 @@
+open Oni_Core;
+
+module Key: {
+  type t;
+
+  let create: (~friendlyName: string) => t;
+};
+
 [@deriving show]
 type event = {
-  path: string,
+  watchedPath: FpExp.t(FpExp.absolute),
+  changedPath: FpExp.t(FpExp.absolute),
   hasRenamed: bool,
   hasChanged: bool,
 };
 
-let watch: (~path: string, ~onEvent: event => 'msg) => Isolinear.Sub.t('msg);
+let watch:
+  (~key: Key.t, ~path: FpExp.t(FpExp.absolute), ~onEvent: event => 'msg) =>
+  Isolinear.Sub.t('msg);

--- a/src/Service/FileWatcher/dune
+++ b/src/Service/FileWatcher/dune
@@ -1,6 +1,6 @@
 (library
  (name Service_FileWatcher)
  (public_name Oni2.service.file-watcher)
- (libraries Oni2.core isolinear luv)
+ (libraries Oni2.core Oni2.service.os isolinear luv)
  (preprocess
   (pps ppx_let ppx_deriving.show)))

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -544,6 +544,15 @@ let update =
              })
           |> Option.value(~default=Isolinear.Effect.none);
         (state, eff);
+
+      | WatchedPathChanged({path, stat}) =>
+        let eff =
+          Service_Exthost.Effects.FileSystemEventService.onPathChanged(
+            ~path,
+            ~maybeStat=stat,
+            extHostClient,
+          );
+        (state, eff);
       }
     );
 
@@ -1373,13 +1382,8 @@ let update =
       (state'', Effect.none);
     | BufferSaved(buffer) =>
       let eff =
-        Service_Exthost.Effects.FileSystemEventService.onFileEvent(
-          ~events=
-            Exthost.Files.FileSystemEvents.{
-              created: [],
-              deleted: [],
-              changed: [buffer |> Oni_Core.Buffer.getUri],
-            },
+        Service_Exthost.Effects.FileSystemEventService.onBufferChanged(
+          ~buffer,
           extHostClient,
         );
 

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -344,7 +344,11 @@ let start =
       );
 
     let fileExplorerSub =
-      Feature_Explorer.sub(~configuration=state.config, state.fileExplorer)
+      Feature_Explorer.sub(
+        ~config,
+        ~configuration=state.config,
+        state.fileExplorer,
+      )
       |> Isolinear.Sub.map(msg => Model.Actions.FileExplorer(msg));
 
     let languageSupportSub =


### PR DESCRIPTION
This implements a manual refresh for the file explorer, as well as an experimental setting for automatically updating the file explorer in response to changes.

To enable the file-explorer auto-update, you can set the following config:

```
"files.useExperimentalFileWatcher": true
```

![2021-04-05 14 29 29](https://user-images.githubusercontent.com/13532591/113634965-9522b180-9624-11eb-8066-f7aea527f4e1.gif)

Hopefully can enable it by default, soon! Keep me posted if you try it out and see any issues.

If that's not set, then there is a new Control+Shift+P command - "Explorer: Refresh". This can be bound to a key with the "workbench.files.action.refreshFilesExplorer", like:

```
{ "key": "R", "command": "workbench.files.action.refreshFilesExplorer", "when": "sideBarFocus && !textInputFocus && activeViewlet == 'workbench.view.explorer'" }
```

Fixes #3350 
Fixes #3253 
Fixes #3158
Fixes #2056
Fixes #792 

__TODO:__
- [x] Set up a proper unique ID for the path subscriptions
- [x] Emit event to trigger the extension file system watcher (so git / SCM extensions know to highlight the new file)
- [x] Add configuration setting for watcher
- [x] Validate reload command