### PR TITLE
refactor(dock): use SVG icons in dock

### DIFF
--- a/ThirdPartyLicenses.txt
+++ b/ThirdPartyLicenses.txt
@@ -37,6 +37,7 @@ This project incorporates components from the projects listed below. The origina
 31. vscode-codicons (https://github.com/microsoft/vscode-codicons)
 32. openssl (https://github.com/openssl/openssl)
 33. fzy (https://github.com/jhawthorn/fzy)
+34. Feather Icons (https://feathericons.com)
 
 %% JetBrainsMono NOTICES AND INFORMATION BEGIN HERE
 ==============================================
@@ -3953,3 +3954,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==============================================
 END of fzy NOTICES AND INFORMATION
+
+%% Feather Icons NOTICES AND INFORMATION BEGIN HERE
+==============================================
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+==============================================
+%END of Feather Icons NOTICES AND INFORMATION

--- a/src/Components/FeatherIcons.re
+++ b/src/Components/FeatherIcons.re
@@ -36,7 +36,7 @@ let folder: SVGIcon.t =
           }
     />;
 
-let codeSandbox: SVGIcon.t =
+let package: SVGIcon.t =
   (~size=24, ~strokeWidth=2, ~color=Colors.white, ()) =>
     <SVG
       src={
@@ -52,14 +52,12 @@ let codeSandbox: SVGIcon.t =
                   stroke-width="%d"
                   stroke-linecap="round"
                   stroke-linejoin="round"
-                  class="feather feather-search"
+                  class="feather feather-package"
                 >
-                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
-                  <polyline points="7.5 4.21 12 6.81 16.5 4.21"/>
-                  <polyline points="7.5 19.79 7.5 14.6 3 12"/>
-                  <polyline points="21 12 16.5 14.6 16.5 19.79"/>
-                  <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
-                  <line x1="12" y1="22.08" x2="12" y2="12"/>
+                  <line x1="16.5" y1="9.4" x2="7.5" y2="4.21" />
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+                  <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+                  <line x1="12" y1="22.08" x2="12" y2="12" />
                 </svg>
             |},
                 size,

--- a/src/Components/FeatherIcons.re
+++ b/src/Components/FeatherIcons.re
@@ -1,5 +1,4 @@
 open Revery;
-open Revery.UI;
 open Revery.UI.Components;
 
 let colorToCSS = color => {

--- a/src/Components/FeatherIcons.re
+++ b/src/Components/FeatherIcons.re
@@ -1,0 +1,149 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+
+let colorToCSS = color => {
+  let (r, g, b, _) = Color.toRgba(color);
+  Printf.sprintf(
+    "#%02X%02X%02X",
+    int_of_float(r *. 255.),
+    int_of_float(g *. 255.),
+    int_of_float(b *. 255.),
+  );
+};
+
+let folder: SVGIcon.t =
+  (~size=24, ~strokeWidth=2, ~color=Colors.white, ()) =>
+    <SVG
+      src={
+            `Str(
+              Printf.sprintf(
+                {|<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="%d"
+                  height="%d"
+                  viewBox="0 0 %d %d"
+                  fill="none"
+                  stroke="%s"
+                  stroke-width="%d"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="feather feather-folder"
+                >
+                  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                </svg>
+            |},
+                size,
+                size,
+                size,
+                size,
+                colorToCSS(color),
+                strokeWidth,
+              ),
+            )
+          }
+    />;
+
+let codeSandbox: SVGIcon.t =
+  (~size=24, ~strokeWidth=2, ~color=Colors.white, ()) =>
+    <SVG
+      src={
+            `Str(
+              Printf.sprintf(
+                {|<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="%d"
+                  height="%d"
+                  viewBox="0 0 %d %d"
+                  fill="none"
+                  stroke="%s"
+                  stroke-width="%d"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="feather feather-search"
+                >
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+                  <polyline points="7.5 4.21 12 6.81 16.5 4.21"/>
+                  <polyline points="7.5 19.79 7.5 14.6 3 12"/>
+                  <polyline points="21 12 16.5 14.6 16.5 19.79"/>
+                  <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+                  <line x1="12" y1="22.08" x2="12" y2="12"/>
+                </svg>
+            |},
+                size,
+                size,
+                size,
+                size,
+                colorToCSS(color),
+                strokeWidth,
+              ),
+            )
+          }
+    />;
+let search: SVGIcon.t =
+  (~size=24, ~strokeWidth=2, ~color=Colors.white, ()) =>
+    <SVG
+      src={
+            `Str(
+              Printf.sprintf(
+                {|<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="%d"
+                  height="%d"
+                  viewBox="0 0 %d %d"
+                  fill="none"
+                  stroke="%s"
+                  stroke-width="%d"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="feather feather-codesandbox"
+                >
+                  <circle cx="11" cy="11" r="8"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+            |},
+                size,
+                size,
+                size,
+                size,
+                colorToCSS(color),
+                strokeWidth,
+              ),
+            )
+          }
+    />;
+
+let gitPullRequest: SVGIcon.t =
+  (~size=24, ~strokeWidth=2, ~color=Colors.white, ()) =>
+    <SVG
+      src={
+            `Str(
+              Printf.sprintf(
+                {|<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="%d"
+                  height="%d"
+                  viewBox="0 0 %d %d"
+                  fill="none"
+                  stroke="%s"
+                  stroke-width="%d"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="feather feather-git-pull-request"
+                >
+                  <circle cx="18" cy="18" r="3"/>
+                  <circle cx="6" cy="6" r="3"/>
+                  <path d="M13 6h3a2 2 0 0 1 2 2v7"/>
+                  <line x1="6" y1="9" x2="6" y2="21"/>
+                </svg>
+            |},
+                size,
+                size,
+                size,
+                size,
+                colorToCSS(color),
+                strokeWidth,
+              ),
+            )
+          }
+    />;

--- a/src/Components/FeatherIcons.re
+++ b/src/Components/FeatherIcons.re
@@ -1,15 +1,8 @@
 open Revery;
 open Revery.UI.Components;
 
-let colorToCSS = color => {
-  let (r, g, b, _) = Color.toRgba(color);
-  Printf.sprintf(
-    "#%02X%02X%02X",
-    int_of_float(r *. 255.),
-    int_of_float(g *. 255.),
-    int_of_float(b *. 255.),
-  );
-};
+/* Sourced from https://feathericons.com
+   Licensed under MIT */
 
 let folder: SVGIcon.t =
   (~size=24, ~strokeWidth=2, ~color=Colors.white, ()) =>
@@ -36,7 +29,7 @@ let folder: SVGIcon.t =
                 size,
                 size,
                 size,
-                colorToCSS(color),
+                SVGIcon.colorToHex(color),
                 strokeWidth,
               ),
             )
@@ -73,7 +66,7 @@ let codeSandbox: SVGIcon.t =
                 size,
                 size,
                 size,
-                colorToCSS(color),
+                SVGIcon.colorToHex(color),
                 strokeWidth,
               ),
             )
