### PR TITLE
fix(editor/#3485): Render deprecated items with strikethrough

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -11,6 +11,7 @@
 - #3419 - Buffers: Implement auto-save functionality (fixes #2431)
 - #3430 - Buffers: Implement workbench.action.quickOpenBuffer (fixes #3413)
 - #3481 - UX: Add 'workbench.tree.renderIndentGuides' setting
+- #3499 - Editor: Render deprecated ranges with strikethrough (fixes #3485)
 
 ### Bug Fixes
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -49,6 +49,10 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `editor.largeFileOptimizations` __(_bool_ default: `true`)__ - When `true`, Onivim will turn off certain settings like syntax highlighting for large files.
 
+- `editor.showDeprecated` __(_bool_ default: `true`)__ - When `true`, Onivim will render deprecated code with a strike-through.
+
+- `editor.showUnused` __(_bool_ default: `true`)__ - When `true`, Onivim will fade out unused code.
+
 - `workbench.editor.enablePreview` __(_bool_ default: `true`)__ - When `true`, Onivim will open files in _preview mode_ unless a change is made or the tab is double-clicked. In _preview mode_, the editor tab will be re-used.
 
 - `editor.lightBulb.enabled` __(_bool_ default: `true`)__ - When `true`, show a lightbulb icon in the editor if there are quick fixes or refactorings available.

--- a/src/Exthost/Diagnostic.re
+++ b/src/Exthost/Diagnostic.re
@@ -1,4 +1,31 @@
 open Oni_Core;
+
+module Tag = {
+  [@deriving show]
+  type t =
+    | Unused
+    | Deprecated;
+
+  let ofInt =
+    fun
+    | 1 => Some(Unused)
+    | 2 => Some(Deprecated)
+    | _ => None;
+
+  let decode =
+    Json.Decode.(
+      {
+        int
+        |> and_then(idx => {
+             switch (ofInt(idx)) {
+             | Some(tag) => succeed(tag)
+             | None => fail("Invalid tag: " ++ string_of_int(idx))
+             }
+           });
+      }
+    );
+};
+
 module Severity = {
   // Must be kept in-sync with:
   // https://github.com/onivim/vscode-exthost/blob/ed480e2fbe01ad85b8d85a2ca2dbd1b85c29242b/src/vs/platform/markers/common/markers.ts#L45
@@ -53,6 +80,7 @@ type t = {
   range: OneBasedRange.t,
   message: string,
   severity: Severity.t,
+  tags: list(Tag.t),
   // TODO:
   // source: string,
   // code: string,
@@ -70,6 +98,7 @@ module Decode = {
       let endColumn = field.required("endColumn", int);
       let severity = field.required("severity", Severity.decode);
       let message = field.required("message", string);
+      let tags = field.withDefault("tags", [], list(Tag.decode));
 
       let range =
         OneBasedRange.create(
@@ -80,7 +109,7 @@ module Decode = {
           (),
         );
 
-      {range, severity, message};
+      {range, severity, message, tags};
     });
 };
 

--- a/src/Exthost/Exthost.rei
+++ b/src/Exthost/Exthost.rei
@@ -801,6 +801,13 @@ module Configuration: {
 };
 
 module Diagnostic: {
+  module Tag: {
+    [@deriving show]
+    type t =
+      | Unused
+      | Deprecated;
+  };
+
   module Severity: {
     [@deriving show]
     type t =
@@ -813,10 +820,12 @@ module Diagnostic: {
     let ofInt: int => option(t);
     let max: (t, t) => t;
   };
+
   type t = {
     range: OneBasedRange.t,
     message: string,
     severity: Severity.t,
+    tags: list(Tag.t),
   };
 
   let decode: Json.decoder(t);

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -373,10 +373,13 @@ module Diagnostics = {
   let handle = (method, args: Yojson.Safe.t) => {
     switch (method, args) {
     | ("$changeMany", `List([`String(owner), diagnosticsJson])) =>
+      prerr_endline(
+        "Diagnostics: " ++ Yojson.Safe.to_string(diagnosticsJson),
+      );
       diagnosticsJson
       |> Json.Decode.decode_value(Json.Decode.list(Decode.entry))
       |> Result.map(entries => ChangeMany({owner, entries}))
-      |> Result.map_error(Json.Decode.string_of_error)
+      |> Result.map_error(Json.Decode.string_of_error);
 
     | ("$clear", `List([`String(owner)])) => Ok(Clear({owner: owner}))
     | _ => Error("Unhandled method: " ++ method)

--- a/src/Exthost/Msg.re
+++ b/src/Exthost/Msg.re
@@ -373,13 +373,10 @@ module Diagnostics = {
   let handle = (method, args: Yojson.Safe.t) => {
     switch (method, args) {
     | ("$changeMany", `List([`String(owner), diagnosticsJson])) =>
-      prerr_endline(
-        "Diagnostics: " ++ Yojson.Safe.to_string(diagnosticsJson),
-      );
       diagnosticsJson
       |> Json.Decode.decode_value(Json.Decode.list(Decode.entry))
       |> Result.map(entries => ChangeMany({owner, entries}))
-      |> Result.map_error(Json.Decode.string_of_error);
+      |> Result.map_error(Json.Decode.string_of_error)
 
     | ("$clear", `List([`String(owner)])) => Ok(Clear({owner: owner}))
     | _ => Error("Unhandled method: " ++ method)

--- a/src/Feature/Diagnostics/Diagnostic.re
+++ b/src/Feature/Diagnostics/Diagnostic.re
@@ -17,9 +17,18 @@ type t = {
   range: CharacterRange.t,
   message: string,
   severity: Exthost.Diagnostic.Severity.t,
+  isUnused: bool,
+  isDeprecated: bool,
+  tags: list(Exthost.Diagnostic.Tag.t),
 };
 
-let create = (~range, ~message, ~severity) => {range, message, severity};
+let create = (~range, ~message, ~severity, ~tags) => {
+  let isUnused =
+    tags |> List.exists(tag => tag == Exthost.Diagnostic.Tag.Unused);
+  let isDeprecated =
+    tags |> List.exists(tag => tag == Exthost.Diagnostic.Tag.Deprecated);
+  {range, message, severity, tags, isUnused, isDeprecated};
+};
 
 let explode = (buffer, diagnostic) => {
   let lineCount = Buffer.getNumberOfLines(buffer);
@@ -40,6 +49,7 @@ let explode = (buffer, diagnostic) => {
          ~range,
          ~message=diagnostic.message,
          ~severity=diagnostic.severity,
+         ~tags=diagnostic.tags,
        )
      );
 };

--- a/src/Feature/Diagnostics/Feature_Diagnostics.re
+++ b/src/Feature/Diagnostics/Feature_Diagnostics.re
@@ -27,7 +27,12 @@ module DiagnosticEntry = {
       extDiag => {
         let range = Exthost.OneBasedRange.toRange(extDiag.range);
         let message = extDiag.message;
-        Diagnostic.create(~range, ~message, ~severity=extDiag.severity);
+        Diagnostic.create(
+          ~range,
+          ~message,
+          ~severity=extDiag.severity,
+          ~tags=extDiag.tags,
+        );
       };
 
     let exthostEntryToEntry: Exthost.Msg.Diagnostics.entry => t =

--- a/src/Feature/Diagnostics/Feature_Diagnostics.rei
+++ b/src/Feature/Diagnostics/Feature_Diagnostics.rei
@@ -15,10 +15,19 @@ module Diagnostic: {
     range: CharacterRange.t,
     message: string,
     severity: Severity.t,
+    isUnused: bool,
+    isDeprecated: bool,
+    tags: list(Exthost.Diagnostic.Tag.t),
   };
 
   let create:
-    (~range: CharacterRange.t, ~message: string, ~severity: Severity.t) => t;
+    (
+      ~range: CharacterRange.t,
+      ~message: string,
+      ~severity: Severity.t,
+      ~tags: list(Tag.t)
+    ) =>
+    t;
 
   /*
     [explode(buffer, diagnostic)] splits up a multi-line diagnostic into a diagnostic per-line

--- a/src/Feature/Editor/Colors.re
+++ b/src/Feature/Editor/Colors.re
@@ -32,6 +32,7 @@ type t = {
   scrollbarSliderBackground: Color.t,
   scrollbarSliderHoverBackground: Color.t,
   normalModeBackground: Color.t,
+  unnecessaryCodeOpacity: Color.t,
   // Minimap
   minimapBackground: Color.t,
   minimapSliderBackground: Color.t,
@@ -71,6 +72,7 @@ let precompute = theme => {
   scrollbarSliderBackground: ScrollbarSlider.background.from(theme),
   scrollbarSliderHoverBackground: ScrollbarSlider.hoverBackground.from(theme),
   normalModeBackground: Oni.normalModeBackground.from(theme),
+  unnecessaryCodeOpacity: EditorUnnecessaryCode.opacity.from(theme),
   // Minimap
   minimapSliderBackground: MinimapSlider.background.from(theme),
   minimapSliderHoverBackground: MinimapSlider.hoverBackground.from(theme),

--- a/src/Feature/Editor/ContentView.re
+++ b/src/Feature/Editor/ContentView.re
@@ -76,6 +76,16 @@ let renderDiagnostics =
       if (diagnostic.isDeprecated) {
         let color = colors.editorForeground;
         Draw.strikethrough(~context, ~color, range);
+      } else if (diagnostic.isUnused)  {
+        let invAlpha = colors.unnecessaryCodeOpacity |> Revery.Color.getAlpha;
+        let alpha = 1.0 -. invAlpha;
+        let color = colors.editorBackground
+        |> Revery.Color.multiplyAlpha(alpha);
+        Draw.rangeCharacter(
+          ~context,
+          ~color,
+          range
+        )
       } else {
         Draw.squiggly(~context, ~color, range);
       };

--- a/src/Feature/Editor/ContentView.re
+++ b/src/Feature/Editor/ContentView.re
@@ -10,14 +10,9 @@ module Diagnostic = Feature_Diagnostics.Diagnostic;
 let renderDiagnostics =
     (
       ~context: Draw.context,
-      ~buffer,
       ~colors: Colors.t,
       ~diagnosticsMap,
-      ~selectionRanges,
-      ~matchingPairs: option((CharacterPosition.t, CharacterPosition.t)),
-      ~vim,
       ~languageConfiguration,
-      ~languageSupport,
       viewLine,
       _offset,
     ) => {
@@ -73,19 +68,17 @@ let renderDiagnostics =
           }
         );
 
-      if (diagnostic.isDeprecated) {
+      if (diagnostic.isDeprecated
+          && Editor.shouldShowDeprecated(context.editor)) {
         let color = colors.editorForeground;
         Draw.strikethrough(~context, ~color, range);
-      } else if (diagnostic.isUnused)  {
+      } else if (diagnostic.isUnused
+                 && Editor.shouldShowUnused(context.editor)) {
         let invAlpha = colors.unnecessaryCodeOpacity |> Revery.Color.getAlpha;
         let alpha = 1.0 -. invAlpha;
-        let color = colors.editorBackground
-        |> Revery.Color.multiplyAlpha(alpha);
-        Draw.rangeCharacter(
-          ~context,
-          ~color,
-          range
-        )
+        let color =
+          colors.editorBackground |> Revery.Color.multiplyAlpha(alpha);
+        Draw.rangeCharacter(~context, ~color, range);
       } else {
         Draw.squiggly(~context, ~color, range);
       };
@@ -104,11 +97,9 @@ let renderLine =
       ~context: Draw.context,
       ~buffer,
       ~colors: Colors.t,
-      ~diagnosticsMap,
       ~selectionRanges,
       ~matchingPairs: option((CharacterPosition.t, CharacterPosition.t)),
       ~vim,
-      ~languageConfiguration,
       ~languageSupport,
       viewLine,
       _offset,
@@ -185,12 +176,10 @@ let renderEmbellishments =
       ~context,
       ~buffer,
       ~colors,
-      ~diagnosticsMap,
       ~selectionRanges,
       ~matchingPairs,
       ~vim,
       ~languageSupport,
-      ~languageConfiguration,
     ) =>
   Draw.renderImmediate(
     ~context,
@@ -198,12 +187,10 @@ let renderEmbellishments =
       ~context,
       ~buffer,
       ~colors,
-      ~diagnosticsMap,
       ~selectionRanges,
       ~matchingPairs,
       ~vim,
       ~languageSupport,
-      ~languageConfiguration,
     ),
   );
 
@@ -342,12 +329,10 @@ let render =
     ~context,
     ~buffer,
     ~colors,
-    ~diagnosticsMap,
     ~selectionRanges,
     ~matchingPairs,
     ~vim,
     ~languageSupport,
-    ~languageConfiguration,
   );
 
   let bufferId = Buffer.getId(buffer);
@@ -383,13 +368,8 @@ let render =
     ~context,
     renderDiagnostics(
       ~context,
-      ~buffer,
       ~colors,
       ~diagnosticsMap,
-      ~selectionRanges,
-      ~matchingPairs,
-      ~vim,
-      ~languageSupport,
       ~languageConfiguration,
     ),
   );

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -238,8 +238,6 @@ let strikethrough =
       context.editor,
     );
 
-  let paddingY = context.editor |> Editor.linePaddingInPixels;
-
   drawRect(
     ~context,
     ~x=startPixelX -. 1.,

--- a/src/Feature/Editor/Draw.re
+++ b/src/Feature/Editor/Draw.re
@@ -224,6 +224,32 @@ let underline =
   );
 };
 
+let strikethrough =
+    (~context, ~color=Revery.Colors.black, range: CharacterRange.t) => {
+  let ({y: startPixelY, x: startPixelX}: PixelPosition.t, _) =
+    Editor.bufferCharacterPositionToPixel(
+      ~position=range.start,
+      context.editor,
+    );
+
+  let ({x: stopPixelX, _}: PixelPosition.t, _) =
+    Editor.bufferCharacterPositionToPixel(
+      ~position=range.stop,
+      context.editor,
+    );
+
+  let paddingY = context.editor |> Editor.linePaddingInPixels;
+
+  drawRect(
+    ~context,
+    ~x=startPixelX -. 1.,
+    ~y=startPixelY +. Editor.lineHeightInPixels(context.editor) /. 2.,
+    ~height=1.,
+    ~width=max(stopPixelX -. startPixelX, 1.0) +. 2.,
+    ~color,
+  );
+};
+
 let squiggly = (~context, ~color=Revery.Colors.black, range: CharacterRange.t) => {
   let ({x: startPixelX, y: startPixelY}: PixelPosition.t, _) =
     Editor.bufferCharacterPositionToPixel(

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -142,6 +142,8 @@ type t = {
   // Animation
   isAnimationOverride: option(bool),
   animationNonce: int,
+  showUnused: bool,
+  showDeprecated: bool,
 };
 
 let setBoundingBox = (bbox, editor) => {
@@ -535,6 +537,8 @@ let configure = (~config, editor) => {
     isScrollAnimated,
     scrollbarVerticalWidth,
     scrollbarHorizontalWidth,
+    showDeprecated: EditorConfiguration.showDeprecated.get(config),
+    showUnused: EditorConfiguration.showUnused.get(config),
     yankHighlightDuration,
   }
   |> setVerticalScrollMargin(~lines=scrolloff)
@@ -617,9 +621,15 @@ let create = (~config, ~buffer, ~preview: bool, ()) => {
 
     scrollbarHorizontalWidth: 8,
     scrollbarVerticalWidth: 15,
+
+    showDeprecated: true,
+    showUnused: true,
   }
   |> configure(~config);
 };
+
+let shouldShowDeprecated = ({showDeprecated, _}) => showDeprecated;
+let shouldShowUnused = ({showUnused, _}) => showUnused;
 
 let cursors = ({mode, _}) => Vim.Mode.cursors(mode);
 

--- a/src/Feature/Editor/Editor.rei
+++ b/src/Feature/Editor/Editor.rei
@@ -143,6 +143,9 @@ let isMouseDown: t => bool;
 let lastMouseMoveTime: t => option(Revery.Time.t);
 let getCharacterUnderMouse: t => option(CharacterPosition.t);
 
+let shouldShowDeprecated: t => bool;
+let shouldShowUnused: t => bool;
+
 // Scale factor between horizontal pixels on the editor surface vs minimap
 let getMinimapWidthScaleFactor: t => float;
 

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -327,6 +327,11 @@ let scrolloff =
     ~default=1,
   );
 let scrollShadow = setting("editor.scrollShadow", bool, ~default=true);
+
+let showDeprecated = setting("editor.showDeprecated", bool, ~default=true);
+
+let showUnused = setting("editor.showUnused", bool, ~default=true);
+
 let smoothScroll =
   setting(
     ~vim=VimSettings.smoothScroll,
@@ -406,6 +411,8 @@ let contributions = [
   rulers.spec,
   scrollShadow.spec,
   scrolloff.spec,
+  showDeprecated.spec,
+  showUnused.spec,
   smoothScroll.spec,
   tabSize.spec,
   wordWrap.spec,

--- a/src/Feature/Theme/Feature_Theme.re
+++ b/src/Feature/Theme/Feature_Theme.re
@@ -24,6 +24,7 @@ let defaults =
     Colors.Dropdown.defaults,
     Colors.Editor.defaults,
     Colors.EditorError.defaults,
+    Colors.EditorUnnecessaryCode.defaults,
     Colors.EditorWarning.defaults,
     Colors.EditorInfo.defaults,
     Colors.EditorHint.defaults,

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -251,7 +251,7 @@ module EditorUnnecessaryCode = {
   let opacity = define(
     "editorUnnecessaryCode.opacity",
     {
-      dark: hex("#000a"), light: hex("#0007"), hc: unspecified
+      dark: hex("#0007"), light: hex("#000a"), hc: unspecified
     }
   );
 

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -242,6 +242,22 @@ module EditorError = {
   let defaults = [foreground, border];
 };
 
+module EditorUnnecessaryCode = {
+  let border = define(
+    "editorUnnecessaryCode.border",
+    {dark: unspecified, light: unspecified, hc: hex("#fff") |> transparent(0.8)}
+  );
+
+  let opacity = define(
+    "editorUnnecessaryCode.opacity",
+    {
+      dark: hex("#000a"), light: hex("#0007"), hc: unspecified
+    }
+  );
+
+  let defaults = [border, opacity];
+};
+
 module EditorWarning = {
   let foreground =
     define(

--- a/src/Feature/Theme/GlobalColors.re
+++ b/src/Feature/Theme/GlobalColors.re
@@ -243,17 +243,21 @@ module EditorError = {
 };
 
 module EditorUnnecessaryCode = {
-  let border = define(
-    "editorUnnecessaryCode.border",
-    {dark: unspecified, light: unspecified, hc: hex("#fff") |> transparent(0.8)}
-  );
+  let border =
+    define(
+      "editorUnnecessaryCode.border",
+      {
+        dark: unspecified,
+        light: unspecified,
+        hc: hex("#fff") |> transparent(0.8),
+      },
+    );
 
-  let opacity = define(
-    "editorUnnecessaryCode.opacity",
-    {
-      dark: hex("#0007"), light: hex("#000a"), hc: unspecified
-    }
-  );
+  let opacity =
+    define(
+      "editorUnnecessaryCode.opacity",
+      {dark: hex("#0007"), light: hex("#000a"), hc: unspecified},
+    );
 
   let defaults = [border, opacity];
 };

--- a/test/Feature/Diagnostics/DiagnosticTest.re
+++ b/test/Feature/Diagnostics/DiagnosticTest.re
@@ -25,6 +25,7 @@ describe("Diagnostics", ({describe, _}) => {
           ~range,
           ~message="test diagnostic",
           ~severity=Exthost.Diagnostic.Severity.Error,
+          ~tags=[],
         );
       let diags =
         Diagnostic.explode(

--- a/test/Feature/Diagnostics/DiagnosticsTests.re
+++ b/test/Feature/Diagnostics/DiagnosticsTests.re
@@ -17,6 +17,7 @@ let singleDiagnostic = [
     ~range=zeroRange,
     ~message="single error",
     ~severity=Exthost.Diagnostic.Severity.Error,
+    ~tags=[],
   ),
 ];
 
@@ -25,11 +26,13 @@ let doubleDiagnostic = [
     ~range=zeroRange,
     ~message="error 1",
     ~severity=Exthost.Diagnostic.Severity.Error,
+    ~tags=[],
   ),
   Diagnostic.create(
     ~range=zeroRange,
     ~message="error 2",
     ~severity=Exthost.Diagnostic.Severity.Error,
+    ~tags=[],
   ),
 ];
 
@@ -100,6 +103,7 @@ describe("Diagnostics", ({describe, _}) => {
             },
           ~message="single error",
           ~severity=Exthost.Diagnostic.Severity.Error,
+          ~tags=[],
         ),
       ];
 


### PR DESCRIPTION
This implements strike-through rendering for deprecated code and fading out of unused code:

![image](https://user-images.githubusercontent.com/13532591/117086478-75ed7180-ad01-11eb-8b9b-7c8c91c2888b.png)

Fixes #3485 