### PR TITLE
fix(quickmenu/#3459): Remove darkening of the background

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -64,6 +64,7 @@
 - #3451 - Terminal: Fix opening file using `oni2` from integrated terminal (fixes #2297)
 - #3456 - Diagnostics: Swift diagnostics not showing in editor surface (related #3434)
 - #3457 - Snippets: Fix parse error when colon is in placeholder (related #3434)
+- #3465 - Quickmenu: Remove darkening of background when menu is open (fixes #3459)
 
 ### Performance
 

--- a/src/Feature/Quickmenu/View.re
+++ b/src/Feature/Quickmenu/View.re
@@ -186,7 +186,6 @@ let make =
           left(0),
           right(0),
           bottom(0),
-          backgroundColor(Revery.Color.rgba(0., 0., 0., 0.2)),
           pointerEvents(`Allow),
           alignItems(`Center),
         ]

--- a/src/UI/QuickmenuView.re
+++ b/src/UI/QuickmenuView.re
@@ -285,7 +285,6 @@ let make =
       left(0),
       right(0),
       bottom(0),
-      backgroundColor(Revery.Color.rgba(0., 0., 0., 0.2)),
       pointerEvents(`Allow),
       alignItems(`Center),
     ]


### PR DESCRIPTION
__Issue:__ The quickmenu would darken the background when open. In the case of switching themes, this is problematic... because after selecting the theme, it doesn't look the same with the darkened background removed.

__Fix:__ Remove the background darkening for the quickmenu.

Fixes #3459 