### PR TITLE
feat(theme): Add workbench.colorCustomizations setting to override theme colors

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -12,6 +12,7 @@
 - #3430 - Buffers: Implement workbench.action.quickOpenBuffer (fixes #3413)
 - #3481 - UX: Add 'workbench.tree.renderIndentGuides' setting
 - #3499 - Editor: Render deprecated ranges with strikethrough (fixes #3485)
+- #3506 - Theme: Add 'workbench.colorCustomizations' setting (related #3495)
 
 ### Bug Fixes
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -126,6 +126,15 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `search.exclude` __(_list of string_ default: `[]`)__ - When using `Find in files` Onivim will not look at files located at the directories listed here, this inherit all the values from `files.exclude`
 
+- `workbench.colorCustomizations` __(_json_ default: `{}`)__ - Color theme overrides, using the same [Theme Colors as Code](https://code.visualstudio.com/api/references/theme-color) - for example:
+
+```json
+  "workbench.colorCustomizations": {
+    "terminal.background": "#0F0",
+    "terminal.foreground": "#FFF"
+  },
+```
+
 - `workbench.colorTheme` __(_string_ default:`"One Dark Pro"`)__ - Color theme to use.
 
 - `workbench.iconTheme` __(_string_ default: `"vs-seti"`)__ - Icon theme to use.

--- a/src/Core/ColorTheme.re
+++ b/src/Core/ColorTheme.re
@@ -27,6 +27,40 @@ module Colors = {
 
   let union = (xs, ys) => Lookup.union((_key, _x, y) => Some(y), xs, ys);
   let unionMany = lookups => List.fold_left(union, Lookup.empty, lookups);
+
+  let decodeColor =
+    Json.Decode.(
+      {
+        string
+        |> and_then(str =>
+             try(Revery.Color.hex(str) |> succeed) {
+             | exn => fail(Printexc.to_string(exn))
+             }
+           );
+      }
+    );
+
+  let decode =
+    Json.Decode.(
+      key_value_pairs(decodeColor)
+      |> map(pairs => {
+           pairs
+           |> List.map(((colorName, color)) => (key(colorName), color))
+           |> fromList
+         })
+    );
+
+  let encode = lookups =>
+    Json.Encode.(
+      {
+        lookups
+        |> Lookup.bindings
+        |> List.map(((key, color)) => {
+             (Lookup.keyName(key), `String(Revery.Color.toString(color)))
+           })
+        |> obj;
+      }
+    );
 };
 
 // DEFAULTS

--- a/src/Core/ColorTheme.rei
+++ b/src/Core/ColorTheme.rei
@@ -21,6 +21,9 @@ module Colors: {
 
   let union: (t, t) => t;
   let unionMany: list(t) => t;
+
+  let encode: Json.Encode.encoder(t);
+  let decode: Json.Decode.decoder(t);
 };
 
 // DEFAULTS

--- a/src/Core/Kernel/KeyedStringMap.rei
+++ b/src/Core/Kernel/KeyedStringMap.rei
@@ -7,6 +7,8 @@ type t(+'a);
 let empty: t('a);
 let is_empty: t('a) => bool;
 
+let bindings: t('a) => list((key, 'a));
+
 let mem: (key, t('a)) => bool;
 let add: (key, 'a, t('a)) => t('a);
 let update: (key, option('a) => option('a), t('a)) => t('a);

--- a/src/Feature/Theme/Feature_Theme.rei
+++ b/src/Feature/Theme/Feature_Theme.rei
@@ -37,11 +37,7 @@ let setTheme: (~themeId: string, model) => model;
 let configurationChanged: (~resolver: Config.resolver, model) => model;
 
 let colors:
-  (
-    ~extensionDefaults: list(ColorTheme.Defaults.t)=?,
-    ~customizations: ColorTheme.Colors.t=?,
-    model
-  ) =>
+  (~extensionDefaults: list(ColorTheme.Defaults.t)=?, model) =>
   ColorTheme.Colors.t;
 
 let tokenColors: model => Oni_Syntax.TokenTheme.t;


### PR DESCRIPTION
This adds a `workbench.colorCustomizations` configuration setting, which uses the same theme colors and formats as the [VSCode Theme Colors](https://code.visualstudio.com/api/references/theme-color)

This can be used to manually override colors, like:

![image](https://user-images.githubusercontent.com/13532591/117330366-76ddea80-ae4a-11eb-8648-34a6b62eea0a.png)

Related #3495 