### PR TITLE
perf(libuv): Run loop once

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -42,6 +42,7 @@
 
 - #3316 - Transport: Re-use Luv.Buffer.t when possible for reads
 - #3374 - FileWatcher: Don't stat on file changes (related #3373)
+- #3378 - libuv: Run event loop once each Revery iteration
 
 ### Documentation
 

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -372,14 +372,10 @@ switch (eff) {
     };
 
     let runEventLoop = () => {
-      // TODO: How many times should we run it?
-      // The ideal amount would be just enough to do pending work,
-      // but not too much to just spin. Unfortunately, it seems
-      // Luv.Loop.run always returns [true] for us, so we don't
-      // have a reliable way to know we're done (at the moment).
-      for (_ in 1 to 100) {
-        ignore(Luv.Loop.run(~mode=`NOWAIT, ()): bool);
-      };
+      // Luv.Loop.run always returns [true] for us, so just keep polling:
+      ignore(
+        Luv.Loop.run(~mode=`NOWAIT, ()): bool,
+      );
     };
 
     let title = (state: Model.State.t) => {


### PR DESCRIPTION
__Issue:__ When we first integrating libuv, we ran the libuv event loop multiple times with each turn of the revery event loop, to workaround some integration issues. However, this is no longer necessary, and it's expensive perf-wise (the polling can be a bottleneck when not much else is going on!)

__Fix:__ Run the libuv event loop once with `NOWAIT` for each Revery event loop iteration