### PR TITLE
fix(terminal/#3513): Pasted text is in reverse order

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -83,6 +83,7 @@
 - #3530 - UX: Fix click inside context menu from closing context menu (fixes #3510)
 - #3532 - OSX: Fix crash when opening folder with Unicode characters (fixes #3519)
 - #3533 - Completion: Fix hang when detail text is large
+- #3537 - Terminal: Fix pasted text showing in reverse order (fixes #3513)
 
 ### Performance
 

--- a/node/pty-helper.js
+++ b/node/pty-helper.js
@@ -4,8 +4,8 @@ const pty = require("node-pty")
 
 process.stdout.write("Hello!")
 // let shouldLog = process.env["ONIVIM2_DEBUG_TERMINAL"];
-let shouldLog = process.env["ONIVIM2_DEBUG_TERMINAL"]
-const log = shouldLog ? (msg) => console.log(`[NODE] ${msg}`) : (_msg) => {}
+let shouldLog = true;
+const log = shouldLog ? (msg) => console.log(`[NODE] ${msg}`) : (_msg) => { }
 
 const pipe = process.argv[2]
 const cwd = process.argv[3]
@@ -29,6 +29,7 @@ const ptyProcess = pty.spawn(cmd, [], {
     rows: initialRows || 30,
     cwd: cwd,
     env: process.env,
+    encoding: "utf8",
 })
 
 let currentId = 0
@@ -88,30 +89,54 @@ ptyProcess.on("exit", (exitCode) => {
     log("js: pty exited")
 })
 
-client.on("data", (buffer) => {
-    let type = buffer.readUInt8(0)
-    let id = buffer.readUInt32BE(1)
-    let ack = buffer.readUInt32BE(5)
-    let length = buffer.readUInt32BE(9)
+let pendingData = Buffer.alloc(0);
 
-    // Protocol augmentation:
-    // The 'ack' field is being used to discriminate between message types
-    let data = buffer.slice(13, buffer.length)
-    switch (ack) {
-        case InMessageType.input:
-            ptyProcess.write(data)
-            break
-        case InMessageType.resize:
-            const size = JSON.parse(data)
-            ptyProcess.resize(size.cols, size.rows)
-            break
-        case InMessageType.kill:
-            ptyProcess.kill()
-        default:
-            // Unknown message type
-            log("Unknown message type: " + ack)
-            break
+let HEADER_SIZE = 13;
+
+let processPendingPackets = () => {
+    while (pendingData.length > HEADER_SIZE) {
+
+        let type = pendingData.readUInt8(0)
+        let id = pendingData.readUInt32BE(1)
+        let ack = pendingData.readUInt32BE(5)
+        let length = pendingData.readUInt32BE(9)
+
+        const packetSize = HEADER_SIZE + length;
+        log("Received packet: " + type + "|" + id + "(" + packetSize + "/" + pendingData.length + ")");
+        // See if the packet is big enough to contain the body
+        if (pendingData.length >= packetSize) {
+            // It is!
+            // Let's grab the packet, and then splice pendingData
+            let data = pendingData.slice(HEADER_SIZE, packetSize)
+            switch (ack) {
+                case InMessageType.input:
+                    log("INPUT2: " + data);
+                    log(" - length: " + data.length);
+
+                    ptyProcess.write(data)
+                    break
+                case InMessageType.resize:
+                    const size = JSON.parse(data)
+                    ptyProcess.resize(size.cols, size.rows)
+                    break
+                case InMessageType.kill:
+                    ptyProcess.kill()
+                default:
+                    // Unknown message type
+                    log("Unknown message type: " + ack)
+                    break
+            }
+
+            pendingData = pendingData.slice(packetSize);
+        } else {
+            return;
+        }
     }
+};
+
+client.on("data", (buffer) => {
+    pendingData = Buffer.concat([pendingData, buffer]);
+    processPendingPackets();
 })
 
 client.on("close", () => {

--- a/node/pty-helper.js
+++ b/node/pty-helper.js
@@ -3,8 +3,8 @@ const net = require("net")
 const pty = require("node-pty")
 
 process.stdout.write("Hello!")
-let shouldLog = process.env["ONIVIM2_DEBUG_TERMINAL"];
-const log = shouldLog ? (msg) => console.log(`[NODE] ${msg}`) : (_msg) => { }
+let shouldLog = process.env["ONIVIM2_DEBUG_TERMINAL"]
+const log = shouldLog ? (msg) => console.log(`[NODE] ${msg}`) : (_msg) => {}
 
 const pipe = process.argv[2]
 const cwd = process.argv[3]
@@ -88,19 +88,18 @@ ptyProcess.on("exit", (exitCode) => {
     log("js: pty exited")
 })
 
-let pendingData = Buffer.alloc(0);
+let pendingData = Buffer.alloc(0)
 
-let HEADER_SIZE = 13;
+let HEADER_SIZE = 13
 
 let processPendingPackets = () => {
     while (pendingData.length > HEADER_SIZE) {
-
         let type = pendingData.readUInt8(0)
         let id = pendingData.readUInt32BE(1)
         let ack = pendingData.readUInt32BE(5)
         let length = pendingData.readUInt32BE(9)
 
-        const packetSize = HEADER_SIZE + length;
+        const packetSize = HEADER_SIZE + length
         // See if the packet is big enough to contain the body
         if (pendingData.length >= packetSize) {
             // It is!
@@ -122,16 +121,16 @@ let processPendingPackets = () => {
                     break
             }
 
-            pendingData = pendingData.slice(packetSize);
+            pendingData = pendingData.slice(packetSize)
         } else {
-            return;
+            return
         }
     }
-};
+}
 
 client.on("data", (buffer) => {
-    pendingData = Buffer.concat([pendingData, buffer]);
-    processPendingPackets();
+    pendingData = Buffer.concat([pendingData, buffer])
+    processPendingPackets()
 })
 
 client.on("close", () => {

--- a/node/pty-helper.js
+++ b/node/pty-helper.js
@@ -3,8 +3,7 @@ const net = require("net")
 const pty = require("node-pty")
 
 process.stdout.write("Hello!")
-// let shouldLog = process.env["ONIVIM2_DEBUG_TERMINAL"];
-let shouldLog = true;
+let shouldLog = process.env["ONIVIM2_DEBUG_TERMINAL"];
 const log = shouldLog ? (msg) => console.log(`[NODE] ${msg}`) : (_msg) => { }
 
 const pipe = process.argv[2]
@@ -102,7 +101,6 @@ let processPendingPackets = () => {
         let length = pendingData.readUInt32BE(9)
 
         const packetSize = HEADER_SIZE + length;
-        log("Received packet: " + type + "|" + id + "(" + packetSize + "/" + pendingData.length + ")");
         // See if the packet is big enough to contain the body
         if (pendingData.length >= packetSize) {
             // It is!
@@ -110,9 +108,6 @@ let processPendingPackets = () => {
             let data = pendingData.slice(HEADER_SIZE, packetSize)
             switch (ack) {
                 case InMessageType.input:
-                    log("INPUT2: " + data);
-                    log(" - length: " + data.length);
-
                     ptyProcess.write(data)
                     break
                 case InMessageType.resize:


### PR DESCRIPTION
__Issue:__ When pasting text into the terminal, the text is in reverse order

__Defect:__ Our 'pty' uses node at the moment, and we send packets to the node process. In the case of pasting, these packets can get bundled together into a single buffer. The pty-helper wasn't 'unbundling' these - it just assumed buffers and packets were 1-to-1.

__Fix:__ Instead of assuming one buffer contains one packet, read the header and splice out individual packets, and refactor the packet-processing logic to be a loop.

Fixes #3513 