### PR TITLE
fix(vim/#3455): Fix alternate-file shortcut key

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -64,6 +64,7 @@
 - #3451 - Terminal: Fix opening file using `oni2` from integrated terminal (fixes #2297)
 - #3456 - Diagnostics: Swift diagnostics not showing in editor surface (related #3434)
 - #3457 - Snippets: Fix parse error when colon is in placeholder (related #3434)
+- #3464 - Vim: Fix alternate-file keybinding (fixes #3455)
 
 ### Performance
 

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -276,10 +276,21 @@ module Keybindings = {
       ~toKeys="<ESC>",
       ~condition=WhenExpr.Value(True),
     );
+
+  // Normalize the Ctrl-^ binding (alternate file) for libvim
+  // #3455: The Control+6 key gets sent as, actually, Ctrl-6, which isn't recognized
+  let controlCaretRemap =
+    remap(
+      ~allowRecursive=true,
+      ~fromKeys="<C-6>",
+      ~toKeys="<C-^>",
+      ~condition=WhenExpr.Value(True),
+    );
 };
 
 module Contributions = {
-  let keybindings = Keybindings.[controlSquareBracketRemap];
+  let keybindings =
+    Keybindings.[controlSquareBracketRemap, controlCaretRemap];
 
   let configuration = Configuration.[experimentalViml.spec];
 };


### PR DESCRIPTION
__Issue:__ The Control-^ binding (Control-6) to jump to an alternate file is not working as expected with Onivim.

__Defect:__ The key is sent in a way (`<C-6>`) that is unrecognized by libvim, which is expecting (`<C-^>`).

__Fix:__ Remap the key to send it in the form libvim is expecting

Fixes #3455 