### PR TITLE
fix(minimap/#3618): Center clicked minimap line

### DIFF
--- a/src/Feature/Editor/Editor.re
+++ b/src/Feature/Editor/Editor.re
@@ -1385,9 +1385,23 @@ let scrollToPixelY = (~animated, ~pixelY as newScrollY, editor) => {
   |> synchronizeMinimapScroll(~animated=!instant);
 };
 
-let scrollToLine = (~line, view) => {
-  let pixelY = float_of_int(line) *. lineHeightInPixels(view);
-  scrollToPixelY(~animated=true, ~pixelY, view);
+let halfViewportHeight = editor => {
+  let heightInPixels = float(editor.pixelHeight);
+  (heightInPixels -. lineHeightInPixels(editor)) /. 2.;
+};
+
+let scrollToLine = (~line, editor) => {
+  let inlineElementSpace =
+    InlineElements.getReservedSpace(
+      EditorCoreTypes.LineNumber.ofZeroBased(line),
+      editor.inlineElements,
+    );
+  let pixelY =
+    float_of_int(line)
+    *. lineHeightInPixels(editor)
+    +. inlineElementSpace
+    -. halfViewportHeight(editor);
+  scrollToPixelY(~animated=true, ~pixelY, editor);
 };
 
 let scrollToPixelX = (~animated, ~pixelX as newScrollX, editor) => {
@@ -1537,12 +1551,10 @@ let scrollCenterCursorVertically = editor => {
       editor,
     );
 
-  let heightInPixels = float(editor.pixelHeight);
   let pixelY =
     pixelPosition.y
     +. Spring.getTarget(editor.scrollY)
-    -. heightInPixels
-    /. 2.;
+    -. halfViewportHeight(editor);
   scrollToPixelY(~animated=true, ~pixelY, editor);
 };
 


### PR DESCRIPTION
- When clicking on a line in the minimap, center that line in the editor (if we can).
- Account for reserved space (ie, codelens or other inline elements)

Fixes #3618 