### PR TITLE
fix(hover): Remove textOverflow(Ellipsis) from hover diagnostics

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -54,6 +54,7 @@
 - #3420 - Vim: Implement C-W, C-Q binding (related #1721)
 - #3422 - Input: Fix terminal key binding not working as expected (fixes #2778)
 - #3435 - Completion: Fix various mouse interactions (fixes #3428)
+- #3439 - Hover: Remove textOverflow(Ellipsis) from hover
 
 ### Performance
 

--- a/src/Feature/LanguageSupport/Hover.re
+++ b/src/Feature/LanguageSupport/Hover.re
@@ -291,7 +291,6 @@ module Styles = {
   module Colors = Feature_Theme.Colors;
 
   let diagnostic = (~theme) => [
-    textOverflow(`Ellipsis),
     color(Colors.Editor.foreground.from(theme)),
     backgroundColor(Colors.EditorHoverWidget.background.from(theme)),
   ];


### PR DESCRIPTION
__Issue:__ The diagnostics section in the hover popup had a `textOverflow(Ellipsis)` setting that wasn't used - however, https://github.com/revery-ui/revery/pull/1056 caused it to be picked up. Now, the diagnostics can be cut off in the hover popup.

__Fix:__ Remove `textOverflow(Ellipsis)` to bring back previous behavior.