### PR TITLE
fix(cli): Fix opening non-existent file in second instance

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -77,6 +77,7 @@
 - #3487 - Quickopen: Filter out spaces in query string (fixes #3473, related #3278)
 - #3488 - Search: Restart search even when query hasn't changed (fixes #3477)
 - #3482 - CodeLens: Make codelenses clickable (related #3468)
+- #3525 - CLI: Fix crash when opening non-existent file in running instance
 
 ### Performance
 

--- a/src/Service/OS/Service_OS.rei
+++ b/src/Service/OS/Service_OS.rei
@@ -31,7 +31,8 @@ module Effect: {
   let openURL: string => Isolinear.Effect.t(_);
   let stat: (string, Unix.stats => 'msg) => Isolinear.Effect.t('msg);
   let statMultiple:
-    (list(string), (string, Unix.stats) => 'msg) => Isolinear.Effect.t('msg);
+    (list(string), (~exists: bool, ~isDirectory: bool, string) => 'msg) =>
+    Isolinear.Effect.t('msg);
 
   module Dialog: {
     let openFolder:


### PR DESCRIPTION
__Issue:__ When trying to create a new file via the command line, like `oni2 some-new-file.txt`, and there is already an instance running, the running instance will crash.

__Defect:__ The command to open a file via a running instance was re-using logic from the drag-and-drop code, which assumes that the files / paths always exist.

__Fix:__ Make the `statMultiple` effect resilient in the case where the path does not exist.