### PR TITLE
fix(editor/#3405): Fix inadvertent scroll when typing in wrapped buffer

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1225,7 +1225,13 @@ let exposePrimaryCursor = (~disableAnimation=false, editor) =>
           editor,
         );
 
-      let scrollOffX = getCharacterWidth(editor) *. 2.;
+      // #3405 - When we're wrapping, don't consider horizontal scroll-off, otherwise
+      // the editor will seem to have less available width than it does in actuality,
+      // which could cause the editor to scroll even without wrapping.
+      let scrollOffX =
+        editor.wrapMode == WrapMode.Viewport
+          ? 0. : getCharacterWidth(editor) *. 2.;
+
       let scrollOffY =
         lineHeightInPixels(editor)
         *. float(max(editor.verticalScrollMargin, 0));

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -244,6 +244,8 @@ describe("Editor", ({describe, _}) => {
         BytePosition.{line: LineNumber.zero, byte: ByteIndex.ofInt(b)};
       };
 
+      // Simulate 'typing' in insert mode across the word wrap boundary -
+      // the same case that occurred in #3405
       let editor' =
         editor
         |> Editor.setMode(Vim.Mode.Insert({cursors: [position(0)]}))

--- a/test/Feature/Editor/EditorTests.re
+++ b/test/Feature/Editor/EditorTests.re
@@ -234,6 +234,27 @@ describe("Editor", ({describe, _}) => {
     });
   });
 
+  describe("setMode", ({test, _}) => {
+    test(
+      "#3405: Moving cursor in insert mode to edge shouldn't cause scroll",
+      ({expect, _}) => {
+      let editor = createThreeWideWithWrapping([|"aaaaaa"|]);
+
+      let position = b => {
+        BytePosition.{line: LineNumber.zero, byte: ByteIndex.ofInt(b)};
+      };
+
+      let editor' =
+        editor
+        |> Editor.setMode(Vim.Mode.Insert({cursors: [position(0)]}))
+        |> Editor.setMode(Vim.Mode.Insert({cursors: [position(1)]}))
+        |> Editor.setMode(Vim.Mode.Insert({cursors: [position(2)]}))
+        |> Editor.setMode(Vim.Mode.Insert({cursors: [position(3)]}));
+
+      expect.float(Editor.scrollX(editor')).toBeCloseTo(0.0);
+    })
+  });
+
   describe("bufferLineByteToPixel", ({test, _}) => {
     test("first line, byte should be at position (nowrap)", ({expect, _}) => {
       let (editor, _buffer) = create([|"aaaaaa"|]);


### PR DESCRIPTION
__Issue:__ When word-wrap is enabled (the default), and you type across a word-wrap boundary in insert mode, there could be an inadvertent and unnecessary scroll.

__Defect:__ There is logic in the editor to ensure the cursor is in view, within a `scrollOffX` value (default of 2 characters on the border). However, this doesn't make sense when word-wrapping is on.

__Fix:__ Treat `scrollOffX` as having a value of zero when word wrap is active.

Fixes #3405 

