### PR TITLE
fix(quick-open/#3473): Filter out spaces for quick open

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -72,6 +72,7 @@
 - #3476 - UX: Ellipsize author in extensions item view
 - #3475 - Buffers: Fix ctrl-tab ordering (fixes #3433)
 - #3469 - CLI: Default to opening files in existing editor (fixes #1250, #2617, #2947, #3058)
+- #3487 - Quickopen: Filter out spaces in query string (fixes #3473, related #3278)
 
 ### Performance
 

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -404,13 +404,13 @@ let extractSnippet = (~maxLength, ~charStart, ~charEnd, text) => {
   };
 };
 
-let removeWindowsNewLines = str => {
+let filterAscii = (f, str) => {
   let len = String.length(str);
   let filteredString = Bytes.of_string(str);
 
   let destIdx = ref(0);
   for (srcIdx in 0 to len - 1) {
-    if (str.[srcIdx] != '\r') {
+    if (f(str.[srcIdx])) {
       Bytes.set(filteredString, destIdx^, str.[srcIdx]);
       incr(destIdx);
     };
@@ -418,6 +418,10 @@ let removeWindowsNewLines = str => {
 
   let destLen = destIdx^;
   Bytes.sub(filteredString, 0, destLen) |> Bytes.to_string;
+};
+
+let removeWindowsNewLines = str => {
+  str |> filterAscii(c => c != '\r');
 };
 
 let%test_module "removeWindowsNewLines" =

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -535,6 +535,9 @@ let subscriptions = (ripgrep, dispatch) => {
   let (itemStream, addItems) = Isolinear.Stream.create();
 
   let filter = (query, items) => {
+    // HACK: Filter out spaces, so queries with spaces behave in a sane way.
+    // However, this won't be needed once Fzy has the full refine behavior,
+    // described in https://github.com/onivim/oni2/issues/3278
     let queryWithoutSpaces = query |> StringEx.filterAscii(c => c != ' ');
     QuickmenuFilterSubscription.create(
       ~id="quickmenu-filter",

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -535,9 +535,10 @@ let subscriptions = (ripgrep, dispatch) => {
   let (itemStream, addItems) = Isolinear.Stream.create();
 
   let filter = (query, items) => {
+    let queryWithoutSpaces = query |> StringEx.filterAscii(c => c != ' ');
     QuickmenuFilterSubscription.create(
       ~id="quickmenu-filter",
-      ~query,
+      ~query=queryWithoutSpaces,
       ~items=items |> Array.to_list, // TODO: This doesn't seem very efficient. Can Array.to_list be removed?
       ~itemStream,
       ~onUpdate=(items, ~progress) => {


### PR DESCRIPTION
__Issue:__ In quick-open, `Core NodeTask` should match a file called `src/Core/NodeTask.re`, but it doesn't.

__Defect:__ We're trying to use the space as a matching character, and since there are no spaces in the path, it's not matching.

__Fix:__ In the short-term, just don't consider spaces for now as a matching character (filter them out of the query). Once we have the full refine behavior in #3278 - this hack will no longer be necessary, though.