### PR TITLE
fix(vim/#3680): Respect silent flag for output command

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -24,6 +24,7 @@
 - #3668 - UX: Toggle drop-down menu on click (fixes #3569 - thanks @sijad !)
 - #3571 - Extension: Implement $tryApplyEdits (fixes #3545)
 - #3335 - Extension: Fix selection bounds (fixes #3335)
+- #3699 - Vim: Respect silent flag for output-producing commands (fixes #3680)
 
 ### Performance
 

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03eb8c5c87c7e0f2548b482b9b318375",
+  "checksum": "ecf83ae9b88f22dd34eef83dfacf2e82",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -371,14 +371,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.88@d41d8cd9": {
-      "id": "libvim@8.10869.88@d41d8cd9",
+    "libvim@8.10869.89@d41d8cd9": {
+      "id": "libvim@8.10869.89@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.88",
+      "version": "8.10869.89",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.88.tgz#sha1:5cccc0c355597a0f9b0845aa2afb3fbc353ba63b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.89.tgz#sha1:e2d62222e8e1802b22d61d57b790952f9fa325e6"
         ]
       },
       "overrides": [],
@@ -857,7 +857,7 @@
         "reperf@1.5.1@d41d8cd9", "rench@1.10.0@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#a80a9d9@d41d8cd9",
         "reason-fzy@github:bryphe/reason-fzy#5a1daf4@d41d8cd9",
-        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.88@d41d8cd9",
+        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.89@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#049ad1e@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#1c81aac@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03eb8c5c87c7e0f2548b482b9b318375",
+  "checksum": "ecf83ae9b88f22dd34eef83dfacf2e82",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -371,14 +371,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.88@d41d8cd9": {
-      "id": "libvim@8.10869.88@d41d8cd9",
+    "libvim@8.10869.89@d41d8cd9": {
+      "id": "libvim@8.10869.89@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.88",
+      "version": "8.10869.89",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.88.tgz#sha1:5cccc0c355597a0f9b0845aa2afb3fbc353ba63b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.89.tgz#sha1:e2d62222e8e1802b22d61d57b790952f9fa325e6"
         ]
       },
       "overrides": [],
@@ -857,7 +857,7 @@
         "rench@1.10.0@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#a80a9d9@d41d8cd9",
         "reason-fzy@github:bryphe/reason-fzy#5a1daf4@d41d8cd9",
-        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.88@d41d8cd9",
+        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.89@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#049ad1e@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#1c81aac@d41d8cd9",

--- a/integrationtest.esy.lock/index.json
+++ b/integrationtest.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03eb8c5c87c7e0f2548b482b9b318375",
+  "checksum": "ecf83ae9b88f22dd34eef83dfacf2e82",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -371,14 +371,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.88@d41d8cd9": {
-      "id": "libvim@8.10869.88@d41d8cd9",
+    "libvim@8.10869.89@d41d8cd9": {
+      "id": "libvim@8.10869.89@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.88",
+      "version": "8.10869.89",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.88.tgz#sha1:5cccc0c355597a0f9b0845aa2afb3fbc353ba63b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.89.tgz#sha1:e2d62222e8e1802b22d61d57b790952f9fa325e6"
         ]
       },
       "overrides": [],
@@ -857,7 +857,7 @@
         "rench@1.10.0@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#a80a9d9@d41d8cd9",
         "reason-fzy@github:bryphe/reason-fzy#5a1daf4@d41d8cd9",
-        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.88@d41d8cd9",
+        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.89@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#049ad1e@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#1c81aac@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -404,7 +404,7 @@
     "esy-skia": "*",
     "esy-tree-sitter": "^1.4.1",
     "isolinear": "^3.0.0",
-    "libvim": "8.10869.88",
+    "libvim": "8.10869.89",
     "ocaml": "~4.12",
     "reason-native-crash-utils": "onivim/reason-native-crash-utils#a80a9d9",
     "reason-fzy": "bryphe/reason-fzy#5a1daf4",

