### PR TITLE
fix(extension): Don't show runtime errors as notification

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -38,6 +38,7 @@
 - #3732 - Input: Fix remapped keys executing in wrong order (fixes #3729)
 - #3747 - Layout: Implement Control+W, C binding (related #1721)
 - #3746 - Extension: Fix edit application in trailing spaces plugin
+- #3753 - Extension: Don't bubble up extension runtime errors to notifications
 
 ### Performance
 

--- a/src/Feature/Extensions/Model.re
+++ b/src/Feature/Extensions/Model.re
@@ -223,8 +223,9 @@ module Effect = {
       Lwt.wakeup(resolver, Exthost.Reply.okJson(json))
     });
 
-  let logFailure = (msg) => Isolinear.Effect.create(~name="Feature_Extensions.Effect.logFailure", () => {
-      Log.error(msg);
+  let logFailure = msg =>
+    Isolinear.Effect.create(~name="Feature_Extensions.Effect.logFailure", () => {
+      Log.error(msg)
     });
 };
 
@@ -620,13 +621,15 @@ let update = (~extHostClient, ~proxy, msg, model) => {
 
   | Exthost(ExtensionRuntimeError({extensionId, errorsJson})) => (
       model,
-      Effect(Effect.logFailure(
-        Printf.sprintf(
-          "Extension runtime error %s:%s",
-          Exthost.ExtensionId.toString(extensionId),
-          Yojson.Safe.to_string(`List(errorsJson)),
+      Effect(
+        Effect.logFailure(
+          Printf.sprintf(
+            "Extension runtime error %s:%s",
+            Exthost.ExtensionId.toString(extensionId),
+            Yojson.Safe.to_string(`List(errorsJson)),
+          ),
         ),
-      )),
+      ),
     )
 
   | Exthost(ActivateExtension({extensionId, _})) => (


### PR DESCRIPTION
There are some cases where runtime errors are 'expected' - for example, in the python extension in transitioning from `vscode.notebook` to `vscode.window`. Another example is https://github.com/onivim/oni2/issues/3593

Code/VSCodium don't log these classes of errors to notifications - we should follow suit (although, still log them as errors in the logfile).