### PR TITLE
Update CLI instructions for new --new-window requirement

### DIFF
--- a/docs/docs/using-onivim/command-line.md
+++ b/docs/docs/using-onivim/command-line.md
@@ -67,7 +67,7 @@ folder. The current folder can be changed once inside Oni2 by using the normal v
 You can set Oni2 as the [default text editor for git](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_code_core_editor_code) by running: 
 
 ```bash
-git config --global core.editor "oni2 --nofork --silent"
+git config --global core.editor "oni2 --nofork --new-window --silent"
 ```
 
 ## Extension Management


### PR DESCRIPTION
The changes in #3469 mean using `--nofork` is no longer enough to get a new instance of `oni2` when one is already running.

This is notable when setting `oni2` as your `$EDITOR` or git editor.

To replicate the issue:

1. Open onivim2
2. On the cli, run `oni2 --nofork`
3. Note the existing instance of `oni2` is attached to

This documentation change ensures future users will have the correct setup.