--- a/release.esy.lock/index.json
+++ b/release.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "03eb8c5c87c7e0f2548b482b9b318375",
+  "checksum": "ecf83ae9b88f22dd34eef83dfacf2e82",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -371,14 +371,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.88@d41d8cd9": {
-      "id": "libvim@8.10869.88@d41d8cd9",
+    "libvim@8.10869.89@d41d8cd9": {
+      "id": "libvim@8.10869.89@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.88",
+      "version": "8.10869.89",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.88.tgz#sha1:5cccc0c355597a0f9b0845aa2afb3fbc353ba63b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.89.tgz#sha1:e2d62222e8e1802b22d61d57b790952f9fa325e6"
         ]
       },
       "overrides": [],
@@ -857,7 +857,7 @@
         "rench@1.10.0@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#a80a9d9@d41d8cd9",
         "reason-fzy@github:bryphe/reason-fzy#5a1daf4@d41d8cd9",
-        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.88@d41d8cd9",
+        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.89@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#049ad1e@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#1c81aac@d41d8cd9",

--- a/src/Feature/Vim/Feature_Vim.re
+++ b/src/Feature/Vim/Feature_Vim.re
@@ -166,10 +166,11 @@ type msg =
   | Output({
       cmd: string,
       output: option(string),
+      isSilent: bool,
     });
 
 module Msg = {
-  let output = (~cmd, ~output) => Output({cmd, output});
+  let output = (~cmd, ~output, ~isSilent) => Output({cmd, output, isSilent});
 
   let settingChanged = (~setting) => SettingChanged(setting);
 
@@ -327,7 +328,10 @@ let update = (~vimContext, msg, model: model) => {
       SettingsChanged({name: fullName, value}),
     )
 
-  | Output({cmd, output}) => (model, Output({cmd, output}))
+  | Output({cmd, output, isSilent}) => (
+      model,
+      isSilent ? Nothing : Output({cmd, output}),
+    )
 
   | SearchHighlightsAvailable({bufferId, highlights}) =>
     let newHighlights =

--- a/src/Feature/Vim/Feature_Vim.rei
+++ b/src/Feature/Vim/Feature_Vim.rei
@@ -34,7 +34,7 @@ module Msg: {
       ~effects: list(Vim.Effect.t)
     ) =>
     msg;
-  let output: (~cmd: string, ~output: option(string)) => msg;
+  let output: (~cmd: string, ~output: option(string), ~isSilent: bool) => msg;
   let pasted: string => msg;
   let settingChanged: (~setting: Vim.Setting.t) => msg;
 };

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -194,9 +194,10 @@ let start =
       | SearchStringChanged(_) => ()
       | SearchClearHighlights => ()
 
