### PR TITLE
fix(completion/#3428): Fix various mouse interactions with completion popup

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -53,6 +53,7 @@
 - #3421 - Lifecycle: Show unsaved dialog when closing last editor via mouse (fixes #417)
 - #3420 - Vim: Implement C-W, C-Q binding (related #1721)
 - #3422 - Input: Fix terminal key binding not working as expected (fixes #2778)
+- #3435 - Completion: Fix various mouse interactions (fixes #3428)
 
 ### Performance
 

--- a/src/Core/Constants.re
+++ b/src/Core/Constants.re
@@ -10,6 +10,9 @@ let defaultFontSize = 14.;
 
 let defaultFontFile = "JetBrainsMono-Regular.ttf";
 
+let diffMarkerWidth = 3.;
+let gutterMargin = 3.;
+
 let isDefaultFont = str => {
   // Before we switched to JetBrains Mono as the default font...
   // "FiraCode-Regular.ttf" was specified in the default configuration file.

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -2162,6 +2162,19 @@ let isMousePressedNearLeftEdge = ({isMouseDown, lastMouseScreenPosition, _}) => 
   |> Option.value(~default=false);
 };
 
+let gutterWidth = (~editorFont: Service_Font.font, {lineNumbers, buffer, _}) => {
+  let lineNumberWidth =
+    lineNumbers != `Off
+      ? LineNumber.getLineNumberPixelWidth(
+          ~lines=EditorBuffer.numberOfLines(buffer),
+          ~fontPixelWidth=editorFont.underscoreWidth,
+          (),
+        )
+      : 0.0;
+
+  lineNumberWidth +. Constants.diffMarkerWidth +. Constants.gutterMargin;
+};
+
 let isMousePressedNearRightEdge =
     ({isMouseDown, lastMouseScreenPosition, _} as editor) => {
   let {bufferWidthInPixels, _}: EditorLayout.t = getLayout(editor);

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -177,6 +177,13 @@ let minimapScrollY: t => float;
 let pixelX: t => float;
 let pixelY: t => float;
 
+// `gutterWidth` returns the size of the gutter, which includes:
+// - Line number rendering
+// - Diff marker rendering
+// - Extra margin
+// (...later, vim signs & debugger breakpoints)
+let gutterWidth: (~editorFont: Service_Font.font, t) => float;
+
 let lineHeightInPixels: t => float;
 let linePaddingInPixels: t => float;
 let setLineHeight: (~lineHeight: LineHeight.t, t) => t;

--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -2,14 +2,6 @@ open EditorCoreTypes;
 open Revery.UI;
 open Oni_Core;
 
-module Constants = {
-  include Constants;
-
-  let diffMarkersMaxLineCount = 2000;
-  let diffMarkerWidth = 3.;
-  let gutterMargin = 3.;
-};
-
 let renderLineNumber =
     (
       ~context: Draw.context,
@@ -180,8 +172,7 @@ let make =
         )
       : 0.0;
 
-  let totalWidth =
-    lineNumberWidth +. Constants.diffMarkerWidth +. Constants.gutterMargin;
+  let totalWidth = Editor.gutterWidth(~editorFont, editor);
 
   let style =
     Style.[

--- a/src/Feature/Editor/OverlaysView.re
+++ b/src/Feature/Editor/OverlaysView.re
@@ -22,34 +22,6 @@ module Styles = {
   ];
 };
 
-let completionsView =
-    (
-      ~buffer,
-      ~cursor,
-      ~languageSupport,
-      ~lineHeight,
-      ~cursorPixelX,
-      ~cursorPixelY,
-      ~theme,
-      ~tokenTheme,
-      ~editorFont: Service_Font.font,
-      (),
-    ) =>
-  Feature_LanguageSupport.Completion.isActive(languageSupport)
-    ? <Feature_LanguageSupport.Completion.View
-        buffer
-        cursor
-        x=cursorPixelX
-        y=cursorPixelY
-        lineHeight
-        theme
-        tokenTheme
-        editorFont
-        //colors
-        model=languageSupport
-      />
-    : React.empty;
-
 let signatureHelpView =
     (
       ~cursorPixelX,
@@ -102,21 +74,9 @@ let make =
 
   let cursorPixelY = pixelY |> int_of_float;
   let cursorPixelX = pixelX +. gutterWidth |> int_of_float;
-  let lineHeight = Editor.lineHeightInPixels(editor);
 
   isActiveSplit
     ? <View style=Styles.bufferViewOverlay>
-        <completionsView
-          cursor=cursorPosition
-          buffer
-          lineHeight
-          languageSupport
-          cursorPixelX
-          cursorPixelY
-          theme
-          tokenTheme
-          editorFont
-        />
         <signatureHelpView
           languageSupport
           cursorPixelX

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -18,7 +18,10 @@ type providerMsg =
 [@deriving show]
 type msg =
   | Command(command)
-  | Provider(providerMsg);
+  | Provider(providerMsg)
+  | CompletionItemClicked(CompletionItem.t)
+  | CompletionClickedOutside
+  | CompletionItemMouseEntered({index: int});
 
 type exthostMsg;
 
@@ -431,6 +434,10 @@ module Selection = {
       };
     };
 
+  let focus = (~index, ~count, _selection) => {
+    Some(index) |> ensureValidFocus(~count);
+  };
+
   let focusPrevious = (~count, selection) => {
     IndexEx.prevRollOverOpt(~last=count - 1, selection);
   };
@@ -578,21 +585,25 @@ let isActive = (model: model) => {
   |> Array.length > 0;
 };
 
+let start = model => {
+  ...model,
+  providers: model.providers |> List.map(Session.start),
+  allItems: [||],
+  selection: None,
+};
+
+let stop = model => {
+  ...model,
+  providers: model.providers |> List.map(Session.stop),
+  allItems: [||],
+  selection: None,
+};
+
 let reset = model =>
   if (model.isInsertMode && !model.isSnippetMode) {
-    {
-      ...model,
-      providers: model.providers |> List.map(Session.start),
-      allItems: [||],
-      selection: None,
-    };
+    start(model);
   } else {
-    {
-      ...model,
-      providers: model.providers |> List.map(Session.stop),
-      allItems: [||],
-      selection: None,
-    };
+    stop(model);
   };
 
 let startInsertMode = model => {
@@ -820,6 +831,50 @@ let update =
        })
     |> Option.value(~default)
 
+  | CompletionItemClicked(completionItem) =>
+    let allItems = allItems(model);
+
+    if (allItems == [||]) {
+      default;
+    } else {
+      let replaceSpan =
+        CompletionItem.replaceSpan(~activeCursor, completionItem);
+
+      let effect =
+        Exthost.SuggestItem.InsertTextRules.(
+          matches(~rule=InsertAsSnippet, completionItem.insertTextRules)
+        )
+          ? Outmsg.InsertSnippet({
+              replaceSpan,
+              snippet: completionItem.insertText,
+              additionalEdits: completionItem.additionalTextEdits,
+            })
+          : Outmsg.ApplyCompletion({
+              replaceSpan,
+              insertText: completionItem.insertText,
+              additionalEdits: completionItem.additionalTextEdits,
+            });
+
+      (
+        {
+          ...model,
+          providers:
+            List.map(
+              provider => {
+                provider
+                |> Session.complete(completionItem.additionalTextEdits)
+              },
+              model.providers,
+            ),
+          allItems: [||],
+          selection: None,
+        },
+        effect,
+      );
+    };
+
+  | CompletionClickedOutside => (stop(model), Nothing)
+
   | Command(AcceptSelected) =>
     let allItems = allItems(model);
 
@@ -870,6 +925,13 @@ let update =
     let count = Array.length(model.allItems);
     (
       {...model, selection: Selection.focusNext(~count, model.selection)},
+      Nothing,
+    );
+
+  | CompletionItemMouseEntered({index}) =>
+    let count = Array.length(model.allItems);
+    (
+      {...model, selection: Selection.focus(~index, ~count, model.selection)},
       Nothing,
     );
 
@@ -1167,20 +1229,24 @@ module View = {
   module Styles = {
     open Style;
 
-    let outerPosition = (~x, ~y) => [
+    let outerPosition = (~x, ~y, ~width, ~height) => [
       position(`Absolute),
-      top(y - 4),
+      top(y),
       left(x + 4),
+      pointerEvents(`Allow),
+      Style.width(width),
+      Style.height(height + 2) // Add 2 to account for border!
     ];
 
-    let innerPosition = (~height, ~width, ~lineHeight, ~colors: Colors.t) => [
+    let innerPosition = (~height, ~width, ~colors: Colors.t) => [
       position(`Absolute),
-      top(int_of_float(lineHeight +. 0.5)),
+      top(0),
       left(0),
       Style.width(width),
       Style.height(height + 2), // Add 2 to account for border!
       border(~color=colors.suggestWidgetBorder, ~width=1),
       backgroundColor(colors.suggestWidgetBackground),
+      opacity(Constants.opacity),
     ];
 
     let item = (~rowHeight, ~isFocused, ~colors: Colors.t) => [
@@ -1190,6 +1256,7 @@ module View = {
       flexDirection(`Row),
       height(rowHeight),
       justifyContent(`Center),
+      cursor(Revery.MouseCursors.pointer),
     ];
 
     let icon = (~size, ~color) => [
@@ -1245,6 +1312,8 @@ module View = {
   let itemView =
       (
         ~isFocused,
+        ~onClick,
+        ~onMouseEnter,
         ~text,
         ~kind,
         ~highlight,
@@ -1300,7 +1369,10 @@ module View = {
       | _ => React.empty
       };
 
-    <View style={Styles.item(~rowHeight, ~isFocused, ~colors)}>
+    <Revery.UI.Components.Clickable
+      onClick
+      onMouseEnter
+      style={Styles.item(~rowHeight, ~isFocused, ~colors)}>
       <View
         style=Style.[
           backgroundColor(iconColor),
@@ -1338,7 +1410,7 @@ module View = {
         />
       </View>
       maybeDetail
-    </View>;
+    </Revery.UI.Components.Clickable>;
   };
 
   let detailView =
@@ -1383,6 +1455,7 @@ module View = {
         ~y: int,
         ~lineHeight: float,
         // TODO
+        ~dispatch,
         ~theme,
         ~tokenTheme,
         ~editorFont,
@@ -1441,8 +1514,7 @@ module View = {
     //   | None => React.empty
     //   };
 
-    let innerStyle =
-      Styles.innerPosition(~height, ~width, ~lineHeight, ~colors);
+    let innerStyle = Styles.innerPosition(~height, ~width, ~colors);
 
     let innerStyleWithShadow =
       if (completions.isShadowEnabled) {
@@ -1461,44 +1533,102 @@ module View = {
         innerStyle;
       };
 
-    <View style={Styles.outerPosition(~x, ~y)}>
-      <Opacity opacity=Constants.opacity>
-        <View style=innerStyleWithShadow>
-          <FlatList
-            rowHeight=itemHeight
-            initialRowsToRender=5
-            count={Array.length(items)}
-            theme
-            focused>
-            ...{index => {
-              let item = items[index];
-              let CompletionItem.{label: text, kind, _} = item;
+    <View
+      style={Styles.outerPosition(~x, ~y, ~height, ~width)}
+      onMouseEnter={_ => prerr_endline("ENTER")}
+      onMouseLeave={_ => prerr_endline("Leave")}>
+      <View style=innerStyleWithShadow>
+        <FlatList
+          rowHeight=itemHeight
+          initialRowsToRender=5
+          count={Array.length(items)}
+          theme
+          focused>
+          ...{index => {
+            let item = items[index];
+            let CompletionItem.{label: text, kind, _} = item;
 
-              let highlight =
-                maybeLine
-                |> Option.map(line => {
-                     CompletionItemScorer.highlights(line, item, cursor)
-                   })
-                |> Option.value(~default=[]);
+            let highlight =
+              maybeLine
+              |> Option.map(line => {
+                   CompletionItemScorer.highlights(line, item, cursor)
+                 })
+              |> Option.value(~default=[]);
 
-              <itemView
-                isFocused={Some(index) == focused}
-                rowHeight=itemHeight
-                text
-                detail={item.detail}
-                kind
-                highlight
-                theme
-                tokenTheme
-                width
-                colors
-                editorFont
-              />;
-            }}
-          </FlatList>
-        </View>
-        detail
-      </Opacity>
+            <itemView
+              isFocused={Some(index) == focused}
+              rowHeight=itemHeight
+              text
+              detail={item.detail}
+              kind
+              highlight
+              theme
+              tokenTheme
+              width
+              colors
+              editorFont
+              onMouseEnter={_ =>
+                dispatch(CompletionItemMouseEntered({index: index}))
+              }
+              onClick={_ => dispatch(CompletionItemClicked(item))}
+            />;
+          }}
+        </FlatList>
+      </View>
+      detail
     </View>;
+  };
+
+  module Overlay = {
+    let make =
+        (
+          ~activeEditorId,
+          ~buffer,
+          ~cursorPosition,
+          ~lineHeight,
+          ~toPixel,
+          ~theme,
+          ~tokenTheme,
+          ~model,
+          ~editorFont,
+          ~uiFont as _,
+          ~dispatch,
+          (),
+        ) =>
+      if (isActive(model)) {
+        let maybePixelPosition =
+          toPixel(~editorId=activeEditorId, cursorPosition);
+        maybePixelPosition
+        |> Option.map((pixelPosition: PixelPosition.t) => {
+             <View
+               onMouseUp={_ => dispatch(CompletionClickedOutside)}
+               style=Revery.UI.Style.[
+                 position(`Absolute),
+                 top(0),
+                 left(0),
+                 bottom(0),
+                 right(0),
+                 backgroundColor(Revery.Colors.transparentBlack),
+                 pointerEvents(`Allow),
+               ]>
+               {make(
+                  ~buffer,
+                  ~x=int_of_float(pixelPosition.x),
+                  ~y=int_of_float(pixelPosition.y),
+                  ~lineHeight,
+                  ~theme,
+                  ~tokenTheme,
+                  ~completions=model,
+                  ~editorFont,
+                  ~cursor=cursorPosition,
+                  ~dispatch,
+                  (),
+                )}
+             </View>
+           })
+        |> Option.value(~default=Revery.UI.React.empty);
+      } else {
+        Revery.UI.React.empty;
+      };
   };
 };

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -873,7 +873,13 @@ let update =
       );
     };
 
-  | CompletionClickedOutside => (stop(model), Nothing)
+  | CompletionClickedOutside =>
+    let allItems = allItems(model);
+    if (allItems == [||]) {
+      (model, Nothing);
+    } else {
+      (stop(model), Nothing);
+    };
 
   | Command(AcceptSelected) =>
     let allItems = allItems(model);
@@ -1229,10 +1235,10 @@ module View = {
   module Styles = {
     open Style;
 
-    let outerPosition = (~x, ~y, ~width, ~height) => [
+    let outerPosition = (~x, ~y, ~fontSize, ~width, ~height) => [
       position(`Absolute),
       top(y),
-      left(x + 4),
+      left(x - int_of_float(fontSize +. 0.5) - 8),
       pointerEvents(`Allow),
       Style.width(width),
       Style.height(height + 2) // Add 2 to account for border!
@@ -1458,7 +1464,7 @@ module View = {
         ~dispatch,
         ~theme,
         ~tokenTheme,
-        ~editorFont,
+        ~editorFont: Service_Font.font,
         ~completions: model,
         (),
       ) => {
@@ -1533,10 +1539,8 @@ module View = {
         innerStyle;
       };
 
-    <View
-      style={Styles.outerPosition(~x, ~y, ~height, ~width)}
-      onMouseEnter={_ => prerr_endline("ENTER")}
-      onMouseLeave={_ => prerr_endline("Leave")}>
+    let fontSize = editorFont.fontSize;
+    <View style={Styles.outerPosition(~x, ~y, ~fontSize, ~height, ~width)}>
       <View style=innerStyleWithShadow>
         <FlatList
           rowHeight=itemHeight

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -809,37 +809,6 @@ module Completion = {
 
   let availableCompletionCount = ({completion, _}: model) =>
     OldCompletion.availableCompletionCount(completion);
-
-  module View = {
-    let make =
-        (
-          ~buffer,
-          ~cursor,
-          ~x,
-          ~y,
-          ~lineHeight,
-          ~theme,
-          ~tokenTheme,
-          ~editorFont,
-          ~model,
-          (),
-        ) => {
-      Revery.UI.React.empty;
-      // OldCompletion.View.make(
-      //   ~buffer,
-      //   ~cursor,
-      //   ~x,
-      //   ~dispatch=_ => (),
-      //   ~y,
-      //   ~lineHeight,
-      //   ~theme,
-      //   ~tokenTheme,
-      //   ~editorFont,
-      //   ~completions=model.completion,
-      //   (),
-      // );
-    };
-  };
 };
 
 module SignatureHelp = {

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.re
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.re
@@ -824,18 +824,20 @@ module Completion = {
           ~model,
           (),
         ) => {
-      OldCompletion.View.make(
-        ~buffer,
-        ~cursor,
-        ~x,
-        ~y,
-        ~lineHeight,
-        ~theme,
-        ~tokenTheme,
-        ~editorFont,
-        ~completions=model.completion,
-        (),
-      );
+      Revery.UI.React.empty;
+      // OldCompletion.View.make(
+      //   ~buffer,
+      //   ~cursor,
+      //   ~x,
+      //   ~dispatch=_ => (),
+      //   ~y,
+      //   ~lineHeight,
+      //   ~theme,
+      //   ~tokenTheme,
+      //   ~editorFont,
+      //   ~completions=model.completion,
+      //   (),
+      // );
     };
   };
 };
@@ -1120,15 +1122,45 @@ module View = {
   };
 
   module Overlay = {
-    let make = (~toPixel, ~theme, ~model, ~editorFont, ~uiFont, ~dispatch, ()) => {
-      <CodeActions.View.Overlay
-        toPixel
-        theme
-        model={model.codeActions}
-        dispatch={msg => dispatch(CodeActions(msg))}
-        editorFont
-        uiFont
-      />;
+    let make =
+        (
+          ~activeEditorId: int,
+          ~activeBuffer: Oni_Core.Buffer.t,
+          ~cursorPosition: CharacterPosition.t,
+          ~lineHeight: float,
+          ~toPixel,
+          ~theme,
+          ~tokenTheme,
+          ~model,
+          ~editorFont,
+          ~uiFont,
+          ~dispatch,
+          (),
+        ) => {
+      [
+        <CodeActions.View.Overlay
+          toPixel
+          theme
+          model={model.codeActions}
+          dispatch={msg => dispatch(CodeActions(msg))}
+          editorFont
+          uiFont
+        />,
+        <OldCompletion.View.Overlay
+          activeEditorId
+          cursorPosition
+          buffer=activeBuffer
+          toPixel
+          theme
+          lineHeight
+          tokenTheme
+          model={model.completion}
+          dispatch={msg => dispatch(Completion(msg))}
+          editorFont
+          uiFont
+        />,
+      ]
+      |> Revery.UI.React.listToElement;
     };
   };
 };

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -267,9 +267,14 @@ module View: {
   module Overlay: {
     let make:
       (
+        ~activeEditorId: int,
+        ~activeBuffer: Oni_Core.Buffer.t,
+        ~cursorPosition: CharacterPosition.t,
+        ~lineHeight: float,
         ~toPixel: (~editorId: int, CharacterPosition.t) =>
                   option(PixelPosition.t),
         ~theme: ColorTheme.Colors.t,
+        ~tokenTheme: Oni_Syntax.TokenTheme.t,
         ~model: model,
         ~editorFont: Service_Font.font,
         ~uiFont: UiFont.t,

--- a/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
+++ b/src/Feature/LanguageSupport/Feature_LanguageSupport.rei
@@ -190,23 +190,6 @@ module Completion: {
   let providerCount: model => int;
 
   let availableCompletionCount: model => int;
-
-  module View: {
-    let make:
-      (
-        ~buffer: Buffer.t,
-        ~cursor: CharacterPosition.t,
-        ~x: int,
-        ~y: int,
-        ~lineHeight: float,
-        ~theme: Oni_Core.ColorTheme.Colors.t,
-        ~tokenTheme: Oni_Syntax.TokenTheme.t,
-        ~editorFont: Service_Font.font,
-        ~model: model,
-        unit
-      ) =>
-      Revery.UI.element;
-  };
 };
 
 module SignatureHelp: {

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -87,6 +87,57 @@ let make = (~dispatch, ~state: State.t, ()) => {
     />;
   };
 
+  let editorToAbsolutePosition = (~editorId, position) => {
+    state.layout
+    |> Feature_Layout.editorById(editorId)
+    |> Option.map(editor => {
+         EditorCoreTypes.(
+           Feature_Editor.(
+             {
+               let (pixelPosition, _) =
+                 Editor.bufferCharacterPositionToPixel(~position, editor);
+
+               let offsetX = Editor.pixelX(editor);
+               let offsetY = Editor.pixelY(editor);
+               let lineHeight = Editor.lineHeightInPixels(editor);
+
+               PixelPosition.{
+                 x: pixelPosition.x +. offsetX,
+                 y: pixelPosition.y +. offsetY +. lineHeight,
+               };
+             }
+           )
+         )
+       });
+  };
+
+  let languageSupportOverlay = () => {
+    let activeEditorId = Feature_Editor.Editor.getId(activeEditor);
+    maybeActiveBuffer
+    |> Option.map(activeBuffer => {
+         let cursorPosition =
+           Feature_Editor.Editor.getPrimaryCursor(activeEditor);
+         let lineHeight =
+           Feature_Editor.Editor.lineHeightInPixels(activeEditor);
+         let tokenTheme = Feature_Theme.tokenColors(state.colorTheme);
+
+         <Feature_LanguageSupport.View.Overlay
+           activeEditorId
+           activeBuffer
+           cursorPosition
+           lineHeight
+           toPixel=editorToAbsolutePosition
+           theme
+           tokenTheme
+           uiFont
+           editorFont={state.editorFont}
+           model={state.languageSupport}
+           dispatch={msg => dispatch(Actions.LanguageSupport(msg))}
+         />;
+       })
+    |> Option.value(~default=React.empty);
+  };
+
   let statusBar = () =>
     if (Feature_StatusBar.Configuration.visible.get(config) && !zenMode) {
       <View style=Styles.statusBar>
@@ -199,30 +250,6 @@ let make = (~dispatch, ~state: State.t, ()) => {
   // Correct for zoom in title bar height
   let titlebarHeight = state.titlebarHeight /. zoom;
 
-  let editorToAbsolutePosition = (~editorId, position) => {
-    state.layout
-    |> Feature_Layout.editorById(editorId)
-    |> Option.map(editor => {
-         EditorCoreTypes.(
-           Feature_Editor.(
-             {
-               let (pixelPosition, _) =
-                 Editor.bufferCharacterPositionToPixel(~position, editor);
-
-               let offsetX = Editor.pixelX(editor);
-               let offsetY = Editor.pixelY(editor);
-               let lineHeight = Editor.lineHeightInPixels(editor);
-
-               PixelPosition.{
-                 x: pixelPosition.x +. offsetX,
-                 y: pixelPosition.y +. offsetY +. lineHeight,
-               };
-             }
-           )
-         )
-       });
-  };
-
   <View style={Styles.root(theme, state.windowDisplayMode)}>
     <Feature_TitleBar.View
       menuBar=menuBarElement
@@ -259,6 +286,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
       />
     </View>
     <Overlay>
+      <languageSupportOverlay />
       {if (Feature_Quickmenu.isMenuOpen(state.newQuickmenu)) {
          <Feature_Quickmenu.View
            theme
@@ -292,14 +320,6 @@ let make = (~dispatch, ~state: State.t, ()) => {
         registration={state.registration}
         font
         dispatch={msg => dispatch(Actions.Registration(msg))}
-      />
-      <Feature_LanguageSupport.View.Overlay
-        toPixel=editorToAbsolutePosition
-        theme
-        uiFont
-        editorFont={state.editorFont}
-        model={state.languageSupport}
-        dispatch={msg => dispatch(Actions.LanguageSupport(msg))}
       />
     </Overlay>
     <statusBar />

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -97,12 +97,14 @@ let make = (~dispatch, ~state: State.t, ()) => {
                let (pixelPosition, _) =
                  Editor.bufferCharacterPositionToPixel(~position, editor);
 
+               let gutterWidth = Editor.gutterWidth(~editorFont, editor);
+
                let offsetX = Editor.pixelX(editor);
                let offsetY = Editor.pixelY(editor);
                let lineHeight = Editor.lineHeightInPixels(editor);
 
                PixelPosition.{
-                 x: pixelPosition.x +. offsetX,
+                 x: pixelPosition.x +. offsetX +. gutterWidth,
                  y: pixelPosition.y +. offsetY +. lineHeight,
                };
              }


### PR DESCRIPTION
__Issue:__ Several mouse interactions weren't working correctly, including dismissing the completion pop-up by clicking outside (#3428) as well as hovering / selecting an item via the mouse.

__Defect:__ The editor surface was hijacking the clicks, and not giving the completion pop-up a chance to respond (in addition, selecting an item wasn't hooked up).

__Fix:__ Move the completion UI to an overlay that can get access to the clicks. Plumb in mouse click / mouse hover interactions.

Fixes #3428 