### PR TITLE
fix(terminal/#3062): Inherit line-height from editor

### DIFF
--- a/src/Core/LineHeight.re
+++ b/src/Core/LineHeight.re
@@ -1,4 +1,3 @@
-open Oni_Core;
 [@deriving show]
 type t =
   | Proportional(float)

--- a/src/Core/LineHeight.rei
+++ b/src/Core/LineHeight.rei
@@ -1,5 +1,3 @@
-open Oni_Core;
-
 [@deriving show]
 type t;
 

--- a/src/Core/Oni_Core.re
+++ b/src/Core/Oni_Core.re
@@ -42,6 +42,7 @@ module Job = Job;
 module KeyedStringMap = Kernel.KeyedStringMap;
 module LanguageConfiguration = LanguageConfiguration;
 module LazyLoader = LazyLoader;
+module LineHeight = LineHeight;
 module LineNumber = LineNumber;
 module Log = Kernel.Log;
 module MarkerUpdate = MarkerUpdate;

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -3,8 +3,9 @@
  (public_name Oni2.feature.buffers)
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.core Oni2.exthost
-   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu Oni2.feature.workspace
-   Oni2.service.exthost Oni2.service.font Revery isolinear base)
+   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu
+   Oni2.feature.workspace Oni2.service.exthost Oni2.service.font Revery
+   isolinear base)
  (preprocess
   (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx
     ppx_inline_test)))

--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -206,6 +206,14 @@ module VimSettings = {
       |> VimSetting.decode_value_opt(bool)
       |> Option.value(~default=false)
     });
