### PR TITLE
fix(vim/#1721): Implement Ctrl-W, Ctrl-Q binding

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -50,6 +50,7 @@
 - #3414 - Code Actions: Fix regression in control-p binding
 - #3416 - Editor: Fix word-wrap calculation with tab characters (fixes #3372)
 - #2329 - UX - Completion: Fix overflowing detail text (fixes #2264)
+- #3420 - Vim: Implement C-W, C-Q binding (related #1721)
 
 ### Performance
 

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -182,6 +182,28 @@ let update = (~focus, model, msg) => {
     | None => (model, RemoveLastWasBlocked)
     }
 
+  | Command(CloseActiveGroup) =>
+    let curLayout = model |> activeLayout;
+    let activeGroupId = curLayout.activeGroupId;
+
+    let rec loop = (newModel: model) => {
+      let newLayout = newModel |> activeLayout;
+      if (newLayout.activeGroupId != activeGroupId) {
+        Some(newModel);
+      } else {
+        switch (removeActiveEditor(newModel)) {
+        | Some(model) => loop(model)
+        | None => None
+        };
+      };
+    };
+
+    let model' = loop(model);
+    switch (model') {
+    | Some(model) => (model, Nothing)
+    | None => (model, RemoveLastWasBlocked)
+    };
+
   | Command(MoveLeft) =>
     switch (focus) {
     | Some(Center) =>
@@ -627,6 +649,14 @@ module Commands = {
       Command(CloseActiveEditor),
     );
 
+  let closeActiveSplit =
+    define(
+      ~category="View",
+      ~title="Close Split",
+      "view.closeSplit",
+      Command(CloseActiveGroup),
+    );
+
   let rotateForward =
     define(
       ~category="View",
@@ -862,6 +892,7 @@ module Contributions = {
       splitVertical,
       splitHorizontal,
       closeActiveEditor,
+      closeActiveSplit,
       rotateForward,
       rotateBackward,
       moveLeft,

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -120,6 +120,7 @@ module Commands: {
   let splitHorizontal: Command.t(msg);
 
   let closeActiveEditor: Command.t(msg);
+  let closeActiveSplit: Command.t(msg);
 
   let moveLeft: Command.t(msg);
   let moveRight: Command.t(msg);

--- a/src/Feature/Layout/Msg.re
+++ b/src/Feature/Layout/Msg.re
@@ -5,6 +5,7 @@ type command =
   | SplitVertical
   | SplitHorizontal
   | CloseActiveEditor
+  | CloseActiveGroup
   | MoveLeft
   | MoveRight
   | MoveUp

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -387,6 +387,16 @@ let defaultKeyBindings =
         ~command=Feature_Layout.Commands.toggleMaximize.id,
         ~condition=windowCommandCondition,
       ),
+      bind(
+        ~key="<C-W><C-Q>",
+        ~command=Feature_Layout.Commands.closeActiveSplit.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W>q",
+        ~command=Feature_Layout.Commands.closeActiveSplit.id,
+        ~condition=windowCommandCondition,
+      ),
     ]
   @ Component_VimWindows.Contributions.keybindings
   @ Component_VimList.Contributions.keybindings


### PR DESCRIPTION
WIP fix to implement Ctrl-W, Ctrl-Q (close active split) binding

Related #1721