### PR TITLE
feat(buffers/#3413) Implement action.workbench.quickOpenBuffer

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -54,6 +54,7 @@
 - #3420 - Vim: Implement C-W, C-Q binding (related #1721)
 - #3422 - Input: Fix terminal key binding not working as expected (fixes #2778)
 - #3435 - Completion: Fix various mouse interactions (fixes #3428)
+- #3430 - Buffers: Implement action.workbench.quickOpenBuffer (fixes #3413)
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/DocumentSymbols.re
+++ b/src/Feature/LanguageSupport/DocumentSymbols.re
@@ -200,7 +200,7 @@ module MenuItems = {
   open MenuBar.Schema;
 
   let gotoBufferSymbol =
-    command(~title="Goto buffer symbol...", Commands.gotoSymbol);
+    command(~title="Go to Symbol in Buffer...", Commands.gotoSymbol);
 };
 
 module Contributions = {

--- a/src/Feature/MenuBar/Global.re
+++ b/src/Feature/MenuBar/Global.re
@@ -75,11 +75,19 @@ module Items = {
       item(~title="Enter license key", ~command="oni.app.enterLicenseKey");
   };
 
+  module Go = {
+    let gotoFile =
+      item(~title="Go to File", ~command="workbench.action.quickOpen");
+    let gotoBuffer =
+      item(
+        ~title="Go to Buffer",
+        ~command="workbench.action.quickOpenBuffer",
+      );
+  };
+
   module View = {
     let commands =
       item(~title="Commands", ~command="workbench.action.showCommands");
-
-    let files = item(~title="Files", ~command="workbench.action.quickOpen");
 
     let cycleOpenFiles =
       item(
@@ -114,11 +122,8 @@ let groups = [
   group(~order=200, ~parent=file, Items.File.[saveFile, saveAll]),
   group(~order=300, ~parent=application, Items.File.Preferences.[submenu]),
   group(~order=999, ~parent=file, Items.File.[quit]),
-  group(
-    ~order=100,
-    ~parent=view,
-    Items.View.[commands, files, cycleOpenFiles],
-  ),
+  group(~order=200, ~parent=go, Items.Go.[gotoFile, gotoBuffer]),
+  group(~order=100, ~parent=view, Items.View.[commands, cycleOpenFiles]),
   group(~order=150, ~parent=view, Items.View.Zoom.[submenu]),
   group(~parent=edit, Items.Edit.[undo, redo]),
   group(

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -121,6 +121,13 @@ module Workbench = {
         QuickmenuShow(FilesPicker),
       );
 
+    let quickOpenBuffer =
+      register(
+        ~title="Go to Buffer...",
+        "workbench.action.quickOpenBuffer",
+        QuickmenuShow(OpenBuffersPicker),
+      );
+
     let quickOpenNavigateNextInEditorPicker =
       register(
         ~title="Navigate Next in Quick Open",


### PR DESCRIPTION
Implement feature for #3413

```changelog
Add new command `action.workbench.quickOpenBuffer` to easily navigate through buffers
```

![2021-04-16 20 50 10](https://user-images.githubusercontent.com/1116942/115070590-6db9c780-9ef5-11eb-80d3-130f96b82c7d.gif)
