### PR TITLE
fix(lifecycle/#417): Add warning when closing last file, if there are unsaved buffers

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -50,6 +50,7 @@
 - #3414 - Code Actions: Fix regression in control-p binding
 - #3416 - Editor: Fix word-wrap calculation with tab characters (fixes #3372)
 - #2329 - UX - Completion: Fix overflowing detail text (fixes #2264)
+- #3421 - Lifecycle: Show unsaved dialog when closing last editor via mouse (fixes #417)
 
 ### Performance
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1734,7 +1734,16 @@ let update =
         Effect.none,
       )
 
-    | RemoveLastWasBlocked => (state, Internal.quitEffect)
+    | RemoveLastWasBlocked =>
+      // #417: If there are any unsaved files... show a warning and give the user a chance to save.
+      if (Feature_Buffers.anyModified(state.buffers)) {
+        (
+          {...state, modal: Some(Feature_Modals.unsavedBuffersWarning)},
+          Isolinear.Effect.none,
+        );
+      } else {
+        (state, Internal.quitEffect);
+      }
 
     | Nothing => (state, Effect.none)
     };


### PR DESCRIPTION
__Issue:__ When clicking the 'close' icon to close an editor window, closing the last editor will always close Onivim, even if there are unsaved buffer changes.

__Fix:__ If there are unsaved changes, show a modal to give the user a chance to save before quitting.

Fixes #417, needed for #3420