+
+  let lineSpace =
+    vim("linespace", lineSpaceSetting => {
+      lineSpaceSetting
+      |> VimSetting.decode_value_opt(int)
+      |> Option.map(LineHeight.padding)
+      |> Option.value(~default=LineHeight.default)
+    });
 };
 
 module Editor = {
@@ -215,6 +223,14 @@ module Editor = {
       "editor.codeLens",
       bool,
       ~default=true,
+    );
+
+  let lineHeight =
+    setting(
+      ~vim=VimSettings.lineSpace,
+      "editor.lineHeight",
+      custom(~decode=LineHeight.decode, ~encode=LineHeight.encode),
+      ~default=LineHeight.default,
     );
 
   let snippetSuggestions =
@@ -295,6 +311,7 @@ let contributions = [
   vsync.spec,
   Editor.codeLensEnabled.spec,
   Editor.largeFileOptimizations.spec,
+  Editor.lineHeight.spec,
   Editor.snippetSuggestions.spec,
   Files.exclude.spec,
   Explorer.autoReveal.spec,

--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -535,7 +535,12 @@ let configure = (~config, editor) => {
        ~enabled=EditorConfiguration.Minimap.enabled.get(config),
        ~maxColumn=EditorConfiguration.Minimap.maxColumn.get(config),
      )
-  |> setLineHeight(~lineHeight=EditorConfiguration.lineHeight.get(config))
+  |> setLineHeight(
+       ~lineHeight=
+         Feature_Configuration.GlobalConfiguration.Editor.lineHeight.get(
+           config,
+         ),
+     )
   |> setLineNumbers(
        ~lineNumbers=EditorConfiguration.lineNumbers.get(config),
      )

--- a/src/Feature/Editor/EditorConfiguration.re
+++ b/src/Feature/Editor/EditorConfiguration.re
@@ -185,14 +185,6 @@ module VimSettings = {
       |> Option.value(~default="JetBrainsMono-Regular.ttf")
     });
 
-  let lineSpace =
-    vim("linespace", lineSpaceSetting => {
-      lineSpaceSetting
-      |> VimSetting.decode_value_opt(int)
-      |> Option.map(LineHeight.padding)
-      |> Option.value(~default=LineHeight.default)
-    });
-
   let wrap =
     vim("wrap", wrapSetting => {
       wrapSetting
@@ -285,13 +277,6 @@ let fontWeight =
     "editor.fontWeight",
     Codecs.fontWeight,
     ~default=Revery.Font.Weight.Normal,
-  );
-let lineHeight =
-  setting(
-    ~vim=VimSettings.lineSpace,
-    "editor.lineHeight",
-    custom(~decode=LineHeight.decode, ~encode=LineHeight.encode),
-    ~default=LineHeight.default,
   );
 let enablePreview =
   setting("workbench.editor.enablePreview", bool, ~default=true);
@@ -398,7 +383,6 @@ let contributions = [
   fontSize.spec,
   fontSmoothing.spec,
   fontWeight.spec,
-  lineHeight.spec,
   enablePreview.spec,
   highlightActiveIndentGuide.spec,
   horizontalScrollbarSize.spec,

--- a/src/Feature/Terminal/Configuration.re
+++ b/src/Feature/Terminal/Configuration.re
@@ -1,0 +1,79 @@
+open Oni_Core;
+
+open Config.Schema;
+module Codecs = Feature_Configuration.GlobalConfiguration.Codecs;
+
+let shellCmd = ShellUtility.getDefaultShell();
+
+module Shell = {
+  let windows =
+    setting("terminal.integrated.shell.windows", string, ~default=shellCmd);
+  let linux =
+    setting("terminal.integrated.shell.linux", string, ~default=shellCmd);
+  let osx =
+    setting("terminal.integrated.shell.osx", string, ~default=shellCmd);
+};
+
+module ShellArgs = {
+  let windows =
+    setting(
+      "terminal.integrated.shellArgs.windows",
+      list(string),
+      ~default=[],
+    );
+  let linux =
+    setting(
+      "terminal.integrated.shellArgs.linux",
+      list(string),
+      ~default=[],
+    );
+  let osx =
+    setting(
+      "terminal.integrated.shellArgs.osx",
+      list(string),
+      // ~/.[bash|zsh}_profile etc is not sourced when logging in on macOS.
+      // Instead, terminals on macOS should run as a login shell (which in turn
+      // sources these files).
+      // See more at http://unix.stackexchange.com/a/119675/115410.
+      ~default=["-l"],
+    );
+};
+
+let fontFamily =
+  setting("terminal.integrated.fontFamily", nullable(string), ~default=None);
+
+let fontSize =
+  setting(
+    "terminal.integrated.fontSize",
+    nullable(Codecs.fontSize),
+    ~default=None,
+  );
+let fontWeight =
+  setting(
+    "terminal.integrated.fontWeight",
+    nullable(Codecs.fontWeight),
+    ~default=None,
+  );
+
+let fontLigatures =
+  setting(
+    "terminal.integrated.fontLigatures",
+    nullable(Codecs.fontLigatures),
+    ~default=None,
+  );
+
+let fontSmoothing =
+  setting(
+    "terminal.integrated.fontSmoothing",
+    nullable(
+      custom(~encode=FontSmoothing.encode, ~decode=FontSmoothing.decode),
+    ),
+    ~default=None,
+  );
+
+let lineHeight =
+  setting(
+    "terminal.integrated.lineHeight",
+    nullable(custom(~encode=LineHeight.encode, ~decode=LineHeight.decode)),
+    ~default=None,
+  );

--- a/src/Feature/Terminal/Feature_Terminal.re
+++ b/src/Feature/Terminal/Feature_Terminal.re
@@ -20,85 +20,9 @@ type outmsg =
       shouldClose: bool,
     });
 
-let shellCmd = ShellUtility.getDefaultShell();
-
 // CONFIGURATION
 
-module Configuration = {
-  open Oni_Core;
-  open Config.Schema;
-  module Codecs = Feature_Configuration.GlobalConfiguration.Codecs;
-
-  module Shell = {
-    let windows =
-      setting("terminal.integrated.shell.windows", string, ~default=shellCmd);
-    let linux =
-      setting("terminal.integrated.shell.linux", string, ~default=shellCmd);
-    let osx =
-      setting("terminal.integrated.shell.osx", string, ~default=shellCmd);
-  };
-
-  module ShellArgs = {
-    let windows =
-      setting(
-        "terminal.integrated.shellArgs.windows",
-        list(string),
-        ~default=[],
-      );
-    let linux =
-      setting(
-        "terminal.integrated.shellArgs.linux",
-        list(string),
-        ~default=[],
-      );
-    let osx =
-      setting(
-        "terminal.integrated.shellArgs.osx",
-        list(string),
-        // ~/.[bash|zsh}_profile etc is not sourced when logging in on macOS.
-        // Instead, terminals on macOS should run as a login shell (which in turn
-        // sources these files).
-        // See more at http://unix.stackexchange.com/a/119675/115410.
-        ~default=["-l"],
-      );
-  };
-
-  let fontFamily =
-    setting(
-      "terminal.integrated.fontFamily",
-      nullable(string),
-      ~default=None,
-    );
-
-  let fontSize =
-    setting(
-      "terminal.integrated.fontSize",
-      nullable(Codecs.fontSize),
-      ~default=None,
-    );
-  let fontWeight =
-    setting(
-      "terminal.integrated.fontWeight",
-      nullable(Codecs.fontWeight),
-      ~default=None,
-    );
-
-  let fontLigatures =
-    setting(
-      "terminal.integrated.fontLigatures",
-      nullable(Codecs.fontLigatures),
-      ~default=None,
-    );
-
-  let fontSmoothing =
-    setting(
-      "terminal.integrated.fontSmoothing",
-      nullable(
-        custom(~encode=FontSmoothing.encode, ~decode=FontSmoothing.decode),
-      ),
-      ~default=None,
-    );
-};
+module Configuration = Configuration;
 
 let shouldClose = (~id, {idToTerminal, _}) => {
   IntMap.find_opt(id, idToTerminal)
@@ -137,7 +61,7 @@ let update =
       | Windows(_) => Configuration.Shell.windows.get(config)
       | Mac(_) => Configuration.Shell.osx.get(config)
       | Linux(_) => Configuration.Shell.linux.get(config)
-      | _ => shellCmd
+      | _ => Configuration.shellCmd
       };
 
     let arguments =
@@ -245,7 +169,7 @@ let update =
         | Windows(_) => Configuration.Shell.windows.get(config)
         | Mac(_) => Configuration.Shell.osx.get(config)
         | Linux(_) => Configuration.Shell.linux.get(config)
-        | _ => shellCmd
+        | _ => Configuration.shellCmd
         }
       | Some(specifiedCommand) => specifiedCommand
       };
