### PR TITLE
fix(explorer/#1104): Reload explorer when files.exclude is updated

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -67,6 +67,7 @@
 - #3464 - Vim: Fix alternate-file keybinding (fixes #3455)
 - #3465 - Quickmenu: Remove darkening of background when menu is open (fixes #3459)
 - #3466 - Input: Fix `gt` binding parsing (fixes #3256)
+- #3474 - Explorer: Reload explorer when `files.exclude` is updated (fixes #1104)
 
 ### Performance
 

--- a/src/Components/FileExplorer/Component_FileExplorer.rei
+++ b/src/Components/FileExplorer/Component_FileExplorer.rei
@@ -34,24 +34,11 @@ type outmsg =
       stat: option(Luv.File.Stat.t),
     });
 
-let update:
-  (
-    ~config: Config.resolver,
-    ~configuration: Feature_Configuration.model,
-    msg,
-    model
-  ) =>
-  (model, outmsg);
+let update: (~config: Config.resolver, msg, model) => (model, outmsg);
 
 // SUBSCRIPTION
 
-let sub:
-  (
-    ~config: Config.resolver,
-    ~configuration: Feature_Configuration.model,
-    model
-  ) =>
-  Isolinear.Sub.t(msg);
+let sub: (~config: Config.resolver, model) => Isolinear.Sub.t(msg);
 
 // VIEW
 

--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -263,6 +263,15 @@ module Explorer = {
     );
 };
 
