### PR TITLE
fix(pane): Fix close button not working in bottom pane

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -85,8 +85,9 @@
 - #3532 - OSX: Fix crash when opening folder with Unicode characters (fixes #3519)
 - #3533 - Completion: Fix hang when detail text is large
 - #3537 - Terminal: Fix pasted text showing in reverse order (fixes #3513)
-- #3541 - Pane: Shoudl grab focus when clicked (fixes #3538)
+- #3541 - Pane: Should grab focus when clicked (fixes #3538)
 - #3547 - Completion: Add `editor.acceptSuggestionOnTab` setting
+- #3556 - Pane: Fix issue with close button
 
 ### Performance
 

--- a/src/Feature/Pane/Feature_Pane.re
+++ b/src/Feature/Pane/Feature_Pane.re
@@ -378,10 +378,16 @@ module View = {
     };
   };
 
+  // TODO: Workaround not having a 'stopPropagation' or 'preventDefault' gesture...
+  let wasCloseButtonClicked = ref(false);
+
   let closeButton = (~theme, ~dispatch, ()) => {
     <Sneakable
       sneakId="close"
-      onClick={() => dispatch(CloseButtonClicked)}
+      onClick={() => {
+        wasCloseButtonClicked := true;
+        dispatch(CloseButtonClicked);
+      }}
       style=Styles.closeButton>
       <Codicon
         icon=Codicon.close
@@ -466,7 +472,12 @@ module View = {
             ~theme,
             ~height,
           )}
-          onMouseUp={_ => dispatch(PaneClicked)}>
+          onMouseUp={_ => {
+            if (! wasCloseButtonClicked^) {
+              dispatch(PaneClicked);
+            };
+            wasCloseButtonClicked := false;
+          }}>
           <View style=Styles.resizer>
             <ResizeHandle.Horizontal
               onDrag={delta =>


### PR DESCRIPTION
__Issue:__ The close (`x`) button in the pane wasn't worked

__Defect:__ Regression from #3538 - the pane-click was being handle after the close button click, causing the pane to retain focus and stay open

__Fix:__ Don't dispatch `PaneClicked` when the close button is clicked.

Would be nice to have `stopPropagation` wired up to help handle this