### PR TITLE
feat(indentation): Easier space/tab indentation switching

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -6,6 +6,7 @@
 - #3352 - Keybindings: Add default keybinding for open configuration (related #1423, thanks @LiHRaM !)
 - #3381 - Language Support: Symbols - implement go-to buffer symbol menu
 - #3387 - Code Actions: Implement context menu for quick fixes
+- #3440 - Indentation: Easier space/tab indentation switching
 
 ### Bug Fixes
 

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -381,6 +381,7 @@ let setIndentation = (indentation, buf) => {
 
   let lines =
     if (originalIndentationValue != newIndentationValue) {
+      prerr_endline("Updating lines!");
       buf.lines
       |> Array.map(line => {
            let raw = BufferLine.raw(line);
@@ -389,7 +390,7 @@ let setIndentation = (indentation, buf) => {
     } else {
       buf.lines;
     };
-  {...buf, lines, indentation};
+  {...buf, measure, lines, indentation};
 };
 
 let getIndentation = buf => buf.indentation |> Inferred.value;

--- a/src/Core/Buffer.re
+++ b/src/Core/Buffer.re
@@ -381,7 +381,6 @@ let setIndentation = (indentation, buf) => {
 
   let lines =
     if (originalIndentationValue != newIndentationValue) {
-      prerr_endline("Updating lines!");
       buf.lines
       |> Array.map(line => {
            let raw = BufferLine.raw(line);

--- a/src/Core/IndentationConverter.re
+++ b/src/Core/IndentationConverter.re
@@ -1,0 +1,83 @@
+open Utility;
+
+let indentationToTabs = (~size, str) => {
+  let leadingWhitespace = StringEx.leadingWhitespace(str);
+  let postWhitespace =
+    String.sub(
+      str,
+      String.length(leadingWhitespace),
+      String.length(str) - String.length(leadingWhitespace),
+    );
+
+  let regexp = Re.Perl.re(String.make(size, ' ')) |> Re.Posix.compile;
+  let replacement = String.make(1, '\t');
+
+  let newWhitespace =
+    Re.replace_string(regexp, ~by=replacement, leadingWhitespace);
+
+  newWhitespace ++ postWhitespace;
+};
+
+let%test_module "indentationToTabs" =
+  (module
+   {
+     let%test "no spaces" = {
+       indentationToTabs(~size=2, "abc") == "abc";
+     };
+     let%test "only whitepsace" = {
+       indentationToTabs(~size=2, "  ") == "\t";
+     };
+     let%test "single tab" = {
+       indentationToTabs(~size=2, "  abc") == "\tabc";
+     };
+     let%test "multiple tabs tab" = {
+       indentationToTabs(~size=2, "    abc") == "\t\tabc";
+     };
+
+     let%test "spaces after leading whitespace don't get converted" = {
+       indentationToTabs(~size=4, "    abc d") == "\tabc d";
+     };
+   });
+
+let indentationToSpaces = (~size, str) => {
+  let leadingWhitespace = StringEx.leadingWhitespace(str);
+  let postWhitespace =
+    String.sub(
+      str,
+      String.length(leadingWhitespace),
+      String.length(str) - String.length(leadingWhitespace),
+    );
+
+  let replacement = String.make(size, ' ');
+  let rec loop = (acc, idx) =>
+    if (idx >= String.length(leadingWhitespace)) {
+      acc;
+    } else if (leadingWhitespace.[idx] == '\t') {
+      loop(acc ++ replacement, idx + 1);
+    } else {
+      loop(acc ++ String.make(1, leadingWhitespace.[idx]), idx + 1);
+    };
+
+  let newWhitespace = loop("", 0);
+  newWhitespace ++ postWhitespace;
+};
+
+let%test_module "indentationToSpaces" =
+  (module
+   {
+     let%test "no tabs" = {
+       indentationToSpaces(~size=2, "abc") == "abc";
+     };
+     let%test "only whitepsace" = {
+       indentationToSpaces(~size=2, "\t") == "  ";
+     };
+     let%test "single tab" = {
+       indentationToSpaces(~size=2, "\tabc") == "  abc";
+     };
+     let%test "multiple tabs" = {
+       indentationToSpaces(~size=3, "\t\tabc") == "      abc";
+     };
+     let%test "doesn't change tabs after leading whitespace tabs" = {
+       indentationToSpaces(~size=1, "\t\tabc\td") == "  abc\td";
+     };
+   });

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -32,6 +32,7 @@ module FontMeasurementCache = FontMeasurementCache;
 module Glob = Glob;
 module IconTheme = IconTheme;
 module Indentation = Indentation;
+module IndentationConverter = IndentationConverter;
 module IndentationSettings = IndentationSettings;
 module Inferred = Inferred;
 module IntMap = Kernel.IntMap;

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -542,6 +542,8 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
         Command(ChangeIndentation({mode: IndentationSettings.Tabs})),
       ),
       ("Auto-detect indentation", Command(DetectIndentation)),
+      ("Convert indentation to tabs", Command(ConvertIndentationToTabs)),
+      ("Convert indentation to spaces", Command(ConvertIndentationToSpaces)),
     ];
 
     let menuFn =

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -155,7 +155,9 @@ let vimSettingChanged = (~activeBufferId, ~name, ~value, model) => {
     let indentation = Buffer.getIndentation(buffer);
     buffer
     |> Buffer.setIndentation(
-         Inferred.explicit(IndentationSettings.{...indentation, size}),
+         Inferred.explicit(
+           IndentationSettings.{...indentation, size, tabSize: size},
+         ),
        );
   };
 

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -615,7 +615,14 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
       | None => (model, Nothing)
       | Some(buffer) =>
         let allLines = Buffer.getLines(buffer);
-        let newLines = allLines |> Array.map(str => "  !!" ++ str);
+        let indentationSettings = Buffer.getIndentation(buffer);
+        let newLines =
+          allLines
+          |> Array.map(
+               IndentationConverter.indentationToSpaces(
+                 ~size=indentationSettings.size,
+               ),
+             );
         (
           model,
           Effect(
@@ -629,7 +636,7 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
                 IndentationChanged({
                   id: activeBufferId,
                   mode: IndentationSettings.Spaces,
-                  size: 2,
+                  size: indentationSettings.size,
                   didBufferGetModified: true,
                 }),
             ),
@@ -643,7 +650,14 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
       | None => (model, Nothing)
       | Some(buffer) =>
         let allLines = Buffer.getLines(buffer);
-        let newLines = allLines |> Array.map(str => "  .." ++ str);
+        let indentationSettings = Buffer.getIndentation(buffer);
+        let newLines =
+          allLines
+          |> Array.map(
+               IndentationConverter.indentationToTabs(
+                 ~size=indentationSettings.size,
+               ),
+             );
         (
           model,
           Effect(
@@ -656,8 +670,8 @@ let update = (~activeBufferId, ~config, msg: msg, model: model) => {
               | Ok(_) =>
                 IndentationChanged({
                   id: activeBufferId,
-                  mode: IndentationSettings.Spaces,
-                  size: 2,
+                  mode: IndentationSettings.Tabs,
+                  size: indentationSettings.size,
                   didBufferGetModified: true,
                 }),
             ),

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -62,6 +62,7 @@ module Msg: {
     msg;
 
   let selectFileTypeClicked: (~bufferId: int) => msg;
+  let statusBarIndentationClicked: msg;
 };
 
 type outmsg =
@@ -142,6 +143,10 @@ module Effects: {
     ) =>
     Isolinear.Effect.t(msg);
 };
+
+let vimSettingChanged:
+  (~activeBufferId: int, ~name: string, ~value: Vim.Setting.value, model) =>
+  model;
 
 let sub: model => Isolinear.Sub.t(msg);
 

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -89,7 +89,9 @@ type outmsg =
       (Exthost.LanguageInfo.t, IconTheme.t) =>
       Feature_Quickmenu.Schema.menu(msg),
     )
-  | NotifyInfo(string);
+  | NotifyInfo(string)
+  | NotifyError(string)
+  | Effect(Isolinear.Effect.t(msg));
 
 // UPDATE
 
@@ -147,7 +149,7 @@ module Effects: {
 
 let vimSettingChanged:
   (~activeBufferId: int, ~name: string, ~value: Vim.Setting.value, model) =>
-  model;
+  Isolinear.Effect.t(msg);
 
 let sub: model => Isolinear.Sub.t(msg);
 

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -67,6 +67,7 @@ module Msg: {
 
 type outmsg =
   | Nothing
+  | BufferIndentationChanged({buffer: Oni_Core.Buffer.t})
   | BufferUpdated({
       update: Oni_Core.BufferUpdate.t,
       markerUpdate: Oni_Core.MarkerUpdate.t,

--- a/src/Feature/StatusBar/Feature_StatusBar.re
+++ b/src/Feature/StatusBar/Feature_StatusBar.re
@@ -53,6 +53,7 @@ type msg =
   | ItemDisposed(string)
   | DiagnosticsClicked
   | FileTypeClicked
+  | IndentationClicked
   | ContextMenu(Component_ContextMenu.msg(contextMenuMsg))
   | NotificationCountClicked
   | NotificationsCountRightClicked
@@ -70,6 +71,7 @@ type outmsg =
   | ToggleProblems
   | ToggleNotifications
   | ShowFileTypePicker
+  | ShowIndentationPicker
   | Effect(Isolinear.Effect.t(msg));
 
 let notificationContextMenu =
@@ -142,6 +144,8 @@ let update = (~client, model, msg) => {
     |> Option.value(~default=(model, Nothing))
 
   | FileTypeClicked => (model, ShowFileTypePicker)
+
+  | IndentationClicked => (model, ShowIndentationPicker)
 
   | NotificationCountClicked => (model, ToggleNotifications)
 
@@ -478,7 +482,12 @@ module View = {
     let indentation = () => {
       let text = indentationSettings |> indentationToString;
 
-      <textItem font theme text />;
+      <textItem
+        font
+        theme
+        text
+        onClick={() => dispatch(IndentationClicked)}
+      />;
     };
 
     let fileType = () => {

--- a/src/Feature/StatusBar/Feature_StatusBar.rei
+++ b/src/Feature/StatusBar/Feature_StatusBar.rei
@@ -39,6 +39,7 @@ type outmsg =
   | ToggleProblems
   | ToggleNotifications
   | ShowFileTypePicker
+  | ShowIndentationPicker
   | Effect(Isolinear.Effect.t(msg));
 
 let update: (~client: Exthost.Client.t, model, msg) => (model, outmsg);

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -85,7 +85,10 @@ type msg =
 type outmsg =
   | Nothing
   | Effect(Isolinear.Effect.t(msg))
-  | SettingsChanged
+  | SettingsChanged({
+      name: string,
+      value: Vim.Setting.value,
+    })
   | ModeDidChange({
       allowAnimation: bool,
       mode: Vim.Mode.t,
@@ -176,7 +179,7 @@ let update = (~vimContext, msg, model: model) => {
     )
   | SettingChanged({fullName, value, _}: Vim.Setting.t) => (
       {...model, settings: model.settings |> StringMap.add(fullName, value)},
-      SettingsChanged,
+      SettingsChanged({name: fullName, value}),
     )
   | MacroRecordingStarted({register}) => (
       {...model, recordingMacro: Some(register)},

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -40,7 +40,10 @@ type msg =
 type outmsg =
   | Nothing
   | Effect(Isolinear.Effect.t(msg))
-  | SettingsChanged
+  | SettingsChanged({
+      name: string,
+      value: Vim.Setting.value,
+    })
   | ModeDidChange({
       allowAnimation: bool,
       mode: Vim.Mode.t,

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -2335,7 +2335,11 @@ let update =
         state,
         e |> Isolinear.Effect.map(msg => Actions.Vim(msg)),
       )
-    | SettingsChanged => state |> Internal.updateConfiguration
+    | SettingsChanged({name, value}) =>
+      prerr_endline(
+        Printf.sprintf("%s: %s", name, Vim.Setting.show_value(value)),
+      );
+      state |> Internal.updateConfiguration;
     | ModeDidChange({allowAnimation, mode, effects}) =>
       Internal.updateMode(~allowAnimation, state, mode, effects)
     | Output({cmd, output}) =>

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1508,6 +1508,28 @@ let update =
         ]),
       );
 
+    | BufferIndentationChanged({buffer}) =>
+      let bufferId = Buffer.getId(buffer);
+      let layout =
+        Feature_Layout.map(
+          editor =>
+            Feature_Editor.(
+              if (Editor.getBufferId(editor) == bufferId) {
+                // Set buffer recalculates word wrap, which is
+                // what we need if the indentation has changed.
+                Editor.setBuffer(
+                  ~buffer=EditorBuffer.ofBuffer(buffer),
+                  editor,
+                );
+              } else {
+                editor;
+              }
+            ),
+          state.layout,
+        );
+
+      ({...state, layout}, Isolinear.Effect.none);
+
     | BufferUpdated({
         update,
         newBuffer,

--- a/src/reason-libvim/Buffer.re
+++ b/src/reason-libvim/Buffer.re
@@ -100,7 +100,8 @@ let setLines =
         };
 
       if (undoable) {
-        Undo.saveRegion(startLine - 1, endLine + 1);
+        let undoEndLine = endLine == (-1) ? getLineCount(buffer) : endLine;
+        Undo.saveRegion(startLine - 1, undoEndLine + 1);
       };
 
       Native.vimBufferSetLines(buffer, startLine, endLine, lines);


### PR DESCRIPTION
This adds a few commands and features to make it easier to switch indent settings:
- Support for the `:set expandtab`/`:set noexpandtab` configuration setting
- Support for the `:set shiftwidth` configuration setting
- New menu items:
  - Indent using tabs
  - Indent using spaces
  - Convert to tabs
  - Convert to spaces
- Clickable status bar item to open menu