### PR TITLE
fix(extensions/#3388): Local history extension doesn't install

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -41,6 +41,7 @@
 - #3379 - Rename: Handle parsing 'rejectReason'
 - #3382 - Input: Handle `<capslock>` key
 - #3389 - Editor: Render diagnostics with squiggly lines (fixes #2827)
+- #3394 - Extensions: Fix error parsing extension manifest with boolean when express (related #3388)
 
 ### Performance
 

--- a/src/Exthost/Extension/Contributions.re
+++ b/src/Exthost/Extension/Contributions.re
@@ -36,7 +36,18 @@ module Command = {
             field.withDefault(
               "when",
               WhenExpr.Value(True),
-              string |> map(WhenExpr.parse),
+              one_of([
+                ("when.string", string |> map(WhenExpr.parse)),
+                (
+                  "when.bool",
+                  bool
+                  |> map(
+                       fun
+                       | true => WhenExpr.Value(True)
+                       | false => WhenExpr.Value(False),
+                     ),
+                ),
+              ]),
             ),
         }
       )


### PR DESCRIPTION
__Issue:__ The local history extension fails to install with the error "Unable to locate extension"

__Defect:__ There is a failure parsing the extension manifest,  with these command json expressions:
```
            {
                "command": "treeLocalHistory.refresh",
                "title": "Refresh",
                "when": false,
                "icon": "$(refresh)"
            },
```

Our `"when"` expression parser only handles strings, not booleans.

__Fix:__ Extend our parser to handle booleans as well.