### PR TITLE
fix(diagnostics/#3434): Swift diagnostics not showing

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -62,6 +62,7 @@
 - #3442 - Buffers: Fix regression causing control+tab menu not to stay open (related #3442)
 - #3443 - App: Fix broken window positioning w/ multiple monitors (fixes #3349)
 - #3451 - Terminal: Fix opening file using `oni2` from integrated terminal (fixes #2297)
+- #3456 - Diagnostics: Swift diagnostics not showing in editor surface (related #3434)
 
 ### Performance
 

--- a/src/Feature/Editor/ContentView.re
+++ b/src/Feature/Editor/ContentView.re
@@ -16,6 +16,7 @@ let renderLine =
       ~selectionRanges,
       ~matchingPairs: option((CharacterPosition.t, CharacterPosition.t)),
       ~vim,
+      ~languageConfiguration,
       ~languageSupport,
       viewLine,
       _offset,
@@ -41,7 +42,7 @@ let renderLine =
       let range =
         if (diagnostic.range.start == diagnostic.range.stop) {
           Editor.getTokenAt(
-            ~languageConfiguration=Oni_Core.LanguageConfiguration.default,
+            ~languageConfiguration,
             diagnostic.range.start,
             context.editor,
           )
@@ -142,6 +143,7 @@ let renderEmbellishments =
       ~matchingPairs,
       ~vim,
       ~languageSupport,
+      ~languageConfiguration,
     ) =>
   Draw.renderImmediate(
     ~context,
@@ -154,6 +156,7 @@ let renderEmbellishments =
       ~matchingPairs,
       ~vim,
       ~languageSupport,
+      ~languageConfiguration,
     ),
   );
 
@@ -297,6 +300,7 @@ let render =
     ~matchingPairs,
     ~vim,
     ~languageSupport,
+    ~languageConfiguration,
   );
 
   let bufferId = Buffer.getId(buffer);


### PR DESCRIPTION
__Issue:__ Swift errors aren't showing on the editor surface, even though they are recognized in the error pane:

![image](https://user-images.githubusercontent.com/13532591/115933863-a6512800-a444-11eb-9bb9-b84f0de47196.png)

__Defect:__ The diagnostic is coming to Onivim as a zero-length range, so we render a zero-length squiggly. However, the expected behavior is that Onivim will render the squiggly under the token at that position.

__Fix:__ Render the squiggly under the token:

![image](https://user-images.githubusercontent.com/13532591/115934043-ffb95700-a444-11eb-9200-7ab335f1091e.png)

Related #3434 