### PR TITLE
feat(ux/#2496): Configurable mode indicator

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -146,6 +146,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `workbench.statusBar.visible` __(_bool_ default: `true`)__ - Controls the visibility of the status bar.
 
+- `workbench.statusBar.modeIndicator` __(_"left"|"right"|"none"_ default: `right`)__ - Controls the position of the mode indicator.
+
 - `window.menuBarVisibility` __(_"visible" | "hidden"_ default: `"visible"`)__ - Controls the visibility of the menu bar.
 
 - `oni.layout.showLayoutTabs` __(_"always"|"smart"|"never"_ default: `"smart"`)__ - Controls the display of layout tabs. `"smart"` will only show the tabs if there's more than one.

--- a/src/Core/ConfigurationDefaults.re
+++ b/src/Core/ConfigurationDefaults.re
@@ -36,6 +36,7 @@ let getDefaultConfigString = configName =>
   "workbench.sideBar.location": "left",
   "workbench.sideBar.visible": true,
   "workbench.statusBar.visible": true,
+  "workbench.statusBar.modeIndicator": "left",
   "workbench.tree.indent": 2,
   "vim.useSystemClipboard": ["yank"]
 }

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -392,6 +392,7 @@ module View = {
         ~theme,
         ~dispatch,
         ~workingDirectory: string,
+        ~modeIndicator: string,
         (),
       ) => {
     let activeNotifications = Feature_Notification.active(notifications);
@@ -557,7 +558,27 @@ module View = {
       |> Option.map(register => <macro register />)
       |> Option.value(~default=React.empty);
 
+    let modeIndicatorStart =
+      switch (modeIndicator) {
+      | "left" =>
+        <section align=`FlexStart>
+          <ModeIndicator font theme mode subMode />
+        </section>
+      | _ => React.empty
+      };
+
+    let modeIndicatorEnd =
+      switch (modeIndicator) {
+      | "left"
+      | "none" => React.empty
+      | _ =>
+        <section align=`FlexEnd>
+          <ModeIndicator font theme mode subMode />
+        </section>
+      };
+
     <View ?key style={Styles.view(background, yOffset)}>
+      modeIndicatorStart
       <section align=`FlexStart>
         <notificationCount
           dispatch
@@ -585,9 +606,7 @@ module View = {
         </section>
         <notificationPopups />
       </sectionGroup>
-      <section align=`FlexEnd>
-        <ModeIndicator font theme mode subMode />
-      </section>
+      modeIndicatorEnd
     </View>;
   };
 };
@@ -595,8 +614,10 @@ module View = {
 module Configuration = {
   open Config.Schema;
   let visible = setting("workbench.statusBar.visible", bool, ~default=true);
+  let modeIndicator =
+    setting("workbench.statusBar.modeIndicator", string, ~default="rigth");
 };
 
 module Contributions = {
-  let configuration = Configuration.[visible.spec];
+  let configuration = Configuration.[visible.spec, modeIndicator.spec];
 };

--- a/src/Feature/StatusBar/Feature_StatusBar.rei
+++ b/src/Feature/StatusBar/Feature_StatusBar.rei
@@ -61,6 +61,7 @@ module View: {
       ~theme: ColorTheme.Colors.t,
       ~dispatch: msg => unit,
       ~workingDirectory: string,
+      ~modeIndicator: string,
       unit
     ) =>
     Revery.UI.element;
@@ -68,7 +69,10 @@ module View: {
 
 // CONFIGURATION
 
-module Configuration: {let visible: Config.Schema.setting(bool);};
+module Configuration: {
+  let visible: Config.Schema.setting(bool);
+  let modeIndicator: Config.Schema.setting(string);
+};
 
 // CONTRIBUTIONS
 

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -107,6 +107,9 @@ let make = (~dispatch, ~state: State.t, ()) => {
           workingDirectory={Feature_Workspace.workingDirectory(
             state.workspace,
           )}
+          modeIndicator={
+            Feature_StatusBar.Configuration.modeIndicator.get(config)
+          }
         />
       </View>;
     } else {


### PR DESCRIPTION
```changelog    
Adds a way to configure the mode indicator position in the status bar.
Also added an entry in the docs for this configuration.

<breaking>configurealbe mode indicator position in the status bar</breaking>
```