### PR TITLE
feat(search/#3713): Default keybindings for next/previous search result

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -6,6 +6,7 @@
 - #3661 - Search: add include/exclude file boxes
 - #3705 - Editor: add right click menus
 - #3718 - Completion: Add `editor.suggest.itemsToShow` setting (fixes #3712)
+- #3736 - Search: add default keys to go to next / previous search result (fixes #3713)
 
 ### Bug Fixes
 

--- a/docs/docs/configuration/key-bindings.md
+++ b/docs/docs/configuration/key-bindings.md
@@ -134,6 +134,7 @@ Common contexts with VSCode:
 | --- | --- |
 | `editorFocus` | An editor has focus |
 | `editorTextFocus` | An editor has focus |
+| `hasSearchResults` | Search results are available |
 | `inSnippetMode` | A snippet session is currently active |
 | `renameInputVisible` | The rename input is visible |
 | `suggestWidgetVisible` | The suggest widget (auto-completion) is visible |
@@ -190,6 +191,13 @@ Onivim-specific contexts:
 | --- | --- | --- |
 | Up Arrow / Control+P | Move focus up | `list.focusUp` |
 | Down Arrow / Control+N | Move focus down | `list.focusDown` |
+
+### Search Pane
+
+| Default Key Binding | Description | Command |
+| --- | --- | --- |
+| F4 | Focus next search result | `search.action.focusNextSearchResult` |
+| Shift+F4 | Focus previous search result | `search.action.focusPreviousSearchResult` |
 
 ### Sidebar
 

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -193,6 +193,8 @@ let setSelected = (~selected, model) => {
   {...model, selected: selected'} |> ensureSelectedVisible;
 };
 
+let getSelected = ({selected, _}) => selected;
+
 let setScrollY = (~allowOverscroll=false, ~scrollY, model) => {
   let maxScroll =
     if (allowOverscroll) {

--- a/src/Components/VimList/Component_VimList.re
+++ b/src/Components/VimList/Component_VimList.re
@@ -193,7 +193,9 @@ let setSelected = (~selected, model) => {
   {...model, selected: selected'} |> ensureSelectedVisible;
 };
 
-let getSelected = ({selected, _}) => selected;
+let selected = ({selected, _} as model) => {
+  get(selected, model);
+};
 
 let setScrollY = (~allowOverscroll=false, ~scrollY, model) => {
   let maxScroll =

--- a/src/Components/VimTree/Component_VimTree.re
+++ b/src/Components/VimTree/Component_VimTree.re
@@ -134,6 +134,48 @@ let setSelected = (~selected, {treeAsList, _} as model) => {
   {...model, treeAsList: treeAsList'};
 };
 
+let getNextNodeFromPosition = (~direction=1, ~position, {treeAsList, _}) => {
+  let count = Component_VimList.count(treeAsList);
+
+  let rec loop = (~start, ~offset) => {
+    let idx = IntEx.modulo(start + offset, count);
+    if (idx < 0 || idx >= count) {
+      None;
+    } else {
+      switch (Component_VimList.get(idx, treeAsList)) {
+      | None => loop(~start, ~offset=offset + direction)
+      | Some(item) when !TreeList.isLeaf(item) =>
+        loop(~start, ~offset=offset + direction)
+      | Some(_item) => Some(idx)
+      };
+    };
+  };
+
+  loop(~start=position + direction, ~offset=0);
+};
+
+let selectNextNode = ({treeAsList, _} as model) => {
+  let selectedIdx = Component_VimList.getSelected(treeAsList);
+  let maybeNextSelected =
+    getNextNodeFromPosition(~direction=1, ~position=selectedIdx, model);
+
+  switch (maybeNextSelected) {
+  | None => model
+  | Some(newIndex) => setSelected(~selected=newIndex, model)
+  };
+};
+
+let selectPreviousNode = ({treeAsList, _} as model) => {
+  let selectedIdx = Component_VimList.getSelected(treeAsList);
+  let maybePreviousSelected =
+    getNextNodeFromPosition(~direction=-1, ~position=selectedIdx, model);
+
+  switch (maybePreviousSelected) {
+  | None => model
+  | Some(newIndex) => setSelected(~selected=newIndex, model)
+  };
+};
+
 let keyPress = (key, {treeAsList, _} as model) => {
   ...model,
   treeAsList: Component_VimList.keyPress(key, treeAsList),

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -59,6 +59,8 @@ let findIndex:
 let setSelected:
   (~selected: int, model('node, 'leaf)) => model('node, 'leaf);
 
+let selected: model('node, 'leaf) => option(nodeOrLeaf('node, 'leaf));
+
 let selectNextNode: model('node, 'leaf) => model('node, 'leaf);
 
 let selectPreviousNode: model('node, 'leaf) => model('node, 'leaf);

--- a/src/Components/VimTree/Component_VimTree.rei
+++ b/src/Components/VimTree/Component_VimTree.rei
@@ -59,6 +59,10 @@ let findIndex:
 let setSelected:
   (~selected: int, model('node, 'leaf)) => model('node, 'leaf);
 
+let selectNextNode: model('node, 'leaf) => model('node, 'leaf);
+
+let selectPreviousNode: model('node, 'leaf) => model('node, 'leaf);
+
 let scrollTo:
   (
     ~index: int,

--- a/src/Core/TreeList.re
+++ b/src/Core/TreeList.re
@@ -10,6 +10,11 @@ type t('node, 'leaf) =
       data: 'node,
     });
 
+let isLeaf =
+  fun
+  | ViewLeaf(_) => true
+  | ViewNode(_) => false;
+
 let ofTree: Tree.t('node, 'leaf') => list(t('node, 'leaf)) =
   tree => {
     let rec loop = (acc, node, indentationLevel) => {

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -164,6 +164,20 @@ type outmsg =
 
 let update = (~previewEnabled, model, msg) => {
   switch (msg) {
+  | Command(NextSearchResult) =>
+    let model' = {
+      ...model,
+      resultsTree: Component_VimTree.selectNextNode(model.resultsTree),
+    };
+    (model', None);
+
+  | Command(PreviousSearchResult) =>
+    let model' = {
+      ...model,
+      resultsTree: Component_VimTree.selectPreviousNode(model.resultsTree),
+    };
+    (model', None);
+
   | Input(key) =>
     switch (model.focus) {
     | FindInput =>

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -663,6 +663,12 @@ module Contributions = {
       isFocused && model.focus == FindInput
         ? Component_InputText.Contributions.contextKeys(model.findInput)
         : empty;
+
+    let hasSearchResult =
+      [Schema.bool("hasSearchResult", ({hits, _}) => hits != [])]
+      |> Schema.fromList
+      |> fromSchema(model);
+
     let vimNavKeys =
       isFocused
         ? Component_VimWindows.Contributions.contextKeys(
@@ -675,7 +681,7 @@ module Contributions = {
         ? Component_VimTree.Contributions.contextKeys(model.resultsTree)
         : empty;
 
-    [inputTextKeys, vimNavKeys, vimTreeKeys] |> unionMany;
+    [inputTextKeys, vimNavKeys, vimTreeKeys, hasSearchResult] |> unionMany;
   };
   let configuration = Configuration.[searchExclude.spec];
 };

--- a/src/Feature/Search/Feature_Search.rei
+++ b/src/Feature/Search/Feature_Search.rei
@@ -58,4 +58,5 @@ module Contributions: {
   let commands: (~isFocused: bool) => list(Command.t(msg));
   let contextKeys: (~isFocused: bool, model) => WhenExpr.ContextKeys.t;
   let configuration: list(Config.Schema.spec);
+  let keybindings: list(Feature_Input.Schema.keybinding);
 };

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -30,6 +30,7 @@ let defaultKeyBindings =
       ~condition="quickmenuCursorEnd" |> WhenExpr.parse,
     ),
   ]
+  @ Feature_Search.Contributions.keybindings
   @ Feature_SideBar.Contributions.keybindings
   @ Feature_Keyboard.Contributions.keybindings
   @ Feature_Clipboard.Contributions.keybindings


### PR DESCRIPTION
Implement #3713 - add default keybindings (F4 / Shift F4) to move to next /previous search result in the search pane.

Fixes #3713 