### PR TITLE
fix(sneak/#2569): Focus buffer when entering via sneak

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -8,6 +8,7 @@
 - #3604 - Editor: Fix CodeLens blocking mousewheel
 - #3606 - Vim: Fix hang when using `function` in `experimental.viml`
 - #3616 - OSX: Fix crash on IME switch (fixes #3614)
+- #3621 - Sneak: Grab editor focus when using sneak to jump to an editor (fixes #2569)
 
 ### Performance
 

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -128,7 +128,7 @@ let update = (~focus, model, msg) => {
         updateGroup(groupId, Group.select(editorId)),
         model,
       ),
-      Nothing,
+      Focus(Center),
     )
   | EditorTabDoubleClicked({groupId, editorId}) => (
       updateActiveLayout(
@@ -155,7 +155,7 @@ let update = (~focus, model, msg) => {
 
   | LayoutTabClicked(index) => (
       {...model, activeLayoutIndex: index},
-      Nothing,
+      Focus(Center),
     )
 
   | LayoutCloseButtonClicked(index) =>


### PR DESCRIPTION
__Issue:__ When using 'sneak' to enter a buffer from another focus point, the buffer gets selected, but focus doesn't go to the editor.

__Defect:__ The focus is implicitly relying on the 'click' to focus the editors.

__Fix:__ When clicking on a tab, use the `Focus(Center)` outmsg to ensure that the editors have focus.

An alternative approach to fixing this would be to create separate `msg`'s for Sneaks - ie, adding an `EditorTabSneaked` to `EditorTabClicked`. This might better communicate the state of the system (it's really just the sneak gesture that requires this extra focus), but it seemed a bit overkill.

Fixes #2569 