### PR TITLE
fix(explorer/#3534): Files in an NFS mount are not showing up in explorer

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -91,6 +91,7 @@
 - #3558 - Extensions: Clicking on search input should focus it
 - #3559 - Explorer: Don't open explorer on `:cd` if `workbench.sideBar.visible` is false
 - #3560 - Shell: Fix incorrect PATH on OSX when launched via Finder (fixes #3199)
+- #3567 - Explorer: Fix files in NFS mount not loading (fixes #3534)
 
 ### Performance
 

--- a/src/Service/OS/Service_OS.re
+++ b/src/Service/OS/Service_OS.re
@@ -6,6 +6,22 @@ let wrap = LuvEx.wrapPromise;
 
 let bind = (fst, snd) => Lwt.bind(snd, fst);
 
+module InnerApi = {
+  let stat = path => {
+    Log.infof(m => m("Luv.stat: %s", path));
+    path
+    |> wrap(Luv.File.stat)
+    |> LwtEx.tap(_ => Log.infof(m => m("Stat completed: %s", path)));
+  };
+
+  let lstat = path => {
+    Log.infof(m => m("Luv.lstat: %s", path));
+    path
+    |> wrap(Luv.File.lstat)
+    |> LwtEx.tap(_ => Log.infof(m => m("Lstat completed: %s", path)));
+  };
+};
+
 module Internal = {
   let copyfile = (~overwrite=true, ~source, target) => {
     source |> wrap(Luv.File.copyfile(~excl=!overwrite, ~to_=target));
@@ -18,7 +34,57 @@ module Internal = {
   let readdir = wrap(Luv.File.readdir);
 };
 
+module DirectoryEntry = {
+  type kind = [ | `File | `Directory];
+
+  type t = {
+    kind,
+    isSymbolicLink: bool,
+    name: string,
+    path: FpExp.t(FpExp.absolute),
+  };
+
+  let name = ({name, _}) => name;
+
+  let path = ({path, _}) => path;
+
+  let isSymbolicLink = ({isSymbolicLink, _}) => isSymbolicLink;
+
+  let isFile = ({kind, _}) => kind == `File;
+
+  let isDirectory = ({kind, _}) => kind == `Directory;
+
+  let fromPath = (~name: string, path: FpExp.t(FpExp.absolute)) => {
+    let ofMode = (~isSymbolicLink, mode) => {
+      let kind =
+        if (Luv.File.Mode.test([`IFDIR], mode)) {
+          `Directory;
+        } else {
+          `File;
+        };
+
+      {path, name, kind, isSymbolicLink};
+    };
+
+    let pathStr = FpExp.toString(path);
+
+    InnerApi.lstat(pathStr)
+    |> LwtEx.flatMap((lstat: Luv.File.Stat.t) =>
+         if (Luv.File.Mode.test([`IFLNK], lstat.mode)) {
+           InnerApi.stat(pathStr)
+           |> Lwt.map((stat: Luv.File.Stat.t) =>
+                ofMode(~isSymbolicLink=true, stat.mode)
+              );
+         } else {
+           Lwt.return(ofMode(~isSymbolicLink=false, lstat.mode));
+         }
+       );
+  };
+};
+
 module Api = {
+  include InnerApi;
+
   let unlink = {
     let wrapped = wrap(Luv.File.unlink);
 
@@ -36,13 +102,6 @@ module Api = {
     };
   };
 
-  let stat = path => {
-    Log.infof(m => m("Luv.stat: %s", path));
-    path
-    |> wrap(Luv.File.stat)
-    |> LwtEx.tap(_ => Log.infof(m => m("Stat completed: %s", path)));
-  };
-
   let readdir = path => {
     Log.infof(m => m("readdir called for: %s", path));
     path
@@ -55,6 +114,23 @@ module Api = {
            m("readdir returned %d items", Array.length(results))
          );
          Internal.closedir(dir) |> Lwt.map(() => results |> Array.to_list);
+       });
+  };
+
+  let readdir2 = path => {
+    readdir(FpExp.toString(path))
+    |> LwtEx.flatMap(dirItems => {
+         let joiner = (acc: list(DirectoryEntry.t), curr: DirectoryEntry.t) => {
+           [curr, ...acc];
+         };
+         let resolvedItems: list(Lwt.t(DirectoryEntry.t)) =
+           dirItems
+           |> List.map(({name, _}: Luv.File.Dirent.t) => {
+                let fullPath = FpExp.At.(path / name);
+                DirectoryEntry.fromPath(~name, fullPath);
+              });
+
+         resolvedItems |> LwtEx.all(~initial=[], joiner);
        });
   };
 
@@ -345,27 +421,28 @@ module Effect = {
 module Sub = {
   type dirParams = {
     id: string,
+    cwdPath: FpExp.t(FpExp.absolute),
     cwd: string,
   };
   module DirSub =
     Isolinear.Sub.Make({
-      type nonrec msg = result(list(Luv.File.Dirent.t), string);
+      type nonrec msg = result(list(DirectoryEntry.t), string);
 
       type nonrec params = dirParams;
 
       type state = unit;
 
       let name = "Service_OS.Sub.dir";
-      let id = ({id, cwd}) => id ++ cwd;
+      let id = ({id, cwd, _}) => id ++ cwd;
 
       let init = (~params, ~dispatch) => {
-        let promise = Api.readdir(params.cwd);
+        let promise = params.cwdPath |> Api.readdir2;
 
-        Lwt.on_success(promise, dirItems => dispatch(Ok(dirItems)));
+        Lwt.on_success(promise, dirItems => {dispatch(Ok(dirItems))});
 
-        Lwt.on_failure(promise, exn =>
+        Lwt.on_failure(promise, exn => {
           dispatch(Error(Printexc.to_string(exn)))
-        );
+        });
 
         ();
       };
@@ -379,6 +456,7 @@ module Sub = {
       };
     });
   let dir = (~uniqueId, ~toMsg, path) => {
-    DirSub.create({id: uniqueId, cwd: path}) |> Isolinear.Sub.map(toMsg);
+    DirSub.create({id: uniqueId, cwdPath: path, cwd: FpExp.toString(path)})
+    |> Isolinear.Sub.map(toMsg);
   };
 };

--- a/src/Service/OS/Service_OS.rei
+++ b/src/Service/OS/Service_OS.rei
@@ -1,5 +1,28 @@
 open Oni_Core;
 
+module DirectoryEntry: {
+  // type kind = [ `File | Directory `];
+
+  // type t = {
+  //   kind: kind,
+  //   isSymbolicLink: bool,
+  //   name: string,
+  //   path: FpExp.t(FpExp.absolute)
+  // };
+
+  type t;
+
+  let name: t => string;
+
+  let path: t => FpExp.t(FpExp.absolute);
+
+  let isSymbolicLink: t => bool;
+
+  let isFile: t => bool;
+
+  let isDirectory: t => bool;
+};
+
 module Api: {
   let glob:
     (
@@ -13,6 +36,7 @@ module Api: {
   let rmdir: (~recursive: bool=?, string) => Lwt.t(unit);
   let stat: string => Lwt.t(Luv.File.Stat.t);
   let readdir: string => Lwt.t(list(Luv.File.Dirent.t));
+  let readdir2: FpExp.t(FpExp.absolute) => Lwt.t(list(DirectoryEntry.t));
   let readFile: (~chunkSize: int=?, string) => Lwt.t(Bytes.t);
   let writeFile: (~contents: Bytes.t, string) => Lwt.t(unit);
   let rename:
@@ -48,8 +72,8 @@ module Sub: {
   let dir:
     (
       ~uniqueId: string,
-      ~toMsg: result(list(Luv.File.Dirent.t), string) => 'msg,
-      string
+      ~toMsg: result(list(DirectoryEntry.t), string) => 'msg,
+      FpExp.t(FpExp.absolute)
     ) =>
     Isolinear.Sub.t('msg);
 };

--- a/src/Service/OS/Service_OS.rei
+++ b/src/Service/OS/Service_OS.rei
@@ -1,15 +1,6 @@
 open Oni_Core;
 
 module DirectoryEntry: {
-  // type kind = [ `File | Directory `];
-
-  // type t = {
-  //   kind: kind,
-  //   isSymbolicLink: bool,
-  //   name: string,
-  //   path: FpExp.t(FpExp.absolute)
-  // };
-
   type t;
 
   let name: t => string;


### PR DESCRIPTION
__Issue:__ When opening Onivim 2 in an NFS mount directory, no files are shown.

__Defect:__ Onivim 2 uses `readdir` to populate the explorer, and uses the `dirent` struct to determine the type of the file/folder. For NFS mounts, this was coming back as `UV_DIRENT_UNKNOWN`/`DT_UNKNOWN` which caused Onivim 2 to ignore the file/folder.

__Fix:__ In the case of `Unknown` (or even a link...), use stat to figure out the actual type of the file.

Fixes #3534
Fixes #3377  