### PR TITLE
fix(packaging/#3706): Linux: Package compiled glib settings to avoid incompatibility

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -54,3 +54,5 @@
 - #3688 - Dependency: esy-skia -> 1c81aac
 
 ### Infrastructure
+
+- #3721 - Packaging - Linux: Bundle compiled glib settings (fixes #3706)

--- a/scripts/linux/AppRun
+++ b/scripts/linux/AppRun
@@ -1,5 +1,6 @@
 #!/bin/sh
 HERE=$(dirname $(readlink -f "${0}"))
+export GSETTINGS_SCHEMA_DIR="${HERE}/usr/share/glib-2.0/schemas/"
 export ONI2_ORIG_PATH="$PATH"
 export ONI2_ORIG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 export PATH="${HERE}/usr/bin:$PATH"

--- a/scripts/linux/package-linux.sh
+++ b/scripts/linux/package-linux.sh
@@ -39,6 +39,12 @@ cp -r extensions/ _release/Onivim2.AppDir/usr/bin
 cp -r node/ _release/Onivim2.AppDir/usr/share
 # cp -r src/textmate_service/ _release/Onivim2.AppDir/usr/bin
 
+# Copy and compile GLib schemas for bundled version of GTK
+# Needed for #3706 - newer schemas may be incompatible with the GTK we bundle with Onivim
+mkdir -p _release/Onivim2.AppDir/usr/share/glib-2.0/schemas
+cp /usr/share/glib-2.0/schemas/*.gschema.xml _release/Onivim2.AppDir/usr/share/glib-2.0/schemas/
+glib-compile-schemas _release/Onivim2.AppDir/usr/share/glib-2.0/schemas
+
 rm -f _release/Onivim2.AppDir/usr/bin/setup.json
 
 ARCH=x86_64 _staging/appimagetool-x86_64.AppImage _release/Onivim2.AppDir _release/Onivim2-x86_64.AppImage


### PR DESCRIPTION
__Issue:__  On some Linux distros (ie Fedora 34) with Gnome 40, the AppImage fails to start

__Defect:__ Newer version of gnome / glib have deprecated the `antialiasing` setting. Onivim bundles GTK in the AppImage, but doesn't bundle glib settings - so querying the glib settings queries an updated set that isn't compatible with the older, bundled GTK.

__Fix:__ Follow the example of Inkscape and bundled the compiled glib settings for the corresponding version, to be more resilient in a differing installed GTK version and to avoid this mismatch: https://gitlab.com/inkscape/inkscape/-/merge_requests/3120/diffs

Fixes #3706 
Fixes #3697 
Fixes #3528 