@@ -748,6 +672,7 @@ module Contributions = {
       fontWeight.spec,
       fontLigatures.spec,
       fontSmoothing.spec,
+      lineHeight.spec,
     ];
 
   let keybindings = {

--- a/src/Feature/Terminal/Feature_Terminal.rei
+++ b/src/Feature/Terminal/Feature_Terminal.rei
@@ -86,7 +86,7 @@ let subscription:
   ) =>
   Isolinear.Sub.t(msg);
 
-let shellCmd: string;
+// let shellCmd: string;
 
 // COLORS
 

--- a/src/Feature/Terminal/TerminalView.re
+++ b/src/Feature/Terminal/TerminalView.re
@@ -46,6 +46,14 @@ module Terminal = {
             config,
           );
 
+    let lineHeight =
+      Configuration.lineHeight.get(config)
+      |> Oni_Core.Utility.OptionEx.value_or_lazy(() => {
+           Feature_Configuration.GlobalConfiguration.Editor.lineHeight.get(
+             config,
+           )
+         });
+
     let%hook lastDimensions = Hooks.ref(None);
 
     // When the terminal id changes, we need to make sure we're dispatching the resized
@@ -67,13 +75,19 @@ module Terminal = {
 
     let Service_Font.{fontSize, smoothing, _} = font;
 
+    let lineHeightSize =
+      Oni_Core.LineHeight.calculate(~measuredFontHeight=fontSize, lineHeight);
+    let terminalFont =
+      EditorTerminal.Font.make(
+        ~size=fontSize,
+        ~lineHeight=lineHeightSize,
+        resolvedFont,
+      );
     let onDimensionsChanged =
         (
           {height, width, _}: Revery.UI.NodeEvents.DimensionsChangedEventParams.t,
         ) => {
       // If we have a loaded font, figure out how many columns and rows we can show
-      let terminalFont =
-        EditorTerminal.Font.make(~size=fontSize, resolvedFont);
       let rows =
         float_of_int(height) /. terminalFont.lineHeight |> int_of_float;
       let columns =
@@ -89,15 +103,13 @@ module Terminal = {
     let {screen, cursor, _}: Model.terminal = terminal;
 
     let element = {
-      let font =
-        EditorTerminal.Font.make(~smoothing, ~size=fontSize, resolvedFont);
       EditorTerminal.render(
         ~opacity,
         ~defaultBackground,
         ~defaultForeground,
         ~theme=terminalTheme,
         ~cursor,
-        ~font,
+        ~font=terminalFont,
         ~scrollBarThickness=Constants.scrollBarThickness,
         ~scrollBarThumb=Constants.scrollThumbColor,
         ~scrollBarBackground=Constants.scrollTrackColor,

--- a/src/Feature/Terminal/TerminalView.re
+++ b/src/Feature/Terminal/TerminalView.re
@@ -79,6 +79,7 @@ module Terminal = {
       Oni_Core.LineHeight.calculate(~measuredFontHeight=fontSize, lineHeight);
     let terminalFont =
       EditorTerminal.Font.make(
+        ~smoothing,
         ~size=fontSize,
         ~lineHeight=lineHeightSize,
         resolvedFont,

--- a/src/editor-terminal/EditorTerminal.rei
+++ b/src/editor-terminal/EditorTerminal.rei
@@ -26,7 +26,13 @@ module Font: {
   };
 
   let make:
-    (~smoothing: Revery.Font.Smoothing.t=?, ~size: float, Revery.Font.t) => t;
+    (
+      ~smoothing: Revery.Font.Smoothing.t=?,
+      ~size: float,
+      ~lineHeight: float,
+      Revery.Font.t
+    ) =>
+    t;
 };
 
 module Screen: {

--- a/src/editor-terminal/Font.re
+++ b/src/editor-terminal/Font.re
@@ -8,9 +8,14 @@ type t = {
 };
 
 let make =
-    (~smoothing=Revery.Font.Smoothing.default, ~size, font: Revery.Font.t) => {
+    (
+      ~smoothing=Revery.Font.Smoothing.default,
+      ~size,
+      ~lineHeight,
+      font: Revery.Font.t,
+    ) => {
   let fontSize = size;
-  let {height, lineHeight, _}: Revery.Font.FontMetrics.t =
+  let {height, _}: Revery.Font.FontMetrics.t =
     Revery.Font.getMetrics(font, fontSize);
   let {width, _}: Revery.Font.measureResult =
     Revery.Font.measure(~smoothing, font, fontSize, "M");

--- a/src/editor-terminal/TerminalView.re
+++ b/src/editor-terminal/TerminalView.re
@@ -133,6 +133,9 @@ let%component make =
 
           Skia.Paint.setLcdRenderText(textPaint, true);
 
+          let lineSpacingOffset =
+            max(0., (lineHeight -. characterHeight) /. 2.);
+
           let columns = Screen.getColumns(screen);
           let rows = Screen.getTotalRows(screen);
 
@@ -147,7 +150,7 @@ let%component make =
                      CanvasContext.drawRectLtwh(
                        ~paint=backgroundPaint,
                        ~left=float(startColumn) *. characterWidth,
-                       ~top=yOffset,
+                       ~top=yOffset +. lineSpacingOffset,
                        ~height=lineHeight,
                        ~width=
                          float(endColumn - startColumn) *. characterWidth,
@@ -184,7 +187,7 @@ let%component make =
                        CanvasContext.drawText(
                          ~paint=textPaint,
                          ~x=float(startColumn) *. characterWidth,
-                         ~y=yOffset +. characterHeight,
+                         ~y=yOffset +. characterHeight +. lineSpacingOffset,
                          ~text=str,
                          canvasContext,
                        );
@@ -226,7 +229,11 @@ let%component make =
             let (yOffset, width, height) =
               switch (cursor.shape) {
               | BarLeft => (0., 2., lineHeight)
-              | Underline => (lineHeight -. 2., characterWidth, 2.)
+              | Underline => (
+                  lineHeight -. 2. -. lineSpacingOffset,
+                  characterWidth,
+                  2.,
+                )
               | Unknown
               | Block => (0., characterWidth, lineHeight)
               };


### PR DESCRIPTION
Last part of the work for #3062 - inherit line-height from the editor, and add `terminal.integrated.lineHeight` setting to overide.

Fixes #3062 