@@ -105,7 +98,7 @@ let search: SVGIcon.t =
                 size,
                 size,
                 size,
-                colorToCSS(color),
+                SVGIcon.colorToHex(color),
                 strokeWidth,
               ),
             )
@@ -140,7 +133,7 @@ let gitPullRequest: SVGIcon.t =
                 size,
                 size,
                 size,
-                colorToCSS(color),
+                SVGIcon.colorToHex(color),
                 strokeWidth,
               ),
             )

--- a/src/Components/FeatherIcons.rei
+++ b/src/Components/FeatherIcons.rei
@@ -1,4 +1,4 @@
 let folder: SVGIcon.t;
-let codeSandbox: SVGIcon.t;
+let package: SVGIcon.t;
 let search: SVGIcon.t;
 let gitPullRequest: SVGIcon.t;

--- a/src/Components/FeatherIcons.rei
+++ b/src/Components/FeatherIcons.rei
@@ -1,0 +1,4 @@
+let folder: SVGIcon.t;
+let codeSandbox: SVGIcon.t;
+let search: SVGIcon.t;
+let gitPullRequest: SVGIcon.t;

--- a/src/Components/SVGIcon.re
+++ b/src/Components/SVGIcon.re
@@ -1,0 +1,3 @@
+type t =
+  (~size: int=?, ~strokeWidth: int=?, ~color: Revery.Color.t=?, unit) =>
+  Revery.UI.element;

--- a/src/Components/SVGIcon.re
+++ b/src/Components/SVGIcon.re
@@ -1,3 +1,13 @@
 type t =
   (~size: int=?, ~strokeWidth: int=?, ~color: Revery.Color.t=?, unit) =>
   Revery.UI.element;
