### PR TITLE
fix(buffers/#3433): Fix control+tab regression

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -58,6 +58,7 @@
 - #3435 - Completion: Fix various mouse interactions (fixes #3428)
 - #3439 - Hover: Remove textOverflow(Ellipsis) from hover
 - #3430 - Buffers: Implement action.workbench.quickOpenBuffer (fixes #3413)
+- #3442 - Buffers: Fix regression causing control+tab menu not to stay open (related #3442)
 
 ### Performance
 

--- a/src/Feature/Input/ReveryKeyConverter.re
+++ b/src/Feature/Input/ReveryKeyConverter.re
@@ -146,12 +146,7 @@ let reveryKeyToKeyPress =
   ignore(repeat);
   let name = Sdl2.Scancode.ofInt(scancode) |> Sdl2.Scancode.getName;
 
-  // Filter out some modifier keys. Otherwise, these keys will be treated as actual key presses,
-  // and can break mapping sequences.
-  if (name == "Left Shift"
-      || name == "Right Shift"
-      || name == "Left Ctrl"
-      || name == "Right Ctrl") {
+  if (name == "Left Shift" || name == "Right Shift") {
     None;
   } else {
     let shift = Revery.Key.Keymod.isShiftDown(keymod);

--- a/src/editor-input/EditorInput.re
+++ b/src/editor-input/EditorInput.re
@@ -694,29 +694,33 @@ module Make = (Config: {
     let id = KeyDownId.get();
     let pressedScancodes = IntSet.add(scancode, bindings.pressedScancodes);
 
-    let (model, effects) =
-      handleKeyCore(
-        ~allowRemaps=true,
-        ~leaderKey,
-        ~context,
-        Down(id, key),
-        {...bindings, pressedScancodes},
-      );
+    // #2778 - Don't allow modifiers to interrupt candidate bindings
+    if (!KeyCandidate.isModifier(key)) {
+      let (model, effects) =
+        handleKeyCore(
+          ~allowRemaps=true,
+          ~leaderKey,
+          ~context,
+          Down(id, key),
+          {...bindings, pressedScancodes},
+        );
 
-    let isUnhandled =
-      switch (effects) {
-      | [Unhandled({isProducedByRemap: false, _})] => true
-      | _ => false
-      };
+      let isUnhandled =
+        switch (effects) {
+        | [Unhandled({isProducedByRemap: false, _})] => true
+        | _ => false
+        };
 
-    let model' =
-      if (isUnhandled) {
-        {...model, suppressText: false};
-      } else {
-        model;
-      };
-
-    (model', effects);
+      let model' =
+        if (isUnhandled) {
+          {...model, suppressText: false};
+        } else {
+          model;
+        };
+      (model', effects);
+    } else {
+      ({...bindings, pressedScancodes}, []);
+    };
   };
 
   let text = (~text, bindings) =>

--- a/src/editor-input/KeyCandidate.re
+++ b/src/editor-input/KeyCandidate.re
@@ -8,3 +8,5 @@ let ofList = keyPresses => keyPresses;
 let toList = keyPresses => keyPresses;
 
 let exists = (~f, presses) => List.exists(f, presses);
+
+let isModifier = exists(~f=key => KeyPress.isModifier(key));

--- a/src/editor-input/KeyPress.re
+++ b/src/editor-input/KeyPress.re
@@ -26,6 +26,12 @@ let equals = (keyA, keyB) => {
   };
 };
 
+let isModifier =
+  fun
+  | PhysicalKey({key: Key.LeftControl, _}) => true
+  | PhysicalKey({key: Key.RightControl, _}) => true
+  | _ => false;
+
 let ofInternal =
     (
       ~addShiftKeyToCapital,


### PR DESCRIPTION
__Issue:__ The fix for #2778 (#3422) caused a regression in the control+tab menu

__Defect:__ The control+tab menu relies on a special key event, `<AllKeysReleased>`. This event requires keeping track of all pressed scancodes (like the control key). The change in #3422 totally ignored the control key, such that it's scancode wasn't being recorded - this then caused the `<AllKeysReleased>` event to be dispatched too early.

__Fix:__ Ignore the modifier for the purposes of binding candidates, such that the original blocker for #2778 is still fixed (the 'control' key press shouldn't interrupt a sequence of bindings, like `<C-W>`, `<C-Q>`). However, we still need to add the scancode to `pressedScancodes` so that we can properly engage the `<AllKeysReleased>` binding.


Related #3433