### PR TITLE
fix(search/#1588): Follow symlinks when using ripgrep by default

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -40,6 +40,7 @@
 - #3746 - Extension: Fix edit application in trailing spaces plugin
 - #3755 - Vim: Fix extra 'editor tab' with `:tabnew`/`:tabedit` (fixes #3150)
 - #3753 - Extension: Don't bubble up extension runtime errors to notifications
+- #3756 - Search: Follow symlinks with ripgrep by default (fixes #1588)
 
 ### Performance
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -130,6 +130,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `search.exclude` __(_list of string_ default: `[]`)__ - When using `Find in files` Onivim will not look at files located at the directories listed here, this inherit all the values from `files.exclude`
 
+- `search.followSymlinks` __(_bool_ default:  `true`)__ - Set whether to follow symlinks when searching
+
 - `workbench.colorCustomizations` __(_json_ default: `{}`)__ - Color theme overrides, using the same [Theme Colors as Code](https://code.visualstudio.com/api/references/theme-color) - for example:
 
 ```json

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -59,6 +59,7 @@ module Log = (val Log.withNamespace("Oni2.Core.Ripgrep"));
 type t = {
   search:
     (
+      ~followSymlinks: bool,
       ~filesExclude: list(string),
       ~directory: string,
       ~onUpdate: list(string) => unit,
@@ -68,6 +69,7 @@ type t = {
     dispose,
   findInFiles:
     (
+      ~followSymlinks: bool,
       ~searchExclude: list(string),
       ~searchInclude: list(string),
       ~directory: string,
@@ -241,6 +243,7 @@ let process = (rgPath, args, onUpdate, onComplete, onError) => {
 let search =
     (
       ~executablePath,
+      ~followSymlinks,
       ~filesExclude,
       ~directory,
       ~onUpdate,
@@ -266,7 +269,9 @@ let search =
     |> List.map(x => ["-g", x])
     |> List.concat;
 
-  let args = globs @ ["--smart-case", "--hidden", "--files", "--", directory];
+  let followArgs = followSymlinks ? ["--follow"] : [];
+
+  let args = globs @ followArgs @ ["--smart-case", "--hidden", "--files", "--", directory];
 
   process(
     executablePath,
@@ -280,6 +285,7 @@ let search =
 let findInFiles =
     (
       ~executablePath,
+      ~followSymlinks,
       ~searchExclude,
       ~searchInclude,
       ~directory,
@@ -299,10 +305,13 @@ let findInFiles =
     searchInclude
     |> List.filter(str => !StringEx.isEmpty(str))
     |> List.concat_map(x => ["-g", x]);
+
+  let followArgs = followSymlinks ? ["--follow"] : [];
   let args =
     excludeArgs
     @ includeArgs
     @ (enableRegex ? [] : ["--fixed-strings"])
+    @ followArgs
     @ (caseSensitive ? ["--case-sensitive"] : ["--ignore-case"])
     @ ["--hidden", "--json", "--", query, directory];
   process(

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -271,7 +271,10 @@ let search =
 
   let followArgs = followSymlinks ? ["--follow"] : [];
 
-  let args = globs @ followArgs @ ["--smart-case", "--hidden", "--files", "--", directory];
+  let args =
+    globs
+    @ followArgs
+    @ ["--smart-case", "--hidden", "--files", "--", directory];
 
   process(
     executablePath,

--- a/src/Core/Ripgrep.rei
+++ b/src/Core/Ripgrep.rei
@@ -11,6 +11,7 @@ module Match: {
 type t = {
   search:
     (
+      ~followSymlinks: bool,
       ~filesExclude: list(string),
       ~directory: string,
       ~onUpdate: list(string) => unit,
@@ -20,6 +21,7 @@ type t = {
     dispose,
   findInFiles:
     (
+      ~followSymlinks: bool,
       ~searchExclude: list(string),
       ~searchInclude: list(string),
       ~directory: string,

--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -289,13 +289,8 @@ module Files = {
 };
 
 module Search = {
-  let followSymlinks =
-    setting(
-      "search.followSymlinks", 
-      bool,
-      ~default=true
-    );
-}
+  let followSymlinks = setting("search.followSymlinks", bool, ~default=true);
+};
 
 module Workbench = {
   let activityBarVisible =

--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -288,6 +288,15 @@ module Files = {
     );
 };
 
+module Search = {
+  let followSymlinks =
+    setting(
+      "search.followSymlinks", 
+      bool,
+      ~default=true
+    );
+}
+
 module Workbench = {
   let activityBarVisible =
     setting("workbench.activityBar.visible", bool, ~default=true);

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -461,7 +461,10 @@ let sub = (~config, ~workingDirectory, ~setup, model) => {
       | Service_Ripgrep.Sub.Completed => Complete
       | Service_Ripgrep.Sub.Error(msg) => SearchError(msg);
 
-    let followSymlinks=Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(config);
+    let followSymlinks =
+      Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(
+        config,
+      );
     Service_Ripgrep.Sub.findInFiles(
       ~followSymlinks,
       ~exclude,

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -461,7 +461,9 @@ let sub = (~config, ~workingDirectory, ~setup, model) => {
       | Service_Ripgrep.Sub.Completed => Complete
       | Service_Ripgrep.Sub.Error(msg) => SearchError(msg);
 
+    let followSymlinks=Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(config);
     Service_Ripgrep.Sub.findInFiles(
+      ~followSymlinks,
       ~exclude,
       ~include_,
       ~directory=workingDirectory,

--- a/src/Service/Ripgrep/Service_Ripgrep.re
+++ b/src/Service/Ripgrep/Service_Ripgrep.re
@@ -9,6 +9,7 @@ module Sub = {
   type findInFilesParams = {
     exclude: list(string),
     include_: list(string),
+    followSymlinks: bool,
     directory: string,
     query: string,
     uniqueId: string,
@@ -38,6 +39,7 @@ module Sub = {
           );
         let dispose =
           ripgrep.Ripgrep.findInFiles(
+            ~followSymlinks=params.followSymlinks,
             ~searchExclude=params.exclude,
             ~searchInclude=params.include_,
             ~directory=params.directory,
@@ -64,6 +66,7 @@ module Sub = {
   let findInFiles =
       (
         ~uniqueId: string,
+        ~followSymlinks: bool,
         ~exclude: list(string),
         ~include_: list(string),
         ~directory: string,
@@ -74,6 +77,7 @@ module Sub = {
         toMsg,
       ) =>
     FindInFilesSub.create({
+      followSymlinks,
       uniqueId,
       exclude,
       include_,

--- a/src/Service/Ripgrep/Service_Ripgrep.rei
+++ b/src/Service/Ripgrep/Service_Ripgrep.rei
@@ -9,6 +9,7 @@ module Sub: {
   let findInFiles:
     (
       ~uniqueId: string,
+      ~followSymlinks: bool,
       ~exclude: list(string),
       ~include_: list(string),
       ~directory: string,

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -563,7 +563,10 @@ let subscriptions = (ripgrep, dispatch) => {
     let filesExclude =
       Feature_Configuration.GlobalConfiguration.Files.exclude.get(config);
 
-    let followSymlinks = Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(config);
+    let followSymlinks =
+      Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(
+        config,
+      );
 
     switch (Feature_Workspace.openedFolder(workspace)) {
     | None =>

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -563,6 +563,8 @@ let subscriptions = (ripgrep, dispatch) => {
     let filesExclude =
       Feature_Configuration.GlobalConfiguration.Files.exclude.get(config);
 
+    let followSymlinks = Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(config);
+
     switch (Feature_Workspace.openedFolder(workspace)) {
     | None =>
       // It's not really clear what the behavior should be for the ripgrep subscription w/o
@@ -589,6 +591,7 @@ let subscriptions = (ripgrep, dispatch) => {
       [
         RipgrepSubscription.create(
           ~id="workspace-search",
+          ~followSymlinks,
           ~filesExclude,
           ~directory,
           ~ripgrep,

--- a/src/Store/RipgrepSubscription.re
+++ b/src/Store/RipgrepSubscription.re
@@ -81,5 +81,13 @@ let create =
   Subscription.create(
     id,
     (module Provider),
-    {followSymlinks, filesExclude, directory, ripgrep, onUpdate, onComplete, onError},
+    {
+      followSymlinks,
+      filesExclude,
+      directory,
+      ripgrep,
+      onUpdate,
+      onComplete,
+      onError,
+    },
   );

--- a/src/Store/RipgrepSubscription.re
+++ b/src/Store/RipgrepSubscription.re
@@ -10,6 +10,7 @@ module Provider = {
   type action = Actions.t;
   type params = {
     filesExclude: list(string),
+    followSymlinks: bool,
     directory: string,
     ripgrep: Ripgrep.t, // TODO: Necessary dependency?
     onUpdate: list(string) => unit, // TODO: Should return action
@@ -23,6 +24,7 @@ module Provider = {
       (
         ~id,
         ~params as {
+          followSymlinks,
           filesExclude,
           directory,
           ripgrep,
@@ -34,8 +36,9 @@ module Provider = {
       ) => {
     Log.debug("Starting: " ++ id);
 
-    let dispose =
+    let dispose: unit => unit =
       ripgrep.Ripgrep.search(
+        ~followSymlinks,
         ~filesExclude,
         ~directory,
         ~onUpdate,
@@ -67,6 +70,7 @@ module Provider = {
 let create =
     (
       ~id,
+      ~followSymlinks,
       ~filesExclude,
       ~directory,
       ~ripgrep,
@@ -77,5 +81,5 @@ let create =
   Subscription.create(
     id,
     (module Provider),
-    {filesExclude, directory, ripgrep, onUpdate, onComplete, onError},
+    {followSymlinks, filesExclude, directory, ripgrep, onUpdate, onComplete, onError},
   );


### PR DESCRIPTION
__Issue:__ Searching (whether via `Control+P` or find-in-files) would ignore symlinks, both symlinked directories and files.

__Defect:__ We weren't  supplying the `--follow` argument to ripgrep

__Fix:__ Supply `--follow` when calling `ripgrep`, but add configuration setting to disable this (`search.followSymlinks`)

Fixes #1588