### PR TITLE
chore(ci): Remove libtools dependency

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -77,3 +77,4 @@
 - #3319 - Dependency: esy-macdylibbundler -> 0.4.5001 to support Big Sur (thanks @brdoney !)
 - #3313 - Packaging: Fix macOS Big Sur release bundling issues (fixes #2813, thanks @brdoney !)
 - #3369 - CI: Install python3 on CentOS dockerfile
+- #3429 - CI: Remove libtools dependency

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "17d60f47dc8c7b212d531ec7a0597c70",
+  "checksum": "31adc0598e8b03a98869b54dca59cd95",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -74,22 +74,6 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9": {
-      "id":
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-      "name": "texinfo",
-      "version":
-        "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
     "shelljs@0.8.4@d41d8cd9": {
       "id": "shelljs@0.8.4@d41d8cd9",
       "name": "shelljs",
@@ -121,7 +105,7 @@
         "revery@github:revery-ui/revery#373b087@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
-        "@revery/esy-libvterm@1.0.3@d41d8cd9",
+        "@revery/esy-libvterm@1.0.4@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -740,22 +724,6 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9": {
-      "id": "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9",
-      "name": "esy-libtools",
-      "version": "github:revery-ui/esy-libtools#c9eb685",
-      "source": {
-        "type": "install",
-        "source": [ "github:revery-ui/esy-libtools#c9eb685" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
         "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
@@ -771,22 +739,6 @@
         "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
-      "devDependencies": []
-    },
-    "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9": {
-      "id":
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9",
-      "name": "esy-help2man",
-      "version":
-        "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
       "devDependencies": []
     },
     "esy-fzy@github:bryphe/esy-fzy#301dbf6@d41d8cd9": {
@@ -929,42 +881,6 @@
       "dependencies": [ "follow-redirects@1.5.10@d41d8cd9" ],
       "devDependencies": []
     },
-    "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9": {
-      "id":
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-      "name": "automake",
-      "version":
-        "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9": {
-      "id":
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9",
-      "name": "autoconf",
-      "version":
-        "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "Oni2@link-dev:./package.json": {
       "id": "Oni2@link-dev:./package.json",
       "name": "Oni2",
@@ -993,9 +909,9 @@
         "@revery/timber@2.0.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/semver2@opam:1.1.0@ec4fbaf4",
+        "@opam/semver2@opam:1.2.0@ced7107e",
         "@opam/reason@opam:3.7.0@191be014", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
         "@opam/ppx_let@opam:v0.14.0@eb9b93e0",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
@@ -1044,20 +960,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-libvterm@1.0.3@d41d8cd9": {
-      "id": "@revery/esy-libvterm@1.0.3@d41d8cd9",
+    "@revery/esy-libvterm@1.0.4@d41d8cd9": {
+      "id": "@revery/esy-libvterm@1.0.4@d41d8cd9",
       "name": "@revery/esy-libvterm",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.3.tgz#sha1:85c1fec989379124c7f1fb0eb015ceeea2659bbe"
+          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.4.tgz#sha1:10af4b9124bf55bb56f19a3fc0075f5f12ce516f"
         ]
       },
       "overrides": [],
-      "dependencies": [
-        "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9"
-      ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8002@d41d8cd9": {
@@ -1489,20 +1403,20 @@
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     },
-    "@opam/semver2@opam:1.1.0@ec4fbaf4": {
-      "id": "@opam/semver2@opam:1.1.0@ec4fbaf4",
+    "@opam/semver2@opam:1.2.0@ced7107e": {
+      "id": "@opam/semver2@opam:1.2.0@ced7107e",
       "name": "@opam/semver2",
-      "version": "opam:1.1.0",
+      "version": "opam:1.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/30/3054c5c107ae2b87246113debbf999fc#md5:3054c5c107ae2b87246113debbf999fc",
-          "archive:https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz#md5:3054c5c107ae2b87246113debbf999fc"
+          "archive:https://opam.ocaml.org/cache/md5/65/657c5113dc0b41f11e659fb24e5cf0f9#md5:657c5113dc0b41f11e659fb24e5cf0f9",
+          "archive:https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz#md5:657c5113dc0b41f11e659fb24e5cf0f9"
         ],
         "opam": {
           "name": "semver2",
-          "version": "1.1.0",
-          "path": "bench.esy.lock/opam/semver2.1.1.0"
+          "version": "1.2.0",
+          "path": "bench.esy.lock/opam/semver2.1.2.0"
         }
       },
       "overrides": [],
@@ -1712,8 +1626,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.15.0@071fae58": {
-      "id": "@opam/ppxlib@opam:0.15.0@071fae58",
+    "@opam/ppxlib@opam:0.15.0@04a04df2": {
+      "id": "@opam/ppxlib@opam:0.15.0@04a04df2",
       "name": "@opam/ppxlib",
       "version": "opam:0.15.0",
       "source": {
@@ -1821,13 +1735,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1850,13 +1764,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1878,12 +1792,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1905,13 +1819,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
@@ -1935,13 +1849,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1963,12 +1877,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1990,14 +1904,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
@@ -2021,12 +1935,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2051,7 +1965,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2059,7 +1973,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2083,7 +1997,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2092,7 +2006,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2142,12 +2056,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2169,12 +2083,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2196,7 +2110,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2206,7 +2120,7 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2234,7 +2148,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -2243,7 +2157,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -3954,7 +3868,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.7.0@191be014",
-        "@opam/ppxlib@opam:0.15.0@071fae58", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/ppxlib@opam:0.15.0@04a04df2", "@opam/dune@opam:2.5.0@e0bac278"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     }

--- a/bench.esy.lock/opam/ppxlib.0.15.0/opam
+++ b/bench.esy.lock/opam/ppxlib.0.15.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
-  "sexplib0"
+  "sexplib0"                {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind"               {with-test}
   "cinaps"                  {with-test & >= "v0.12.1"}

--- a/bench.esy.lock/opam/semver2.1.2.0/opam
+++ b/bench.esy.lock/opam/semver2.1.2.0/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
-maintainer: "info@dividat.com"
-authors: ["Dividat AG"]
 synopsis: "Semantic version handling for OCaml"
+maintainer: "info@dividat.com"
+authors: "Dividat AG"
 license: "MIT"
 homepage: "https://github.com/dividat/ocaml-semver"
 bug-reports: "https://github.com/dividat/ocaml-semver/issues"
+dev-repo: "git+https://github.com/dividat/ocaml-semver.git"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
@@ -14,14 +15,15 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
-  src: "https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz"
+  src:
+    "https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz"
   checksum: [
-    "md5=3054c5c107ae2b87246113debbf999fc"
-    "sha512=02527d9591acb722529e54bc41832fef390f10964304074ac96b2dc09b77d84296d7363477921b721a16be66e3d79b12b6388f2637c2360d5e79d6260f24d722"
+    "md5=657c5113dc0b41f11e659fb24e5cf0f9"
+    "sha512=c8f45011fc49dea4be5ed30f0a1391a1fa8b862e3f6f06b6f82d5baefbbb6c9aee632fd5bb1ed0a77b764bb59bd704f559bdf713e195976c39034431b2099b8f"
   ]
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "17d60f47dc8c7b212d531ec7a0597c70",
+  "checksum": "31adc0598e8b03a98869b54dca59cd95",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -74,22 +74,6 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9": {
-      "id":
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-      "name": "texinfo",
-      "version":
-        "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
     "shelljs@0.8.4@d41d8cd9": {
       "id": "shelljs@0.8.4@d41d8cd9",
       "name": "shelljs",
@@ -121,7 +105,7 @@
         "revery@github:revery-ui/revery#373b087@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
-        "@revery/esy-libvterm@1.0.3@d41d8cd9",
+        "@revery/esy-libvterm@1.0.4@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -740,22 +724,6 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9": {
-      "id": "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9",
-      "name": "esy-libtools",
-      "version": "github:revery-ui/esy-libtools#c9eb685",
-      "source": {
-        "type": "install",
-        "source": [ "github:revery-ui/esy-libtools#c9eb685" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
         "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
@@ -771,22 +739,6 @@
         "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
-      "devDependencies": []
-    },
-    "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9": {
-      "id":
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9",
-      "name": "esy-help2man",
-      "version":
-        "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
       "devDependencies": []
     },
     "esy-fzy@github:bryphe/esy-fzy#301dbf6@d41d8cd9": {
@@ -929,42 +881,6 @@
       "dependencies": [ "follow-redirects@1.5.10@d41d8cd9" ],
       "devDependencies": []
     },
-    "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9": {
-      "id":
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-      "name": "automake",
-      "version":
-        "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9": {
-      "id":
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9",
-      "name": "autoconf",
-      "version":
-        "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "Oni2@link-dev:./package.json": {
       "id": "Oni2@link-dev:./package.json",
       "name": "Oni2",
@@ -992,9 +908,9 @@
         "@revery/timber@2.0.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/semver2@opam:1.1.0@ec4fbaf4",
+        "@opam/semver2@opam:1.2.0@ced7107e",
         "@opam/reason@opam:3.7.0@191be014", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
         "@opam/ppx_let@opam:v0.14.0@eb9b93e0",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
@@ -1043,20 +959,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-libvterm@1.0.3@d41d8cd9": {
-      "id": "@revery/esy-libvterm@1.0.3@d41d8cd9",
+    "@revery/esy-libvterm@1.0.4@d41d8cd9": {
+      "id": "@revery/esy-libvterm@1.0.4@d41d8cd9",
       "name": "@revery/esy-libvterm",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.3.tgz#sha1:85c1fec989379124c7f1fb0eb015ceeea2659bbe"
+          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.4.tgz#sha1:10af4b9124bf55bb56f19a3fc0075f5f12ce516f"
         ]
       },
       "overrides": [],
-      "dependencies": [
-        "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9"
-      ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8002@d41d8cd9": {
@@ -1488,20 +1402,20 @@
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     },
-    "@opam/semver2@opam:1.1.0@ec4fbaf4": {
-      "id": "@opam/semver2@opam:1.1.0@ec4fbaf4",
+    "@opam/semver2@opam:1.2.0@ced7107e": {
+      "id": "@opam/semver2@opam:1.2.0@ced7107e",
       "name": "@opam/semver2",
-      "version": "opam:1.1.0",
+      "version": "opam:1.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/30/3054c5c107ae2b87246113debbf999fc#md5:3054c5c107ae2b87246113debbf999fc",
-          "archive:https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz#md5:3054c5c107ae2b87246113debbf999fc"
+          "archive:https://opam.ocaml.org/cache/md5/65/657c5113dc0b41f11e659fb24e5cf0f9#md5:657c5113dc0b41f11e659fb24e5cf0f9",
+          "archive:https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz#md5:657c5113dc0b41f11e659fb24e5cf0f9"
         ],
         "opam": {
           "name": "semver2",
-          "version": "1.1.0",
-          "path": "esy.lock/opam/semver2.1.1.0"
+          "version": "1.2.0",
+          "path": "esy.lock/opam/semver2.1.2.0"
         }
       },
       "overrides": [],
@@ -1711,8 +1625,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.15.0@071fae58": {
-      "id": "@opam/ppxlib@opam:0.15.0@071fae58",
+    "@opam/ppxlib@opam:0.15.0@04a04df2": {
+      "id": "@opam/ppxlib@opam:0.15.0@04a04df2",
       "name": "@opam/ppxlib",
       "version": "opam:0.15.0",
       "source": {
@@ -1820,13 +1734,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1849,13 +1763,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1877,12 +1791,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1904,13 +1818,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
@@ -1934,13 +1848,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1962,12 +1876,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1989,14 +1903,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
@@ -2020,12 +1934,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2050,7 +1964,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2058,7 +1972,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2082,7 +1996,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2091,7 +2005,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2141,12 +2055,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2168,12 +2082,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2195,7 +2109,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2205,7 +2119,7 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2233,7 +2147,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -2242,7 +2156,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -3953,7 +3867,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.7.0@191be014",
-        "@opam/ppxlib@opam:0.15.0@071fae58", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/ppxlib@opam:0.15.0@04a04df2", "@opam/dune@opam:2.5.0@e0bac278"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     }

--- a/esy.lock/opam/ppxlib.0.15.0/opam
+++ b/esy.lock/opam/ppxlib.0.15.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
-  "sexplib0"
+  "sexplib0"                {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind"               {with-test}
   "cinaps"                  {with-test & >= "v0.12.1"}

--- a/esy.lock/opam/semver2.1.2.0/opam
+++ b/esy.lock/opam/semver2.1.2.0/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
-maintainer: "info@dividat.com"
-authors: ["Dividat AG"]
 synopsis: "Semantic version handling for OCaml"
+maintainer: "info@dividat.com"
+authors: "Dividat AG"
 license: "MIT"
 homepage: "https://github.com/dividat/ocaml-semver"
 bug-reports: "https://github.com/dividat/ocaml-semver/issues"
+dev-repo: "git+https://github.com/dividat/ocaml-semver.git"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
@@ -14,14 +15,15 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
-  src: "https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz"
+  src:
+    "https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz"
   checksum: [
-    "md5=3054c5c107ae2b87246113debbf999fc"
-    "sha512=02527d9591acb722529e54bc41832fef390f10964304074ac96b2dc09b77d84296d7363477921b721a16be66e3d79b12b6388f2637c2360d5e79d6260f24d722"
+    "md5=657c5113dc0b41f11e659fb24e5cf0f9"
+    "sha512=c8f45011fc49dea4be5ed30f0a1391a1fa8b862e3f6f06b6f82d5baefbbb6c9aee632fd5bb1ed0a77b764bb59bd704f559bdf713e195976c39034431b2099b8f"
   ]
 }

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "17d60f47dc8c7b212d531ec7a0597c70",
+  "checksum": "31adc0598e8b03a98869b54dca59cd95",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -74,22 +74,6 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9": {
-      "id":
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-      "name": "texinfo",
-      "version":
-        "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
     "shelljs@0.8.4@d41d8cd9": {
       "id": "shelljs@0.8.4@d41d8cd9",
       "name": "shelljs",
@@ -121,7 +105,7 @@
         "revery@github:revery-ui/revery#373b087@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
-        "@revery/esy-libvterm@1.0.3@d41d8cd9",
+        "@revery/esy-libvterm@1.0.4@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -740,22 +724,6 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9": {
-      "id": "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9",
-      "name": "esy-libtools",
-      "version": "github:revery-ui/esy-libtools#c9eb685",
-      "source": {
-        "type": "install",
-        "source": [ "github:revery-ui/esy-libtools#c9eb685" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
         "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
@@ -771,22 +739,6 @@
         "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
-      "devDependencies": []
-    },
-    "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9": {
-      "id":
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9",
-      "name": "esy-help2man",
-      "version":
-        "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
       "devDependencies": []
     },
     "esy-fzy@github:bryphe/esy-fzy#301dbf6@d41d8cd9": {
@@ -929,42 +881,6 @@
       "dependencies": [ "follow-redirects@1.5.10@d41d8cd9" ],
       "devDependencies": []
     },
-    "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9": {
-      "id":
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-      "name": "automake",
-      "version":
-        "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9": {
-      "id":
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9",
-      "name": "autoconf",
-      "version":
-        "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "Oni2@link-dev:./package.json": {
       "id": "Oni2@link-dev:./package.json",
       "name": "Oni2",
@@ -992,9 +908,9 @@
         "@revery/timber@2.0.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/semver2@opam:1.1.0@ec4fbaf4",
+        "@opam/semver2@opam:1.2.0@ced7107e",
         "@opam/reason@opam:3.7.0@191be014", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
         "@opam/ppx_let@opam:v0.14.0@eb9b93e0",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
@@ -1043,20 +959,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-libvterm@1.0.3@d41d8cd9": {
-      "id": "@revery/esy-libvterm@1.0.3@d41d8cd9",
+    "@revery/esy-libvterm@1.0.4@d41d8cd9": {
+      "id": "@revery/esy-libvterm@1.0.4@d41d8cd9",
       "name": "@revery/esy-libvterm",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.3.tgz#sha1:85c1fec989379124c7f1fb0eb015ceeea2659bbe"
+          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.4.tgz#sha1:10af4b9124bf55bb56f19a3fc0075f5f12ce516f"
         ]
       },
       "overrides": [],
-      "dependencies": [
-        "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9"
-      ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8002@d41d8cd9": {
@@ -1488,20 +1402,20 @@
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     },
-    "@opam/semver2@opam:1.1.0@ec4fbaf4": {
-      "id": "@opam/semver2@opam:1.1.0@ec4fbaf4",
+    "@opam/semver2@opam:1.2.0@ced7107e": {
+      "id": "@opam/semver2@opam:1.2.0@ced7107e",
       "name": "@opam/semver2",
-      "version": "opam:1.1.0",
+      "version": "opam:1.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/30/3054c5c107ae2b87246113debbf999fc#md5:3054c5c107ae2b87246113debbf999fc",
-          "archive:https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz#md5:3054c5c107ae2b87246113debbf999fc"
+          "archive:https://opam.ocaml.org/cache/md5/65/657c5113dc0b41f11e659fb24e5cf0f9#md5:657c5113dc0b41f11e659fb24e5cf0f9",
+          "archive:https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz#md5:657c5113dc0b41f11e659fb24e5cf0f9"
         ],
         "opam": {
           "name": "semver2",
-          "version": "1.1.0",
-          "path": "integrationtest.esy.lock/opam/semver2.1.1.0"
+          "version": "1.2.0",
+          "path": "integrationtest.esy.lock/opam/semver2.1.2.0"
         }
       },
       "overrides": [],
@@ -1711,8 +1625,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.15.0@071fae58": {
-      "id": "@opam/ppxlib@opam:0.15.0@071fae58",
+    "@opam/ppxlib@opam:0.15.0@04a04df2": {
+      "id": "@opam/ppxlib@opam:0.15.0@04a04df2",
       "name": "@opam/ppxlib",
       "version": "opam:0.15.0",
       "source": {
@@ -1820,13 +1734,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1849,13 +1763,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1877,12 +1791,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1904,13 +1818,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
@@ -1934,13 +1848,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1962,12 +1876,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1989,14 +1903,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
@@ -2020,12 +1934,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2050,7 +1964,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2058,7 +1972,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2082,7 +1996,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2091,7 +2005,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2141,12 +2055,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2168,12 +2082,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2195,7 +2109,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2205,7 +2119,7 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2233,7 +2147,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -2242,7 +2156,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -3954,7 +3868,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.7.0@191be014",
-        "@opam/ppxlib@opam:0.15.0@071fae58", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/ppxlib@opam:0.15.0@04a04df2", "@opam/dune@opam:2.5.0@e0bac278"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     }

--- a/integrationtest.esy.lock/opam/ppxlib.0.15.0/opam
+++ b/integrationtest.esy.lock/opam/ppxlib.0.15.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
-  "sexplib0"
+  "sexplib0"                {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind"               {with-test}
   "cinaps"                  {with-test & >= "v0.12.1"}

--- a/integrationtest.esy.lock/opam/semver2.1.2.0/opam
+++ b/integrationtest.esy.lock/opam/semver2.1.2.0/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
-maintainer: "info@dividat.com"
-authors: ["Dividat AG"]
 synopsis: "Semantic version handling for OCaml"
+maintainer: "info@dividat.com"
+authors: "Dividat AG"
 license: "MIT"
 homepage: "https://github.com/dividat/ocaml-semver"
 bug-reports: "https://github.com/dividat/ocaml-semver/issues"
+dev-repo: "git+https://github.com/dividat/ocaml-semver.git"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
@@ -14,14 +15,15 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
-  src: "https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz"
+  src:
+    "https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz"
   checksum: [
-    "md5=3054c5c107ae2b87246113debbf999fc"
-    "sha512=02527d9591acb722529e54bc41832fef390f10964304074ac96b2dc09b77d84296d7363477921b721a16be66e3d79b12b6388f2637c2360d5e79d6260f24d722"
+    "md5=657c5113dc0b41f11e659fb24e5cf0f9"
+    "sha512=c8f45011fc49dea4be5ed30f0a1391a1fa8b862e3f6f06b6f82d5baefbbb6c9aee632fd5bb1ed0a77b764bb59bd704f559bdf713e195976c39034431b2099b8f"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -423,7 +423,8 @@
     "@opam/dir": "bryphe/reason-native:dir.opam#e16590c",
     "@opam/conf-pkg-config": "1.2",
     "@opam/yojson": "onivim/yojson:yojson.opam#f480aef",
-    "flex": "bryphe/flex#5e19b05"
+    "flex": "bryphe/flex#5e19b05",
+    "@revery/esy-libvterm": "1.0.4"
   },
   "devDependencies": {
     "ocaml": "4.10.0",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "17d60f47dc8c7b212d531ec7a0597c70",
+  "checksum": "31adc0598e8b03a98869b54dca59cd95",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -74,22 +74,6 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9": {
-      "id":
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-      "name": "texinfo",
-      "version":
-        "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
     "shelljs@0.8.4@d41d8cd9": {
       "id": "shelljs@0.8.4@d41d8cd9",
       "name": "shelljs",
@@ -121,7 +105,7 @@
         "revery@github:revery-ui/revery#373b087@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
-        "@revery/esy-libvterm@1.0.3@d41d8cd9",
+        "@revery/esy-libvterm@1.0.4@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -740,22 +724,6 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9": {
-      "id": "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9",
-      "name": "esy-libtools",
-      "version": "github:revery-ui/esy-libtools#c9eb685",
-      "source": {
-        "type": "install",
-        "source": [ "github:revery-ui/esy-libtools#c9eb685" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
         "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
@@ -771,22 +739,6 @@
         "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
-      "devDependencies": []
-    },
-    "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9": {
-      "id":
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9",
-      "name": "esy-help2man",
-      "version":
-        "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
       "devDependencies": []
     },
     "esy-fzy@github:bryphe/esy-fzy#301dbf6@d41d8cd9": {
@@ -929,42 +881,6 @@
       "dependencies": [ "follow-redirects@1.5.10@d41d8cd9" ],
       "devDependencies": []
     },
-    "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9": {
-      "id":
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-      "name": "automake",
-      "version":
-        "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9": {
-      "id":
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9",
-      "name": "autoconf",
-      "version":
-        "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "Oni2@link-dev:./package.json": {
       "id": "Oni2@link-dev:./package.json",
       "name": "Oni2",
@@ -992,9 +908,9 @@
         "@revery/timber@2.0.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/semver2@opam:1.1.0@ec4fbaf4",
+        "@opam/semver2@opam:1.2.0@ced7107e",
         "@opam/reason@opam:3.7.0@191be014", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
         "@opam/ppx_let@opam:v0.14.0@eb9b93e0",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
@@ -1043,20 +959,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-libvterm@1.0.3@d41d8cd9": {
-      "id": "@revery/esy-libvterm@1.0.3@d41d8cd9",
+    "@revery/esy-libvterm@1.0.4@d41d8cd9": {
+      "id": "@revery/esy-libvterm@1.0.4@d41d8cd9",
       "name": "@revery/esy-libvterm",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.3.tgz#sha1:85c1fec989379124c7f1fb0eb015ceeea2659bbe"
+          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.4.tgz#sha1:10af4b9124bf55bb56f19a3fc0075f5f12ce516f"
         ]
       },
       "overrides": [],
-      "dependencies": [
-        "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9"
-      ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8002@d41d8cd9": {
@@ -1488,20 +1402,20 @@
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     },
-    "@opam/semver2@opam:1.1.0@ec4fbaf4": {
-      "id": "@opam/semver2@opam:1.1.0@ec4fbaf4",
+    "@opam/semver2@opam:1.2.0@ced7107e": {
+      "id": "@opam/semver2@opam:1.2.0@ced7107e",
       "name": "@opam/semver2",
-      "version": "opam:1.1.0",
+      "version": "opam:1.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/30/3054c5c107ae2b87246113debbf999fc#md5:3054c5c107ae2b87246113debbf999fc",
-          "archive:https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz#md5:3054c5c107ae2b87246113debbf999fc"
+          "archive:https://opam.ocaml.org/cache/md5/65/657c5113dc0b41f11e659fb24e5cf0f9#md5:657c5113dc0b41f11e659fb24e5cf0f9",
+          "archive:https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz#md5:657c5113dc0b41f11e659fb24e5cf0f9"
         ],
         "opam": {
           "name": "semver2",
-          "version": "1.1.0",
-          "path": "release.esy.lock/opam/semver2.1.1.0"
+          "version": "1.2.0",
+          "path": "release.esy.lock/opam/semver2.1.2.0"
         }
       },
       "overrides": [],
@@ -1711,8 +1625,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.15.0@071fae58": {
-      "id": "@opam/ppxlib@opam:0.15.0@071fae58",
+    "@opam/ppxlib@opam:0.15.0@04a04df2": {
+      "id": "@opam/ppxlib@opam:0.15.0@04a04df2",
       "name": "@opam/ppxlib",
       "version": "opam:0.15.0",
       "source": {
@@ -1820,13 +1734,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1849,13 +1763,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1877,12 +1791,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1904,13 +1818,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
@@ -1934,13 +1848,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1962,12 +1876,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1989,14 +1903,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
@@ -2020,12 +1934,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2050,7 +1964,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2058,7 +1972,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2082,7 +1996,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2091,7 +2005,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2141,12 +2055,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2168,12 +2082,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2195,7 +2109,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2205,7 +2119,7 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2233,7 +2147,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -2242,7 +2156,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -3953,7 +3867,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.7.0@191be014",
-        "@opam/ppxlib@opam:0.15.0@071fae58", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/ppxlib@opam:0.15.0@04a04df2", "@opam/dune@opam:2.5.0@e0bac278"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     }

--- a/release.esy.lock/opam/ppxlib.0.15.0/opam
+++ b/release.esy.lock/opam/ppxlib.0.15.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
-  "sexplib0"
+  "sexplib0"                {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind"               {with-test}
   "cinaps"                  {with-test & >= "v0.12.1"}

--- a/release.esy.lock/opam/semver2.1.2.0/opam
+++ b/release.esy.lock/opam/semver2.1.2.0/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
-maintainer: "info@dividat.com"
-authors: ["Dividat AG"]
 synopsis: "Semantic version handling for OCaml"
+maintainer: "info@dividat.com"
+authors: "Dividat AG"
 license: "MIT"
 homepage: "https://github.com/dividat/ocaml-semver"
 bug-reports: "https://github.com/dividat/ocaml-semver/issues"
+dev-repo: "git+https://github.com/dividat/ocaml-semver.git"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
@@ -14,14 +15,15 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
-  src: "https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz"
+  src:
+    "https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz"
   checksum: [
-    "md5=3054c5c107ae2b87246113debbf999fc"
-    "sha512=02527d9591acb722529e54bc41832fef390f10964304074ac96b2dc09b77d84296d7363477921b721a16be66e3d79b12b6388f2637c2360d5e79d6260f24d722"
+    "md5=657c5113dc0b41f11e659fb24e5cf0f9"
+    "sha512=c8f45011fc49dea4be5ed30f0a1391a1fa8b862e3f6f06b6f82d5baefbbb6c9aee632fd5bb1ed0a77b764bb59bd704f559bdf713e195976c39034431b2099b8f"
   ]
 }

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5ce50cb83877569a4dd2cb715b86aa0b",
+  "checksum": "bc7dab49479adbf04b9c6349a52a8676",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -74,22 +74,6 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9": {
-      "id":
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-      "name": "texinfo",
-      "version":
-        "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
     "shelljs@0.8.4@d41d8cd9": {
       "id": "shelljs@0.8.4@d41d8cd9",
       "name": "shelljs",
@@ -121,7 +105,7 @@
         "revery@github:revery-ui/revery#373b087@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#53fc4eb@d41d8cd9",
         "@revery/timber@2.0.0@d41d8cd9",
-        "@revery/esy-libvterm@1.0.3@d41d8cd9",
+        "@revery/esy-libvterm@1.0.4@d41d8cd9",
         "@onivim/reason-native-crash-utils@1.0.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -740,22 +724,6 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9": {
-      "id": "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9",
-      "name": "esy-libtools",
-      "version": "github:revery-ui/esy-libtools#c9eb685",
-      "source": {
-        "type": "install",
-        "source": [ "github:revery-ui/esy-libtools#c9eb685" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9": {
       "id":
         "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#dbb3dd5@d41d8cd9",
@@ -771,22 +739,6 @@
         "@revery/esy-cmake@0.3.5001@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
-      "devDependencies": []
-    },
-    "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9": {
-      "id":
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9",
-      "name": "esy-help2man",
-      "version":
-        "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
       "devDependencies": []
     },
     "esy-fzy@github:bryphe/esy-fzy#301dbf6@d41d8cd9": {
@@ -929,42 +881,6 @@
       "dependencies": [ "follow-redirects@1.5.10@d41d8cd9" ],
       "devDependencies": []
     },
-    "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9": {
-      "id":
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-      "name": "automake",
-      "version":
-        "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9": {
-      "id":
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9",
-      "name": "autoconf",
-      "version":
-        "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "Oni2@link-dev:./package.json": {
       "id": "Oni2@link-dev:./package.json",
       "name": "Oni2",
@@ -993,9 +909,9 @@
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
-        "@opam/semver2@opam:1.1.0@ec4fbaf4",
+        "@opam/semver2@opam:1.2.0@ced7107e",
         "@opam/reason@opam:3.7.0@191be014", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
         "@opam/ppx_let@opam:v0.14.0@eb9b93e0",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
@@ -1044,20 +960,18 @@
       ],
       "devDependencies": []
     },
-    "@revery/esy-libvterm@1.0.3@d41d8cd9": {
-      "id": "@revery/esy-libvterm@1.0.3@d41d8cd9",
+    "@revery/esy-libvterm@1.0.4@d41d8cd9": {
+      "id": "@revery/esy-libvterm@1.0.4@d41d8cd9",
       "name": "@revery/esy-libvterm",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.3.tgz#sha1:85c1fec989379124c7f1fb0eb015ceeea2659bbe"
+          "archive:https://registry.npmjs.org/@revery/esy-libvterm/-/esy-libvterm-1.0.4.tgz#sha1:10af4b9124bf55bb56f19a3fc0075f5f12ce516f"
         ]
       },
       "overrides": [],
-      "dependencies": [
-        "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9"
-      ],
+      "dependencies": [],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8002@d41d8cd9": {
@@ -1489,20 +1403,20 @@
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     },
-    "@opam/semver2@opam:1.1.0@ec4fbaf4": {
-      "id": "@opam/semver2@opam:1.1.0@ec4fbaf4",
+    "@opam/semver2@opam:1.2.0@ced7107e": {
+      "id": "@opam/semver2@opam:1.2.0@ced7107e",
       "name": "@opam/semver2",
-      "version": "opam:1.1.0",
+      "version": "opam:1.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/30/3054c5c107ae2b87246113debbf999fc#md5:3054c5c107ae2b87246113debbf999fc",
-          "archive:https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz#md5:3054c5c107ae2b87246113debbf999fc"
+          "archive:https://opam.ocaml.org/cache/md5/65/657c5113dc0b41f11e659fb24e5cf0f9#md5:657c5113dc0b41f11e659fb24e5cf0f9",
+          "archive:https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz#md5:657c5113dc0b41f11e659fb24e5cf0f9"
         ],
         "opam": {
           "name": "semver2",
-          "version": "1.1.0",
-          "path": "test.esy.lock/opam/semver2.1.1.0"
+          "version": "1.2.0",
+          "path": "test.esy.lock/opam/semver2.1.2.0"
         }
       },
       "overrides": [],
@@ -1712,8 +1626,8 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ppxlib@opam:0.15.0@071fae58": {
-      "id": "@opam/ppxlib@opam:0.15.0@071fae58",
+    "@opam/ppxlib@opam:0.15.0@04a04df2": {
+      "id": "@opam/ppxlib@opam:0.15.0@04a04df2",
       "name": "@opam/ppxlib",
       "version": "opam:0.15.0",
       "source": {
@@ -1821,13 +1735,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1850,13 +1764,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1878,12 +1792,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1905,13 +1819,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
@@ -1935,13 +1849,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1963,12 +1877,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -1990,14 +1904,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
@@ -2021,12 +1935,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2051,7 +1965,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -2059,7 +1973,7 @@
         "ocaml@4.10.0@d41d8cd9",
         "@opam/yojson@github:onivim/yojson:yojson.opam#f480aef@d41d8cd9",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_deriving@opam:5.1@089b343d",
         "@opam/dune@opam:2.5.0@e0bac278"
       ]
@@ -2083,7 +1997,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2092,7 +2006,7 @@
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@071fae58",
+        "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocaml-migrate-parsetree@opam:1.8.0@caf9847c",
@@ -2142,12 +2056,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2169,12 +2083,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/dune@opam:2.5.0@e0bac278", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -2196,7 +2110,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2206,7 +2120,7 @@
         "@opam/dune@opam:2.5.0@e0bac278", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -2234,7 +2148,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -2243,7 +2157,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@071fae58",
+        "ocaml@4.10.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@04a04df2",
         "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -3954,7 +3868,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/reason@opam:3.7.0@191be014",
-        "@opam/ppxlib@opam:0.15.0@071fae58", "@opam/dune@opam:2.5.0@e0bac278"
+        "@opam/ppxlib@opam:0.15.0@04a04df2", "@opam/dune@opam:2.5.0@e0bac278"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     }

--- a/test.esy.lock/opam/ppxlib.0.15.0/opam
+++ b/test.esy.lock/opam/ppxlib.0.15.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
-  "sexplib0"
+  "sexplib0"                {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind"               {with-test}
   "cinaps"                  {with-test & >= "v0.12.1"}

--- a/test.esy.lock/opam/semver2.1.2.0/opam
+++ b/test.esy.lock/opam/semver2.1.2.0/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
-maintainer: "info@dividat.com"
-authors: ["Dividat AG"]
 synopsis: "Semantic version handling for OCaml"
+maintainer: "info@dividat.com"
+authors: "Dividat AG"
 license: "MIT"
 homepage: "https://github.com/dividat/ocaml-semver"
 bug-reports: "https://github.com/dividat/ocaml-semver/issues"
+dev-repo: "git+https://github.com/dividat/ocaml-semver.git"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
@@ -14,14 +15,15 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
-  src: "https://github.com/dividat/ocaml-semver/archive/1.1.0.tar.gz"
+  src:
+    "https://github.com/dividat/ocaml-semver/archive/refs/tags/1.2.0.tar.gz"
   checksum: [
-    "md5=3054c5c107ae2b87246113debbf999fc"
-    "sha512=02527d9591acb722529e54bc41832fef390f10964304074ac96b2dc09b77d84296d7363477921b721a16be66e3d79b12b6388f2637c2360d5e79d6260f24d722"
+    "md5=657c5113dc0b41f11e659fb24e5cf0f9"
+    "sha512=c8f45011fc49dea4be5ed30f0a1391a1fa8b862e3f6f06b6f82d5baefbbb6c9aee632fd5bb1ed0a77b764bb59bd704f559bdf713e195976c39034431b2099b8f"
   ]
 }


### PR DESCRIPTION
This is needed to unblock Windows builds on master/nightly - picks up https://github.com/revery-ui/esy-libvterm/pull/5