### PR TITLE
fix(filewatcher/#3373): Part 1 - Don't stat on changed files

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -39,6 +39,7 @@
 ### Performance
 
 - #3316 - Transport: Re-use Luv.Buffer.t when possible for reads
+- #3374 - FileWatcher: Don't stat on file changes (related #3373)
 
 ### Documentation
 

--- a/integration_test/FileWatcherTest.re
+++ b/integration_test/FileWatcherTest.re
@@ -17,6 +17,7 @@ let key = Service_FileWatcher.Key.create(~friendlyName="FileWatcherTest");
 // System under test
 let sub =
   Service_FileWatcher.watch(
+    ~watchChanges=true,
     ~key,
     ~path=FpExp.absoluteCurrentPlatform(tempFilePath) |> Option.get,
     ~onEvent=_ => {

--- a/src/Components/FileExplorer/Component_FileExplorer.re
+++ b/src/Components/FileExplorer/Component_FileExplorer.re
@@ -436,6 +436,7 @@ let sub =
       : allPathsToWatch
         |> List.map(path => {
              Service_FileWatcher.watch(
+               ~watchChanges=false,
                ~key=fileWatcherKey,
                ~path,
                ~onEvent=onEvent(path),

--- a/src/Service/FileWatcher/Service_FileWatcher.rei
+++ b/src/Service/FileWatcher/Service_FileWatcher.rei
@@ -16,5 +16,10 @@ type event = {
 };
 
 let watch:
-  (~key: Key.t, ~path: FpExp.t(FpExp.absolute), ~onEvent: event => 'msg) =>
+  (
+    ~watchChanges: bool,
+    ~key: Key.t,
+    ~path: FpExp.t(FpExp.absolute),
+    ~onEvent: event => 'msg
+  ) =>
   Isolinear.Sub.t('msg);

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -1070,7 +1070,7 @@ let subscriptions = (state: State.t) => {
        |> OptionEx.flatMap(Core.FpExp.absoluteCurrentPlatform)
        |> Option.map(path =>
             Service_FileWatcher.watch(
-              ~key=vimFileWatcherKey, ~path, ~onEvent=event =>
+              ~watchChanges=true, ~key=vimFileWatcherKey, ~path, ~onEvent=event =>
               Actions.FileChanged(event)
             )
           )


### PR DESCRIPTION
__Issue:__ In #3373 , we're stat'ing on files that are just changed (not added, unlinked, moved) - this is wasteful in the general case, but in the worst case of the log-file writing, we get caught in an infinite loop of:
1) Writing to the log file
2) Detecting a change event
3) Stat'ing the log file
4) Log out the stat results
5) Goto 1...

__Fix:__ Only stat if there was a rename - don't bother stat'ing for changes.

This should unblock the log file issue; but there is still the original issue of 100% CPU usage - hopefully, since we can use the log file, we can track that down now