### PR TITLE
fix(editor/#3629): Fix missing line number / cursor when deleting entire file

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -11,6 +11,7 @@
 - #3606 - Vim: Fix hang when using `function` in `experimental.viml`
 - #3616 - OSX: Fix crash on IME switch (fixes #3614)
 - #3621 - Sneak: Grab editor focus when using sneak to jump to an editor (fixes #2569)
+- #3630 - Editor: Cursor / line number disappearing when deleting entire buffer (fixes #3629)
 
 ### Performance
 

--- a/src/Feature/Editor/EditorBuffer.re
+++ b/src/Feature/Editor/EditorBuffer.re
@@ -1,14 +1,24 @@
-type t = Oni_Core.Buffer.t;
+open Oni_Core;
 
-let ofBuffer = buffer => buffer;
-let id = Oni_Core.Buffer.getId;
-let getEstimatedMaxLineLength = Oni_Core.Buffer.getEstimatedMaxLineLength;
-let numberOfLines = Oni_Core.Buffer.getNumberOfLines;
-let line = Oni_Core.Buffer.getLine;
-let font = Oni_Core.Buffer.getFont;
+type t = Buffer.t;
 
-let fileType = Oni_Core.Buffer.getFileType;
-let measure = Oni_Core.Buffer.measure;
+let ofBuffer = buffer =>
+  if (Buffer.getNumberOfLines(buffer) > 0) {
+    buffer;
+  } else {
+    let font = Buffer.getFont(buffer);
+    let id = Buffer.getId(buffer);
+
+    Buffer.ofLines(~id, ~font, [|""|]);
+  };
+let id = Buffer.getId;
+let getEstimatedMaxLineLength = Buffer.getEstimatedMaxLineLength;
+let numberOfLines = Buffer.getNumberOfLines;
+let line = Buffer.getLine;
+let font = Buffer.getFont;
+
+let fileType = Buffer.getFileType;
+let measure = Buffer.measure;
 
 let hasLine = (lineNumber, buffer) => {
   let lineIdx = EditorCoreTypes.LineNumber.toZeroBased(lineNumber);

--- a/src/Feature/Editor/EditorBuffer.re
+++ b/src/Feature/Editor/EditorBuffer.re
@@ -6,6 +6,7 @@ let ofBuffer = buffer =>
   if (Buffer.getNumberOfLines(buffer) > 0) {
     buffer;
   } else {
+    // #3629 - From the editor UI perspective, never render a totally empty buffer.
     let font = Buffer.getFont(buffer);
     let id = Buffer.getId(buffer);
 


### PR DESCRIPTION
Fixes #3629 
Fixes #3634 