### PR TITLE
fix(snippet): Crash on replace-selection

### DIFF
--- a/src/editor-core-types/ByteIndex.re
+++ b/src/editor-core-types/ByteIndex.re
@@ -30,4 +30,7 @@ let%test_module "next" =
      let%test "utf-8" = {
        next("κόσμε", zero) |> toInt == 2;
      };
+     let%test "past length" = {
+       next("abc", 99) |> toInt == 3;
+     };
    });

--- a/src/editor-core-types/ByteIndex.re
+++ b/src/editor-core-types/ByteIndex.re
@@ -12,7 +12,14 @@ let (>) = (a, b) => a > b;
 let (<=) = (a, b) => a <= b;
 let (>=) = (a, b) => a >= b;
 
-let next = (str, idx) => Zed_utf8.next(str, idx);
+let next = (str, idx) => {
+  let len = String.length(str);
+  if (idx >= len) {
+    len;
+  } else {
+    Zed_utf8.next(str, idx);
+  };
+};
 
 let%test_module "next" =
   (module


### PR DESCRIPTION
__Issue:__ Experimenting with the snippet replace-selection feature:

![image](https://user-images.githubusercontent.com/13532591/114247018-fa3e1600-9948-11eb-8da2-c6cc666cb2dd.png)

I hit a crash - there was a specific case where the snippet could try and extract past the length of the current line, causing an exception in `Zed_utf8.next`

__Fix:__ Clamp `ByteIndex.next` to length of string