### PR TITLE
chore(ci): Updated codesign cert

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -73,3 +73,4 @@
 
 - #3721 - Packaging - Linux: Bundle compiled glib settings (fixes #3706)
 - #3770 - Build: Fix `esy watch` command (thanks @eEQK !)
+- #3780 - Chore: Update windows codesigning certificate

--- a/scripts/windows/publish.ps1
+++ b/scripts/windows/publish.ps1
@@ -14,7 +14,7 @@ function CodeSign {
 
 
 
-    &"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" sign /tr http://timestamp.digicert.com /fd sha256 /td sha256 /f $env:CODESIGN_CERTIFICATE /p $env:CODESIGN_PASSWORD $path
+    &"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" sign /tr http://timestamp.digicert.com /fd sha256 /td sha256 /f $env:CODESIGN_CERTIFICATE /p $env:CODESIGN_PASSWORD_WIN $path
 
 }
 


### PR DESCRIPTION
Updated codesigning cert for Windows build (requires codesign certificate password update)