### PR TITLE
fix(layout): Window cycle binding

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -35,6 +35,7 @@
 - #3361 - Clipboard: Add command+v binding for paste in normal mode (fixes #3353)
 - #3364 - Input: Add context key to differentiate sidebar panels
 - #3365 - Explorer: Add manual refresh command and experimental `files.useExperimentalFileWatcher` setting (fixes #3350)
+- #3376 - Vim: Missing Control+W,W bindings (related #1721)
 
 ### Performance
 

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -308,6 +308,47 @@ let update = (~focus, model, msg) => {
     | None => (model, Nothing)
     }
 
+  | Command(MoveTopLeft) =>
+    switch (focus) {
+    | Some(Center) =>
+      let layout = model |> activeLayout;
+      let newActiveGroupId =
+        layout |> activeTree |> moveTopLeft(layout.activeGroupId);
+      (
+        updateActiveLayout(
+          layout => {...layout, activeGroupId: newActiveGroupId},
+          model,
+        ),
+        Nothing,
+      );
+
+    | Some(Left)
+    | Some(Right)
+    | Some(Bottom)
+    | None => (model, Nothing)
+    }
+  | Command(MoveBottomRight) =>
+    switch (focus) {
+    | Some(Center) =>
+      let layout = model |> activeLayout;
+      let newActiveGroupId =
+        layout |> activeTree |> moveBottomRight(layout.activeGroupId);
+      (
+        updateActiveLayout(
+          layout => {...layout, activeGroupId: newActiveGroupId},
+          model,
+        ),
+        Nothing,
+      );
+
+    | Some(Left)
+    | Some(Right)
+    | Some(Bottom)
+    | None => (model, Nothing)
+    }
+  | Command(CycleForward)
+  | Command(CycleBackward) => failwith("Not implemented yet")
+
   | Command(RotateForward) =>
     switch (focus) {
     | Some(Center) => (rotate(`Forward, model), Nothing)
@@ -608,6 +649,26 @@ module Commands = {
       Command(MoveDown),
     );
 
+  let moveTopLeft =
+    define(
+      ~category="View",
+      ~title="Focus Top Left Window",
+      "window.moveTopLeft",
+      Command(MoveTopLeft),
+    );
+
+  let moveBottomRight =
+    define(
+      ~category="View",
+      ~title="Focus Bottom Right Window",
+      "window.moveBottomRight",
+      Command(MoveBottomRight),
+    );
+
+  let cycleForward = define("window.cycleForward", Command(CycleForward));
+
+  let cycleBackward = define("window.cycleBackward", Command(CycleBackward));
+
   let decreaseSize =
     define(
       ~category="View",
@@ -785,6 +846,10 @@ module Contributions = {
       moveRight,
       moveUp,
       moveDown,
+      moveTopLeft,
+      moveBottomRight,
+      cycleForward,
+      cycleBackward,
       increaseSize,
       decreaseSize,
       increaseHorizontalSize,

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -312,8 +312,7 @@ let update = (~focus, model, msg) => {
     switch (focus) {
     | Some(Center) =>
       let layout = model |> activeLayout;
-      let newActiveGroupId =
-        layout |> activeTree |> moveTopLeft(layout.activeGroupId);
+      let newActiveGroupId = layout |> activeTree |> Layout.topLeft;
       (
         updateActiveLayout(
           layout => {...layout, activeGroupId: newActiveGroupId},
@@ -331,8 +330,7 @@ let update = (~focus, model, msg) => {
     switch (focus) {
     | Some(Center) =>
       let layout = model |> activeLayout;
-      let newActiveGroupId =
-        layout |> activeTree |> moveBottomRight(layout.activeGroupId);
+      let newActiveGroupId = layout |> activeTree |> Layout.bottomRight;
       (
         updateActiveLayout(
           layout => {...layout, activeGroupId: newActiveGroupId},
@@ -346,8 +344,32 @@ let update = (~focus, model, msg) => {
     | Some(Bottom)
     | None => (model, Nothing)
     }
-  | Command(CycleForward)
-  | Command(CycleBackward) => failwith("Not implemented yet")
+  | Command(CycleForward) =>
+    let layout = model |> activeLayout;
+    let newActiveGroupId =
+      layout
+      |> activeTree
+      |> Layout.cycle(~direction=`Forward, ~activeId=layout.activeGroupId);
+    (
+      updateActiveLayout(
+        layout => {...layout, activeGroupId: newActiveGroupId},
+        model,
+      ),
+      Nothing,
+    );
+  | Command(CycleBackward) =>
+    let layout = model |> activeLayout;
+    let newActiveGroupId =
+      layout
+      |> activeTree
+      |> Layout.cycle(~direction=`Backward, ~activeId=layout.activeGroupId);
+    (
+      updateActiveLayout(
+        layout => {...layout, activeGroupId: newActiveGroupId},
+        model,
+      ),
+      Nothing,
+    );
 
   | Command(RotateForward) =>
     switch (focus) {

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -125,6 +125,10 @@ module Commands: {
   let moveRight: Command.t(msg);
   let moveUp: Command.t(msg);
   let moveDown: Command.t(msg);
+  let moveTopLeft: Command.t(msg);
+  let moveBottomRight: Command.t(msg);
+  let cycleForward: Command.t(msg);
+  let cycleBackward: Command.t(msg);
 
   let rotateForward: Command.t(msg);
   let rotateBackward: Command.t(msg);

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -265,6 +265,26 @@ let moveRight = current => move(current, 1, 0);
 let moveUp = current => move(current, 0, -1);
 let moveDown = current => move(current, 0, 1);
 
+let rec moveTopLeft = (current, layout) => {
+  let next = move(current, -1, -1, layout);
+
+  if (next == current) {
+    current;
+  } else {
+    moveTopLeft(next, layout);
+  };
+};
+
+let rec moveBottomRight = (current, layout) => {
+  let next = move(current, 1, 1, layout);
+
+  if (next == current) {
+    current;
+  } else {
+    moveBottomRight(next, layout);
+  };
+};
+
 let hasSplitToRight = model => {
   let layout = model |> activeLayout;
   let newActiveGroupId =

--- a/src/Feature/Layout/Msg.re
+++ b/src/Feature/Layout/Msg.re
@@ -9,6 +9,10 @@ type command =
   | MoveRight
   | MoveUp
   | MoveDown
+  | MoveTopLeft
+  | MoveBottomRight
+  | CycleForward
+  | CycleBackward
   | RotateForward
   | RotateBackward
   | DecreaseSize

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -243,6 +243,41 @@ let defaultKeyBindings =
         ~condition=windowCommandCondition,
       ),
       bind(
+        ~key="<C-W>T",
+        ~command=Feature_Layout.Commands.moveTopLeft.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-T>",
+        ~command=Feature_Layout.Commands.moveTopLeft.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>B",
+        ~command=Feature_Layout.Commands.moveBottomRight.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-B>",
+        ~command=Feature_Layout.Commands.moveBottomRight.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>W",
+        ~command=Feature_Layout.Commands.cycleForward.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-W>",
+        ~command=Feature_Layout.Commands.cycleForward.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><S-W>",
+        ~command=Feature_Layout.Commands.cycleBackward.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
         ~key="<C-W><C-S>",
         ~command=Feature_Layout.Commands.splitHorizontal.id,
         ~condition=windowCommandCondition,


### PR DESCRIPTION
Add a few missing window movement bindings:

- Control+w, Control-t -> move to furthermost top left
- Control+w, Control-b -> move to furthermost bottom right
- Control+w, Control+w -> move to next right/bottom, or top -left
- Control+w, Shift+W -> move to next top/left, or bottom right