### PR TITLE
chore(ci): Fix concurrent upload issue

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -90,3 +90,4 @@
 - #3369 - CI: Install python3 on CentOS dockerfile
 - #3429 - CI: Remove libtools dependency
 - #3450 - CI: Fix esy cache path after upgrade to 0.6.10
+- #3452 - CI: Fix concurrent artifact upload for macOS VMs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,8 @@ jobs:
 
 - job: Hygiene_Checks
   displayName: 'Hygiene Checks'
+  # Run if not master - don't need to run hygiene checks for 'master' builds, just for PR validation
+  condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
   timeoutInMinutes: 0
   pool:
     vmImage: 'macOS 10.14'


### PR DESCRIPTION
Fix for a build error:
```
Total file: 1 ---- Processed file: 0 (0%)
Fail to upload '/Users/runner/work/1/a/esy-cache.tar' due to 'Blob is incomplete (missing block). Blob: 2b3f8daca8a3eb1185aa281878e01ace, Expected Offset: 0, Actual Offset: 4194304'.
Microsoft.VisualStudio.Services.WebApi.VssServiceResponseException: Blob is incomplete (missing block). Blob: 2b3f8daca8a3eb1185aa281878e01ace, Expected Offset: 0, Actual Offset: 4194304
 ---> System.InvalidOperationException: Blob is incomplete (missing block). Blob: 2b3f8daca8a3eb1185aa281878e01ace, Expected Offset: 0, Actual Offset: 4194304
   --- End of inner exception stack trace ---
```
https://dev.azure.com/onivim/oni2/_build/results?buildId=16435&view=logs&j=83eba23a-9ede-5c86-668a-3657d4d2e8d1&t=caeb8a87-5847-54ed-1bb9-47821a9bb3ac&l=950

Seems like a similar issue to https://github.com/microsoft/azure-pipelines-tasks/issues/12102#issuecomment-676736884 - which was due to a concurrent build upload (both MacOS strategies for Onivim - the hygiene check and mac build - were both trying to push up the cache artifact). For `master` builds, this disables the hygiene check strategy, which will remove the concurrent artifact upload.