### PR TITLE
chore(ci): Additional fixes for codesigning/publish on windows

### DIFF
--- a/.ci/clean-windows-deps.yml
+++ b/.ci/clean-windows-deps.yml
@@ -1,6 +1,10 @@
 steps:
   # Remove Rust:
   # https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-Rust.ps1
+  - script: dir "C:\Program Files"
+    displayName: "List PF"
+  - script: dir "C:\Program Files (x86)"
+    displayName: "List PF x86"
   - script: rd /s /q "C:\Rust"
     displayName: 'Remove Rust'
   # Remove R

--- a/.ci/clean-windows-deps.yml
+++ b/.ci/clean-windows-deps.yml
@@ -25,7 +25,7 @@ steps:
     displayName: "Remove TortoiseSVN"
   - script: rd /s /q "C:\Program Files\Internet Explorer"
     displayName: "Remove Internet Explorer"
-  - script: rd /s /q "C:\Program Files\Unity"
+  - script: rd /s /q "C:\Program Files\Unity Hub"
     displayName: "Remove Unity"
   - script: rd /s /q "C:\Program Files\Android"
     displayName: "Remove Android SDK"

--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -77,4 +77,4 @@
 
 - #3721 - Packaging - Linux: Bundle compiled glib settings (fixes #3706)
 - #3770 - Build: Fix `esy watch` command (thanks @eEQK !)
-- #3780 - Chore: Update windows codesigning certificate
+- #3780, #3786 - Chore: Update windows codesigning certificate

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ jobs:
   timeoutInMinutes: 180
   displayName: "Windows - Build & Package"
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,7 @@ jobs:
   # Run if not master
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)

--- a/scripts/windows/publish.ps1
+++ b/scripts/windows/publish.ps1
@@ -14,7 +14,7 @@ function CodeSign {
 
 
 
-    &"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" sign /tr http://timestamp.digicert.com /fd sha256 /td sha256 /f $env:CODESIGN_CERTIFICATE /p $env:CODESIGN_PASSWORD_WIN $path
+    &"C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe" sign /tr http://timestamp.digicert.com /fd sha256 /td sha256 /f $env:CODESIGN_CERTIFICATE /p $env:CODESIGN_PASSWORD_WIN $path
 
 }
 

--- a/scripts/windows/verify-signtool.ps1
+++ b/scripts/windows/verify-signtool.ps1
@@ -1,1 +1,1 @@
-&"C:/Program Files (x86)/Windows Kits/8.1/bin/x64/signtool.exe" sign /?
+&"C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe" sign /?


### PR DESCRIPTION
- The new codesigning certificate requires a newer version of `signtool` - need to update the build VM
- `signtool` on `windows-2019` is in a different location than `vs2017-win2016`