### PR TITLE
fix(osx/#3614): Hang on IME

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -6,6 +6,7 @@
 - #3431 - Extensions: Serialize file system errors correctly to extensions (fixes #3418)
 - #3600 - OSX: Fix crash on selecting native menu item
 - #3604 - Editor: Fix CodeLens blocking mousewheel
+- #3616 - OSX: Fix crash on IME switch (fixes #3614)
 
 ### Performance
 

--- a/src/oni2-keyboard-layout/stubs/keyboard-layout-mac.c
+++ b/src/oni2-keyboard-layout/stubs/keyboard-layout-mac.c
@@ -61,14 +61,9 @@ static void notificationHandler(
     }
   }
 
-  caml_c_thread_register();
-  caml_acquire_runtime_system();
-
   value args[] = {Val_unit};
   caml_callbackN(*callbackFunc, 1, args);
 
-  caml_release_runtime_system();
-  
   CAMLreturn0;
 }
 


### PR DESCRIPTION
__Issue:__ Crash when switching input language on OSX

__Defect:__ The change in https://github.com/revery-ui/revery/pull/1072 means that the runtime is no longer released - however, when the input changes,  the keyboard handler was trying to acquire the runtime, causing a crash.

__Fix:__ Remove release/acquire runtime calls in the keyboard handler on OSX

Fixes #3614 
