### PR TITLE
fix(docs/#3407): Missing link on vim tips page

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -57,6 +57,7 @@
 
 - #3293 - Formatting: Initial formatting documentation
 - #3296 - Emmet: Add documentation on using Emmet for tsx/jsx files (fixes #3283)
+- #3411 - Vim Tips: Fix missing links (fixes #3407)
 
 ### Refactoring
 

--- a/docs/docs/getting-started/vim-tips.md
+++ b/docs/docs/getting-started/vim-tips.md
@@ -39,11 +39,3 @@ There's currently no support for creating native keybindings for Vim motions.
 For now, please use VimL keybindings with the
 [`"experimental.viml"`](https://onivim.github.io/docs/configuration/settings#experimental)
 setting.
-
-<!--
-
-### How to format on save?
-
-By running the format comamnd with `autocmd`. Help, vim people?
-
--->


### PR DESCRIPTION
Fixes #3407 

We have a separate documentation on formatOnSave here: https://onivim.github.io/docs/using-onivim/formatting#format-on-save