### PR TITLE
fix(completion): Add editor.acceptSuggestionOnTab setting

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -86,6 +86,7 @@
 - #3533 - Completion: Fix hang when detail text is large
 - #3537 - Terminal: Fix pasted text showing in reverse order (fixes #3513)
 - #3541 - Pane: Shoudl grab focus when clicked (fixes #3538)
+- #3547 - Completion: Add `editor.acceptSuggestionOnTab` setting
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -23,7 +23,9 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 ### Editor
 
-- `editor.acceptSuggestionOnEnter` __(_bool_ default: `false`)__ - When `true`, the enter key can be used to select a suggestion. By default, the enter key will not be used, so as not to interfere with creating a new line.
+- `editor.acceptSuggestionOnEnter` __(_bool_ default: `true`)__ - When `true`, the enter key can be used to accept a suggestion. Users may wish to set to `false` to avoid a conflict with inserting a new line.
+
+- `editor.acceptSuggestionOnTab` __(_bool_ default: `true`)__ - When `true`, the tab key can be used to accept a suggestion. Users may wish to turn to `false` to avoid ambiguity with inserting a tab character.
 
 - `editor.autoClosingBrackets` __(_"LanguageDefined"|"Never"_ default: `"LanguageDefined"`)__ - When set to `"LanguageDefined"`, Onivim will automatically close brackets and pairs, based on language configuration.
 

--- a/src/Feature/LanguageSupport/Completion.re
+++ b/src/Feature/LanguageSupport/Completion.re
@@ -454,6 +454,7 @@ type model = {
   isInsertMode: bool,
   isSnippetMode: bool,
   acceptOnEnter: bool,
+  acceptOnTab: bool,
   snippetSortOrder: [ | `Bottom | `Hidden | `Inline | `Top],
   isShadowEnabled: bool,
   isAnimationEnabled: bool,
@@ -463,6 +464,7 @@ let initial = {
   isInsertMode: false,
   isSnippetMode: false,
   acceptOnEnter: false,
+  acceptOnTab: true,
   providers: [
     Session.create(
       ~triggerCharacters=[],
@@ -494,6 +496,7 @@ let configurationChanged = (~config, model) => {
   {
     ...model,
     acceptOnEnter: CompletionConfig.acceptSuggestionOnEnter.get(config),
+    acceptOnTab: CompletionConfig.acceptSuggestionOnTab.get(config),
     snippetSortOrder: CompletionConfig.snippetSuggestions.get(config),
     isAnimationEnabled:
       Feature_Configuration.GlobalConfiguration.animation.get(config),
@@ -1012,6 +1015,9 @@ module ContextKeys = {
 
   let acceptSuggestionOnEnter =
     bool("acceptSuggestionOnEnter", model => model.acceptOnEnter);
+
+  let acceptSuggestionOnTab =
+    bool("acceptSuggestionOnTab", model => model.acceptOnTab);
 };
 
 // KEYBINDINGS
@@ -1023,6 +1029,10 @@ module KeyBindings = {
     "editorTextFocus && suggestWidgetVisible" |> WhenExpr.parse;
   let acceptOnEnter =
     "acceptSuggestionOnEnter && suggestWidgetVisible && editorTextFocus"
+    |> WhenExpr.parse;
+
+  let acceptOnTab =
+    "acceptSuggestionOnTab && suggestWidgetVisible && editorTextFocus"
     |> WhenExpr.parse;
 
   let triggerSuggestCondition =
@@ -1085,7 +1095,7 @@ module KeyBindings = {
     bind(
       ~key="<TAB>",
       ~command=Commands.acceptSelected.id,
-      ~condition=suggestWidgetVisible,
+      ~condition=acceptOnTab,
     );
 
   let acceptSuggestionShiftTab =
@@ -1111,6 +1121,7 @@ module Contributions = {
       quickSuggestions.spec,
       wordBasedSuggestions.spec,
       acceptSuggestionOnEnter.spec,
+      acceptSuggestionOnTab.spec,
       snippetSuggestions.spec,
     ];
 
@@ -1123,7 +1134,11 @@ module Contributions = {
     ];
 
   let contextKeys =
-    ContextKeys.[acceptSuggestionOnEnter, suggestWidgetVisible];
+    ContextKeys.[
+      acceptSuggestionOnTab,
+      acceptSuggestionOnEnter,
+      suggestWidgetVisible,
+    ];
 
   let keybindings =
     KeyBindings.[

--- a/src/Feature/LanguageSupport/CompletionConfig.re
+++ b/src/Feature/LanguageSupport/CompletionConfig.re
@@ -154,6 +154,16 @@ let acceptSuggestionOnEnter =
     ~default=true,
   );
 
+let acceptSuggestionOnTab =
+  setting(
+    "editor.acceptSuggestionOnTab",
+    custom(
+      ~decode=Decode.AcceptSuggestionOnEnter.decode,
+      ~encode=Json.Encode.bool,
+    ),
+    ~default=true,
+  );
+
 let snippetSuggestions =
   setting(
     "editor.snippetSuggestions",


### PR DESCRIPTION
__Issue:__ It's not straightforward to disable the `<tab>` key behavior of completion

__Fix:__ Add an `editor.acceptSuggestionOnTab` setting, which is similar to the `editor.acceptSuggestionOnEnter` setting.