### PR TITLE
fix(minimap/#3648): Fix minimap diff marker position

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -43,6 +43,7 @@
 - #3753 - Extension: Don't bubble up extension runtime errors to notifications
 - #3756 - Search: Follow symlinks with ripgrep by default (fixes #1588)
 - #3757 - Buffers: Fix welcome buffer appearing when splitting (fixes #3631)
+- #3767 - Minimap: Fix diff marker positions on scroll (fixes #3648)
 
 ### Performance
 

--- a/src/Feature/Editor/EditorDiffMarkers.re
+++ b/src/Feature/Editor/EditorDiffMarkers.re
@@ -93,7 +93,7 @@ let renderMinimap =
         if (marker != Unmodified) {
           renderMarker(
             ~x,
-            ~y=y -. scrollY,
+            ~y,
             ~rowHeight,
             ~width,
             ~canvasContext,


### PR DESCRIPTION
Fix #3648.

Very tiny change! Perhaps I'm missing something here, but it looks like the diff markers don't need to include this offset, at least in the calc for the y pos.

Before / After:


https://user-images.githubusercontent.com/10038688/125708244-36845971-c357-4b89-8e53-a0fa3e24775e.mov

If you look at the two add markers, in the before on the left they move about when scrolled.
On the right, they stay locked on the actual lines that changed.
They should be attached to the three comment lines (above and below the long comment line).
(Sorry for the short video, only allowed 10MB here!).

Assuming this is sensible, just needs the changelog updating.