### PR TITLE
fix(extension): Fix edit application from trailing spaces plugin

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -36,6 +36,7 @@
 - #3717 - Terminal: Fix mousewheel / trackpad scroll direction (fixes #3711)
 - #3719 - Input: Add 'editorFocus' context key (fixes #3716)
 - #3732 - Input: Fix remapped keys executing in wrong order (fixes #3729)
+- #3746 - Extension: Fix edit application in trailing spaces plugin
 
 ### Performance
 

--- a/src/Exthost/Edit.re
+++ b/src/Exthost/Edit.re
@@ -24,7 +24,7 @@ module SingleEditOperation = {
       obj(({field, _}) =>
         {
           range: field.required("range", OneBasedRange.decode),
-          text: field.optional("text", string),
+          text: field.withDefault("text", None, nullable(string)),
           forceMoveMarkers:
             field.withDefault("forceMoveMarkers", false, bool),
         }

--- a/src/Service/Vim/Service_Vim.re
+++ b/src/Service/Vim/Service_Vim.re
@@ -8,7 +8,7 @@ module EditConverter = {
 
   let textToArray = (~removeTrailingNewLine) =>
     fun
-    | None => [||]
+    | None => [|""|]
     | Some(text) =>
       text
       |> Utility.StringEx.removeWindowsNewLines


### PR DESCRIPTION
__Issue:__ The [trailing spaces](https://open-vsx.org/extension/shardulm94/trailing-spaces) plugin isn't working as expected - there is a statusbar message reporting that trailing spaces have been removed... but they aren't actually removed.

__Defect:__ There were two problems:
1) The `$tryApplyEdits` API wasn't parsing single-edits correctly in the case where the text property is null as opposed to a string
2) In the `null` case, if there was no text on the line, the line would be completely removed

__Fix:__
1) Correctly parse the text property - handling either null or a string
2) When text is null, treat it as an empty string