### PR TITLE
fix(buffers/#3433): Stamp last used anytime the current focused buffer changes

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -67,6 +67,7 @@
 - #3464 - Vim: Fix alternate-file keybinding (fixes #3455)
 - #3465 - Quickmenu: Remove darkening of background when menu is open (fixes #3459)
 - #3466 - Input: Fix `gt` binding parsing (fixes #3256)
+- #3475 - Buffers: Fix ctrl-tab ordering (fixes #3433)
 
 ### Performance
 


### PR DESCRIPTION
__Issue:__ There were some cases where we weren't setting the last-used buffer time correctly.

__Fix:__ Instead of trying to catch every place the  buffer could change, and calling `stampLastUsed`, observe when the focused buffer has changed via a subscription, and stamp it in that case.

Fixes #3433 