### PR TITLE
feat(language-support): Go-to symbols menu

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -4,6 +4,7 @@
 - #2881 - Extensions: Initial rename support
 - #3348 - Code Actions: Implement extension host protocol for quick fix / code actions
 - #3352 - Keybindings: Add default keybinding for open configuration (related #1423, thanks @LiHRaM !)
+- #3381 - Language Support: Symbols - implement go-to buffer symbol menu
 
 ### Bug Fixes
 

--- a/docs/docs/using-onivim/language-features.md
+++ b/docs/docs/using-onivim/language-features.md
@@ -66,3 +66,5 @@ Typing the closing pair will result in the cursor 'passing through'. Pressing <k
 ## Symbol Outline
 
 If the language extension supports it, `gO` can be used to navigate to the symbol outline.
+
+In addition, `gs` can be used in normal to go-to a specific symbol in the file.

--- a/docs/docs/using-onivim/language-features.md
+++ b/docs/docs/using-onivim/language-features.md
@@ -67,4 +67,6 @@ Typing the closing pair will result in the cursor 'passing through'. Pressing <k
 
 If the language extension supports it, `gO` can be used to navigate to the symbol outline.
 
-In addition, `gs` can be used in normal to go-to a specific symbol in the file.
+In addition, `gs` can be used in normal to go-to a specific symbol in the file:!
+
+[goto-symbol](https://user-images.githubusercontent.com/13532591/114098552-57b56280-9876-11eb-8298-d9f764efd48f.gif)

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -443,9 +443,12 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
                )
              );
 
