### PR TITLE
fix(input): Add missing case for caps-lock key

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -37,6 +37,7 @@
 - #3365 - Explorer: Add manual refresh command and experimental `files.useExperimentalFileWatcher` setting (fixes #3350)
 - #3371 - Explorer: Fix regression in auto-focus behavior
 - #3376 - Vim: Missing Control+W,W bindings (related #1721)
+- #3382 - Input: Handle `<capslock>` key
 
 ### Performance
 

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -15,6 +15,7 @@ module Internal = {
       | v when v == Revery.Key.Keycode.backspace => Some(Key.Backspace)
       | v when v == Revery.Key.Keycode.delete => Some(Key.Delete)
       | v when v == Revery.Key.Keycode.space => Some(Key.Space)
+      | v when v == 1073741881 => Some(Key.CapsLock)
       | v when v == 1073741897 => Some(Key.Insert)
       | v when v == 1073741898 => Some(Key.Home)
       | v when v == 1073741899 => Some(Key.PageUp)


### PR DESCRIPTION
__Issue:__ Although our keybindings would properly parse `<capslock>`, the binding would never be matched, even when capslock is pressed

__Defect:__ We didn't include the case in our conversion code from Revery/SDL2 keycodes -> Onivim's editor input key variant.

__Fix:__ Add missing case.

This unblocks bindings like:
```
{ "key": "<capslock>", "command": "vim.esc" }
```

But it's not super useful, because capslock still toggles state when pressing it. Ideally, if we're using it or matching it, we could block it from altering keyboard state.