### PR TITLE
fix(extensions/#3551): Preserve scroll when updating list, if possible

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -93,6 +93,7 @@
 - #3560 - Shell: Fix incorrect PATH on OSX when launched via Finder (fixes #3199)
 - #3567 - Explorer: Fix files in NFS mount not loading (fixes #3534)
 - #3568 - Explorer: Fix symlinks showing up as empty files (fixes #2657)
+- #3585 - Extensions: Fix scroll resetting while search is in progress (fixes #3551)
 
 ### Performance
 

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -193,18 +193,6 @@ let setSelected = (~selected, model) => {
   {...model, selected: selected'} |> ensureSelectedVisible;
 };
 
-let set = (~searchText=?, items, model) => {
-  let searchContext =
-    switch (searchText) {
-    | None => model.searchContext
-    | Some(f) =>
-      let searchIds = Array.map(f, items);
-      SearchContext.setSearchIds(searchIds, model.searchContext);
-    };
-
-  {...model, searchContext, items} |> setSelected(~selected=model.selected);
-};
-
 let setScrollY = (~allowOverscroll=false, ~scrollY, model) => {
   let maxScroll =
     if (allowOverscroll) {
@@ -222,6 +210,22 @@ let setScrollY = (~allowOverscroll=false, ~scrollY, model) => {
 
   let newScrollY = FloatEx.clamp(scrollY, ~hi=maxScroll, ~lo=minScroll);
   {...model, scrollY: newScrollY};
+};
+
+let set = (~searchText=?, items, model) => {
+  let searchContext =
+    switch (searchText) {
+    | None => model.searchContext
+    | Some(f) =>
+      let searchIds = Array.map(f, items);
+      SearchContext.setSearchIds(searchIds, model.searchContext);
+    };
+
+  let originalScrollY = model.scrollY;
+
+  {...model, searchContext, items}
+  |> setSelected(~selected=model.selected)
+  |> setScrollY(~scrollY=originalScrollY);
 };
 
 let enableScrollAnimation = model => {...model, isScrollAnimated: true};

--- a/src/Feature/Buffers/dune
+++ b/src/Feature/Buffers/dune
@@ -3,8 +3,9 @@
  (public_name Oni2.feature.buffers)
  (inline_tests)
  (libraries Oni2.editor-core-types Oni2.core Oni2.exthost
-   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu Oni2.feature.workspace
-   Oni2.service.exthost Oni2.service.font Revery isolinear base)
+   Oni2.feature.commands Oni2.feature.configuration Oni2.feature.quickmenu
+   Oni2.feature.workspace Oni2.service.exthost Oni2.service.font Revery
+   isolinear base)
  (preprocess
   (pps ppx_let ppx_deriving_yojson ppx_deriving.show brisk-reconciler.ppx
     ppx_inline_test)))


### PR DESCRIPTION
__Issue:__ Scrolling through the extensions list while searching for extensions is frustrating, because the view always resets - making it hard to focus on any particular item while the search is in progress.

__Defect:__ When new items came in, the current item would be focused, which is usually the top item. However, if there is a mouse scroll, that should be taken into consideration, too.

__Fix:__ Preserve scroll when repopulating the list, if possible.

Fixes #3551 