+
+let colorToHex = color => {
+  let (r, g, b, _) = Revery.Color.toRgba(color);
+  Printf.sprintf(
+    "#%02X%02X%02X",
+    int_of_float(r *. 255.),
+    int_of_float(g *. 255.),
+    int_of_float(b *. 255.),
+  );
+};

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -2,6 +2,7 @@ open Revery.UI;
 
 open Oni_Core;
 open Oni_Model;
+open Oni_Components;
 
 module FontAwesome = Oni_Components.FontAwesome;
 module FontIcon = Oni_Components.FontIcon;
@@ -105,8 +106,7 @@ let%component item =
                 ~sideBar,
                 ~theme,
                 ~isActive,
-                ~icon,
-                ~iconStyle=`Solid,
+                ~icon: SVGIcon.t,
                 ~font: UiFont.t,
                 (),
               ) => {
@@ -114,16 +114,8 @@ let%component item =
   let onMouseOver = _ => setHovered(_ => true);
   let onMouseOut = _ => setHovered(_ => false);
 
-  let icon = () => {
-    let color = isActive ? Colors.foreground : Colors.inactiveForeground;
-    let fontFamily =
-      switch (iconStyle) {
-      | `Solid => FontAwesome.FontFamily.solid
-      | `Regular => FontAwesome.FontFamily.regular
-      };
-
-    <FontIcon fontFamily color={color.from(theme)} fontSize=22. icon />;
-  };
+  let color =
+    (isActive ? Colors.foreground : Colors.inactiveForeground).from(theme);
 
   let notificationElement =
     switch (notification) {
@@ -136,7 +128,7 @@ let%component item =
       sneakId="item"
       onClick
       style={Styles.item(~isHovered, ~isActive, ~theme, ~sideBar)}>
-      <icon />
+      <icon size=24 strokeWidth=2 color />
       notificationElement
     </Sneakable>
   </View>;
@@ -183,8 +175,7 @@ let make =
       sideBar
       theme
       isActive={isSidebarVisible(FileExplorer)}
-      icon=FontAwesome.copy
-      iconStyle=`Regular
+      icon=FeatherIcons.folder
     />
     <item
       font
@@ -192,7 +183,7 @@ let make =
       sideBar
       theme
       isActive={isSidebarVisible(Search)}
-      icon=FontAwesome.search
+      icon=FeatherIcons.search
     />
     <item
       font
@@ -200,7 +191,7 @@ let make =
       sideBar
       theme
       isActive={isSidebarVisible(SCM)}
-      icon=FontAwesome.codeBranch
+      icon=FeatherIcons.gitPullRequest
       notification=?scmNotification
     />
     <item
@@ -209,7 +200,7 @@ let make =
       sideBar
       theme
       isActive={isSidebarVisible(Extensions)}
-      icon=FontAwesome.thLarge
+      icon=FeatherIcons.codeSandbox
       notification=?extensionNotification
     />
   </View>;

--- a/src/UI/Dock.re
+++ b/src/UI/Dock.re
@@ -200,7 +200,7 @@ let make =
       sideBar
       theme
       isActive={isSidebarVisible(Extensions)}
-      icon=FeatherIcons.codeSandbox
+      icon=FeatherIcons.package
       notification=?extensionNotification
     />
   </View>;


### PR DESCRIPTION
Now that we have SVG support in Revery, I think it makes sense to swap out some of the old Font Awesome icons we have for parameterize-able SVG icons. 

The Font Awesome icons are great, but they aren't meant to be rendered at the size we are currently, leading to stroke widths that look too thick, etc.

I chose to use [Feather Icons](https://feathericons.com) to replace the ones in the dock since they are configurable and MIT-licensed, but if anyone has any better ideas, let me know!

**Before:**
![image](https://user-images.githubusercontent.com/4527949/120053541-c69e7480-bff8-11eb-8981-6fcad95ab286.png)

**After:**
![image](https://user-images.githubusercontent.com/4527949/120080384-a5846500-c086-11eb-89c1-10dd51243cc6.png)

The beautiful thing about the SVGs is that they're configurable -- I created an `SVGIcon.t` which takes a size, stroke-width, and color and re-writes the SVG accordingly.