### PR TITLE
fix(code-action): Fix a couple bugs around lightbulb+quickfixes

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -43,6 +43,7 @@
 - #3389 - Editor: Render diagnostics with squiggly lines (fixes #2827)
 - #3394 - Extensions: Fix error parsing extension manifest with boolean when express (related #3388)
 - #3390 - Diagnostics: Some diagnostics wouldn't show in hover UI (related #3231)
+- #3396 - Code Actions: Fix some issues around light bulb rendering
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/CodeActions.re
+++ b/src/Feature/LanguageSupport/CodeActions.re
@@ -38,8 +38,6 @@ module QuickFixes = {
   };
 
   let addQuickFixes = (~handle, ~bufferId, ~position, ~newActions, quickFixes) => {
-    newActions |> List.iter(qf => prerr_endline(Exthost.CodeAction.show(qf)));
-
     let actions = newActions |> List.map(CodeAction.ofExthost(~handle));
     // If at the same location, just append!
     let fixes =

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -962,6 +962,7 @@ let sub =
       ~isInsertMode,
       ~isAnimatingScroll,
       ~activeBuffer,
+      ~activeEditor,
       ~activePosition,
       ~lineHeightInPixels,
       ~positionToRelativePixel,
@@ -997,6 +998,7 @@ let sub =
     CodeActions.sub(
       ~buffer=activeBuffer,
       ~activePosition,
+      ~activeEditor,
       ~topVisibleBufferLine,
       ~bottomVisibleBufferLine,
       ~lineHeightInPixels,
@@ -1079,6 +1081,7 @@ module View = {
         (
           ~x as _,
           ~y as _,
+          ~editorId,
           ~theme,
           ~model,
           ~editorFont,
@@ -1086,7 +1089,7 @@ module View = {
           ~dispatch as _,
           (),
         ) => {
-      <CodeActions.View editorFont theme model={model.codeActions} />;
+      <CodeActions.View editorId editorFont theme model={model.codeActions} />;
     };
   };
 };

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -170,6 +170,7 @@ let sub:
     ~isInsertMode: bool,
     ~isAnimatingScroll: bool,
     ~activeBuffer: Oni_Core.Buffer.t,
+    ~activeEditor: int,
     ~activePosition: CharacterPosition.t,
     ~lineHeightInPixels: float,
     ~positionToRelativePixel: CharacterPosition.t => PixelPosition.t,
@@ -250,6 +251,7 @@ module View: {
       (
         ~x: int,
         ~y: int,
+        ~editorId: int,
         ~theme: ColorTheme.Colors.t,
         ~model: model,
         ~editorFont: Service_Font.font,

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -370,6 +370,7 @@ let start =
              ~isInsertMode=isInsertOrSelectMode,
              ~isAnimatingScroll,
              ~activeBuffer,
+             ~activeEditor=activeEditorId,
              ~activePosition,
              ~lineHeightInPixels,
              ~positionToRelativePixel,

--- a/src/UI/EditorView.re
+++ b/src/UI/EditorView.re
@@ -132,6 +132,7 @@ module Parts = {
             <Feature_LanguageSupport.View.EditorWidgets
               x=cursorPixelX
               y=cursorPixelY
+              editorId={Feature_Editor.Editor.getId(editor)}
               theme
               uiFont
               editorFont


### PR DESCRIPTION
Fix a couple of bugs with the lightbulb showing up when 'quick fixes' are available:

1) The light bulb would be rendered across all open editors. Scope to just the active editor.
2) The light bulb would only show up if the fix had associated diagnostics, which some providers don't give. Scope to the current position, in that case.