+module Files = {
+  let exclude =
+    setting(
+      "files.exclude",
+      list(string),
+      ~default=["_esy", ".git", "node_modules"],
+    );
+};
+
 module Workbench = {
   let activityBarVisible =
     setting("workbench.activityBar.visible", bool, ~default=true);
@@ -284,6 +293,7 @@ let contributions = [
   Editor.codeLensEnabled.spec,
   Editor.largeFileOptimizations.spec,
   Editor.snippetSuggestions.spec,
+  Files.exclude.spec,
   Explorer.autoReveal.spec,
   Workbench.activityBarVisible.spec,
   Workbench.editorShowTabs.spec,

--- a/src/Feature/Configuration/LegacyConfigurationParser.re
+++ b/src/Feature/Configuration/LegacyConfigurationParser.re
@@ -6,20 +6,6 @@
 open Oni_Core;
 open LegacyConfigurationValues;
 
-let parseStringList = json => {
-  switch (json) {
-  | `List(items) =>
-    List.filter_map(
-      fun
-      | `String(v) => Some(v)
-      | _ => None,
-      items,
-    )
-  | `String(v) => [v]
-  | _ => []
-  };
-};
-
 let parseVimUseSystemClipboardSetting = json => {
   let parseItems = items =>
     List.fold_left(
@@ -53,13 +39,8 @@ type configurationTuple = (string, parseFunction);
 
 let configurationParsers: list(configurationTuple) = [
   (
-    "files.exclude",
-    (config, json) => {...config, filesExclude: parseStringList(json)},
-  ),
-  (
     "vim.useSystemClipboard",
-    (config, json) => {
-      ...config,
+    (_config, json) => {
       vimUseSystemClipboard: parseVimUseSystemClipboardSetting(json),
     },
   ),

--- a/src/Feature/Configuration/LegacyConfigurationValues.re
+++ b/src/Feature/Configuration/LegacyConfigurationValues.re
@@ -11,7 +11,6 @@ type vimUseSystemClipboard = {
 };
 
 type t = {
-  filesExclude: list(string),
   vimUseSystemClipboard,
   // Experimental feature flags
   // These are 'use-at-your-own-risk' features
@@ -20,7 +19,6 @@ type t = {
 };
 
 let default = {
-  filesExclude: ["_esy", "node_modules", ".git"],
   vimUseSystemClipboard: {
     yank: true,
     delete: false,

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -98,6 +98,13 @@ let focusOutline = model => {
     ExpandedState.implicitlyOpen(model.isSymbolOutlineExpanded),
 };
 
+let configurationChanged = (~config as _, model) => {
+  let fileExplorer' =
+    model.fileExplorer |> Option.map(Component_FileExplorer.reload);
+
+  {...model, fileExplorer: fileExplorer'};
+};
+
 let setRoot = (~rootPath, model) =>
   if (Option.equal(
         FpExp.eq,
@@ -140,7 +147,7 @@ type outmsg =
   | SymbolSelected(Feature_LanguageSupport.DocumentSymbols.symbol)
   | PickFolder;
 
-let update = (~config, ~configuration, msg, model) => {
+let update = (~config, msg, model) => {
   switch (msg) {
   | Command(Reload) => (
       {
@@ -188,7 +195,6 @@ let update = (~config, ~configuration, msg, model) => {
          let (fileExplorer, outmsg) =
            Component_FileExplorer.update(
              ~config,
-             ~configuration,
              fileExplorerMsg,
              fileExplorer,
            );
@@ -521,10 +527,10 @@ module View = {
   };
 };
 
-let sub = (~config, ~configuration, model) => {
+let sub = (~config, model) => {
   model.fileExplorer
   |> Option.map(explorer => {
-       Component_FileExplorer.sub(~config, ~configuration, explorer)
+       Component_FileExplorer.sub(~config, explorer)
        |> Isolinear.Sub.map(msg => FileExplorer(msg))
      })
   |> Option.value(~default=Isolinear.Sub.none);

--- a/src/Feature/Explorer/Feature_Explorer.re
+++ b/src/Feature/Explorer/Feature_Explorer.re
@@ -47,6 +47,7 @@ module ExpandedState = {
 type model = {
   focus,
   isFileExplorerExpanded: ExpandedState.t,
+  excludeFiles: list(string),
   fileExplorer: option(Component_FileExplorer.model),
   isSymbolOutlineExpanded: ExpandedState.t,
   symbolOutline:
@@ -88,6 +89,7 @@ let initial = (~rootPath) => {
   fileExplorer:
     rootPath
     |> Option.map(rootPath => Component_FileExplorer.initial(~rootPath)),
+  excludeFiles: [],
   symbolOutline: Component_VimTree.create(~rowHeight=20),
   vimWindowNavigation: Component_VimWindows.initial,
 };
@@ -98,11 +100,18 @@ let focusOutline = model => {
     ExpandedState.implicitlyOpen(model.isSymbolOutlineExpanded),
 };
 
-let configurationChanged = (~config as _, model) => {
-  let fileExplorer' =
-    model.fileExplorer |> Option.map(Component_FileExplorer.reload);
+let configurationChanged = (~config, model) => {
+  let excludeFiles =
+    Feature_Configuration.GlobalConfiguration.Files.exclude.get(config);
 
-  {...model, fileExplorer: fileExplorer'};
+  if (excludeFiles != model.excludeFiles) {
+    let fileExplorer' =
+      model.fileExplorer |> Option.map(Component_FileExplorer.reload);
+
+    {...model, excludeFiles, fileExplorer: fileExplorer'};
+  } else {
+    model;
+  };
 };
 
 let setRoot = (~rootPath, model) =>

--- a/src/Feature/Explorer/Feature_Explorer.rei
+++ b/src/Feature/Explorer/Feature_Explorer.rei
@@ -20,6 +20,8 @@ let root: model => option(FpExp.t(FpExp.absolute));
 
 let focusOutline: model => model;
 
+let configurationChanged: (~config: Config.resolver, model) => model;
+
 // UPDATE
 
 type outmsg =
@@ -36,24 +38,11 @@ type outmsg =
   | SymbolSelected(Feature_LanguageSupport.DocumentSymbols.symbol)
   | PickFolder;
 
-let update:
-  (
-    ~config: Config.resolver,
-    ~configuration: Feature_Configuration.model,
-    msg,
-    model
-  ) =>
-  (model, outmsg);
+let update: (~config: Config.resolver, msg, model) => (model, outmsg);
 
 // SUBSCRIPTION
 
-let sub:
-  (
-    ~config: Config.resolver,
-    ~configuration: Feature_Configuration.model,
-    model
-  ) =>
-  Isolinear.Sub.t(msg);
+let sub: (~config: Config.resolver, model) => Isolinear.Sub.t(msg);
 
 // VIEW
 

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -43,12 +43,6 @@ let initial = {
 module Configuration = {
   open Config.Schema;
   let searchExclude = setting("search.exclude", list(string), ~default=[]);
-  let filesExclude =
-    setting(
-      "files.exclude",
-      list(string),
-      ~default=["_esy", ".git", "node_modules"],
-    );
 };
 
 let matchToLocListItem = (hit: Ripgrep.Match.t) =>
@@ -236,7 +230,9 @@ let subscriptions =
     (~config: Oni_Core.Config.resolver, ~workingDirectory, ripgrep, dispatch) => {
   let searchExclude =
     Configuration.searchExclude.get(config)
-    |> List.append(Configuration.filesExclude.get(config));
+    |> List.append(
+         Feature_Configuration.GlobalConfiguration.Files.exclude.get(config),
+       );
 
   let search = query => {
     SearchSubscription.create(
@@ -412,5 +408,5 @@ module Contributions = {
 
     [inputTextKeys, vimNavKeys, vimTreeKeys] |> unionMany;
   };
-  let configuration = Configuration.[searchExclude.spec, filesExclude.spec];
+  let configuration = Configuration.[searchExclude.spec];
 };

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -187,6 +187,9 @@ module Internal = {
       let resolver = Selectors.configResolver(state);
       let maybeRoot = Feature_Explorer.root(state.fileExplorer);
 
+      let fileExplorer =
+        state.fileExplorer
+        |> Feature_Explorer.configurationChanged(~config=resolver);
       let zen = Feature_Zen.configurationChanged(resolver, state.zen);
       let sideBar =
         state.sideBar
@@ -238,6 +241,7 @@ module Internal = {
           ...state,
           buffers,
           colorTheme,
+          fileExplorer,
           languageSupport,
           sideBar,
           layout,
@@ -528,12 +532,7 @@ let update =
   | FileExplorer(msg) =>
     let config = Selectors.configResolver(state);
     let (model, outmsg) =
-      Feature_Explorer.update(
-        ~config,
-        ~configuration=state.config,
-        msg,
-        state.fileExplorer,
-      );
+      Feature_Explorer.update(~config, msg, state.fileExplorer);
 
     let state = {...state, fileExplorer: model};
 

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -555,12 +555,9 @@ let subscriptions = (ripgrep, dispatch) => {
     );
   };
 
-  let ripgrep = (workspace, languageInfo, iconTheme, configuration) => {
+  let ripgrep = (workspace, languageInfo, iconTheme, config) => {
     let filesExclude =
-      Feature_Configuration.Legacy.getValue(
-        c => c.filesExclude,
-        configuration,
-      );
+      Feature_Configuration.GlobalConfiguration.Files.exclude.get(config);
 
     switch (Feature_Workspace.openedFolder(workspace)) {
     | None =>
@@ -624,7 +621,7 @@ let subscriptions = (ripgrep, dispatch) => {
             state.workspace,
             state.languageSupport |> Feature_LanguageSupport.languageInfo,
             state.iconTheme,
-            state.config,
+            state |> Oni_Model.Selectors.configResolver,
           )
 
       | Wildmenu(_) => []

--- a/src/Store/StoreThread.re
+++ b/src/Store/StoreThread.re
@@ -346,11 +346,7 @@ let start =
       );
 
     let fileExplorerSub =
-      Feature_Explorer.sub(
-        ~config,
-        ~configuration=state.config,
-        state.fileExplorer,
-      )
+      Feature_Explorer.sub(~config, state.fileExplorer)
       |> Isolinear.Sub.map(msg => Model.Actions.FileExplorer(msg));
 
     let positionToRelativePixel = position => {


### PR DESCRIPTION
Fix #1104 - when `files.exclude` is updated, reload the file explorer to show the result