### PR TITLE
fix(completion): Fix hang when detail text is large

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -82,6 +82,7 @@
 - #3525 - CLI: Fix crash when opening non-existent file in running instance
 - #3530 - UX: Fix click inside context menu from closing context menu (fixes #3510)
 - #3532 - OSX: Fix crash when opening folder with Unicode characters (fixes #3519)
+- #3533 - Completion: Fix hang when detail text is large
 
 ### Performance
 

--- a/src/Core/Utility/StringEx.re
+++ b/src/Core/Utility/StringEx.re
@@ -34,6 +34,12 @@ let characterCount = (~startByte, ~endByte, str) => {
   loop(0, startByte);
 };
 
+let clamp = (~characters, str) => {
+  let characterCount = characterCount(~startByte=0, ~endByte=characters, str);
+
+  Zed_utf8.sub(str, 0, characterCount);
+};
+
 let characterToByte = (~index: EditorCoreTypes.CharacterIndex.t, str) => {
   let idx = CharacterIndex.toInt(index);
   let len = String.length(str);

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -1348,6 +1348,7 @@ module View = {
     let maybeDetail =
       switch (detail) {
       | Some(detail) when isFocused && remainingWidth > 0 =>
+        let detail = StringEx.clamp(~characters=128, detail);
         <View
           style=Style.[
             position(`Absolute),
@@ -1371,7 +1372,7 @@ module View = {
               text=detail
             />
           </View>
-        </View>
+        </View>;
       | _ => React.empty
       };
 


### PR DESCRIPTION
__Issue:__ In some cases, the 'detail' text for completion is massive... and it hits a degenerate case in Revery's word-wrap / ellipsizing that causes a hang.

__Fix:__ For the completion UI, constrain the amount of detail text we show, to work around the bug and prevent a hang.