### PR TITLE
feat(quickopen): Add binds to open in splits to Quick Open

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -6,6 +6,7 @@
 - #3661 - Search: add include/exclude file boxes
 - #3705 - Editor: add right click menus
 - #3718 - Completion: Add `editor.suggest.itemsToShow` setting (fixes #3712)
+- #3733 - Quick Open: Add bindings to open in splits, not current buffer.
 
 ### Bug Fixes
 

--- a/bench/lib/FilterJobBench.re
+++ b/bench/lib/FilterJobBench.re
@@ -12,7 +12,7 @@ let createItem = name => {
   let ret: Actions.menuItem = {
     category: None,
     name,
-    command: (_) => Oni_Model.Actions.Noop,
+    command: _ => Oni_Model.Actions.Noop,
     icon: None,
     highlight: [],
     handle: None,

--- a/bench/lib/FilterJobBench.re
+++ b/bench/lib/FilterJobBench.re
@@ -12,7 +12,7 @@ let createItem = name => {
   let ret: Actions.menuItem = {
     category: None,
     name,
-    command: () => Oni_Model.Actions.Noop,
+    command: (_) => Oni_Model.Actions.Noop,
     icon: None,
     highlight: [],
     handle: None,

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -187,10 +187,16 @@ Onivim-specific contexts:
 
 ### List / Menu commands
 
+> NOTE: Some of the list select commands may not be fully hooked up yet, such that they may not respect vertical/horizontal opening.
+
 | Default Key Binding | Description | Command |
 | --- | --- | --- |
 | Up Arrow / Control+P | Move focus up | `list.focusUp` |
 | Down Arrow / Control+N | Move focus down | `list.focusDown` |
+| Enter | Select current item | `list.select` |
+| Shift-Enter | Select current item (vertical open) | `oni.list.selectVertical` |
+| Ctrl-x | Select current item (horizontal open) | `oni.list.selectHorizontal` |
+| Ctrl-t | Select current item (new tab) | `oni.list.selectNewTab` |
 
 ### Search Pane
 

--- a/src/Model/Actions.re
+++ b/src/Model/Actions.re
@@ -97,7 +97,7 @@ type t =
   | ListFocus(int)
   | ListFocusUp
   | ListFocusDown
-  | ListSelect
+  | ListSelect({direction: SplitDirection.t})
   | ListSelectBackground
   | NewBuffer({direction: SplitDirection.t})
   | OpenBufferById({
@@ -176,7 +176,7 @@ and tick = {
 and menuItem = {
   category: option(string),
   name: string,
-  command: unit => t,
+  command: option(SplitDirection.t) => t,
   icon: [@opaque] option(IconTheme.IconDefinition.t),
   highlight: list((int, int)),
   handle: option(int),

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -51,9 +51,7 @@ module List = {
   let selectHorizontal =
     register(
       "list.selectHorizontal",
-      ListSelect({
-        direction: Oni_Core.SplitDirection.Horizontal,
-      }),
+      ListSelect({direction: Oni_Core.SplitDirection.Horizontal}),
     );
   let selectVertical =
     register(
@@ -65,9 +63,7 @@ module List = {
   let selectNewTab =
     register(
       "list.selectNewTab",
-      ListSelect({
-        direction: Oni_Core.SplitDirection.NewTab,
-      }),
+      ListSelect({direction: Oni_Core.SplitDirection.NewTab}),
     );
 
   let selectBackground =

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -48,26 +48,29 @@ module List = {
       "list.select",
       ListSelect({direction: Oni_Core.SplitDirection.Current}),
     );
+
+  let selectBackground =
+    register("list.selectBackground", ListSelectBackground);
+
   let selectHorizontal =
     register(
-      "list.selectHorizontal",
+      "oni.list.selectHorizontal",
       ListSelect({direction: Oni_Core.SplitDirection.Horizontal}),
     );
+
   let selectVertical =
     register(
-      "list.selectVertical",
+      "oni.list.selectVertical",
       ListSelect({
         direction: Oni_Core.SplitDirection.Vertical({shouldReuse: false}),
       }),
     );
+
   let selectNewTab =
     register(
-      "list.selectNewTab",
+      "oni.list.selectNewTab",
       ListSelect({direction: Oni_Core.SplitDirection.NewTab}),
     );
-
-  let selectBackground =
-    register("list.selectBackground", ListSelectBackground);
 };
 
 module Oni = {

--- a/src/Model/GlobalCommands.re
+++ b/src/Model/GlobalCommands.re
@@ -43,7 +43,33 @@ module List = {
   let focusDown = register("list.focusDown", ListFocusDown);
   let focusUp = register("list.focusUp", ListFocusUp);
 
-  let select = register("list.select", ListSelect);
+  let select =
+    register(
+      "list.select",
+      ListSelect({direction: Oni_Core.SplitDirection.Current}),
+    );
+  let selectHorizontal =
+    register(
+      "list.selectHorizontal",
+      ListSelect({
+        direction: Oni_Core.SplitDirection.Horizontal,
+      }),
+    );
+  let selectVertical =
+    register(
+      "list.selectVertical",
+      ListSelect({
+        direction: Oni_Core.SplitDirection.Vertical({shouldReuse: false}),
+      }),
+    );
+  let selectNewTab =
+    register(
+      "list.selectNewTab",
+      ListSelect({
+        direction: Oni_Core.SplitDirection.NewTab,
+      }),
+    );
+
   let selectBackground =
     register("list.selectBackground", ListSelectBackground);
 };

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -126,6 +126,21 @@ let defaultKeyBindings =
         ~condition="listFocus" |> WhenExpr.parse,
       ),
       bind(
+        ~key="<C-v>",
+        ~command=Commands.List.selectVertical.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<C-s>",
+        ~command=Commands.List.selectHorizontal.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
+        ~key="<S-CR>",
+        ~command=Commands.List.selectNewTab.id,
+        ~condition="listFocus" |> WhenExpr.parse,
+      ),
+      bind(
         ~key="<D-Z>",
         ~command=Commands.undo.id,
         ~condition="isMac && editorTextFocus" |> WhenExpr.parse,

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -126,17 +126,17 @@ let defaultKeyBindings =
         ~condition="listFocus" |> WhenExpr.parse,
       ),
       bind(
-        ~key="<C-v>",
+        ~key="<S-CR>",
         ~command=Commands.List.selectVertical.id,
         ~condition="listFocus" |> WhenExpr.parse,
       ),
       bind(
-        ~key="<C-s>",
+        ~key="<C-x>",
         ~command=Commands.List.selectHorizontal.id,
         ~condition="listFocus" |> WhenExpr.parse,
       ),
       bind(
-        ~key="<S-CR>",
+        ~key="<C-t>",
         ~command=Commands.List.selectNewTab.id,
         ~condition="listFocus" |> WhenExpr.parse,
       ),

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -512,7 +512,7 @@ let start =
               name,
               category: None,
               icon: None,
-              command: (_) => Noop,
+              command: _ => Noop,
               highlight: [],
               handle: None,
             }

--- a/src/Store/VimStoreConnector.re
+++ b/src/Store/VimStoreConnector.re
@@ -512,7 +512,7 @@ let start =
               name,
               category: None,
               icon: None,
-              command: () => Noop,
+              command: (_) => Noop,
               highlight: [],
               handle: None,
             }

--- a/src/UI/QuickmenuView.re
+++ b/src/UI/QuickmenuView.re
@@ -60,7 +60,10 @@ module Styles = {
 let onFocusedChange = index =>
   GlobalContext.current().dispatch(ListFocus(index));
 
-let onSelect = _ => GlobalContext.current().dispatch(ListSelect);
+let onSelect = _ =>
+  GlobalContext.current().dispatch(
+    ListSelect({direction: Oni_Core.SplitDirection.Current}),
+  );
 
 let progressBar = (~progress, ~theme, ()) => {
   let indicator = () => {

--- a/test/Model/FilterJobTest.re
+++ b/test/Model/FilterJobTest.re
@@ -13,7 +13,7 @@ describe("FilterJob", ({describe, _}) => {
     Actions.{
       category: None,
       name,
-      command: (_) => Actions.Noop,
+      command: _ => Actions.Noop,
       icon: None,
       highlight: [],
       handle: None,

--- a/test/Model/FilterJobTest.re
+++ b/test/Model/FilterJobTest.re
@@ -13,7 +13,7 @@ describe("FilterJob", ({describe, _}) => {
     Actions.{
       category: None,
       name,
-      command: () => Actions.Noop,
+      command: (_) => Actions.Noop,
       icon: None,
       highlight: [],
       handle: None,


### PR DESCRIPTION
Fix #564
Fix #2232

A rough first pass, but adds default bindings for selecting items from the quick open to open in current/vertical/horizontal/new tab.

Binds aren't finalised, so some input there would be nice (Ctrl-s and Ctrl-v are the defaults in Fzf in vim which is why I went with them).