### PR TITLE
fix(clipboard/#3549): Add commands to copy absolute/relative file paths

### DIFF
--- a/integration_test/CopyActiveFilepathToClipboardTest.re
+++ b/integration_test/CopyActiveFilepathToClipboardTest.re
@@ -7,7 +7,7 @@ runTest(
     "CopyActiveFilepathToClipboard writes the active buffer's file path to the clipboard",
   ({dispatch, wait, runEffects, _}) => {
     setClipboard(Some("def"));
-    dispatch(CopyActiveFilepathToClipboard);
+    dispatch(Actions.Buffers(Feature_Buffers.Msg.copyActivePathToClipboard));
     runEffects();
 
     wait(~name="clipboard contains file path", (state: State.t) => {

--- a/integration_test/lib/Oni_IntegrationTestLib.re
+++ b/integration_test/lib/Oni_IntegrationTestLib.re
@@ -24,7 +24,10 @@ let _currentRaised: ref(bool) = ref(false);
 let setClipboard = v => _currentClipboard := v;
 let getClipboard = () => _currentClipboard^;
 
-Service_Clipboard.Testing.setClipboardProvider(~get=() => _currentClipboard^);
+Service_Clipboard.Testing.setClipboardProvider(
+  ~get=() => _currentClipboard^,
+  ~set=str => setClipboard(Some(str)),
+);
 
 let setTime = v => _currentTime := v;
 

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -1,5 +1,4 @@
 open Oni_Core;
-open Utility;
 
 [@deriving show({with_path: false})]
 type metadata = {

--- a/src/Components/FileExplorer/FsTreeNode.re
+++ b/src/Components/FileExplorer/FsTreeNode.re
@@ -19,7 +19,7 @@ module PathHasher = {
 
   let make = (~base, path) => {
     switch (FpExp.relativize(~source=base, ~dest=path)) {
-    | Ok(relativePath) => FpEx.explode(relativePath) |> List.map(hash)
+    | Ok(relativePath) => FpExp.explode(relativePath) |> List.map(hash)
     | Error(_) => []
     };
   };

--- a/src/Core/Utility/FpEx.re
+++ b/src/Core/Utility/FpEx.re
@@ -1,10 +1,9 @@
-let explode = (fp: Fp.t('a)) => {
-  let rec loop = (acc, currentPath) => {
-    switch (Fp.baseName(currentPath)) {
-    | None => acc
-    | Some(basename) => loop([basename, ...acc], Fp.dirName(currentPath))
-    };
-  };
-
-  loop([], fp);
-};
+// let explode = (fp: Fp.t('a)) => {
+//   let rec loop = (acc, currentPath) => {
+//     switch (Fp.baseName(currentPath)) {
+//     | None => acc
+//     | Some(basename) => loop([basename, ...acc], Fp.dirName(currentPath))
+//     };
+//   };
+//   loop([], fp);
+/* }*/

--- a/src/Core/Utility/FpEx.re
+++ b/src/Core/Utility/FpEx.re
@@ -1,9 +1,0 @@
-// let explode = (fp: Fp.t('a)) => {
-//   let rec loop = (acc, currentPath) => {
-//     switch (Fp.baseName(currentPath)) {
-//     | None => acc
-//     | Some(basename) => loop([basename, ...acc], Fp.dirName(currentPath))
-//     };
-//   };
-//   loop([], fp);
-/* }*/

--- a/src/Core/Utility/OptionEx.re
+++ b/src/Core/Utility/OptionEx.re
@@ -14,6 +14,12 @@ let flatMap = f =>
   | Some(x) => f(x)
   | None => None;
 
+let flatMap2 = (f, x, y) =>
+  switch (x, y) {
+  | (Some(x), Some(y)) => f(x, y)
+  | _ => None
+  };
+
 let map2 = (f, a, b) =>
   switch (a, b) {
   | (Some(aVal), Some(bVal)) => Some(f(aVal, bVal))

--- a/src/Core/Utility/Utility.re
+++ b/src/Core/Utility/Utility.re
@@ -3,7 +3,6 @@ module ChunkyQueue = ChunkyQueue;
 module Cache = Cache;
 module File = File;
 module FloatEx = FloatEx;
-module FpEx = FpEx;
 module FunEx = FunEx;
 module IndexEx = IndexEx;
 module IntEx = IntEx;

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -391,7 +391,7 @@ let guessIndentation = (~config, buffer) => {
   |> Option.value(~default=Inferred.implicit(defaultIndentation(~config)));
 };
 
-let update = (~activeBufferId, ~config, msg: msg, model: model) => {
+let update = (~activeBufferId, ~config, ~workspace as _, msg: msg, model: model) => {
   switch (msg) {
   | AutoSave(msg) =>
     let (autoSave', outmsg) = AutoSave.update(msg, model.autoSave);

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -252,6 +252,8 @@ module Msg = {
     Command(ChangeFiletype({maybeBufferId: Some(bufferId)}));
 
   let statusBarIndentationClicked = StatusBarIndentationClicked;
+
+  let copyActivePathToClipboard = Command(CopyAbsolutePathToClipboard);
 };
 
 let vimSettingChanged = (~activeBufferId, ~name, ~value, model) => {

--- a/src/Feature/Buffers/Feature_Buffers.re
+++ b/src/Feature/Buffers/Feature_Buffers.re
@@ -154,6 +154,8 @@ type command =
   | ChangeFiletype({maybeBufferId: option(int)})
   | ConvertIndentationToTabs
   | ConvertIndentationToSpaces
+  | CopyAbsolutePathToClipboard
+  | CopyRelativePathToClipboard
   | DetectIndentation
   | SaveWithoutFormatting;
 
@@ -336,6 +338,7 @@ type outmsg =
       preview: bool,
     })
   | BufferModifiedSet(int, bool)
+  | SetClipboardText(string)
   | ShowMenu(
       (Exthost.LanguageInfo.t, IconTheme.t) =>
       Feature_Quickmenu.Schema.menu(msg),
@@ -391,7 +394,8 @@ let guessIndentation = (~config, buffer) => {
   |> Option.value(~default=Inferred.implicit(defaultIndentation(~config)));
 };
 
-let update = (~activeBufferId, ~config, ~workspace as _, msg: msg, model: model) => {
+let update =
+    (~activeBufferId, ~config, ~workspace as _, msg: msg, model: model) => {
   switch (msg) {
   | AutoSave(msg) =>
     let (autoSave', outmsg) = AutoSave.update(msg, model.autoSave);
@@ -714,6 +718,10 @@ let update = (~activeBufferId, ~config, ~workspace as _, msg: msg, model: model)
         );
       };
 
+    | CopyAbsolutePathToClipboard => failwith("Not implemented")
+
+    | CopyRelativePathToClipboard => failwith("Not implemented")
+
     | DetectIndentation =>
       let maybeBuffer = IntMap.find_opt(activeBufferId, model.buffers);
 
@@ -950,6 +958,21 @@ module Commands = {
       Command(ChangeFiletype({maybeBufferId: None})),
     );
 
+  let copyAbsolutePath =
+    define(
+      ~category="File",
+      ~title="Copy Path of Active File",
+      "copyFilePath",
+      Command(CopyAbsolutePathToClipboard),
+    );
+  let copyRelativePath =
+    define(
+      ~category="File",
+      ~title="Copy Relative Path of Active File",
+      "copyRelativeFilePath",
+      Command(CopyRelativePathToClipboard),
+    );
+
   let saveWithoutFormatting =
     define(
       ~category="File",
@@ -1013,6 +1036,8 @@ module Contributions = {
       changeFiletype,
       convertIndentationToSpaces,
       convertIndentationToTabs,
+      copyAbsolutePath,
+      copyRelativePath,
       detectIndentation,
       indentUsingSpaces,
       indentUsingTabs,

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -63,6 +63,8 @@ module Msg: {
 
   let selectFileTypeClicked: (~bufferId: int) => msg;
   let statusBarIndentationClicked: msg;
+
+  let copyActivePathToClipboard: msg;
 };
 
 type outmsg =

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -99,7 +99,7 @@ type outmsg =
 // UPDATE
 
 let update:
-  (~activeBufferId: int, ~config: Config.fileTypeResolver, msg, model) =>
+  (~activeBufferId: int, ~config: Config.fileTypeResolver, ~workspace: Feature_Workspace.model, msg, model) =>
   (model, outmsg);
 
 let configurationChanged: (~config: Config.resolver, model) => model;

--- a/src/Feature/Buffers/Feature_Buffers.rei
+++ b/src/Feature/Buffers/Feature_Buffers.rei
@@ -88,6 +88,7 @@ type outmsg =
       preview: bool,
     })
   | BufferModifiedSet(int, bool)
+  | SetClipboardText(string)
   | ShowMenu(
       (Exthost.LanguageInfo.t, IconTheme.t) =>
       Feature_Quickmenu.Schema.menu(msg),
@@ -99,7 +100,13 @@ type outmsg =
 // UPDATE
 
 let update:
-  (~activeBufferId: int, ~config: Config.fileTypeResolver, ~workspace: Feature_Workspace.model, msg, model) =>
+  (
+    ~activeBufferId: int,
+    ~config: Config.fileTypeResolver,
+    ~workspace: Feature_Workspace.model,
+    msg,
+    model
+  ) =>
   (model, outmsg);
 
 let configurationChanged: (~config: Config.resolver, model) => model;

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -3,7 +3,7 @@
  (public_name Oni2.feature.buffers)
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.core Oni2.exthost
-   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu
+   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu Oni2.feature.workspace
    Oni2.service.exthost Oni2.service.font Revery isolinear base)
  (preprocess
   (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -120,7 +120,6 @@ type t =
   | SetGrammarRepository([@opaque] Oni_Syntax.GrammarRepository.t)
   | SetIconTheme([@opaque] IconTheme.t)
   | StatusBar(Feature_StatusBar.msg)
-  | CopyActiveFilepathToClipboard
   | SCM(Feature_SCM.msg)
   | Search(Feature_Search.msg)
   | SideBar(Feature_SideBar.msg)

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -13,14 +13,6 @@ module Internal = {
 
 open Internal;
 
-let copyFilePath =
-  register(
-    ~category="Editor",
-    ~title="Copy Active Filepath to Clipboard",
-    "copyFilePath",
-    CopyActiveFilepathToClipboard,
-  );
-
 let noop = register("noop", Noop);
 
 let command = cmd => CommandInvoked({command: cmd, arguments: `Null});

--- a/src/Service/Clipboard/Service_Clipboard.re
+++ b/src/Service/Clipboard/Service_Clipboard.re
@@ -1,7 +1,8 @@
 module GlobalState = {
-  type provider = {get: unit => option(string)};
+  type provider = {get: unit => option(string), set: string => unit};
 
-  let providerInstance = ref({get: Sdl2.Clipboard.getText});
+  let providerInstance = ref({get: Sdl2.Clipboard.getText,
+  set: Sdl2.Clipboard.setText});
 };
 
 module Effects = {
@@ -12,10 +13,16 @@ module Effects = {
       dispatch(toMsg(clipboardText));
     });
   };
+
+  let setClipboardText = (text) => 
+    Isolinear.Effect.create(
+      ~name="Service_Clipboard.setClipboardText", () => {
+       GlobalState.providerInstance^.set(text);
+    });
 };
 
 module Testing = {
-  let setClipboardProvider = (~get) => {
-    GlobalState.providerInstance := {get: get};
+  let setClipboardProvider = (~get, ~set) => {
+    GlobalState.providerInstance := {get: get, set: set};
   };
 };

--- a/src/Service/Clipboard/Service_Clipboard.re
+++ b/src/Service/Clipboard/Service_Clipboard.re
@@ -1,8 +1,11 @@
 module GlobalState = {
-  type provider = {get: unit => option(string), set: string => unit};
+  type provider = {
+    get: unit => option(string),
+    set: string => unit,
+  };
 
-  let providerInstance = ref({get: Sdl2.Clipboard.getText,
-  set: Sdl2.Clipboard.setText});
+  let providerInstance =
+    ref({get: Sdl2.Clipboard.getText, set: Sdl2.Clipboard.setText});
 };
 
 module Effects = {
@@ -14,15 +17,14 @@ module Effects = {
     });
   };
 
-  let setClipboardText = (text) => 
-    Isolinear.Effect.create(
-      ~name="Service_Clipboard.setClipboardText", () => {
-       GlobalState.providerInstance^.set(text);
+  let setClipboardText = text =>
+    Isolinear.Effect.create(~name="Service_Clipboard.setClipboardText", () => {
+      GlobalState.providerInstance^.set(text)
     });
 };
 
 module Testing = {
   let setClipboardProvider = (~get, ~set) => {
-    GlobalState.providerInstance := {get: get, set: set};
+    GlobalState.providerInstance := {get, set};
   };
 };

--- a/src/Service/Clipboard/Service_Clipboard.rei
+++ b/src/Service/Clipboard/Service_Clipboard.rei
@@ -2,10 +2,10 @@ module Effects: {
   let getClipboardText:
     (~toMsg: option(string) => 'a) => Isolinear.Effect.t('a);
 
-  let setClipboardText: 
-    (string) => Isolinear.Effect.t(_);
+  let setClipboardText: string => Isolinear.Effect.t(_);
 };
 
 module Testing: {
-  let setClipboardProvider: (~get: unit => option(string), ~set: string => unit) => unit;
+  let setClipboardProvider:
+    (~get: unit => option(string), ~set: string => unit) => unit;
 };

--- a/src/Service/Clipboard/Service_Clipboard.rei
+++ b/src/Service/Clipboard/Service_Clipboard.rei
@@ -1,8 +1,11 @@
 module Effects: {
   let getClipboardText:
     (~toMsg: option(string) => 'a) => Isolinear.Effect.t('a);
+
+  let setClipboardText: 
+    (string) => Isolinear.Effect.t(_);
 };
 
 module Testing: {
-  let setClipboardProvider: (~get: unit => option(string)) => unit;
+  let setClipboardProvider: (~get: unit => option(string), ~set: string => unit) => unit;
 };

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1307,7 +1307,7 @@ let update =
     let config = Feature_Configuration.resolver(state.config, state.vim);
 
     let (buffers, outmsg) =
-      Feature_Buffers.update(~activeBufferId, ~config, msg, state.buffers);
+      Feature_Buffers.update(~activeBufferId, ~config, ~workspace=state.workspace, msg, state.buffers);
 
     let state = {...state, buffers};
 

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1307,7 +1307,13 @@ let update =
     let config = Feature_Configuration.resolver(state.config, state.vim);
 
     let (buffers, outmsg) =
-      Feature_Buffers.update(~activeBufferId, ~config, ~workspace=state.workspace, msg, state.buffers);
+      Feature_Buffers.update(
+        ~activeBufferId,
+        ~config,
+        ~workspace=state.workspace,
+        msg,
+        state.buffers,
+      );
 
     let state = {...state, buffers};
 
@@ -1317,6 +1323,11 @@ let update =
     | Effect(eff) => (
         state,
         eff |> Isolinear.Effect.map(msg => Buffers(msg)),
+      )
+
+    | SetClipboardText(text) => (
+        state,
+        Service_Clipboard.Effects.setClipboardText(text),
       )
 
     | ShowMenu(menuFn) =>

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -703,14 +703,6 @@ let start =
       }
     );
 
-  let copyActiveFilepathToClipboardEffect =
-    Isolinear.Effect.create(~name="vim.copyActiveFilepathToClipboard", () =>
-      switch (Vim.Buffer.getCurrent() |> Vim.Buffer.getFilename) {
-      | Some(filename) => setClipboardText(filename)
-      | None => ()
-      }
-    );
-
   let prevViml = ref([]);
   let synchronizeViml = lines =>
     Isolinear.Effect.create(~name="vim.synchronizeViml", () =>
@@ -816,11 +808,6 @@ let start =
 
     | Init => (state, initEffect)
     | KeyboardInput({isText, input}) => (state, inputEffect(~isText, input))
-
-    | CopyActiveFilepathToClipboard => (
-        state,
-        copyActiveFilepathToClipboardEffect,
-      )
 
     | VimMessageReceived({priority, message, _}) =>
       let kind =


### PR DESCRIPTION
Adds commands to copy the relative file path / absolute file path (ports over the existing command to `Feature_Buffers`):

![image](https://user-images.githubusercontent.com/13532591/119047359-a9bbce80-b972-11eb-83a8-460b56a7f762.png)

Fixes #3549 