### PR TITLE
chore(ci): Fix up cache path for esy #1172 after upgrading to esy@0.6.10

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -89,3 +89,4 @@
 - #3313 - Packaging: Fix macOS Big Sur release bundling issues (fixes #2813, thanks @brdoney !)
 - #3369 - CI: Install python3 on CentOS dockerfile
 - #3429 - CI: Remove libtools dependency
+- #3450 - CI: Fix esy cache path after upgrade to 0.6.10

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,8 @@ jobs:
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3__________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3__________________________________________________________________/b
+    ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3_________________________________________________________________/i
+    ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3_________________________________________________________________/b
     ESY__CACHE_SOURCE_TARBALL_PATH: /Users/runner/.esy/source/i
     MACOSX_DEPLOYMENT_TARGET: 10.12
     CACHE_ARTIFACT_NAME: cache-$(Agent.OS)-install
@@ -64,8 +64,8 @@ jobs:
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_____________________________________________________________________/b
+    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3____________________________________________________________________/i
+    ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3____________________________________________________________________/b
     ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
     CACHE_ARTIFACT_NAME: cache-$(Agent.OS)-install
     DISPLAY: :99
@@ -94,8 +94,8 @@ jobs:
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3__________________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3__________________________________________________________________________/b
+    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_________________________________________________________________________/i
+    ESY__CACHE_BUILD_PATH: /home/vsts/.esy/3_________________________________________________________________________/b
     ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
     CACHE_ARTIFACT_NAME: cache-$(Agent.OS)-CentOS-docker-install
     # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
@@ -126,8 +126,8 @@ jobs:
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3__________________________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3__________________________________________________________________/b
+    ESY__CACHE_INSTALL_PATH: /Users/runner/.esy/3_________________________________________________________________/i
+    ESY__CACHE_BUILD_PATH: /Users/runner/.esy/3_________________________________________________________________/b
     ESY__CACHE_SOURCE_TARBALL_PATH: /Users/runner/.esy/source/i
     MACOSX_DEPLOYMENT_TARGET: 10.12
     CACHE_ARTIFACT_NAME: cache-$(Agent.OS)-install
@@ -162,8 +162,8 @@ jobs:
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/b
+    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3_____________________________________________________/i
+    ESY__CACHE_BUILD_PATH: /C/Users/VssAdministrator/.esy/3_____________________________________________________/b
     ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
     CACHE_ARTIFACT_NAME: cache-$(Agent.OS)-install
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
@@ -195,8 +195,8 @@ jobs:
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
-    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/i
-    ESY__CACHE_BUILD_PATH: /C/Users/VssAdministrator/.esy/3______________________________________________________/b
+    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3_____________________________________________________/i
+    ESY__CACHE_BUILD_PATH: /C/Users/VssAdministrator/.esy/3_____________________________________________________/b
     ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
     CACHE_ARTIFACT_NAME: cache-$(Agent.OS)-install
     # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy


### PR DESCRIPTION
`esy@0.6.10` changes the cache path, such that there is one less underscore in the path padding (https://github.com/esy/esy/issues/1127). Update our CI to accommodate new cache paths.