### PR TITLE
fix(snippet/#3434): Swift print snippet fails

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -62,6 +62,7 @@
 - #3442 - Buffers: Fix regression causing control+tab menu not to stay open (related #3442)
 - #3443 - App: Fix broken window positioning w/ multiple monitors (fixes #3349)
 - #3451 - Terminal: Fix opening file using `oni2` from integrated terminal (fixes #2297)
+- #3457 - Snippets: Fix parse error when colon is in placeholder (related #3434)
 
 ### Performance
 

--- a/src/Core/Snippet/Snippet.re
+++ b/src/Core/Snippet/Snippet.re
@@ -165,4 +165,7 @@ let%test_module "parse" =
      let%test "sprintf parse bug (comma in placeholder)" = {
        parse("sprintf(${1:char *,})") |> Result.is_ok;
      };
+     let%test "colon parse bug" = {
+       parse("print(${1:items:Any..})") |> Result.is_ok;
+     };
    });

--- a/src/Core/Snippet/Snippet_parser.mly
+++ b/src/Core/Snippet/Snippet_parser.mly
@@ -38,6 +38,7 @@ additionalChoices }) }
 | DOLLAR; LB; text = TEXT; { Text("${" ^ text) }
 | text = TEXT { Text(text) }
 | COMMA; { Text(",") }
+| COLON; { Text(":") }
 | numberAsText = NUMBER { Text(string_of_int(numberAsText)) }
 | variableAsText = VARIABLE { Snippet_internal.Text(variableAsText) }
 


### PR DESCRIPTION
__Issue:__ When trying to use the `print` completion snippet w/ the Swift extension, get an error:

<img width="320" alt="Screen Shot 2021-04-23 at 3 18 11 PM" src="https://user-images.githubusercontent.com/13532591/115940490-9f331580-a456-11eb-9be1-a18b58f04346.png">

__Fix:__ Allow colons in placeholder text