### PR TITLE
fix(registration): Trim license key string prior to submitting to API

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+- #3597 - Registration: Trim license key before submitting
+
 ### Performance
 
 ### Documentation

--- a/src/Service/Registration/Service_Registration.re
+++ b/src/Service/Registration/Service_Registration.re
@@ -9,6 +9,7 @@ module Effect = {
   let checkLicenseKeyValidity = (~proxy, licenseKey) =>
     Isolinear.Effect.createWithDispatch(
       ~name="registration.checkLicenseKeyValidity", dispatch => {
+      let licenseKey = licenseKey |> String.trim;
       let url =
         "https://v2.onivim.io/api/isLicenseKeyValid?licenseKey=" ++ licenseKey;
       let setup = Setup.init();


### PR DESCRIPTION
Fix case where spaces are copied before / after license key string -