### PR TITLE
fix(ux/#3510): Fix click inside context menu - prevent from closing

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -79,6 +79,7 @@
 - #3488 - Search: Restart search even when query hasn't changed (fixes #3477)
 - #3482 - CodeLens: Make codelenses clickable (related #3468)
 - #3525 - CLI: Fix crash when opening non-existent file in running instance
+- #3530 - UX: Fix click inside context menu from closing context menu (fixes #3510)
 
 ### Performance
 

--- a/src/Feature/MenuBar/Feature_MenuBar.re
+++ b/src/Feature/MenuBar/Feature_MenuBar.re
@@ -239,8 +239,6 @@ module View = {
           ~backgroundColor,
           (),
         ) => {
-      // let%hook (isFocused, setIsFocused) = Hooks.state(false);
-
       let uniqueId = Menu.uniqueId(menu);
       let isFocused = Some(uniqueId) == model.hoverId;
       let maybeElem =


### PR DESCRIPTION
Fixes #3510 - prevent clicking inside from context menu from closing the entire context menu