### PR TITLE
fix(rename): Handle reject reason

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,6 +37,7 @@
 - #3365 - Explorer: Add manual refresh command and experimental `files.useExperimentalFileWatcher` setting (fixes #3350)
 - #3371 - Explorer: Fix regression in auto-focus behavior
 - #3376 - Vim: Missing Control+W,W bindings (related #1721)
+- #3379 - Rename: Handle parsing 'rejectReason'
 
 ### Performance
 

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -2073,7 +2073,7 @@ module Request: {
         ~position: OneBasedPosition.t,
         Client.t
       ) =>
-      Lwt.t(option(RenameLocation.t));
+      Lwt.t(result(option(RenameLocation.t), string));
 
     let provideTypeDefinition:
       (

--- a/src/Exthost/RejectReason.re
+++ b/src/Exthost/RejectReason.re
@@ -1,0 +1,6 @@
+open Oni_Core;
+
+type t = string;
+
+let decode =
+  Json.Decode.(obj(({field, _}) => field.required("rejectReason", string)));

--- a/src/Exthost/Request.re
+++ b/src/Exthost/Request.re
@@ -633,8 +633,21 @@ module LanguageFeatures = {
   };
 
   let resolveRenameLocation = (~handle, ~resource, ~position) => {
+    let decoder =
+      Json.Decode.(
+        one_of([
+          (
+            "RenameLocation.ok",
+            nullable(RenameLocation.decode) |> map(rl => Ok(rl)),
+          ),
+          (
+            "RenameLocation.rejection",
+            RejectReason.decode |> map(Result.error),
+          ),
+        ])
+      );
     Client.request(
-      ~decoder=Json.Decode.(nullable(RenameLocation.decode)),
+      ~decoder,
       ~usesCancellationToken=true,
       ~rpcName="ExtHostLanguageFeatures",
       ~method="$resolveRenameLocation",

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -58,6 +58,7 @@ type outmsg =
       insertText: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
+  | ApplyWorkspaceEdit(Exthost.WorkspaceEdit.t)
   | FormattingApplied({
       displayName: string,
       editCount: int,
@@ -96,6 +97,7 @@ let map: ('a => msg, Outmsg.internalMsg('a)) => outmsg =
     fun
     | Outmsg.ApplyCompletion({replaceSpan, insertText, additionalEdits}) =>
       ApplyCompletion({replaceSpan, insertText, additionalEdits})
+    | Outmsg.ApplyWorkspaceEdit(edit) => ApplyWorkspaceEdit(edit)
     | Outmsg.FormattingApplied({displayName, editCount, needsToSave}) =>
       FormattingApplied({displayName, editCount, needsToSave})
     | Outmsg.InsertSnippet({replaceSpan, snippet, additionalEdits}) =>

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -59,6 +59,7 @@ type outmsg =
       insertText: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
+  | ApplyWorkspaceEdit(Exthost.WorkspaceEdit.t)
   | FormattingApplied({
       displayName: string,
       editCount: int,

--- a/src/Feature/LanguageSupport/Outmsg.re
+++ b/src/Feature/LanguageSupport/Outmsg.re
@@ -8,6 +8,7 @@ type internalMsg('a) =
       insertText: string,
       additionalEdits: list(Exthost.Edit.SingleEditOperation.t),
     })
+  | ApplyWorkspaceEdit(Exthost.WorkspaceEdit.t)
   | FormattingApplied({
       displayName: string,
       editCount: int,

--- a/src/Feature/LanguageSupport/Rename.re
+++ b/src/Feature/LanguageSupport/Rename.re
@@ -17,6 +17,7 @@ type msg =
       handle: int,
     })
   | RenameLocationUnavailable
+  | RenameLocationError(string)
   // Candidate edits - preview of edits while user is typing
   | CandidateEditsFailed(string)
   | CandidateEditsAvailable(Exthost.WorkspaceEdit.t)
@@ -139,6 +140,8 @@ let update = (~client, ~maybeBuffer, ~cursorLocation, msg, model) => {
 
   | RenameLocationUnavailable => (model, Outmsg.Nothing)
 
+  | RenameLocationError(msg) => (model, Outmsg.NotifyFailure(msg))
+
   | NoCandidateEditsAvailable => (model, Outmsg.Nothing)
 
   | CandidateEditsAvailable(edits) =>
@@ -223,7 +226,7 @@ let update = (~client, ~maybeBuffer, ~cursorLocation, msg, model) => {
         switch (maybeLocationResult) {
         | Ok(Some(location)) => RenameLocationAvailable({location, handle})
         | Ok(None) => RenameLocationUnavailable
-        | Error(_msg) => RenameLocationUnavailable
+        | Error(msg) => RenameLocationError(msg)
         };
       };
       let eff =

--- a/src/Service/Exthost/Service_Exthost.re
+++ b/src/Service/Exthost/Service_Exthost.re
@@ -289,7 +289,7 @@ module Effects = {
           );
 
         Lwt.on_success(promise, maybeLocation =>
-          dispatch(toMsg(Ok(maybeLocation)))
+          dispatch(toMsg(maybeLocation))
         );
 
         Lwt.on_failure(promise, err =>


### PR DESCRIPTION
- Handle parsing `rejectReason` from the extension
- Refactor the application of workspace edits to a more common place, so that it can be used by #3358 