### PR TITLE
fix(explorer/#2657): Fix symlinks showing up as empty files

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -92,6 +92,7 @@
 - #3559 - Explorer: Don't open explorer on `:cd` if `workbench.sideBar.visible` is false
 - #3560 - Shell: Fix incorrect PATH on OSX when launched via Finder (fixes #3199)
 - #3567 - Explorer: Fix files in NFS mount not loading (fixes #3534)
+- #3568 - Explorer: Fix symlinks showing up as empty files (fixes #2657)
 
 ### Performance
 

--- a/src/Components/FileExplorer/FileTreeView.re
+++ b/src/Components/FileExplorer/FileTreeView.re
@@ -32,25 +32,8 @@ module Styles = {
     alignItems(`Center),
   ];
 
-  let text = (~isFocus, ~isActive, ~decoration, ~theme) => [
-    color(
-      switch (
-        Option.bind(
-          decoration, (decoration: Feature_Decorations.Decoration.t) =>
-          ColorTheme.(Colors.get(key(decoration.color), theme))
-        )
-      ) {
-      | Some(color) => color
-      | None =>
-        if (isActive) {
-          Colors.List.activeSelectionForeground.from(theme);
-        } else if (isFocus) {
-          Colors.List.focusForeground.from(theme);
-        } else {
-          Colors.SideBar.foreground.from(theme);
-        }
-      },
-    ),
+  let text = (~color as c, ~isFocus, ~isActive, ~decoration, ~theme) => [
+    color(c),
     // Minor adjustment to align with seti-icon
     marginTop(4),
     textWrap(TextWrapping.NoWrap),
@@ -60,6 +43,7 @@ module Styles = {
 
 let nodeView =
     (
+      ~isSymlink,
       ~isFocus,
       ~isActive,
       ~font: UiFont.t,
@@ -75,6 +59,23 @@ let nodeView =
     | [] => None
     };
 
+  let color =
+    switch (
+      Option.bind(decoration, (decoration: Feature_Decorations.Decoration.t) =>
+        ColorTheme.(Colors.get(key(decoration.color), theme))
+      )
+    ) {
+    | Some(color) => color
+    | None =>
+      if (isActive) {
+        Colors.List.activeSelectionForeground.from(theme);
+      } else if (isFocus) {
+        Colors.List.focusForeground.from(theme);
+      } else {
+        Colors.SideBar.foreground.from(theme);
+      }
+    };
+
   let tooltipText = {
     let path = node.path;
     switch (decoration) {
@@ -84,16 +85,34 @@ let nodeView =
     };
   };
 
+  let maybeSymlink =
+    if (isSymlink) {
+      let symlinkColor = Colors.SideBar.foreground.from(theme);
+      <View style=Revery.UI.Style.[flexGrow(0), flexShrink(0)]>
+        <View style=Revery.UI.Style.[paddingHorizontal(8), marginTop(4)]>
+          <Codicon
+            icon=Codicon.reply
+            rotation=Float.pi
+            fontSize=10.
+            color=symlinkColor
+          />
+        </View>
+      </View>;
+    } else {
+      React.empty;
+    };
+
   <Tooltip text=tooltipText style=Styles.item>
     <View style=Revery.UI.Style.[flexGrow(0), flexShrink(0)]> icon </View>
     <View style=Revery.UI.Style.[flexGrow(1), flexShrink(1)]>
       <Text
         text={node.displayName}
-        style={Styles.text(~isFocus, ~isActive, ~decoration, ~theme)}
+        style={Styles.text(~color, ~isFocus, ~isActive, ~decoration, ~theme)}
         fontFamily={font.family}
         fontSize=12.
       />
     </View>
+    maybeSymlink
   </Tooltip>;
 };
 
@@ -156,9 +175,11 @@ let make =
           ~path=FpExp.toString(data.path),
           decorations,
         );
+      let isSymlink = data.isSymlink;
       <nodeView
         icon
         isFocus=selected
+        isSymlink
         isActive={Some(data.path) == active}
         font
         theme

--- a/src/Components/FileExplorer/FileTreeView.re
+++ b/src/Components/FileExplorer/FileTreeView.re
@@ -32,7 +32,7 @@ module Styles = {
     alignItems(`Center),
   ];
 
-  let text = (~color as c, ~isFocus, ~isActive, ~decoration, ~theme) => [
+  let text = (~color as c) => [
     color(c),
     // Minor adjustment to align with seti-icon
     marginTop(4),
@@ -107,7 +107,7 @@ let nodeView =
     <View style=Revery.UI.Style.[flexGrow(1), flexShrink(1)]>
       <Text
         text={node.displayName}
-        style={Styles.text(~color, ~isFocus, ~isActive, ~decoration, ~theme)}
+        style={Styles.text(~color)}
         fontFamily={font.family}
         fontSize=12.
       />

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -5,7 +5,8 @@ open Utility;
 type metadata = {
   path: [@opaque] FpExp.t(FpExp.absolute),
   displayName: string,
-  hash: int // hash of basename, so only comparable locally
+  hash: int, // hash of basename, so only comparable locally
+  isSymlink: bool,
 };
 
 [@deriving show({with_path: false})]
@@ -38,19 +39,29 @@ module PathHasher = {
   };
 };
 
-let file = path => {
+let file = (~isSymlink, path) => {
   let basename = FpExp.baseName(path) |> Option.value(~default="(empty)");
 
-  Tree.leaf({path, hash: PathHasher.hash(basename), displayName: basename});
+  Tree.leaf({
+    isSymlink,
+    path,
+    hash: PathHasher.hash(basename),
+    displayName: basename,
+  });
 };
 
-let directory = (~isOpen=false, path, ~children) => {
+let directory = (~isOpen=false, ~isSymlink, path, ~children) => {
   let basename = FpExp.baseName(path) |> Option.value(~default="(empty)");
 
   Tree.node(
     ~expanded=isOpen,
     ~children,
-    {path, hash: PathHasher.hash(basename), displayName: basename},
+    {
+      isSymlink,
+      path,
+      hash: PathHasher.hash(basename),
+      displayName: basename,
+    },
   );
 };
 
@@ -58,6 +69,8 @@ let get = f =>
   fun
   | Tree.Node({data, _})
   | Tree.Leaf(data) => f(data);
+
+let isSymlink = get(({isSymlink, _}) => isSymlink);
 
 let getHash = get(({hash, _}) => hash);
 let getPath = get(({path, _}) => path);
@@ -130,8 +143,8 @@ let replace = (~replacement, tree) => {
     // Merge the 'old' children with the 'new' children, so that we don't have to recursively
     // refresh if we don't have to.
     | (
-        Tree.Node({children: oldChildren, expanded, _}),
-        Tree.Node({children: newChildren, data, _}),
+        Tree.Node({children: oldChildren, expanded, data: prevData, _}),
+        Tree.Node({children: newChildren, data: newData, _}),
       ) =>
       // Grab a map of previous children. For any that were existing, use the old metadata - some children might be expanded, for example.
       let previousMap =
@@ -162,6 +175,9 @@ let replace = (~replacement, tree) => {
                |> Option.value(~default=child)
              }
            });
+
+      // We assume that the 'symlink' state doesn't change when re-loading...
+      let data = {...newData, isSymlink: prevData.isSymlink};
 
       Tree.Node({children, expanded, data});
     };

--- a/src/Components/FileExplorer/FsTreeNode.rei
+++ b/src/Components/FileExplorer/FsTreeNode.rei
@@ -4,18 +4,27 @@ open Oni_Core;
 type metadata = {
   path: FpExp.t(FpExp.absolute),
   displayName: string,
-  hash: int // hash of basename, so only comparable locally
+  hash: int, // hash of basename, so only comparable locally
+  isSymlink: bool,
 };
 
 [@deriving show({with_path: false})]
 type t = Tree.t(metadata, metadata);
 
-let file: FpExp.t(FpExp.absolute) => t;
+let file: (~isSymlink: bool, FpExp.t(FpExp.absolute)) => t;
 let directory:
-  (~isOpen: bool=?, FpExp.t(FpExp.absolute), ~children: list(t)) => t;
+  (
+    ~isOpen: bool=?,
+    ~isSymlink: bool,
+    FpExp.t(FpExp.absolute),
+    ~children: list(t)
+  ) =>
+  t;
 
 let getPath: t => FpExp.t(FpExp.absolute);
 let displayName: t => string;
+
+let isSymlink: t => bool;
 
 let findNodesByPath:
   (FpExp.t(FpExp.absolute), t) =>

--- a/src/Core/Codicon.re
+++ b/src/Core/Codicon.re
@@ -845,7 +845,7 @@ module Animation = {
     );
 };
 
-let make = (~rotation=0., ~spin=false, ~icon, ~fontSize=15., ~color, ()) => {
+let make = (~rotation=0., ~icon, ~fontSize=15., ~color, ()) => {
   <View
     style=Style.[
       transform([

--- a/src/Core/Codicon.re
+++ b/src/Core/Codicon.re
@@ -845,13 +845,7 @@ module Animation = {
     );
 };
 
-let%component make = (~spin=false, ~icon, ~fontSize=15., ~color, ()) => {
-  let%hook (rotation, _animationState, _reset) =
-    Hooks.animation(
-      ~name="Codicon Spinner",
-      Animation.rotation,
-      ~active=spin,
-    );
+let make = (~rotation=0., ~spin=false, ~icon, ~fontSize=15., ~color, ()) => {
   <View
     style=Style.[
       transform([


### PR DESCRIPTION
__Issue:__ Symlinks in the explorer were always showing up as files - regardless if they were links to a file or a directory.

__Defect:__ We weren't handling symlinks correctly - they were defaulting to files in the explorer.

__Fix:__ Use `stat` to figure out what the link is actually pointing to (implemented in #3567) and, for symlinks, show an arrow in the explorer UI:

Depends on #3567 

Fixes #2657