### PR TITLE
docs(build): add steps for the Docker based build

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -14,6 +14,7 @@
 ### Documentation
 
 - #3601 - Visual Mode: Add note about switching to block mode on Windows / Linux (thanks @rogererens !)
+- #3620 - Building: Add steps for Docker based build.
 
 ### Refactoring
 


### PR DESCRIPTION
Just copies over and tidies up the steps for the Linux Dockerfile based build. Should hopefully help some of the people who are having issues/don't want to install the other deps.