-      // TODO: Move internal to Feature_Vim
-      | Output({cmd, output}) => {
-          dispatch(Actions.Vim(Feature_Vim.Msg.output(~cmd, ~output)));
+      | Output({cmd, output, isSilent}) => {
+          dispatch(
+            Actions.Vim(Feature_Vim.Msg.output(~cmd, ~output, ~isSilent)),
+          );
         }
 
       | Clear({target, count}) =>

--- a/src/reason-libvim/Effect.re
+++ b/src/reason-libvim/Effect.re
@@ -24,5 +24,6 @@ type t =
   | Output({
       cmd: string,
       output: option(string),
+      isSilent: bool,
     })
   | WindowSplit(Split.t);

--- a/src/reason-libvim/Vim.re
+++ b/src/reason-libvim/Vim.re
@@ -465,8 +465,8 @@ let _onGoto = (_line: int, _column: int, gotoType: Goto.effect) => {
   queueEffect(Effect.Goto(gotoType));
 };
 
-let _onOutput = (cmd, output) => {
-  queueEffect(Effect.Output({cmd, output}));
+let _onOutput = (cmd, output, isSilent) => {
+  queueEffect(Effect.Output({cmd, output, isSilent}));
 };
 
 let _onClear = (target: Clear.target, count: int) => {

--- a/src/reason-libvim/Vim.rei
+++ b/src/reason-libvim/Vim.rei
@@ -522,6 +522,7 @@ module Effect: {
     | Output({
         cmd: string,
         output: option(string),
+        isSilent: bool,
       })
     | WindowSplit(Split.t);
 };

--- a/src/reason-libvim/bindings.c
+++ b/src/reason-libvim/bindings.c
@@ -723,7 +723,7 @@ void onCursorMoveScreenLine(screenLineMotion_T motion, int count, linenr_T start
 
 }
 
-void onOutput(char_u *cmd, char_u* output) {
+void onOutput(char_u *cmd, char_u* output, int isSilent) {
   CAMLparam0();
   CAMLlocal2(vStr, vMaybeOutput);
 
@@ -744,7 +744,7 @@ void onOutput(char_u *cmd, char_u* output) {
    if (lv_onOutput == NULL) {
      lv_onOutput = caml_named_value("lv_onOutput");
    }
-  caml_callback2(*lv_onOutput, vStr, vMaybeOutput);
+  caml_callback3(*lv_onOutput, vStr, vMaybeOutput, Val_bool(isSilent));
 
   CAMLreturn0;
 }

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3782d8cbedc21969913b840c43781688",
+  "checksum": "9e4005db7d95b748960ffc43db7ff6a9",
   "root": "Oni2@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -371,14 +371,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "libvim@8.10869.88@d41d8cd9": {
-      "id": "libvim@8.10869.88@d41d8cd9",
+    "libvim@8.10869.89@d41d8cd9": {
+      "id": "libvim@8.10869.89@d41d8cd9",
       "name": "libvim",
-      "version": "8.10869.88",
+      "version": "8.10869.89",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.88.tgz#sha1:5cccc0c355597a0f9b0845aa2afb3fbc353ba63b"
+          "archive:https://registry.npmjs.org/libvim/-/libvim-8.10869.89.tgz#sha1:e2d62222e8e1802b22d61d57b790952f9fa325e6"
         ]
       },
       "overrides": [],
@@ -857,7 +857,7 @@
         "rench@1.10.0@d41d8cd9",
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#a80a9d9@d41d8cd9",
         "reason-fzy@github:bryphe/reason-fzy#5a1daf4@d41d8cd9",
-        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.88@d41d8cd9",
+        "ocaml@4.12.0@d41d8cd9", "libvim@8.10869.89@d41d8cd9",
         "isolinear@github:revery-ui/isolinear#049ad1e@d41d8cd9",
         "esy-tree-sitter@1.4.1@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#1c81aac@d41d8cd9",

--- a/test/reason-libvim/CommandTest.re
+++ b/test/reason-libvim/CommandTest.re
@@ -3,6 +3,39 @@ open TestFramework;
 let reset = () => Helpers.resetBuffer("test/reason-libvim/testfile.txt");
 
 describe("Command", ({describe, _}) => {
+  describe("output", ({test, _}) => {
+    test("output is produced", ({expect, _}) => {
+      let _ = reset();
+
+      let (_context, effects) = Vim.command("!echo 'hi'");
+
+      let matchingEffect =
+        effects
+        |> List.filter(
+             fun
+             | Vim.Effect.Output({isSilent, _}) when isSilent == false => true
+             | _ => false,
+           );
+
+      expect.equal(List.length(matchingEffect), 1);
+    });
+
+    test("output is produced, respecting silent flag", ({expect, _}) => {
+      let _ = reset();
+
+      let (_context, effects) = Vim.command("silent !echo 'hi'");
+
+      let matchingEffect =
+        effects
+        |> List.filter(
+             fun
+             | Vim.Effect.Output({isSilent, _}) when isSilent == true => true
+             | _ => false,
+           );
+
+      expect.equal(List.length(matchingEffect), 1);
+    });
+  });
   describe("vimCommands", ({test, _}) => {
     test("define multi-line function", ({expect, _}) => {
       let _ = reset();
@@ -31,5 +64,5 @@ describe("Command", ({describe, _}) => {
 
       expect.equal(Vim.eval("_AnotherFunction()"), Ok("99"));
     });
-  })
+  });
 });


### PR DESCRIPTION
Fix #3680 - respect the `isSilent` flag for executing output commands

Pick up https://github.com/onivim/libvim/pull/264