### PR TITLE
fix(cli/#1250): 'oni2' command should open in existing editor

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -67,6 +67,7 @@
 - #3464 - Vim: Fix alternate-file keybinding (fixes #3455)
 - #3465 - Quickmenu: Remove darkening of background when menu is open (fixes #3459)
 - #3466 - Input: Fix `gt` binding parsing (fixes #3256)
+- #3469 - CLI: Default to opening files in existing editor (fixes #1250, #2617, #2947, #3058)
 
 ### Performance
 

--- a/manual_test/cases.md
+++ b/manual_test/cases.md
@@ -273,6 +273,30 @@ __Pass:__
 - [ ] OSX
 - [ ] Linux
 
+## 9.2 Open a file from integrated terminal
+
+- Open Onivim 2
+- Run `:term`
+- Run `oni2 test-file.ts`
+- Validate `test-file.ts` is opened in a new split
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux
+
+## 9.3 Open a folder from integrated terminal
+
+- Open Onivim2
+- Run `:term`
+- Run `oni2 ~/some-valid-folder`, replacing `some-valid-folder` with an actual folder on the filesystem
+- Validate the explorer has switched to the new folder
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux
+
 # 10. Menubar
 
 ## 10.1 Verify simple command 
@@ -355,3 +379,38 @@ __Setup:__
 
 __Pass:__
 - [ ] Win
+
+# 13. CLI
+
+## 13.1 Single Instance - Open file in running instance
+
+- Open Onivim 2
+- From CLI, run `oni2 some-file-that-exists.txt`
+- Validate the file is opened in the current instance
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux
+
+## 13.2 Single Instance - Open folder in running instance
+
+- Open Onivim 2
+- From CLI, run `oni2 /some/folder/that/exists`
+- Validate the folder is opened in the current instance
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux
+
+## 13.3 Force new instance
+
+- Open Onivim 2
+- From CLI, run `oni2 --new-window test.txt`
+- Validate a new instance of Onivim is opened, with the specified file active
+
+__Pass:__
+- [ ] Win
+- [ ] OSX
+- [ ] Linux

--- a/src/CLI/Oni_CLI.re
+++ b/src/CLI/Oni_CLI.re
@@ -35,6 +35,7 @@ type t = {
   folder: option(string),
   filesToOpen: list(string),
   forceScaleFactor: option(float),
+  forceNewWindow: bool,
   overriddenExtensionsDir: option(FpExp.t(FpExp.absolute)),
   shouldLoadExtensions: bool,
   shouldLoadConfiguration: bool,
@@ -120,6 +121,7 @@ let parse = (~getenv: string => option(string), args) => {
   let shouldSyntaxHighlight = ref(true);
 
   let attachToForeground = ref(false);
+  let forceNewWindow = ref(false);
   let logLevel = ref(None);
   let isSilent = ref(false);
   let logExthost = ref(false);
@@ -167,6 +169,10 @@ let parse = (~getenv: string => option(string), args) => {
 
   getenv("ONI2_LOG_FILTER") |> Option.iter(v => logFilter := Some(v));
 
+  let setForceNewWindow = () => {
+    forceNewWindow := true;
+  };
+
   Arg.parse_argv(
     ~current=ref(0),
     sysArgs,
@@ -174,6 +180,8 @@ let parse = (~getenv: string => option(string), args) => {
       ("-c", String(str => vimExCommands := [str, ...vimExCommands^]), ""),
       ("-f", Unit(setAttached), ""),
       ("-v", setEffect(PrintVersion), ""),
+      ("-n", Unit(setForceNewWindow), ""),
+      ("--new-window", Unit(setForceNewWindow), ""),
       ("--nofork", Unit(setAttached), ""),
       ("--debug", Unit(() => logLevel := Some(Timber.Level.debug)), ""),
       ("--debug-exthost", Unit(() => logExthost := true), ""),
@@ -344,6 +352,7 @@ let parse = (~getenv: string => option(string), args) => {
   let cli = {
     folder,
     filesToOpen,
+    forceNewWindow: forceNewWindow^,
     forceScaleFactor: scaleFactor^,
     gpuAcceleration: gpuAcceleration^,
     overriddenExtensionsDir:

--- a/src/CLI/Oni_CLI.rei
+++ b/src/CLI/Oni_CLI.rei
@@ -10,6 +10,7 @@ type t = {
   folder: option(string),
   filesToOpen: list(string),
   forceScaleFactor: option(float),
+  forceNewWindow: bool,
   overriddenExtensionsDir: option(FpExp.t(FpExp.absolute)),
   shouldLoadExtensions: bool,
   shouldLoadConfiguration: bool,

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -57,6 +57,7 @@ module Persistence = Persistence;
 module SaveReason = SaveReason;
 module Setup = Setup;
 module ShellUtility = ShellUtility;
+module SingleInstance = SingleInstance;
 module SplitDirection = SplitDirection;
 module StringMap = Kernel.StringMap;
 module StringSet = Kernel.StringSet;

--- a/src/Core/SingleInstance.re
+++ b/src/Core/SingleInstance.re
@@ -1,56 +1,147 @@
+// SingleInstance
+// This is essentially a port of the `node-single-instance` library, into native reason:
+// https://github.com/pierrefourgeaud/node-single-instance/blob/master/index.js
 
-let tryToConnectToExistingServer = (~name, pipe: Luv.Pipe.t) => {
+exception ConnectError(string);
+
+module Log = (val Kernel.Log.withNamespace("Oni2.SingleInstance"));
+
+module Internal = {
+  let tryToConnectToExistingServer = (~name, ~serialize, ~arguments) => {
+    let pipe = Luv.Pipe.init() |> Result.get_ok;
     let (promise, resolver) = Lwt.task();
-    Luv.Pipe.connect(pipe, name,
-    fun
-    | Error(e) =>  {
-    prerr_endline ("Connect error!");
-    Lwt.failwith(resolver, "Error");
-    }
-    | Ok () =>  {
-        prerr_endline ("Wrote to server");
-        let message = Luv.Buffer.from_string("Hello world");
-        Luv.Stream.write(pipe, [message], (_result, _bytes_written) => {
-            Luv.Stream.shutdown(client, ignore)
-        });
-
-        Lwt.wakeup(resolver, ());
+    Luv.Pipe.connect(
+      pipe,
+      name,
+      fun
+      | Error(e) => {
+          Log.infof(m =>
+            m(
+              "Unable to connect to existing pipe [%s]: %s",
+              name,
+              Luv.Error.strerror(e),
+            )
+          );
+          Lwt.wakeup_exn(
+            resolver,
+            ConnectError("Connect error: " ++ Luv.Error.strerror(e)),
+          );
         }
-     );
+      | Ok () => {
+          Log.infof(m => m("Trying to write to server: %s", name));
+          let message = arguments |> serialize |> Luv.Buffer.from_bytes;
+          Luv.Stream.write(pipe, [message], (_result, _bytes_written) => {
+            Luv.Stream.shutdown(pipe, ignore)
+          });
 
-    promise
-    |> LwtEx.sync;
+          Log.infof(m => m("Wrote to server: %s", name));
+          Lwt.wakeup(resolver, ());
+        },
+    );
+
+    promise |> Utility.LwtEx.sync;
+  };
+
+  let tryToCreateServer = (~name, ~onConnected) => {
+    let server = Luv.Pipe.init() |> Result.get_ok;
+    ignore(Luv.Pipe.bind(server, name));
+
+    Luv.Stream.listen(
+      server,
+      fun
+      | Error(msg) =>
+        Log.errorf(m =>
+          m("Listen error [%s]: %s", name, Luv.Error.strerror(msg))
+        )
+      | Ok () => {
+          let client = Luv.Pipe.init() |> Result.get_ok;
+
+          switch (Luv.Stream.accept(~server, ~client)) {
+          | Error(msg) =>
+            Log.errorf(m =>
+              m(
+                "Error accepting client [%s]: %s",
+                name,
+                Luv.Error.strerror(msg),
+              )
+            );
+            Luv.Handle.close(client, ignore);
+          | Ok () =>
+            Luv.Stream.read_start(
+              client,
+              fun
+              | Error(`EOF) => Luv.Handle.close(client, ignore)
+              | Error(e) => {
+                  Log.errorf(m =>
+                    m("Read error[%s]: %s", name, Luv.Error.strerror(e))
+                  );
+                  Luv.Handle.close(client, ignore);
+                }
+              | Ok(buf) => {
+                  Log.errorf(m =>
+                    m("Got %d bytes from %s", Luv.Buffer.size(buf), name)
+                  );
+                  onConnected(Luv.Buffer.to_bytes(buf));
+                },
+            )
+          };
+        },
+    );
+  };
 };
 
-let lock = (
-    ~name: string,
-    ~arguments: 'a,
-    ~serialize: 'a => Bytes.t,
-    ~deserialize: Bytes.t => 'a,
-    ~firstInstance: 'a => unit,
-    ~additionalInstance: 'a => unit,
-) => {
-    let pipe = Luv.Pipe.init () |> Result.get_ok;
-    let tryConnect = tryToConnectToExistingServer(~name="echo-pipe", client);
+let lock =
+    (
+      ~name: string,
+      ~arguments: 'a,
+      ~serialize: 'a => Bytes.t,
+      ~deserialize: Bytes.t => 'a,
+      ~firstInstance: 'a => unit,
+      ~additionalInstance: 'a => unit,
+    ) => {
+  let name =
+    if (Sys.win32) {
+      Printf.sprintf("\\\\.\\pipe\\%s%s", name, "-sock");
+    } else {
+      Filename.get_temp_dir_name() ++ "/name.sock";
+    };
 
-    switch (tryConnect) {
-    | Ok() => "Success!");
-    }
+  Log.infof(m => m("Using socket: %s", name));
+  let tryConnect =
+    Internal.tryToConnectToExistingServer(~name, ~arguments, ~serialize);
 
-    // TODO: Fix name
-    // let%bind _ = Luv.Pipe.bind(server, "echo-pipe");
+  switch (tryConnect) {
+  | Ok () => Log.infof(m => m("Connected to existing socket: %s", name))
+  | Error(msg) =>
+    Log.infof(m =>
+      m("Unable to connect to exiting server: %s", Printexc.to_string(msg))
+    );
 
-    // Luv.Stream.listen(server, fun
-    // | Error(msg) => prerr_endline ("Listen error: " ++ Luv.Error.strerror(msg))
-    // | Ok() => {
-    //     prerr_endline ("Listening!")
-    //     let client = Luv.Pipe.init() |> Result.get_ok;
-    //     switch (Luv.Stream.accept(~server, ~client)) {
-    //     | Error(msg) => prerr_endline ("Accept error: " ++ Luv.Error.strerror(msg));
-    //         Luv.Handle.close(client ignore)
+    if (!Sys.win32) {
+      switch (Luv.File.Sync.unlink(name)) {
+      | Ok () => Log.infof(m => m("Deleted file %s", name))
+      | Error(msg) =>
+        Log.infof(m =>
+          m("Unable to delete file %s: %s", name, Luv.Error.strerror(msg))
+        )
+      };
+    };
 
-    //     | Ok () => Luv.Stream.write(client, [Luv.Buffer.of_string("Hello, world")])
-    //     }
-        
-    // })
-}
+    let _ =
+      Internal.tryToCreateServer(
+        ~name,
+        ~onConnected=bytes => {
+          Log.infof(m =>
+            m("Client connected - received %d bytes", Bytes.length(bytes))
+          );
+          try(bytes |> deserialize |> additionalInstance) {
+          | exn =>
+            Log.errorf(m =>
+              m("error deserializing bytes: %s", Printexc.to_string(exn))
+            )
+          };
+        },
+      );
+    firstInstance(arguments);
+  };
+};

--- a/src/Core/SingleInstance.re
+++ b/src/Core/SingleInstance.re
@@ -1,0 +1,56 @@
+
+let tryToConnectToExistingServer = (~name, pipe: Luv.Pipe.t) => {
+    let (promise, resolver) = Lwt.task();
+    Luv.Pipe.connect(pipe, name,
+    fun
+    | Error(e) =>  {
+    prerr_endline ("Connect error!");
+    Lwt.failwith(resolver, "Error");
+    }
+    | Ok () =>  {
+        prerr_endline ("Wrote to server");
+        let message = Luv.Buffer.from_string("Hello world");
+        Luv.Stream.write(pipe, [message], (_result, _bytes_written) => {
+            Luv.Stream.shutdown(client, ignore)
+        });
+
+        Lwt.wakeup(resolver, ());
+        }
+     );
+
+    promise
+    |> LwtEx.sync;
+};
+
+let lock = (
+    ~name: string,
+    ~arguments: 'a,
+    ~serialize: 'a => Bytes.t,
+    ~deserialize: Bytes.t => 'a,
+    ~firstInstance: 'a => unit,
+    ~additionalInstance: 'a => unit,
+) => {
+    let pipe = Luv.Pipe.init () |> Result.get_ok;
+    let tryConnect = tryToConnectToExistingServer(~name="echo-pipe", client);
+
+    switch (tryConnect) {
+    | Ok() => "Success!");
+    }
+
+    // TODO: Fix name
+    // let%bind _ = Luv.Pipe.bind(server, "echo-pipe");
+
+    // Luv.Stream.listen(server, fun
+    // | Error(msg) => prerr_endline ("Listen error: " ++ Luv.Error.strerror(msg))
+    // | Ok() => {
+    //     prerr_endline ("Listening!")
+    //     let client = Luv.Pipe.init() |> Result.get_ok;
+    //     switch (Luv.Stream.accept(~server, ~client)) {
+    //     | Error(msg) => prerr_endline ("Accept error: " ++ Luv.Error.strerror(msg));
+    //         Luv.Handle.close(client ignore)
+
+    //     | Ok () => Luv.Stream.write(client, [Luv.Buffer.of_string("Hello, world")])
+    //     }
+        
+    // })
+}

--- a/src/Core/SingleInstance.rei
+++ b/src/Core/SingleInstance.rei
@@ -1,0 +1,15 @@
+// SingleInstance.rei
+//
+// This is essentially a port of the `node-single-instance` library, into native reason:
+// https://github.com/pierrefourgeaud/node-single-instance/blob/master/index.js
+
+let lock:
+  (
+    ~name: string,
+    ~arguments: 'a,
+    ~serialize: 'a => Bytes.t,
+    ~deserialize: Bytes.t => 'a,
+    ~firstInstance: 'a => unit,
+    ~additionalInstance: 'a => unit
+  ) =>
+  unit;

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -609,8 +609,12 @@ switch (eff) {
           win^ |> Option.iter(Window.raise);
           globalDispatch^
           |> Option.iter(dispatch => {
-               Model.Actions.FilesDropped({paths: args.filesToOpen})
-               |> dispatch
+               let paths =
+                 switch (args.folderToOpen) {
+                 | None => args.filesToOpen
+                 | Some(folder) => [folder, ...args.filesToOpen]
+                 };
+               Model.Actions.FilesDropped({paths: paths}) |> dispatch;
              });
         },
     );

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -595,19 +595,24 @@ switch (eff) {
     let deserialize = bytes => Marshal.from_bytes(bytes, 0);
   };
 
-  Core.SingleInstance.lock(
-    ~name="onivim2",
-    ~arguments=SingleInstanceData.fromCli(cliOptions),
-    ~serialize=SingleInstanceData.serialize,
-    ~deserialize=SingleInstanceData.deserialize,
-    ~firstInstance=(_: SingleInstanceData.t) => run(),
-    ~additionalInstance=
-      (args: SingleInstanceData.t) => {
-        win^ |> Option.iter(Window.raise);
-        globalDispatch^
-        |> Option.iter(dispatch => {
-             Model.Actions.FilesDropped({paths: args.filesToOpen}) |> dispatch
-           });
-      },
-  );
+  if (cliOptions.forceNewWindow) {
+    run();
+  } else {
+    Core.SingleInstance.lock(
+      ~name="onivim2",
+      ~arguments=SingleInstanceData.fromCli(cliOptions),
+      ~serialize=SingleInstanceData.serialize,
+      ~deserialize=SingleInstanceData.deserialize,
+      ~firstInstance=(_: SingleInstanceData.t) => run(),
+      ~additionalInstance=
+        (args: SingleInstanceData.t) => {
+          win^ |> Option.iter(Window.raise);
+          globalDispatch^
+          |> Option.iter(dispatch => {
+               Model.Actions.FilesDropped({paths: args.filesToOpen})
+               |> dispatch
+             });
+        },
+    );
+  };
 };

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -581,7 +581,6 @@ switch (eff) {
   };
 
   module SingleInstanceData = {
-    [@deriving show]
     type t = {
       filesToOpen: list(string),
       folderToOpen: option(string),

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -605,10 +605,6 @@ switch (eff) {
     ~additionalInstance=
       (args: SingleInstanceData.t) => {
         win^ |> Option.iter(Window.raise);
-        prerr_endline(
-          "Additional instance: " ++ SingleInstanceData.show(args),
-        );
-
         globalDispatch^
         |> Option.iter(dispatch => {
              Model.Actions.FilesDropped({paths: args.filesToOpen}) |> dispatch

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -73,497 +73,546 @@ switch (eff) {
     HealthCheck.run(~checks=Common, cliOptions)
   )
 | Run =>
-  initializeLogging();
+  let win = ref(None);
+  let globalDispatch = ref(None);
+  let run = () => {
+    initializeLogging();
 
-  // #1161 - OSX - Make sure we're using the terminal / shell PATH.
-  // Only fix path when launched from finder -
-  // it seems running `zsh -ilc` hangs when running from terminal.
-  if (Sys.getenv_opt("ONI2_LAUNCHED_FROM_FINDER") |> Option.is_some) {
-    Core.ShellUtility.fixOSXPath();
-  };
-
-  let initWorkspace = () => {
-    let maybePath =
-      switch (Oni_CLI.(cliOptions.folder)) {
-      // If a folder was specified, we should for sure use that
-      | Some(folder) => Some(folder)
-
-      // If no files were specified, we can pull from persistence
-      | None when cliOptions.filesToOpen == [] =>
-        Store.Persistence.Global.workspace()
-
-      // If files were specified (#1983), don't open workspace from persistence
-      | None => None
-      };
-
-    let couldChangeDirectory = ref(false);
-    maybePath
-    |> Option.iter(path => {
-         Log.infof(m => m("Startup: Trying to change folder to: %s", path));
-
-         let chdirResult = {
-           open Base.Result.Let_syntax;
-           // First, check if we have permission to read the directory.
-           // In some cases - like #2742 - the directory might not be valid.
-           let%bind _: Luv.File.Dir.t = Luv.File.Sync.opendir(path);
-           Log.info(" - Have read permission");
-           let%bind () = Luv.Path.chdir(path);
-           Log.info("- Ran chdir");
-           Ok();
-         };
-
-         chdirResult
-         |> Result.iter(() => {
-              couldChangeDirectory := true;
-              Log.infof(m =>
-                m("Successfully changed working directory to: %s", path)
-              );
-            });
-       });
-
-    // The directory that was persisted is a valid workspace, so we can use it
-    if (couldChangeDirectory^) {
-      maybePath |> OptionEx.flatMap(FpExp.absoluteCurrentPlatform);
-    } else {
-      None;
-    };
-  };
-
-  // Fix for https://github.com/onivim/oni2/issues/2229
-  // Can we take the displays into account, to see if the negative position is actually valid?
-  // It's normal for positions to be negative, depending on display configuration - but this filters
-  // out the extreme case where we are persisting incorrect values (like -32000 in the case of #2229).
-  let isValidPosition = position => position > (-2000);
-
-  let positionToString = (
-    fun
-    | `Absolute(v) => Printf.sprintf("Absolute(%d)", v)
-    | `Centered => "Centered"
-  );
-
-  let maybeWindowPositionX =
-    cliOptions.windowPosition |> Option.map(({x, _}: Oni_CLI.position) => x);
-
-  let defaultPositionX =
-    maybeWindowPositionX
-    |> Option.map(pos => `Absolute(pos))
-    |> Option.value(~default=`Centered);
-
-  let maybeWindowPositionY =
-    cliOptions.windowPosition |> Option.map(({y, _}: Oni_CLI.position) => y);
-
-  let defaultPositionY =
-    maybeWindowPositionY
-    |> Option.map(pos => `Absolute(pos))
-    |> Option.value(~default=`Centered);
-
-  let createWindow = (~forceScaleFactor, ~maybeWorkspace, app) => {
-    let (x, y, width, height, maximized) = {
-      Store.Persistence.Workspace.(
-        maybeWorkspace
-        |> Option.map(workspace => {
-             let store = storeFor(FpExp.toString(workspace));
-             (
-               maybeWindowPositionX
-               |> OptionEx.or_(windowX(store))
-               |> OptionEx.tap(x =>
-                    Log.infof(m => m("Unsanitized x value: %d", x))
-                  )
-               |> OptionEx.filter(isValidPosition)
-               |> Option.fold(~some=x => `Absolute(x), ~none=`Centered),
-               maybeWindowPositionY
-               |> OptionEx.or_(windowY(store))
-               |> OptionEx.tap(y =>
-                    Log.infof(m => m("Unsanitized x value: %d", y))
-                  )
-               |> OptionEx.filter(isValidPosition)
-               |> Option.fold(~some=y => `Absolute(y), ~none=`Centered),
-               windowWidth(store),
-               windowHeight(store),
-               windowMaximized(store),
-             );
-           })
-        |> Option.value(
-             ~default=(defaultPositionX, defaultPositionY, 800, 600, false),
-           )
-      );
+    // #1161 - OSX - Make sure we're using the terminal / shell PATH.
+    // Only fix path when launched from finder -
+    // it seems running `zsh -ilc` hangs when running from terminal.
+    if (Sys.getenv_opt("ONI2_LAUNCHED_FROM_FINDER") |> Option.is_some) {
+      Core.ShellUtility.fixOSXPath();
     };
 
-    Log.infof(m =>
-      m(
-        "Sanitized values from persistence - x: %s y: %s width: %d height: %d",
-        x |> positionToString,
-        y |> positionToString,
-        width,
-        height,
-      )
-    );
+    let initWorkspace = () => {
+      let maybePath =
+        switch (Oni_CLI.(cliOptions.folder)) {
+        // If a folder was specified, we should for sure use that
+        | Some(folder) => Some(folder)
 
-    let decorated =
-      switch (Revery.Environment.os) {
-      | Windows(_) => false
-      | _ => true
-      };
+        // If no files were specified, we can pull from persistence
+        | None when cliOptions.filesToOpen == [] =>
+          Store.Persistence.Global.workspace()
 
-    let icon =
-      switch (Revery.Environment.os) {
-      | Mac(_) =>
-        switch (Sys.getenv_opt("ONI2_BUNDLED")) {
-        | Some(_) => None
-        | None => Some("logo.png")
-        }
-      | _ => Some("logo.png")
-      };
-
-    let window =
-      App.createWindow(
-        ~createOptions=
-          WindowCreateOptions.create(
-            ~forceScaleFactor,
-            ~acceleration=cliOptions.gpuAcceleration,
-            ~maximized,
-            ~vsync=Vsync.Immediate,
-            ~icon,
-            ~titlebarStyle=WindowStyles.Transparent,
-            ~x,
-            ~y,
-            ~width,
-            ~height,
-            ~decorated,
-            (),
-          ),
-        app,
-        "Oni2",
-      );
-
-    Window.setBackgroundColor(window, Colors.black);
-
-    window;
-  };
-  Log.infof(m =>
-    m(
-      "Starting Onivim 2 (%s / %s / %s / %s)",
-      Core.BuildInfo.version,
-      Core.BuildInfo.commitId,
-      Feature_AutoUpdate.defaultUpdateChannel,
-      Core.BuildInfo.extensionHostVersion,
-    )
-  );
-
-  /* The 'main' function for our app */
-  let init = app => {
-    Log.debug("Init");
-
-    Vim.init();
-    Oni2_KeyboardLayout.init();
-    Oni2_Sparkle.init();
-
-    Log.infof(m =>
-      m(
-        "Keyboard Language: %s Layout: %s",
-        Oni2_KeyboardLayout.getCurrentLanguage(),
-        Oni2_KeyboardLayout.getCurrentLayout(),
-      )
-    );
-
-    // Grab initial working directory prior to trying to set it -
-    // in some cases, a directory that does not have permissions may be persisted (ie #2742)
-    let initialWorkingDirectory = Sys.getcwd();
-    let maybeWorkspace = initWorkspace();
-    let workingDirectory =
-      maybeWorkspace
-      |> Option.map(FpExp.toString)
-      |> Option.value(~default=initialWorkingDirectory);
-
-    let window =
-      createWindow(
-        ~forceScaleFactor=cliOptions.forceScaleFactor,
-        ~maybeWorkspace,
-        app,
-      );
-
-    Log.debug("Initializing setup.");
-    let setup = Core.Setup.init();
-
-    let initialBuffer = {
-      let Vim.BufferMetadata.{id, version, filePath, modified, _} =
-        Vim.Buffer.openFile(Core.BufferPath.welcome)
-        |> Vim.BufferMetadata.ofBuffer;
-      Core.Buffer.ofMetadata(
-        ~font=Service_Font.default(),
-        ~id,
-        ~version,
-        ~filePath,
-        ~modified,
-      );
-    };
-
-    let initialBufferRenderers =
-      Model.BufferRenderers.(
-        initial
-        |> setById(
-             Core.Buffer.getId(initialBuffer),
-             Model.BufferRenderer.Welcome,
-           )
-      );
-
-    let extensionGlobalPersistence =
-      Store.Persistence.Global.extensionValues();
-
-    let licenseKeyPersistence = Store.Persistence.Global.licenseKey();
-
-    let initialWorkspaceStore =
-      Store.Persistence.Workspace.storeFor(workingDirectory);
-    let extensionWorkspacePersistence =
-      Store.Persistence.Workspace.extensionValues(initialWorkspaceStore);
-
-    let getZoom = () => {
-      Window.getZoom(window);
-    };
-
-    let setZoom = zoomFactor => Window.setZoom(window, zoomFactor);
-
-    let keybindingsLoader =
-      Oni_Core.Filesystem.getOrCreateConfigFile("keybindings.json")
-      |> Result.map(Feature_Input.KeybindingsLoader.file)
-      |> Oni_Core.Utility.ResultEx.tapError(msg =>
-           Log.errorf(m => m("Error initializing keybindings file: %s", msg))
-         )
-      |> Result.value(~default=Feature_Input.KeybindingsLoader.none);
-
-    let configurationLoader =
-      Feature_Configuration.(
-        if (!cliOptions.shouldLoadConfiguration) {
-          ConfigurationLoader.none;
-        } else {
-          Oni_Core.Filesystem.getOrCreateConfigFile("configuration.json")
-          |> Result.map(ConfigurationLoader.file)
-          |> Oni_Core.Utility.ResultEx.tapError(msg =>
-               Log.errorf(m =>
-                 m("Error initializing configurationj file: %s", msg)
-               )
-             )
-          |> Result.value(~default=ConfigurationLoader.none);
-        }
-      );
-
-    let currentState =
-      ref(
-        Model.State.initial(
-          ~cli=cliOptions,
-          ~initialBuffer,
-          ~initialBufferRenderers,
-          ~configurationLoader,
-          ~keybindingsLoader,
-          ~extensionGlobalPersistence,
-          ~extensionWorkspacePersistence,
-          ~workingDirectory,
-          ~maybeWorkspace,
-          // TODO: Use `FpExp.t` all the way down
-          ~extensionsFolder=cliOptions.overriddenExtensionsDir,
-          ~licenseKeyPersistence,
-          ~titlebarHeight=Revery.Window.getTitlebarHeight(window),
-          ~setZoom,
-          ~getZoom,
-        ),
-      );
-
-    let persistGlobal = () => Store.Persistence.Global.persist(currentState^);
-    let persistWorkspace = () => {
-      Feature_Workspace.openedFolder(currentState^.workspace)
-      |> Option.iter(workspace => {
-           Store.Persistence.Workspace.(
-             persist((currentState^, window), storeFor(workspace))
-           )
-         });
-    };
-
-    let uiDispatch = ref(_ => ());
-
-    let update =
-      UI.start(window, <Root state=currentState^ dispatch=uiDispatch^ />);
-
-    let setTitle = title => {
-      Window.setTitle(window, title);
-    };
-
-    let lastTitle = ref("");
-    let isDirty = ref(false);
-    let onStateChanged = state => {
-      currentState := state;
-      isDirty := true;
-    };
-
-    let runEventLoop = () => {
-      // Luv.Loop.run always returns [true] for us, so just keep polling:
-      ignore(
-        Luv.Loop.run(~mode=`NOWAIT, ()): bool,
-      );
-    };
-
-    let title = (state: Model.State.t) => {
-      let activeBuffer = Model.Selectors.getActiveBuffer(state);
-      let config = Model.Selectors.configResolver(state);
-
-      Feature_TitleBar.title(
-        ~activeBuffer,
-        ~config,
-        ~workspaceRoot=Feature_Workspace.rootName(state.workspace),
-        ~workspaceDirectory=
-          Feature_Workspace.workingDirectory(state.workspace),
-      );
-    };
-
-    let tick = _dt => {
-      runEventLoop();
-
-      if (isDirty^) {
-        update(<Root state=currentState^ dispatch=uiDispatch^ />);
-        isDirty := false;
-        persistGlobal();
-      };
-
-      let currentTitle = title(currentState^);
-      if (lastTitle^ != currentTitle) {
-        Log.infof(m => m("Setting title: %s", currentTitle));
-        lastTitle := currentTitle;
-        setTitle(currentTitle);
-      };
-    };
-    let _: unit => unit =
-      Tick.interval(~name="Oni2_Editor Apploop", tick, Time.zero);
-
-    let maximize = () => {
-      Window.maximize(window);
-    };
-
-    let minimize = () => {
-      Window.minimize(window);
-    };
-
-    let close = () => {
-      App.quit(~askNicely=true, app);
-    };
-
-    Callback.register("oni2_close", close);
-
-    let restore = () => {
-      Window.restore(window);
-    };
-
-    // This is called raiseWIndow because if it were simply raise, it would shadow the exception raising function
-    let raiseWindow = () => {
-      Window.raise(window);
-    };
-
-    let setVsync = vsync => Window.setVsync(window, vsync);
-
-    let quit = code => {
-      App.quit(~askNicely=false, ~code, app);
-    };
-
-    Log.debug("Startup: Starting StoreThread");
-    let (dispatch, runEffects) =
-      Store.StoreThread.start(
-        ~setup,
-        ~getClipboardText=() => Sdl2.Clipboard.getText(),
-        ~setClipboardText=text => Sdl2.Clipboard.setText(text),
-        ~executingDirectory=Revery.Environment.executingDirectory,
-        ~getState=() => currentState^,
-        ~onStateChanged,
-        ~setVsync,
-        ~maximize,
-        ~minimize,
-        ~restore,
-        ~raiseWindow,
-        ~close,
-        ~window=Some(window),
-        ~shouldLoadExtensions=cliOptions.shouldLoadConfiguration,
-        ~shouldSyntaxHighlight=cliOptions.shouldSyntaxHighlight,
-        ~overriddenExtensionsDir=cliOptions.overriddenExtensionsDir,
-        ~quit,
-        (),
-      );
-
-    uiDispatch := dispatch;
-    Log.debug("Startup: StoreThread started!");
-
-    let _: App.unsubscribe =
-      App.onFileOpen(app, path => {
-        dispatch(Model.Actions.FilesDropped({paths: [path]}))
-      });
-    let _: Window.unsubscribe =
-      Window.onMaximized(window, () =>
-        dispatch(Model.Actions.WindowMaximized)
-      );
-    let _: Window.unsubscribe =
-      Window.onFullscreen(window, () =>
-        dispatch(Model.Actions.WindowFullscreen)
-      );
-    let _: Window.unsubscribe =
-      Window.onMinimized(window, () =>
-        dispatch(Model.Actions.WindowMinimized)
-      );
-    let _: Window.unsubscribe =
-      Window.onRestored(window, () => dispatch(Model.Actions.WindowRestored));
-    let _: Window.unsubscribe =
-      Window.onFocusGained(window, () =>
-        dispatch(Model.Actions.WindowFocusGained)
-      );
-    let _: Window.unsubscribe =
-      Window.onFocusLost(window, () =>
-        dispatch(Model.Actions.WindowFocusLost)
-      );
-    let _: Window.unsubscribe =
-      Window.onSizeChanged(window, _ => persistWorkspace());
-    let _: Window.unsubscribe =
-      Window.onMoved(window, _ => persistWorkspace());
-
-    GlobalContext.set({dispatch: dispatch});
-
-    dispatch(Model.Actions.Init);
-    runEffects();
-
-    // Add a quit handler, so that regardless of how we quit -
-    // we have the opportunity to clean up
-    Revery.App.onBeforeQuit(
-      app,
-      _code => {
-        if (!currentState^.isQuitting) {
-          dispatch(Model.Actions.ReallyQuitting);
+        // If files were specified (#1983), don't open workspace from persistence
+        | None => None
         };
-        // We perform asynchronous cleanup, and
-        // exit(0) ourselves when that's complete
-        Revery.App.PreventQuit;
-      },
-    )
-    |> (ignore: Revery.App.unsubscribe => unit);
 
-    List.iter(
-      v =>
-        dispatch(
-          Model.Actions.OpenFileByPath(
-            v,
-            Oni_Core.SplitDirection.Current,
-            None,
-          ),
-        ),
-      cliOptions.filesToOpen,
+      let couldChangeDirectory = ref(false);
+      maybePath
+      |> Option.iter(path => {
+           Log.infof(m => m("Startup: Trying to change folder to: %s", path));
+
+           let chdirResult = {
+             open Base.Result.Let_syntax;
+             // First, check if we have permission to read the directory.
+             // In some cases - like #2742 - the directory might not be valid.
+             let%bind _: Luv.File.Dir.t = Luv.File.Sync.opendir(path);
+             Log.info(" - Have read permission");
+             let%bind () = Luv.Path.chdir(path);
+             Log.info("- Ran chdir");
+             Ok();
+           };
+
+           chdirResult
+           |> Result.iter(() => {
+                couldChangeDirectory := true;
+                Log.infof(m =>
+                  m("Successfully changed working directory to: %s", path)
+                );
+              });
+         });
+
+      // The directory that was persisted is a valid workspace, so we can use it
+      if (couldChangeDirectory^) {
+        maybePath |> OptionEx.flatMap(FpExp.absoluteCurrentPlatform);
+      } else {
+        None;
+      };
+    };
+
+    // Fix for https://github.com/onivim/oni2/issues/2229
+    // Can we take the displays into account, to see if the negative position is actually valid?
+    // It's normal for positions to be negative, depending on display configuration - but this filters
+    // out the extreme case where we are persisting incorrect values (like -32000 in the case of #2229).
+    let isValidPosition = position => position > (-2000);
+
+    let positionToString = (
+      fun
+      | `Absolute(v) => Printf.sprintf("Absolute(%d)", v)
+      | `Centered => "Centered"
     );
 
-    List.iter(
-      command => {
-        dispatch(
-          Model.Actions.VimExecuteCommand({allowAnimation: false, command}),
+    let maybeWindowPositionX =
+      cliOptions.windowPosition
+      |> Option.map(({x, _}: Oni_CLI.position) => x);
+
+    let defaultPositionX =
+      maybeWindowPositionX
+      |> Option.map(pos => `Absolute(pos))
+      |> Option.value(~default=`Centered);
+
+    let maybeWindowPositionY =
+      cliOptions.windowPosition
+      |> Option.map(({y, _}: Oni_CLI.position) => y);
+
+    let defaultPositionY =
+      maybeWindowPositionY
+      |> Option.map(pos => `Absolute(pos))
+      |> Option.value(~default=`Centered);
+
+    let createWindow = (~forceScaleFactor, ~maybeWorkspace, app) => {
+      let (x, y, width, height, maximized) = {
+        Store.Persistence.Workspace.(
+          maybeWorkspace
+          |> Option.map(workspace => {
+               let store = storeFor(FpExp.toString(workspace));
+               (
+                 maybeWindowPositionX
+                 |> OptionEx.or_(windowX(store))
+                 |> OptionEx.tap(x =>
+                      Log.infof(m => m("Unsanitized x value: %d", x))
+                    )
+                 |> OptionEx.filter(isValidPosition)
+                 |> Option.fold(~some=x => `Absolute(x), ~none=`Centered),
+                 maybeWindowPositionY
+                 |> OptionEx.or_(windowY(store))
+                 |> OptionEx.tap(y =>
+                      Log.infof(m => m("Unsanitized x value: %d", y))
+                    )
+                 |> OptionEx.filter(isValidPosition)
+                 |> Option.fold(~some=y => `Absolute(y), ~none=`Centered),
+                 windowWidth(store),
+                 windowHeight(store),
+                 windowMaximized(store),
+               );
+             })
+          |> Option.value(
+               ~default=(defaultPositionX, defaultPositionY, 800, 600, false),
+             )
         );
-        runEffects();
-      },
-      cliOptions.vimExCommands,
+      };
+
+      Log.infof(m =>
+        m(
+          "Sanitized values from persistence - x: %s y: %s width: %d height: %d",
+          x |> positionToString,
+          y |> positionToString,
+          width,
+          height,
+        )
+      );
+
+      let decorated =
+        switch (Revery.Environment.os) {
+        | Windows(_) => false
+        | _ => true
+        };
+
+      let icon =
+        switch (Revery.Environment.os) {
+        | Mac(_) =>
+          switch (Sys.getenv_opt("ONI2_BUNDLED")) {
+          | Some(_) => None
+          | None => Some("logo.png")
+          }
+        | _ => Some("logo.png")
+        };
+
+      let window =
+        App.createWindow(
+          ~createOptions=
+            WindowCreateOptions.create(
+              ~forceScaleFactor,
+              ~acceleration=cliOptions.gpuAcceleration,
+              ~maximized,
+              ~vsync=Vsync.Immediate,
+              ~icon,
+              ~titlebarStyle=WindowStyles.Transparent,
+              ~x,
+              ~y,
+              ~width,
+              ~height,
+              ~decorated,
+              (),
+            ),
+          app,
+          "Oni2",
+        );
+
+      Window.setBackgroundColor(window, Colors.black);
+
+      win := Some(window);
+      window;
+    };
+    Log.infof(m =>
+      m(
+        "Starting Onivim 2 (%s / %s / %s / %s)",
+        Core.BuildInfo.version,
+        Core.BuildInfo.commitId,
+        Feature_AutoUpdate.defaultUpdateChannel,
+        Core.BuildInfo.extensionHostVersion,
+      )
     );
+
+    /* The 'main' function for our app */
+    let init = app => {
+      Log.debug("Init");
+
+      Vim.init();
+      Oni2_KeyboardLayout.init();
+      Oni2_Sparkle.init();
+
+      Log.infof(m =>
+        m(
+          "Keyboard Language: %s Layout: %s",
+          Oni2_KeyboardLayout.getCurrentLanguage(),
+          Oni2_KeyboardLayout.getCurrentLayout(),
+        )
+      );
+
+      // Grab initial working directory prior to trying to set it -
+      // in some cases, a directory that does not have permissions may be persisted (ie #2742)
+      let initialWorkingDirectory = Sys.getcwd();
+      let maybeWorkspace = initWorkspace();
+      let workingDirectory =
+        maybeWorkspace
+        |> Option.map(FpExp.toString)
+        |> Option.value(~default=initialWorkingDirectory);
+
+      let window =
+        createWindow(
+          ~forceScaleFactor=cliOptions.forceScaleFactor,
+          ~maybeWorkspace,
+          app,
+        );
+
+      Log.debug("Initializing setup.");
+      let setup = Core.Setup.init();
+
+      let initialBuffer = {
+        let Vim.BufferMetadata.{id, version, filePath, modified, _} =
+          Vim.Buffer.openFile(Core.BufferPath.welcome)
+          |> Vim.BufferMetadata.ofBuffer;
+        Core.Buffer.ofMetadata(
+          ~font=Service_Font.default(),
+          ~id,
+          ~version,
+          ~filePath,
+          ~modified,
+        );
+      };
+
+      let initialBufferRenderers =
+        Model.BufferRenderers.(
+          initial
+          |> setById(
+               Core.Buffer.getId(initialBuffer),
+               Model.BufferRenderer.Welcome,
+             )
+        );
+
+      let extensionGlobalPersistence =
+        Store.Persistence.Global.extensionValues();
+
+      let licenseKeyPersistence = Store.Persistence.Global.licenseKey();
+
+      let initialWorkspaceStore =
+        Store.Persistence.Workspace.storeFor(workingDirectory);
+      let extensionWorkspacePersistence =
+        Store.Persistence.Workspace.extensionValues(initialWorkspaceStore);
+
+      let getZoom = () => {
+        Window.getZoom(window);
+      };
+
+      let setZoom = zoomFactor => Window.setZoom(window, zoomFactor);
+
+      let keybindingsLoader =
+        Oni_Core.Filesystem.getOrCreateConfigFile("keybindings.json")
+        |> Result.map(Feature_Input.KeybindingsLoader.file)
+        |> Oni_Core.Utility.ResultEx.tapError(msg =>
+             Log.errorf(m =>
+               m("Error initializing keybindings file: %s", msg)
+             )
+           )
+        |> Result.value(~default=Feature_Input.KeybindingsLoader.none);
+
+      let configurationLoader =
+        Feature_Configuration.(
+          if (!cliOptions.shouldLoadConfiguration) {
+            ConfigurationLoader.none;
+          } else {
+            Oni_Core.Filesystem.getOrCreateConfigFile("configuration.json")
+            |> Result.map(ConfigurationLoader.file)
+            |> Oni_Core.Utility.ResultEx.tapError(msg =>
+                 Log.errorf(m =>
+                   m("Error initializing configurationj file: %s", msg)
+                 )
+               )
+            |> Result.value(~default=ConfigurationLoader.none);
+          }
+        );
+
+      let currentState =
+        ref(
+          Model.State.initial(
+            ~cli=cliOptions,
+            ~initialBuffer,
+            ~initialBufferRenderers,
+            ~configurationLoader,
+            ~keybindingsLoader,
+            ~extensionGlobalPersistence,
+            ~extensionWorkspacePersistence,
+            ~workingDirectory,
+            ~maybeWorkspace,
+            // TODO: Use `FpExp.t` all the way down
+            ~extensionsFolder=cliOptions.overriddenExtensionsDir,
+            ~licenseKeyPersistence,
+            ~titlebarHeight=Revery.Window.getTitlebarHeight(window),
+            ~setZoom,
+            ~getZoom,
+          ),
+        );
+
+      let persistGlobal = () =>
+        Store.Persistence.Global.persist(currentState^);
+      let persistWorkspace = () => {
+        Feature_Workspace.openedFolder(currentState^.workspace)
+        |> Option.iter(workspace => {
+             Store.Persistence.Workspace.(
+               persist((currentState^, window), storeFor(workspace))
+             )
+           });
+      };
+
+      let uiDispatch = ref(_ => ());
+
+      let update =
+        UI.start(window, <Root state=currentState^ dispatch=uiDispatch^ />);
+
+      let setTitle = title => {
+        Window.setTitle(window, title);
+      };
+
+      let lastTitle = ref("");
+      let isDirty = ref(false);
+      let onStateChanged = state => {
+        currentState := state;
+        isDirty := true;
+      };
+
+      let runEventLoop = () => {
+        // Luv.Loop.run always returns [true] for us, so just keep polling:
+        ignore(
+          Luv.Loop.run(~mode=`NOWAIT, ()): bool,
+        );
+      };
+
+      let title = (state: Model.State.t) => {
+        let activeBuffer = Model.Selectors.getActiveBuffer(state);
+        let config = Model.Selectors.configResolver(state);
+
+        Feature_TitleBar.title(
+          ~activeBuffer,
+          ~config,
+          ~workspaceRoot=Feature_Workspace.rootName(state.workspace),
+          ~workspaceDirectory=
+            Feature_Workspace.workingDirectory(state.workspace),
+        );
+      };
+
+      let tick = _dt => {
+        runEventLoop();
+
+        if (isDirty^) {
+          update(<Root state=currentState^ dispatch=uiDispatch^ />);
+          isDirty := false;
+          persistGlobal();
+        };
+
+        let currentTitle = title(currentState^);
+        if (lastTitle^ != currentTitle) {
+          Log.infof(m => m("Setting title: %s", currentTitle));
+          lastTitle := currentTitle;
+          setTitle(currentTitle);
+        };
+      };
+      let _: unit => unit =
+        Tick.interval(~name="Oni2_Editor Apploop", tick, Time.zero);
+
+      let maximize = () => {
+        Window.maximize(window);
+      };
+
+      let minimize = () => {
+        Window.minimize(window);
+      };
+
+      let close = () => {
+        App.quit(~askNicely=true, app);
+      };
+
+      Callback.register("oni2_close", close);
+
+      let restore = () => {
+        Window.restore(window);
+      };
+
+      // This is called raiseWIndow because if it were simply raise, it would shadow the exception raising function
+      let raiseWindow = () => {
+        Window.raise(window);
+      };
+
+      let setVsync = vsync => Window.setVsync(window, vsync);
+
+      let quit = code => {
+        App.quit(~askNicely=false, ~code, app);
+      };
+
+      Log.debug("Startup: Starting StoreThread");
+      let (dispatch, runEffects) =
+        Store.StoreThread.start(
+          ~setup,
+          ~getClipboardText=() => Sdl2.Clipboard.getText(),
+          ~setClipboardText=text => Sdl2.Clipboard.setText(text),
+          ~executingDirectory=Revery.Environment.executingDirectory,
+          ~getState=() => currentState^,
+          ~onStateChanged,
+          ~setVsync,
+          ~maximize,
+          ~minimize,
+          ~restore,
+          ~raiseWindow,
+          ~close,
+          ~window=Some(window),
+          ~shouldLoadExtensions=cliOptions.shouldLoadConfiguration,
+          ~shouldSyntaxHighlight=cliOptions.shouldSyntaxHighlight,
+          ~overriddenExtensionsDir=cliOptions.overriddenExtensionsDir,
+          ~quit,
+          (),
+        );
+
+      globalDispatch := Some(dispatch);
+      uiDispatch := dispatch;
+      Log.debug("Startup: StoreThread started!");
+
+      let _: App.unsubscribe =
+        App.onFileOpen(app, path => {
+          dispatch(Model.Actions.FilesDropped({paths: [path]}))
+        });
+      let _: Window.unsubscribe =
+        Window.onMaximized(window, () =>
+          dispatch(Model.Actions.WindowMaximized)
+        );
+      let _: Window.unsubscribe =
+        Window.onFullscreen(window, () =>
+          dispatch(Model.Actions.WindowFullscreen)
+        );
+      let _: Window.unsubscribe =
+        Window.onMinimized(window, () =>
+          dispatch(Model.Actions.WindowMinimized)
+        );
+      let _: Window.unsubscribe =
+        Window.onRestored(window, () =>
+          dispatch(Model.Actions.WindowRestored)
+        );
+      let _: Window.unsubscribe =
+        Window.onFocusGained(window, () =>
+          dispatch(Model.Actions.WindowFocusGained)
+        );
+      let _: Window.unsubscribe =
+        Window.onFocusLost(window, () =>
+          dispatch(Model.Actions.WindowFocusLost)
+        );
+      let _: Window.unsubscribe =
+        Window.onSizeChanged(window, _ => persistWorkspace());
+      let _: Window.unsubscribe =
+        Window.onMoved(window, _ => persistWorkspace());
+
+      GlobalContext.set({dispatch: dispatch});
+
+      dispatch(Model.Actions.Init);
+      runEffects();
+
+      // Add a quit handler, so that regardless of how we quit -
+      // we have the opportunity to clean up
+      Revery.App.onBeforeQuit(
+        app,
+        _code => {
+          if (!currentState^.isQuitting) {
+            dispatch(Model.Actions.ReallyQuitting);
+          };
+          // We perform asynchronous cleanup, and
+          // exit(0) ourselves when that's complete
+          Revery.App.PreventQuit;
+        },
+      )
+      |> (ignore: Revery.App.unsubscribe => unit);
+
+      List.iter(
+        v =>
+          dispatch(
+            Model.Actions.OpenFileByPath(
+              v,
+              Oni_Core.SplitDirection.Current,
+              None,
+            ),
+          ),
+        cliOptions.filesToOpen,
+      );
+
+      List.iter(
+        command => {
+          dispatch(
+            Model.Actions.VimExecuteCommand({allowAnimation: false, command}),
+          );
+          runEffects();
+        },
+        cliOptions.vimExCommands,
+      );
+    };
+
+    /* Let's get this party started! */
+    Log.debug("Calling App.start");
+    let () = App.start(init);
+    ();
   };
 
-  /* Let's get this party started! */
-  Log.debug("Calling App.start");
-  let () = App.start(init);
-  ();
+  module SingleInstanceData = {
+    [@deriving show]
+    type t = {
+      filesToOpen: list(string),
+      folderToOpen: option(string),
+    };
+
+    let fromCli = (cli: Oni_CLI.t) => {
+      folderToOpen: cli.folder,
+      filesToOpen: cli.filesToOpen,
+    };
+
+    let serialize = data => Marshal.to_bytes(data, []);
+    let deserialize = bytes => Marshal.from_bytes(bytes, 0);
+  };
+
+  Core.SingleInstance.lock(
+    ~name="test-instance-name",
+    ~arguments=SingleInstanceData.fromCli(cliOptions),
+    ~serialize=SingleInstanceData.serialize,
+    ~deserialize=SingleInstanceData.deserialize,
+    ~firstInstance=(_: SingleInstanceData.t) => run(),
+    ~additionalInstance=
+      (args: SingleInstanceData.t) => {
+        win^ |> Option.iter(Window.raise);
+        prerr_endline(
+          "Additional instance: " ++ SingleInstanceData.show(args),
+        );
+
+        globalDispatch^
+        |> Option.iter(dispatch => {
+             Model.Actions.FilesDropped({paths: args.filesToOpen}) |> dispatch
+           });
+      },
+  );
 };

--- a/src/bin_editor/Oni2_editor.re
+++ b/src/bin_editor/Oni2_editor.re
@@ -597,7 +597,7 @@ switch (eff) {
   };
 
   Core.SingleInstance.lock(
-    ~name="test-instance-name",
+    ~name="onivim2",
     ~arguments=SingleInstanceData.fromCli(cliOptions),
     ~serialize=SingleInstanceData.serialize,
     ~deserialize=SingleInstanceData.deserialize,

--- a/src/bin_editor/dune
+++ b/src/bin_editor/dune
@@ -7,4 +7,4 @@
    Oni2.syntax_client Oni2.syntax_server Oni2.ui reason-sdl2 reason-harfbuzz
    Oni2.sparkle Oni2.KeyboardLayout fp dir.lib)
  (preprocess
-  (pps ppx_let lwt_ppx brisk-reconciler.ppx)))
+  (pps ppx_let ppx_deriving.show lwt_ppx brisk-reconciler.ppx)))

--- a/src/bin_launcher/Oni2.re
+++ b/src/bin_launcher/Oni2.re
@@ -22,6 +22,8 @@ let spec =
       Arg.Set(stayAttached),
       " Stay attached to the foreground terminal.",
     ),
+    ("-n", passthrough, " Open a new Onivim 2 session"),
+    ("--new-window", passthrough, " Open a new Onivim 2 session"),
     ("-v", passthroughAndStayAttached, " Print version information."),
     (
       "-f",


### PR DESCRIPTION
__Issue:__ On every platform, the `oni2` CLI command always opens a new window. In general, though, it's preferred to open and focus the existing window.

__Fix:__ Implement a similar strategy to [`node-single-instance`](https://github.com/pierrefourgeaud/node-single-instance/blob/master/index.js), just with native reasonml.

__Todo:__
- [x] Add flag to force open in a new instance
- [x] Fix stat crash for new files/directories
- [x] Add manual test case (open fresh instance, re-use instance, force new instance, open from terminal)
- [x] Fix opening folder for command line
- [x] Verify latest on Windows
- [x] Verify latest on OSX

Fixes #1250
Fixes #2947 
Fixes #3058 