### PR TITLE
fix(sidebar/#3681): Always focus sidebar on unhandled left/right window movement

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -26,6 +26,7 @@
 - #3335 - Extension: Fix selection bounds (fixes #3335)
 - #3699 - Vim: Respect silent flag for output-producing commands (fixes #3680)
 - #3692 - CodeLens: Fix delegated commands not executing (related #2380)
+- #3703 - Sidebar: Fix window navigation to sidebar when closed or zen mode (related #3681)
 
 ### Performance
 

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -123,7 +123,6 @@ let update = (~isFocused, msg, model) => {
 
   switch (msg) {
   | ResizeInProgress(delta) =>
-    prerr_endline("ResizeInProgress!");
     let model' =
       if (model.isOpen) {
         {...model, resizeDelta: delta};

--- a/src/Feature/SideBar/Feature_SideBar.re
+++ b/src/Feature/SideBar/Feature_SideBar.re
@@ -58,7 +58,7 @@ type outmsg =
   | PopFocus;
 
 let selected = ({selected, _}) => selected;
-let isOpen = ({isOpen, _}) => isOpen;
+let isOpen = ({isOpen, resizeDelta, _}) => isOpen || resizeDelta != 0;
 let location = ({location, _}) => location;
 
 let isOpenByDefault = ({openByDefault, _}) => openByDefault;
@@ -73,24 +73,21 @@ let initial = {
   location: Left,
 };
 
-let width = ({width, resizeDelta, isOpen, location, shouldSnapShut, _}) =>
-  if (!isOpen) {
-    0;
-  } else {
-    let candidate =
-      switch (location) {
-      | Left => width + resizeDelta
-      | Right => width - resizeDelta
-      };
-
-    if (candidate < Constants.minWidth && shouldSnapShut) {
-      0;
-    } else if (candidate > Constants.maxWidth) {
-      Constants.maxWidth;
-    } else {
-      max(0, candidate);
+let width = ({width, resizeDelta, location, shouldSnapShut, _}) => {
+  let candidate =
+    switch (location) {
+    | Left => width + resizeDelta
+    | Right => width - resizeDelta
     };
+
+  if (candidate < Constants.minWidth && shouldSnapShut) {
+    0;
+  } else if (candidate > Constants.maxWidth) {
+    Constants.maxWidth;
+  } else {
+    max(0, candidate);
   };
+};
 
 let update = (~isFocused, msg, model) => {
   // Focus a pane if it is not open, or close it
@@ -126,17 +123,12 @@ let update = (~isFocused, msg, model) => {
 
   switch (msg) {
   | ResizeInProgress(delta) =>
+    prerr_endline("ResizeInProgress!");
     let model' =
       if (model.isOpen) {
         {...model, resizeDelta: delta};
       } else {
-        {
-          ...model,
-          width: 0,
-          resizeDelta: delta,
-          isOpen: true,
-          shouldSnapShut: false,
-        };
+        {...model, resizeDelta: delta, isOpen: true, shouldSnapShut: false};
       };
 
     (model', Nothing);
@@ -191,6 +183,10 @@ let toggle = (pane, state) =>
   } else {
     {...state, shouldSnapShut: true, isOpen: true, selected: pane};
   };
+
+let show = state => {
+  {...state, shouldSnapShut: true, isOpen: true};
+};
 
 let setDefaultLocation = (state, setting) => {
   let location = setting == `Right ? Right : Left;

--- a/src/Feature/SideBar/Feature_SideBar.rei
+++ b/src/Feature/SideBar/Feature_SideBar.rei
@@ -55,6 +55,7 @@ let location: model => location;
 
 let isVisible: (pane, model) => bool;
 let toggle: (pane, model) => model;
+let show: model => model;
 
 let configurationChanged:
   (~hasWorkspace: bool, ~config: Oni_Core.Config.resolver, model) => model;

--- a/src/Model/Focus.re
+++ b/src/Model/Focus.re
@@ -41,3 +41,11 @@ let isLayoutFocused =
   | Editor
   | Terminal(_) => true
   | _ => false;
+
+let isSidebarFocused =
+  fun
+  | Extensions
+  | FileExplorer
+  | SCM
+  | Search => true
+  | _ => false;

--- a/src/Model/Focus.rei
+++ b/src/Model/Focus.rei
@@ -27,3 +27,4 @@ let pop: (focusable, stack) => stack;
 let current: stack => option(focusable);
 
 let isLayoutFocused: focusable => bool;
+let isSidebarFocused: focusable => bool;

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1889,26 +1889,22 @@ let update =
     | Focus(Center) => (FocusManager.push(Editor, state), Effect.none)
 
     | Focus(Left) when sideBarLocation == Feature_SideBar.Left => (
-        Feature_SideBar.isOpen(state.sideBar)
-          ? switch (state.sideBar |> Feature_SideBar.selected) {
-            | FileExplorer => FocusManager.push(FileExplorer, state)
-            | SCM => FocusManager.push(SCM, state)
-            | Extensions => FocusManager.push(Extensions, state)
-            | Search => FocusManager.push(Search, state)
-            }
-          : state,
+        switch (state.sideBar |> Feature_SideBar.selected) {
+        | FileExplorer => FocusManager.push(FileExplorer, state)
+        | SCM => FocusManager.push(SCM, state)
+        | Extensions => FocusManager.push(Extensions, state)
+        | Search => FocusManager.push(Search, state)
+        },
         Effect.none,
       )
 
     | Focus(Right) when sideBarLocation == Feature_SideBar.Right => (
-        Feature_SideBar.isOpen(state.sideBar)
-          ? switch (state.sideBar |> Feature_SideBar.selected) {
-            | FileExplorer => FocusManager.push(FileExplorer, state)
-            | SCM => FocusManager.push(SCM, state)
-            | Extensions => FocusManager.push(Extensions, state)
-            | Search => FocusManager.push(Search, state)
-            }
-          : state,
+        switch (state.sideBar |> Feature_SideBar.selected) {
+        | FileExplorer => FocusManager.push(FileExplorer, state)
+        | SCM => FocusManager.push(SCM, state)
+        | Extensions => FocusManager.push(Extensions, state)
+        | Search => FocusManager.push(Search, state)
+        },
         Effect.none,
       )
 

--- a/src/UI/Root.re
+++ b/src/UI/Root.re
@@ -184,7 +184,7 @@ let make = (~dispatch, ~state: State.t, ()) => {
     };
 
   let sideBar = () =>
-    if (!zenMode) {
+    if (!zenMode || Focus.isSidebarFocused(FocusManager.current(state))) {
       <SideBarView config theme state dispatch />;
     } else {
       React.empty;

--- a/src/UI/SideBarView.re
+++ b/src/UI/SideBarView.re
@@ -78,9 +78,13 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
          )
        );
 
+  let isOpen =
+    Feature_SideBar.isOpen(state.sideBar)
+    || Focus.isSidebarFocused(FocusManager.current(state));
   let width = Feature_SideBar.width(state.sideBar);
+
   let elem =
-    width > 25
+    width > 25 && isOpen
       ? switch (sideBar |> selected) {
         | FileExplorer =>
           let dispatch = msg => dispatch(Actions.FileExplorer(msg));
@@ -143,9 +147,7 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
         }
       : React.empty;
 
-  let separator =
-    Feature_SideBar.isOpen(state.sideBar) && width > 4
-      ? <separator /> : React.empty;
+  let separator = isOpen && width > 4 ? <separator /> : React.empty;
 
   let focus = FocusManager.current(state);
   let isFocused =
@@ -154,8 +156,10 @@ let make = (~key=?, ~config, ~theme, ~state: State.t, ~dispatch, ()) => {
     || focus == Focus.Extensions
     || focus == Focus.Search;
 
+  let widthTakingIntoAccountOpen = isOpen ? width : 0;
+
   let content =
-    <View ?key style={Styles.contents(~width)}>
+    <View ?key style={Styles.contents(~width=widthTakingIntoAccountOpen)}>
       <View style={Styles.heading(theme)}>
         <View style=Styles.titleContainer>
           <Text


### PR DESCRIPTION
This PR fixes some window navigation issues when navigating into the sidebar.

1) In Zen mode, prior to this fix, the user could `Control+W L` or `Control+W H` into the sidebar, but the sidebar would be offscreen - very confusing.

2) When the sidebar is closed, `Control+W L` or `Control+W H` (depending on if the sidebar is on the left or right) will temporarily open the sidebar while it is focused, much like the bottom pane.

Related to #3681 