### PR TITLE
fix(terminal/#3711): Normalize scroll direction from mouse wheel

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -30,6 +30,7 @@
 - #3703 - Sidebar: Fix window navigation to sidebar when closed or zen mode (related #3681)
 - #3709 - Extension: Fix activation error with nim extension (fixes #3685)
 - #3612 - Input: Fix unicode parsing for keybindings (fixes #3599)
+- #3717 - Terminal: Fix mousewheel / trackpad scroll direction (fixes #3711)
 
 ### Performance
 

--- a/src/Feature/Terminal/TerminalView.re
+++ b/src/Feature/Terminal/TerminalView.re
@@ -98,7 +98,7 @@ module Terminal = {
       dispatch(
         Terminal({
           id: terminal.id,
-          msg: MouseWheelScrolled({deltaY: deltaY *. 25.0}),
+          msg: MouseWheelScrolled({deltaY: deltaY *. (-25.0)}),
         }),
       );
     };


### PR DESCRIPTION
__Issue:__ When scrolling using the mousewheel / trackpad in terminal, the direction is the opposite the expected.

__Defect:__ Regression from https://github.com/onivim/oni2/pull/3645 - when refactoring to track the scroll in the model, the mousewheel direction wasn't normalized like it was in the editor/scrollable lists.

__Fix:__ Normalize mouse-wheel factor so the scroll direction is correct and consistent with the rest of the UI.

Fixes #3711 