### PR TITLE
fix(tabs/#3150): Multiple 'editor tabs' open with tabnew/tabedit

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -38,6 +38,7 @@
 - #3732 - Input: Fix remapped keys executing in wrong order (fixes #3729)
 - #3747 - Layout: Implement Control+W, C binding (related #1721)
 - #3746 - Extension: Fix edit application in trailing spaces plugin
+- #3755 - Vim: Fix extra 'editor tab' with `:tabnew`/`:tabedit` (fixes #3150)
 
 ### Performance
 

--- a/integration_test/RegressionLayoutTabSingleEditor.re
+++ b/integration_test/RegressionLayoutTabSingleEditor.re
@@ -22,9 +22,10 @@ runTest(~name="RegressionLayoutTabSingleEditor", ({wait, _}) => {
     maybeFilePath != None;
   });
 
-  wait(~name="Prior to new tab, there should be a single layout", (state: State.t) => {
-    let layoutCount =
-      state.layout |> Feature_Layout.layouts |> List.length;
+  wait(
+    ~name="Prior to new tab, there should be a single layout",
+    (state: State.t) => {
+    let layoutCount = state.layout |> Feature_Layout.layouts |> List.length;
 
     layoutCount == 1;
   });
@@ -33,15 +34,15 @@ runTest(~name="RegressionLayoutTabSingleEditor", ({wait, _}) => {
   ignore(Vim.command("tabnew"): (Vim.Context.t, list(Vim.Effect.t)));
 
   wait(~name="Wait for group to be created", (state: State.t) => {
-    let layoutCount =
-      state.layout |> Feature_Layout.layouts |> List.length;
+    let layoutCount = state.layout |> Feature_Layout.layouts |> List.length;
 
     layoutCount == 2;
   });
 
-  wait(~name="There should only be a single editor in the new tab", (state: State.t) => {
-    let group =
-      state.layout |> Feature_Layout.activeGroup;
+  wait(
+    ~name="There should only be a single editor in the new tab",
+    (state: State.t) => {
+    let group = state.layout |> Feature_Layout.activeGroup;
 
     let editorCount = group |> Feature_Layout.Group.allEditors |> List.length;
 

--- a/integration_test/RegressionLayoutTabSingleEditor.re
+++ b/integration_test/RegressionLayoutTabSingleEditor.re
@@ -1,0 +1,50 @@
+// Regression test for #3150:
+// When running ':tabnew'/':tabedit' on a buffer, only a single
+// editor tab should be visible.
+
+open Oni_Core;
+open Oni_Model;
+open Oni_IntegrationTestLib;
+module Editor = Feature_Editor.Editor;
+
+runTest(~name="RegressionLayoutTabSingleEditor", ({wait, _}) => {
+  wait(~name="Wait for split to be created 1", (state: State.t) => {
+    let splitCount =
+      state.layout |> Feature_Layout.visibleEditors |> List.length;
+    splitCount == 1;
+  });
+
+  // Wait for initial buffer
+  wait(~name="Initial buffer", state => {
+    let maybeFilePath =
+      state |> Selectors.getActiveBuffer |> Option.map(Buffer.getFilePath);
+
+    maybeFilePath != None;
+  });
+
+  wait(~name="Prior to new tab, there should be a single layout", (state: State.t) => {
+    let layoutCount =
+      state.layout |> Feature_Layout.layouts |> List.length;
+
+    layoutCount == 1;
+  });
+
+  /* :vsp with no arguments should create a second split w/ same buffer */
+  ignore(Vim.command("tabnew"): (Vim.Context.t, list(Vim.Effect.t)));
+
+  wait(~name="Wait for group to be created", (state: State.t) => {
+    let layoutCount =
+      state.layout |> Feature_Layout.layouts |> List.length;
+
+    layoutCount == 2;
+  });
+
+  wait(~name="There should only be a single editor in the new tab", (state: State.t) => {
+    let group =
+      state.layout |> Feature_Layout.activeGroup;
+
+    let editorCount = group |> Feature_Layout.Group.allEditors |> List.length;
+
+    editorCount == 1;
+  });
+});

--- a/integration_test/RegressionVspEmptyInitialBufferTest.re
+++ b/integration_test/RegressionVspEmptyInitialBufferTest.re
@@ -11,7 +11,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
 
-runTest(~name="RegressionVspEmpty", ({wait, _}) => {
+runTest(~name="RegressionLayoutTabSingleEditor", ({wait, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/RegressionVspEmptyInitialBufferTest.re
+++ b/integration_test/RegressionVspEmptyInitialBufferTest.re
@@ -11,7 +11,7 @@ open Oni_Model;
 open Oni_IntegrationTestLib;
 module Editor = Feature_Editor.Editor;
 
-runTest(~name="RegressionLayoutTabSingleEditor", ({wait, _}) => {
+runTest(~name="RegressionVspEmpty", ({wait, _}) => {
   wait(~name="Wait for split to be created 1", (state: State.t) => {
     let splitCount =
       state.layout |> Feature_Layout.visibleEditors |> List.length;

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,14 +1,81 @@
 (executables
- (names InsertModeTest 
-    RegressionLayoutTabSingleEditor
-   )
+ (names InsertModeTest ClipboardInsertModePasteMultiLineTest
+   ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
+   ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
+   ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
+   ConfigurationInvalidThemeTest ConfigurationPerFileTypeTest
+   EditorFontFromPathTest EditorFontValidTest EditorSplitFileTest
+   EditorUtf8Test ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
+   ExCommandKeybindingNormTest ExtConfigurationChangedTest ExtHostContextTest
+   ExtHostBufferOpenTest ExtHostBufferUpdatesTest
+   ExtHostCommandActivationTest ExtHostCompletionTest ExtHostDefinitionTest
+   ExtHostFileSystemTest
+   ExtHostFormatSingleEditTest ExtHostFormatFullEditTest
+   ExtHostWorkspaceSearchTest FileWatcherTest FormatOnSaveTest
+   KeybindingsInvalidJsonTest KeySequenceJJTest InputIgnoreTest
+   InputContextKeysTest InputRemapMotionTest LanguageCssTest
+   LanguageTypeScriptTest LineEndingsLFTest LineEndingsCRLFTest
+   QuickOpenEventuallyCompletesTest SearchShowClearHighlightsTest
+   SyntaxServer SyntaxServerCloseTest SyntaxServerMessageExceptionTest
+   SyntaxServerParentPidTest SyntaxServerParentPidCorrectTest
+   SyntaxServerReadExceptionTest Regression1671Test Regression2349EnewTest
+   Regression2988SwitchEditorTest Regression3084CommandLoopTest
+   Regression3323DiagnosticsTest RegressionCommandLineNoCompletionTest
+   RegressionFontFallbackTest RegressionFileModifiedIndicationTest
+   RegressionNonExistentDirectory 
+   RegressionLayoutTabSingleEditor
+   RegressionVspEmptyInitialBufferTest
+   RegressionVspEmptyExistingBufferTest SCMGitTest SyntaxHighlightPhpTest
+   SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
+   AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
+   TypingBatchedTest TypingUnbatchedTest VimIncsearchScrollTest
+   VimExperimentalVimlTest VimRemapTimeoutTest VimSimpleRemapTest
+   VimlRemapCmdlineTest ClipboardChangeTest VimScriptLocalFunctionTest
+   ZenModeSingleFileModeTest ZenModeSplitTest)
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
  (section bin)
  (package OniIntegrationTests)
  (files run-tests.sh InsertModeTest.exe
+   ClipboardInsertModePasteMultiLineTest.exe
+   ClipboardInsertModePasteSingleLineTest.exe
+   ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
+   ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
+   ConfigurationInvalidThemeTest.exe ConfigurationPerFileTypeTest.exe
+   CopyActiveFilepathToClipboardTest.exe EchoNotificationTest.exe
+   EditorFontFromPathTest.exe EditorFontValidTest.exe EditorSplitFileTest.exe
+   EditorUtf8Test.exe ExCommandKeybindingTest.exe
+   ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
+   ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
+   ExtHostBufferUpdatesTest.exe ExtHostCommandActivationTest.exe
+   ExtHostContextTest.exe ExtHostCompletionTest.exe ExtHostDefinitionTest.exe
+   ExtHostFileSystemTest.exe
+   ExtHostWorkspaceSearchTest.exe FileWatcherTest.exe FormatOnSaveTest.exe
+   KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
+   InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
+   LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
+   QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
+   Regression2349EnewTest.exe Regression2988SwitchEditorTest.exe
+   Regression3084CommandLoopTest.exe
+   RegressionCommandLineNoCompletionTest.exe
+   RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
    RegressionLayoutTabSingleEditor.exe
+   RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe
+   RegressionVspEmptyExistingBufferTest.exe SCMGitTest.exe
+   SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
+   SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
+   SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
+   SyntaxHighlightPhpTest.exe SyntaxServerParentPidTest.exe
+   SyntaxServerParentPidCorrectTest.exe SyntaxServerReadExceptionTest.exe
+   TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
+   AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
+   VimExperimentalVimlTest.exe VimIncsearchScrollTest.exe
+   VimScriptLocalFunctionTest.exe VimRemapTimeoutTest.exe
+   Regression3323DiagnosticsTest.exe VimSimpleRemapTest.exe
+   VimlRemapCmdlineTest.exe ZenModeSingleFileModeTest.exe
+   ZenModeSplitTest.exe ClipboardChangeTest.exe
+   ExtHostFormatSingleEditTest.exe ExtHostFormatFullEditTest.exe
    unformatted1.oni-dev test.unformatted.js large-c-file.c lsan.supp
    some-test-file.json some-test-file.txt test.crlf test.lf test-syntax.php
    utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf PlugScriptLocal.vim))

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,78 +1,14 @@
 (executables
- (names InsertModeTest ClipboardInsertModePasteMultiLineTest
-   ClipboardInsertModePasteSingleLineTest ClipboardInsertModePasteEmptyTest
-   ClipboardNormalModePasteTest ClipboardYankTest ClipboardxpTest
-   ClipboardyypTest CopyActiveFilepathToClipboardTest EchoNotificationTest
-   ConfigurationInvalidThemeTest ConfigurationPerFileTypeTest
-   EditorFontFromPathTest EditorFontValidTest EditorSplitFileTest
-   EditorUtf8Test ExCommandKeybindingTest ExCommandKeybindingWithArgsTest
-   ExCommandKeybindingNormTest ExtConfigurationChangedTest ExtHostContextTest
-   ExtHostBufferOpenTest ExtHostBufferUpdatesTest
-   ExtHostCommandActivationTest ExtHostCompletionTest ExtHostDefinitionTest
-   ExtHostFileSystemTest
-   ExtHostFormatSingleEditTest ExtHostFormatFullEditTest
-   ExtHostWorkspaceSearchTest FileWatcherTest FormatOnSaveTest
-   KeybindingsInvalidJsonTest KeySequenceJJTest InputIgnoreTest
-   InputContextKeysTest InputRemapMotionTest LanguageCssTest
-   LanguageTypeScriptTest LineEndingsLFTest LineEndingsCRLFTest
-   QuickOpenEventuallyCompletesTest SearchShowClearHighlightsTest
-   SyntaxServer SyntaxServerCloseTest SyntaxServerMessageExceptionTest
-   SyntaxServerParentPidTest SyntaxServerParentPidCorrectTest
-   SyntaxServerReadExceptionTest Regression1671Test Regression2349EnewTest
-   Regression2988SwitchEditorTest Regression3084CommandLoopTest
-   Regression3323DiagnosticsTest RegressionCommandLineNoCompletionTest
-   RegressionFontFallbackTest RegressionFileModifiedIndicationTest
-   RegressionNonExistentDirectory RegressionVspEmptyInitialBufferTest
-   RegressionVspEmptyExistingBufferTest SCMGitTest SyntaxHighlightPhpTest
-   SyntaxHighlightTextMateTest SyntaxHighlightTreesitterTest
-   AddRemoveSplitTest TerminalSetPidTitleTest TerminalConfigurationTest
-   TypingBatchedTest TypingUnbatchedTest VimIncsearchScrollTest
-   VimExperimentalVimlTest VimRemapTimeoutTest VimSimpleRemapTest
-   VimlRemapCmdlineTest ClipboardChangeTest VimScriptLocalFunctionTest
-   ZenModeSingleFileModeTest ZenModeSplitTest)
+ (names InsertModeTest 
+    RegressionLayoutTabSingleEditor
+   )
  (libraries Oni_CLI Oni_IntegrationTestLib reason-native-crash-utils.asan))
 
 (install
  (section bin)
  (package OniIntegrationTests)
  (files run-tests.sh InsertModeTest.exe
-   ClipboardInsertModePasteMultiLineTest.exe
-   ClipboardInsertModePasteSingleLineTest.exe
-   ClipboardInsertModePasteEmptyTest.exe ClipboardNormalModePasteTest.exe
-   ClipboardYankTest.exe ClipboardxpTest.exe ClipboardyypTest.exe
-   ConfigurationInvalidThemeTest.exe ConfigurationPerFileTypeTest.exe
-   CopyActiveFilepathToClipboardTest.exe EchoNotificationTest.exe
-   EditorFontFromPathTest.exe EditorFontValidTest.exe EditorSplitFileTest.exe
-   EditorUtf8Test.exe ExCommandKeybindingTest.exe
-   ExCommandKeybindingNormTest.exe ExCommandKeybindingWithArgsTest.exe
-   ExtConfigurationChangedTest.exe ExtHostBufferOpenTest.exe
-   ExtHostBufferUpdatesTest.exe ExtHostCommandActivationTest.exe
-   ExtHostContextTest.exe ExtHostCompletionTest.exe ExtHostDefinitionTest.exe
-   ExtHostFileSystemTest.exe
-   ExtHostWorkspaceSearchTest.exe FileWatcherTest.exe FormatOnSaveTest.exe
-   KeybindingsInvalidJsonTest.exe KeySequenceJJTest.exe InputIgnoreTest.exe
-   InputContextKeysTest.exe InputRemapMotionTest.exe LanguageCssTest.exe
-   LanguageTypeScriptTest.exe LineEndingsCRLFTest.exe LineEndingsLFTest.exe
-   QuickOpenEventuallyCompletesTest.exe Regression1671Test.exe
-   Regression2349EnewTest.exe Regression2988SwitchEditorTest.exe
-   Regression3084CommandLoopTest.exe
-   RegressionCommandLineNoCompletionTest.exe
-   RegressionFileModifiedIndicationTest.exe RegressionFontFallbackTest.exe
-   RegressionVspEmptyInitialBufferTest.exe RegressionNonExistentDirectory.exe
-   RegressionVspEmptyExistingBufferTest.exe SCMGitTest.exe
-   SearchShowClearHighlightsTest.exe SyntaxHighlightTextMateTest.exe
-   SyntaxHighlightTreesitterTest.exe SyntaxServer.exe
-   SyntaxServerCloseTest.exe SyntaxServerMessageExceptionTest.exe
-   SyntaxHighlightPhpTest.exe SyntaxServerParentPidTest.exe
-   SyntaxServerParentPidCorrectTest.exe SyntaxServerReadExceptionTest.exe
-   TerminalSetPidTitleTest.exe TerminalConfigurationTest.exe
-   AddRemoveSplitTest.exe TypingBatchedTest.exe TypingUnbatchedTest.exe
-   VimExperimentalVimlTest.exe VimIncsearchScrollTest.exe
-   VimScriptLocalFunctionTest.exe VimRemapTimeoutTest.exe
-   Regression3323DiagnosticsTest.exe VimSimpleRemapTest.exe
-   VimlRemapCmdlineTest.exe ZenModeSingleFileModeTest.exe
-   ZenModeSplitTest.exe ClipboardChangeTest.exe
-   ExtHostFormatSingleEditTest.exe ExtHostFormatFullEditTest.exe
+   RegressionLayoutTabSingleEditor.exe
    unformatted1.oni-dev test.unformatted.js large-c-file.c lsan.supp
    some-test-file.json some-test-file.txt test.crlf test.lf test-syntax.php
    utf8.txt utf8-test-file.htm Inconsolata-Regular.ttf PlugScriptLocal.vim))

--- a/src/Feature/Layout/Feature_Layout.re
+++ b/src/Feature/Layout/Feature_Layout.re
@@ -571,7 +571,9 @@ let update = (~focus, model, msg) => {
 
   | Command(ResetSizes) => (resetWeights(model), Nothing)
 
-  | Command(AddLayout) => (addLayoutTab(model), Nothing)
+  | Command(AddLayout) =>
+    let editor = Feature_Editor.Editor.copy(activeEditor(model));
+    (addLayoutTab(~editor, model), Nothing);
 
   | Command(PreviousLayout) => (
       {

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -47,7 +47,7 @@ let activeGroupEditors: model => list(Editor.t);
 let openEditor: (~config: Config.resolver, Editor.t, model) => model;
 let closeBuffer: (~force: bool, Vim.Types.buffer, model) => option(model);
 
-let addLayoutTab: model => model;
+let addLayoutTab: (~editor: Editor.t, model) => model;
 let gotoLayoutTab: (int, model) => model;
 let previousLayoutTab: (~count: int=?, model) => model;
 let nextLayoutTab: (~count: int=?, model) => model;

--- a/src/Feature/Layout/Feature_Layout.rei
+++ b/src/Feature/Layout/Feature_Layout.rei
@@ -20,11 +20,20 @@ module Group: {
   let allEditors: t => list(Editor.t);
 };
 
+module LayoutTab: {
+  type t;
+
+  let groups: t => list(Group.t);
+};
+
 type model;
 
 let activeGroup: model => Group.t;
 let activeLayoutGroups: model => list(Group.t);
 let setActiveGroup: (Group.id, model) => model;
+
+let layouts: model => list(LayoutTab.t);
+let activeLayout: model => LayoutTab.t;
 
 let initial: list(Editor.t) => model;
 

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -174,6 +174,12 @@ type layout = {
   activeGroupId: int,
 };
 
+module LayoutTab = {
+  type t = layout;
+
+  let groups = ({groups, _}: layout) => groups;
+};
+
 let activeTree = layout =>
   switch (layout.uncommittedTree) {
   | `Resizing(tree)
@@ -198,6 +204,8 @@ let initial = editors => {
 
   {layouts: [initialLayout], activeLayoutIndex: 0};
 };
+
+let layouts = ({layouts, _}) => layouts;
 
 let groups = ({groups, _}) => groups;
 

--- a/src/Feature/Layout/Model.re
+++ b/src/Feature/Layout/Model.re
@@ -471,9 +471,8 @@ let closeBuffer = (~force, buffer, model) => {
   };
 };
 
-let addLayoutTab = model => {
-  let newEditor = activeEditor(model) |> Editor.copy;
-  let newGroup = Group.create([newEditor]);
+let addLayoutTab = (~editor, model) => {
+  let newGroup = Group.create([editor]);
 
   let newLayout = {
     tree: Layout.singleton(newGroup.id),

--- a/src/Store/Features.re
+++ b/src/Store/Features.re
@@ -1529,7 +1529,8 @@ let update =
           )
         | SplitDirection.Vertical({shouldReuse}) =>
           Feature_Layout.split(~shouldReuse, ~editor, `Vertical, state.layout)
-        | SplitDirection.NewTab => Feature_Layout.addLayoutTab(state.layout)
+        | SplitDirection.NewTab =>
+          Feature_Layout.addLayoutTab(~editor, state.layout)
         };
 
       let editor' =


### PR DESCRIPTION
__Issue:__ Using `:tabnew` or `:tabedit` (or Control+T in #3733) would create a new vim-style layout tab, but there'd be an extra 'editor tab' in the initial window split.

__Defect:__ There was an extra copy/create of the editor in the layout code.

__Fix:__ Remove extraneous copy

__Todo:__
- [x] Add regression test