### PR TITLE
fix(code-action): Add editor.lightBulb.enabled configuration setting

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -43,6 +43,7 @@
 - #3389 - Editor: Render diagnostics with squiggly lines (fixes #2827)
 - #3394 - Extensions: Fix error parsing extension manifest with boolean when express (related #3388)
 - #3390 - Diagnostics: Some diagnostics wouldn't show in hover UI (related #3231)
+- #3403 - Code Actions: Add 'editor.lightBulb.enabled' configuration setting
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -51,6 +51,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `workbench.editor.enablePreview` __(_bool_ default: `true`)__ - When `true`, Onivim will open files in _preview mode_ unless a change is made or the tab is double-clicked. In _preview mode_, the editor tab will be re-used.
 
+- `editor.lightBulb.enabled` __(_bool_ default: `true`)__ - When `true`, show a lightbulb icon in the editor if there are quick fixes or refactorings available.
+
 - `editor.lineHeight` __(_float_ default: `0.`)__ - Controls the absolute height of lines on the editor surface. Use 0 to compute lineHeight from the font size.
 
 - `editor.lineNumbers` __(_"on"|"off"|"relative"_ default: `"on"`)__ - Controls how line numbers are rendered on the editor surface

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -741,7 +741,8 @@ module Contributions = {
     );
 
   let configuration =
-    CodeLens.Contributions.configuration
+    CodeActions.Contributions.configuration
+    @ CodeLens.Contributions.configuration
     @ Completion.Contributions.configuration
     @ DocumentHighlights.Contributions.configuration
     @ Formatting.Contributions.configuration
@@ -997,6 +998,7 @@ let sub =
   let codeActionsSub =
     CodeActions.sub(
       ~buffer=activeBuffer,
+      ~config,
       ~activePosition,
       ~topVisibleBufferLine,
       ~bottomVisibleBufferLine,


### PR DESCRIPTION
This adds an `editor.lightBulb.enabled` setting to the editor - which toggles a 'lightbulb` icon on/off to show if there are available quick-fixes or refactorings:

![image](https://user-images.githubusercontent.com/13532591/114416930-02bf6800-9b66-11eb-8017-9b9a72183563.png)


