### PR TITLE
fix(layout): Wire up window close command (Control+W, C)

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -36,6 +36,7 @@
 - #3717 - Terminal: Fix mousewheel / trackpad scroll direction (fixes #3711)
 - #3719 - Input: Add 'editorFocus' context key (fixes #3716)
 - #3732 - Input: Fix remapped keys executing in wrong order (fixes #3729)
+- #3747 - Layout: Implement Control+W, C binding (related #1721)
 
 ### Performance
 

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -127,6 +127,7 @@ module Commands: {
 
   let closeActiveEditor: Command.t(msg);
   let closeActiveSplit: Command.t(msg);
+  let closeActiveSplitUnlessLast: Command.t(msg);
 
   let moveLeft: Command.t(msg);
   let moveRight: Command.t(msg);

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -439,6 +439,25 @@ let removeActiveEditor = model => {
   removeEditor(activeEditorId, model);
 };
 
+let tryCloseActiveGroup = model => {
+  let curLayout = model |> activeLayout;
+  let activeGroupId = curLayout.activeGroupId;
+
+  let rec loop = (newModel: model) => {
+    let newLayout = newModel |> activeLayout;
+    if (newLayout.activeGroupId != activeGroupId) {
+      Some(newModel);
+    } else {
+      switch (removeActiveEditor(newModel)) {
+      | Some(model) => loop(model)
+      | None => None
+      };
+    };
+  };
+
+  loop(model);
+};
+
 let closeBuffer = (~force, buffer, model) => {
   let activeEditor = activeEditor(model);
   let activeEditorId = Editor.getId(activeEditor);

--- a/src/Feature/Layout/Msg.re
+++ b/src/Feature/Layout/Msg.re
@@ -6,6 +6,7 @@ type command =
   | SplitHorizontal
   | CloseActiveEditor
   | CloseActiveGroup
+  | CloseActiveGroupUnlessLast
   | MoveLeft
   | MoveRight
   | MoveUp

--- a/src/Model/State.re
+++ b/src/Model/State.re
@@ -399,6 +399,16 @@ let defaultKeyBindings =
         ~command=Feature_Layout.Commands.closeActiveSplit.id,
         ~condition=windowCommandCondition,
       ),
+      bind(
+        ~key="<C-W>c",
+        ~command=Feature_Layout.Commands.closeActiveSplitUnlessLast.id,
+        ~condition=windowCommandCondition,
+      ),
+      bind(
+        ~key="<C-W><C-c>",
+        ~command=Feature_Layout.Commands.closeActiveSplitUnlessLast.id,
+        ~condition=windowCommandCondition,
+      ),
     ]
   @ Component_VimWindows.Contributions.keybindings
   @ Component_VimList.Contributions.keybindings


### PR DESCRIPTION
Related to #1721

This implements the Control+W, C binding (similar to the Control+W, Q binding: #3420 - except doesn't close the last split). 