+        let itemToIcon = item => {
+          item |> snd |> Option.map(Feature_Quickmenu.Schema.Icon.seti);
+        };
         Feature_Quickmenu.Schema.menu(
           ~itemRenderer=
-            Feature_Quickmenu.Schema.Renderer.defaultWithIcon(snd),
+            Feature_Quickmenu.Schema.Renderer.defaultWithIcon(itemToIcon),
           ~onItemSelected=
             language =>
               FileTypeChanged({

--- a/src/Feature/LanguageSupport/DocumentSymbols.re
+++ b/src/Feature/LanguageSupport/DocumentSymbols.re
@@ -107,10 +107,20 @@ let update = (~maybeBuffer, msg, model) => {
                Quickmenu(SymbolSelected({filePath, symbol}));
              };
 
+             let itemToIcon = ({kind, _}: symbol) => {
+               let icon =
+                 Oni_Components.SymbolIcon.Internal.symbolToIcon(kind);
+               let color =
+                 Oni_Components.SymbolIcon.Internal.symbolToColor(kind);
+               Some(Feature_Quickmenu.Schema.Icon.codicon(~color, icon));
+             };
+             let itemRenderer =
+               Feature_Quickmenu.Schema.Renderer.defaultWithIcon(itemToIcon);
              Outmsg.ShowMenu(
                Feature_Quickmenu.Schema.menu(
                  ~onItemSelected,
                  ~toString=(symbol: symbol) => symbol.name,
+                 ~itemRenderer,
                  allItems,
                ),
              );

--- a/src/Feature/LanguageSupport/DocumentSymbols.re
+++ b/src/Feature/LanguageSupport/DocumentSymbols.re
@@ -6,6 +6,7 @@ type provider = {
   selector: Exthost.DocumentSelector.t,
 };
 
+[@deriving show]
 type symbol = {
   uniqueId: string,
   name: string,
@@ -13,6 +14,10 @@ type symbol = {
   kind: Exthost.SymbolKind.t,
   range: CharacterRange.t,
   selectionRange: CharacterRange.t,
+};
+
+let sortSymbolsByPosition = (a: symbol, b: symbol) => {
+  CharacterRange.compare(a.range, b.range);
 };
 
 type t = list(Tree.t(symbol, symbol));
@@ -51,24 +56,85 @@ type model = {
 let initial = {providers: [], bufferToSymbols: IntMap.empty};
 
 [@deriving show]
+type command =
+  | GotoSymbol;
+
+[@deriving show]
+type quickmenu =
+  | SymbolSelected({
+      filePath: string,
+      symbol,
+    });
+
+[@deriving show]
 type msg =
+  | Command(command)
+  | Quickmenu(quickmenu)
   | DocumentSymbolsAvailable({
       bufferId: int,
       symbols: list(Exthost.DocumentSymbol.t),
     });
 
-let update = (msg, model) => {
+let get = (~bufferId, model) => {
+  IntMap.find_opt(bufferId, model.bufferToSymbols);
+};
+
+let update = (~maybeBuffer, msg, model) => {
   switch (msg) {
+  | Command(GotoSymbol) =>
+    let maybeFilePath =
+      maybeBuffer |> Utility.OptionEx.flatMap(Buffer.getFilePath);
+    let outmsg =
+      maybeBuffer
+      |> Option.map(Oni_Core.Buffer.getId)
+      |> Utility.OptionEx.flatMap(bufferId => get(~bufferId, model))
+      |> Utility.OptionEx.map2(
+           (filePath, symbols) => {
+             let allItems =
+               symbols
+               |> List.map(TreeList.ofTree)
+               |> List.flatten
+               |> List.map(
+                    TreeList.(
+                      fun
+                      | ViewLeaf({data, _}) => data
+                      | ViewNode({data, _}) => data
+                    ),
+                  )
+               |> List.sort(sortSymbolsByPosition);
+
+             let onItemSelected = symbol => {
+               Quickmenu(SymbolSelected({filePath, symbol}));
+             };
+
+             Outmsg.ShowMenu(
+               Feature_Quickmenu.Schema.menu(
+                 ~onItemSelected,
+                 ~toString=(symbol: symbol) => symbol.name,
+                 allItems,
+               ),
+             );
+           },
+           maybeFilePath,
+         )
+      |> Option.value(~default=Outmsg.Nothing);
+
+    (model, outmsg);
   | DocumentSymbolsAvailable({bufferId, symbols}) =>
     let symbolTrees = symbols |> List.rev_map(extHostSymbolToTree);
     let bufferToSymbols =
       IntMap.add(bufferId, symbolTrees, model.bufferToSymbols);
-    {...model, bufferToSymbols};
-  };
-};
+    ({...model, bufferToSymbols}, Outmsg.Nothing);
 
-let get = (~bufferId, model) => {
-  IntMap.find_opt(bufferId, model.bufferToSymbols);
+  | Quickmenu(SymbolSelected({filePath, symbol})) => (
+      model,
+      Outmsg.OpenFile({
+        filePath,
+        location: Some(symbol.range.start),
+        direction: SplitDirection.Current,
+      }),
+    )
+  };
 };
 
 let register = (~handle: int, ~selector, model) => {
@@ -97,4 +163,31 @@ let sub = (~buffer, ~client, model) => {
        Service_Exthost.Sub.documentSymbols(~handle, ~buffer, ~toMsg, client)
      })
   |> Isolinear.Sub.batch;
+};
+
+module Commands = {
+  open Feature_Commands.Schema;
+
+  let gotoSymbol =
+    define(
+      ~category="Language Support",
+      ~title="Go to buffer symbol",
+      "workbench.action.gotoSymbol",
+      Command(GotoSymbol),
+    );
+};
+
+module Keybindings = {
+  open Feature_Input.Schema;
+
+  let condition = "editorTextFocus && normalMode" |> WhenExpr.parse;
+
+  let gotoSymbol =
+    bind(~key="gs", ~command=Commands.gotoSymbol.id, ~condition);
+};
+
+module Contributions = {
+  let commands = Commands.[gotoSymbol];
+
+  let keybindings = Keybindings.[gotoSymbol];
 };

--- a/src/Feature/LanguageSupport/DocumentSymbols.re
+++ b/src/Feature/LanguageSupport/DocumentSymbols.re
@@ -196,8 +196,24 @@ module Keybindings = {
     bind(~key="gs", ~command=Commands.gotoSymbol.id, ~condition);
 };
 
+module MenuItems = {
+  open MenuBar.Schema;
+
+  let gotoBufferSymbol =
+    command(~title="Goto buffer symbol...", Commands.gotoSymbol);
+};
+
 module Contributions = {
   let commands = Commands.[gotoSymbol];
 
   let keybindings = Keybindings.[gotoSymbol];
+
+  let menuGroups =
+    MenuBar.Schema.[
+      group(
+        ~order=200,
+        ~parent=Feature_MenuBar.Global.go,
+        MenuItems.[gotoBufferSymbol],
+      ),
+    ];
 };

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -723,7 +723,9 @@ module Contributions = {
     @ References.Contributions.keybindings
     @ SignatureHelp.Contributions.keybindings;
 
-  let menuGroups = Formatting.Contributions.menuGroups;
+  let menuGroups =
+    DocumentSymbols.Contributions.menuGroups
+    @ Formatting.Contributions.menuGroups;
 };
 
 module OldCompletion = Completion;

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -387,9 +387,16 @@ let update =
     );
 
   | DocumentSymbols(documentSymbolsMsg) =>
-    let documentSymbols' =
-      DocumentSymbols.update(documentSymbolsMsg, model.documentSymbols);
-    ({...model, documentSymbols: documentSymbols'}, Nothing);
+    let (documentSymbols', outmsg) =
+      DocumentSymbols.update(
+        ~maybeBuffer,
+        documentSymbolsMsg,
+        model.documentSymbols,
+      );
+    (
+      {...model, documentSymbols: documentSymbols'},
+      outmsg |> map(msg => DocumentSymbols(msg)),
+    );
 
   | References(referencesMsg) =>
     let (references', outmsg) =
@@ -664,6 +671,10 @@ module Contributions = {
       |> List.map(Oni_Core.Command.map(msg => DocumentHighlights(msg)))
     )
     @ (
+      DocumentSymbols.Contributions.commands
+      |> List.map(Oni_Core.Command.map(msg => DocumentSymbols(msg)))
+    )
+    @ (
       Hover.Contributions.commands
       |> List.map(Oni_Core.Command.map(msg => Hover(msg)))
     )
@@ -707,6 +718,7 @@ module Contributions = {
     @ Completion.Contributions.keybindings
     @ Definition.Contributions.keybindings
     @ DocumentHighlights.Contributions.keybindings
+    @ DocumentSymbols.Contributions.keybindings
     @ Formatting.Contributions.keybindings
     @ References.Contributions.keybindings
     @ SignatureHelp.Contributions.keybindings;

--- a/src/Feature/MenuBar/Global.re
+++ b/src/Feature/MenuBar/Global.re
@@ -13,6 +13,8 @@ let application = Revery.Environment.isMac ? OSX.application : file;
 
 let edit = menu(~order=200, ~uniqueId="edit", ~parent=None, "Edit");
 
+let go = menu(~order=250, ~uniqueId="go", ~parent=None, "Go");
+
 let view = menu(~order=300, ~uniqueId="view", ~parent=None, "View");
 
 let help = menu(~order=1000, ~uniqueId="help", ~parent=None, "Help");
@@ -105,7 +107,7 @@ module Items = {
 
 let menus =
   (Revery.Environment.isMac ? [OSX.application] : [])
-  @ [file, edit, view, help];
+  @ [file, edit, go, view, help];
 
 let groups = [
   group(~order=100, ~parent=file, Items.File.[newFile]),

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -10,7 +10,8 @@ module Schema: {
 
     let seti: IconTheme.IconDefinition.t => t;
 
-    let codicon: (~fontSize: float=?, ~color: Revery.Color.t=?, int) => t;
+    let codicon:
+      (~fontSize: float=?, ~color: ColorTheme.Schema.definition=?, int) => t;
   };
 
   module Renderer: {

--- a/src/Feature/Quickmenu/Feature_Quickmenu.rei
+++ b/src/Feature/Quickmenu/Feature_Quickmenu.rei
@@ -5,6 +5,14 @@ open Oni_Core;
 module Schema: {
   type menu('outmsg);
 
+  module Icon: {
+    type t;
+
+    let seti: IconTheme.IconDefinition.t => t;
+
+    let codicon: (~fontSize: float=?, ~color: Revery.Color.t=?, int) => t;
+  };
+
   module Renderer: {
     type t('item) =
       (
@@ -18,8 +26,7 @@ module Schema: {
 
     let default: t(_);
 
-    let defaultWithIcon:
-      ('item => option(IconTheme.IconDefinition.t)) => t('item);
+    let defaultWithIcon: ('item => option(Icon.t)) => t('item);
   };
 
   let menu:

--- a/src/Feature/Quickmenu/Schema.re
+++ b/src/Feature/Quickmenu/Schema.re
@@ -6,7 +6,7 @@ module Icon = {
     | Seti(IconTheme.IconDefinition.t)
     | Codicon({
         fontSize: option(float),
-        color: option(Revery.Color.t),
+        color: option(ColorTheme.Schema.definition),
         icon: int,
       });
 
@@ -55,6 +55,14 @@ module Renderer = {
         textWrap(TextWrapping.NoWrap),
         marginRight(10),
       ];
+
+    let codiconStyle =
+      Style.[
+        marginRight(10),
+        flexDirection(`Row),
+        justifyContent(`Center),
+        alignItems(`Center),
+      ];
   };
 
   let common: t(_) =
@@ -96,7 +104,16 @@ module Renderer = {
             text={Oni_Components.FontIcon.codeToIcon(icon.fontCharacter)}
           />
         )
-      | Some(Icon.Codicon({fontSize, color, icon})) => <Text text="*" />
+      | Some(Icon.Codicon({fontSize, color, icon})) =>
+        let fontSize = fontSize |> Option.value(~default=font.size);
+        let colorSchema: Oni_Core.ColorTheme.Schema.definition =
+          color |> Option.value(~default=Feature_Theme.Colors.Menu.foreground);
+
+        let color = colorSchema.from(theme);
+
+        <Revery.UI.View style=Styles.codiconStyle>
+          <Codicon icon fontSize color />
+        </Revery.UI.View>;
       | None =>
         <Text style={Styles.icon(Revery.Colors.transparentWhite)} text="" />
       };

--- a/src/editor-core-types/CharacterIndex.re
+++ b/src/editor-core-types/CharacterIndex.re
@@ -16,3 +16,5 @@ let (<=) = (a, b) => a <= b;
 let (>=) = (a, b) => a >= b;
 
 let max = max;
+
+let compare = (a, b) => a - b;

--- a/src/editor-core-types/CharacterIndex.rei
+++ b/src/editor-core-types/CharacterIndex.rei
@@ -17,3 +17,5 @@ let (<=): (t, t) => bool;
 let (>=): (t, t) => bool;
 
 let max: (t, t) => t;
+
+let compare: (t, t) => int;

--- a/src/editor-core-types/CharacterRange.re
+++ b/src/editor-core-types/CharacterRange.re
@@ -125,5 +125,16 @@ let toHash = ranges => {
   hash;
 };
 
+let compare = (a, b) =>
+  if (a.start.line != b.start.line) {
+    LineNumber.compare(a.start.line, b.start.line);
+  } else if (a.start.character != b.stop.character) {
+    CharacterIndex.compare(a.start.character, b.start.character);
+  } else if (a.stop.line != b.stop.line) {
+    LineNumber.compare(a.stop.line, b.stop.line);
+  } else {
+    CharacterIndex.compare(a.stop.character, b.stop.character);
+  };
+
 let equals = (a, b) =>
   CharacterPosition.(a.start == b.start && a.stop == b.stop);

--- a/src/editor-core-types/CharacterRange.rei
+++ b/src/editor-core-types/CharacterRange.rei
@@ -30,3 +30,4 @@ let shiftCharacters:
 let toHash: list(t) => Hashtbl.t(LineNumber.t, list(t));
 
 let equals: (t, t) => bool;
+let compare: (t, t) => int;

--- a/src/editor-core-types/LineNumber.re
+++ b/src/editor-core-types/LineNumber.re
@@ -16,3 +16,5 @@ let equals = (a, b) => a == b;
 let (==) = (a, b) => a == b;
 let (<) = (a, b) => a < b;
 let (>) = (a, b) => a > b;
+
+let compare = (a, b) => a - b;

--- a/src/editor-core-types/LineNumber.rei
+++ b/src/editor-core-types/LineNumber.rei
@@ -15,3 +15,5 @@ let equals: (t, t) => bool;
 let (==): (t, t) => bool;
 let (>): (t, t) => bool;
 let (<): (t, t) => bool;
+
+let compare: (t, t) => int;


### PR DESCRIPTION
This implements a quickmenu for the symbols language feature, to make it easy to quickly navigate to a symbol:

![goto-symbol](https://user-images.githubusercontent.com/13532591/114098552-57b56280-9876-11eb-8298-d9f764efd48f.gif)


__TODO:__
- [x] Add gif to docs