### PR TITLE
fix(input/#2778): Terminal-to-normal keybinding not working as expected

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -50,6 +50,7 @@
 - #3414 - Code Actions: Fix regression in control-p binding
 - #3416 - Editor: Fix word-wrap calculation with tab characters (fixes #3372)
 - #2329 - UX - Completion: Fix overflowing detail text (fixes #2264)
+- #3422 - Input: Fix terminal key binding not working as expected (fixes #2778)
 
 ### Performance
 

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -146,8 +146,13 @@ let reveryKeyToKeyPress =
   ignore(repeat);
   let name = Sdl2.Scancode.ofInt(scancode) |> Sdl2.Scancode.getName;
 
-  if (name == "Left Shift" || name == "Right Shift") {
-    None;
+  // Filter out some modifier keys. Otherwise, these keys will be treated as actual key presses,
+  // and can break mapping sequences.
+  if (name == "Left Shift"
+      || name == "Right Shift"
+      || name == "Left Ctrl"
+      || name == "Right Ctrl") {
+    {};
   } else {
     let shift = Revery.Key.Keymod.isShiftDown(keymod);
     let control = Revery.Key.Keymod.isControlDown(keymod);

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -152,7 +152,7 @@ let reveryKeyToKeyPress =
       || name == "Right Shift"
       || name == "Left Ctrl"
       || name == "Right Ctrl") {
-    {};
+    None;
   } else {
     let shift = Revery.Key.Keymod.isShiftDown(keymod);
     let control = Revery.Key.Keymod.isControlDown(keymod);


### PR DESCRIPTION
__Issue:__ The 'control' key is itself being treated as a key-press, which can break key sequences.

For example, in this sequence of key-presses (where control is held across the duration of the key sequence):
- Control DOWN
- W DOWN
- W UP
- N DOWN
- N UP
- Control UP

The terminal-to-normal mode behaves as expected.

However, in this sequence:
- Control DOWN
- W DOWN
- W UP
- Control UP
- Control DOWN
- N DOWN
- N UP
- Control UP

This sequence of key presses does not work as expected, because the second 'Control' down is treated as an individual key press - so the `Control+\`, `Control+N` key sequence doesn't actually trigger it, as the system is seeing: `Control+\`, `Control`, `Control+N`.

__Fix:__ For the purpose of key bindings, don't treat `Control` as an individual key press - just as a modifier.

Fixes #2778 