### PR TITLE
fix(input/#3729): Fix remapped keys executing in wrong order

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -34,6 +34,7 @@
 - #3612 - Input: Fix unicode parsing for keybindings (fixes #3599)
 - #3717 - Terminal: Fix mousewheel / trackpad scroll direction (fixes #3711)
 - #3719 - Input: Add 'editorFocus' context key (fixes #3716)
+- #3732 - Input: Fix remapped keys executing in wrong order (fixes #3729)
 
 ### Performance
 

--- a/src/editor-input/EditorInput.re
+++ b/src/editor-input/EditorInput.re
@@ -593,11 +593,11 @@ module Make = (Config: {
                  bindings,
                );
 
-             (bindings', effects' @ effs);
+             (bindings', effs @ effects');
            },
            (bindings, []),
          );
-    (bindings', List.rev(effects'));
+    (bindings', effects');
   }
 
   and flush =

--- a/src/editor-input/KeyCandidate.re
+++ b/src/editor-input/KeyCandidate.re
@@ -10,3 +10,6 @@ let toList = keyPresses => keyPresses;
 let exists = (~f, presses) => List.exists(f, presses);
 
 let isModifier = exists(~f=key => KeyPress.isModifier(key));
+
+let toString = keys =>
+  keys |> List.map(KeyPress.toString) |> String.concat("\n");


### PR DESCRIPTION
__Issue:__ In the specific case of specifying a remap, where some of the remapped keys are used in another binding, the remapped keys could be emitted in the wrong order.

__Defect:__ The emitted keys in this case were being incorrectly reversed.

__Fix:__ Fix the accumulation of remapped keys, such that they work both in the special case exposed by #3729 and the more general cases.

Fixes #3729 

