### PR TITLE
fix(input/#3256): Fix 'gt' binding parse case

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -65,6 +65,7 @@
 - #3456 - Diagnostics: Swift diagnostics not showing in editor surface (related #3434)
 - #3457 - Snippets: Fix parse error when colon is in placeholder (related #3434)
 - #3464 - Vim: Fix alternate-file keybinding (fixes #3455)
+- #3466 - Input: Fix `gt` binding parsing (fixes #3256)
 
 ### Performance
 

--- a/src/editor-input/Matcher_lexer.mll
+++ b/src/editor-input/Matcher_lexer.mll
@@ -63,8 +63,6 @@
 	"numpad_multiply", BINDING(Physical(NumpadMultiply));
 	"leader", BINDING(Special(Leader));
 	"plug", BINDING(Special(Plug));
-	"lt", BINDING(Physical(Character(Uchar.of_char '<')));
-	"gt", BINDING(Physical(Character(Uchar.of_char '>')));
 	"plus", BINDING(Physical(Character(Uchar.of_char '+')));
 	]
 }
@@ -102,6 +100,8 @@ rule token = parse
 | ['f' 'F'] '1' (['0'-'9'] as m) { BINDING ( Physical(Function(int_of_string ("1" ^ (String.make 1 m))) ) ) }
 | ['f' 'F'] '1' (['0'-'9'] as m) { BINDING ( Physical (Function(int_of_string ("1" ^ (String.make 1 m))) ) ) }
 | white { token lexbuf }
+| '<' ['l' 'L'] ['t' 'T'] '>' { BINDING (Physical(Character(Uchar.of_char '<'))) }
+| '<' ['g' 'G'] ['t' 'T'] '>' { BINDING (Physical(Character(Uchar.of_char '>'))) }
 | binding as i
  { BINDING (Physical(Character (Uchar.of_char i))) }
 | '<' { LT }

--- a/test/editor-input/MatcherTest.re
+++ b/test/editor-input/MatcherTest.re
@@ -83,6 +83,8 @@ describe("Matcher", ({describe, _}) => {
         ("~", keyPress(Key.Character(Uchar.of_char('~')))),
         ("_", keyPress(Key.Character(Uchar.of_char('_')))),
         ("+", keyPress(Key.Character(Uchar.of_char('+')))),
+        ("<gt>", keyPress(Key.Character(Uchar.of_char('>')))),
+        ("<lt>", keyPress(Key.Character(Uchar.of_char('<')))),
       ];
 
       let runCase = case => {
@@ -114,6 +116,18 @@ describe("Matcher", ({describe, _}) => {
     test("all keys released", ({expect, _}) => {
       let result = defaultParse("<RELEASE>");
       expect.equal(result, Ok(AllKeysReleased));
+    });
+    // https://github.com/onivim/oni2/issues/3256
+    test("gt #3256)", ({expect, _}) => {
+      expect.equal(
+        defaultParse("gt"),
+        Ok(
+          Sequence([
+            keyPress(Key.Character(Uchar.of_char('g'))),
+            keyPress(Key.Character(Uchar.of_char('t'))),
+          ]),
+        ),
+      )
     });
     test("vim bindings", ({expect, _}) => {
       let result = defaultParse("<a>");


### PR DESCRIPTION
__Issue:__ Binding to `gt` binds to <kbd>></kbd> instead of <kbd>g</kbd><kbd>t</kbd>

__Fix:__ Recognize just `<gt>` instead of `gt` - this is the same behavior as Vim. Note that modifier keys don't make sense in this context (`<c-gt>` isn't a key recognized by Vim), so we can simplify the parsing for the `<gt>` and `<lt>` case

Fixes #3256 