### PR TITLE
fix(editor/#3372): Fix word-wrap calculation with tabs

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -47,6 +47,7 @@
 - #3403 - Code Actions: Add 'editor.lightBulb.enabled' configuration setting
 - #3396 - Code Actions: Fix some issues around light bulb rendering
 - #3404 - UX - Explorer: Fix text overflow in explorer (fixes #3362)
+- #3416 - Editor: Fix word-wrap calculation with tab characters (fixes #3372)
 
 ### Performance
 

--- a/src/Core/WordWrap.re
+++ b/src/Core/WordWrap.re
@@ -16,10 +16,14 @@ module Internal = {
     let singleWidthCharacter =
       BufferLine.measure(bufferLine, Uchar.of_char('W'));
     let doubleWidthCharacter = singleWidthCharacter *. 2.;
+    let tabChar = Uchar.of_char('\t');
+    let tabSize = BufferLine.measure(bufferLine, tabChar);
     if (simpleMeasurement) {
       uchar =>
         if (Uucp.Break.tty_width_hint(uchar) > 1) {
           doubleWidthCharacter;
+        } else if (Uchar.equal(uchar, tabChar)) {
+          tabSize;
         } else {
           singleWidthCharacter;
         };

--- a/src/Feature/Editor/ScrollShadow.re
+++ b/src/Feature/Editor/ScrollShadow.re
@@ -24,7 +24,8 @@ let renderHorizontal = (~color, ~editor: Editor.t, ~width: float, ~context) => {
     );
   };
 
-  if (scrollX +. width < Editor.getTotalWidthInPixels(editor)) {
+  // Use 'floor' on total width - allow a fractional component, so we don't get a scroll shadow when word wrapped.
+  if (scrollX +. width < floor(Editor.getTotalWidthInPixels(editor))) {
     let () =
       Draw.Shadow.render(
         ~color,

--- a/test/Core/WordWrapTests.re
+++ b/test/Core/WordWrapTests.re
@@ -4,6 +4,15 @@ open TestFramework;
 
 let makeLine = BufferLine.make(~measure=_ => 1.0);
 
+let makeLineWithWideTabs =
+  BufferLine.make(~measure=uchar =>
+    if (Uchar.equal(uchar, Uchar.of_char('\t'))) {
+      2.0;
+    } else {
+      1.0;
+    }
+  );
+
 let characterWidth = {
   let (_, width) =
     makeLine("a")
@@ -27,6 +36,29 @@ describe("WordWrap", ({describe, _}) => {
     })
   });
   describe("fixed", ({test, _}) => {
+    test("#3372 - handle tabs correctly", ({expect, _}) => {
+      let line = "\tabc" |> makeLineWithWideTabs;
+      let wrap = WordWrap.fixed(~pixels=threeCharacterWidth, line);
+      // This should end up with:
+      // [
+      //  "\ta",
+      //  "bc"
+      // ]
+
+      expect.equal(
+        wrap,
+        (
+          [|
+            {byte: ByteIndex.zero, character: CharacterIndex.zero},
+            {
+              byte: ByteIndex.(zero + 2),
+              character: CharacterIndex.(zero + 2),
+            },
+          |],
+          threeCharacterWidth,
+        ),
+      );
+    });
     test("ascii line within wrap point", ({expect, _}) => {
       let line = "abc" |> makeLine;
       let wrap = WordWrap.fixed(~pixels=threeCharacterWidth, line);


### PR DESCRIPTION
__Issue:__ Our word-wrap logic was not correctly accounting for tab widths, and therefore, files with tab indentation could show as overflowing horizontally.

__Defect:__ Tab characters were always considered as single width, regardless of settings.

__Fix:__ Use full width for tab characters in the word wrap calculation

Fixes #3372 