### PR TITLE
fix(search/#3792): Add setting to control '--no-ignore' flag for ripgrep

### DIFF
--- a/CHANGES_CURRENT.md
+++ b/CHANGES_CURRENT.md
@@ -1,5 +1,7 @@
 ### Features 
 
+- #3795 - Search: Add `search.useIgnoreFiles` configuration setting (fixes #3792)
+
 ### Bug Fixes
 
 ### Performance

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -132,6 +132,8 @@ The configuration file, `configuration.json` is in the Oni2 directory, whose loc
 
 - `search.followSymlinks` __(_bool_ default:  `true`)__ - Set whether to follow symlinks when searching
 
+- `search.useIgnoreFiles` __(_bool_ default:  `true`)__ - Set whether to `.gitignore` should be respected when searching
+
 - `workbench.colorCustomizations` __(_json_ default: `{}`)__ - Color theme overrides, using the same [Theme Colors as Code](https://code.visualstudio.com/api/references/theme-color) - for example:
 
 ```json

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -60,6 +60,7 @@ type t = {
   search:
     (
       ~followSymlinks: bool,
+      ~useIgnoreFiles: bool,
       ~filesExclude: list(string),
       ~directory: string,
       ~onUpdate: list(string) => unit,
@@ -70,6 +71,7 @@ type t = {
   findInFiles:
     (
       ~followSymlinks: bool,
+      ~useIgnoreFiles: bool,
       ~searchExclude: list(string),
       ~searchInclude: list(string),
       ~directory: string,
@@ -244,6 +246,7 @@ let search =
     (
       ~executablePath,
       ~followSymlinks,
+      ~useIgnoreFiles,
       ~filesExclude,
       ~directory,
       ~onUpdate,
@@ -271,7 +274,7 @@ let search =
 
   let followArgs = followSymlinks ? ["--follow"] : [];
 
-  let ignoreArgs = ["--no-ignore"];
+  let ignoreArgs = useIgnoreFiles ? [] : ["--no-ignore"];
 
   let args =
     globs
@@ -292,6 +295,7 @@ let findInFiles =
     (
       ~executablePath,
       ~followSymlinks,
+      ~useIgnoreFiles,
       ~searchExclude,
       ~searchInclude,
       ~directory,
@@ -314,7 +318,7 @@ let findInFiles =
 
   let followArgs = followSymlinks ? ["--follow"] : [];
 
-  let ignoreArgs = ["--no-ignore"];
+  let ignoreArgs = useIgnoreFiles ? [] : ["--no-ignore"];
 
   let args =
     excludeArgs

--- a/src/Core/Ripgrep.re
+++ b/src/Core/Ripgrep.re
@@ -271,9 +271,12 @@ let search =
 
   let followArgs = followSymlinks ? ["--follow"] : [];
 
+  let ignoreArgs = ["--no-ignore"];
+
   let args =
     globs
     @ followArgs
+    @ ignoreArgs
     @ ["--smart-case", "--hidden", "--files", "--", directory];
 
   process(
@@ -310,9 +313,13 @@ let findInFiles =
     |> List.concat_map(x => ["-g", x]);
 
   let followArgs = followSymlinks ? ["--follow"] : [];
+
+  let ignoreArgs = ["--no-ignore"];
+
   let args =
     excludeArgs
     @ includeArgs
+    @ ignoreArgs
     @ (enableRegex ? [] : ["--fixed-strings"])
     @ followArgs
     @ (caseSensitive ? ["--case-sensitive"] : ["--ignore-case"])

--- a/src/Core/Ripgrep.rei
+++ b/src/Core/Ripgrep.rei
@@ -12,6 +12,7 @@ type t = {
   search:
     (
       ~followSymlinks: bool,
+      ~useIgnoreFiles: bool,
       ~filesExclude: list(string),
       ~directory: string,
       ~onUpdate: list(string) => unit,
@@ -22,6 +23,7 @@ type t = {
   findInFiles:
     (
       ~followSymlinks: bool,
+      ~useIgnoreFiles: bool,
       ~searchExclude: list(string),
       ~searchInclude: list(string),
       ~directory: string,

--- a/src/Feature/Configuration/GlobalConfiguration.re
+++ b/src/Feature/Configuration/GlobalConfiguration.re
@@ -305,6 +305,8 @@ module Files = {
 
 module Search = {
   let followSymlinks = setting("search.followSymlinks", bool, ~default=true);
+
+  let useIgnoreFiles = setting("search.useIgnoreFiles", bool, ~default=true);
 };
 
 module Window = {
@@ -352,6 +354,8 @@ let contributions = [
   Editor.snippetSuggestions.spec,
   Files.exclude.spec,
   Explorer.autoReveal.spec,
+  Search.followSymlinks.spec,
+  Search.useIgnoreFiles.spec,
   Window.titleBarStyle.spec,
   Workbench.activityBarVisible.spec,
   Workbench.editorShowTabs.spec,

--- a/src/Feature/Search/Feature_Search.re
+++ b/src/Feature/Search/Feature_Search.re
@@ -465,8 +465,15 @@ let sub = (~config, ~workingDirectory, ~setup, model) => {
       Feature_Configuration.GlobalConfiguration.Search.followSymlinks.get(
         config,
       );
+
+    let useIgnoreFiles =
+      Feature_Configuration.GlobalConfiguration.Search.useIgnoreFiles.get(
+        config,
+      );
+
     Service_Ripgrep.Sub.findInFiles(
       ~followSymlinks,
+      ~useIgnoreFiles,
       ~exclude,
       ~include_,
       ~directory=workingDirectory,

--- a/src/Service/Ripgrep/Service_Ripgrep.re
+++ b/src/Service/Ripgrep/Service_Ripgrep.re
@@ -10,6 +10,7 @@ module Sub = {
     exclude: list(string),
     include_: list(string),
     followSymlinks: bool,
+    useIgnoreFiles: bool,
     directory: string,
     query: string,
     uniqueId: string,
@@ -40,6 +41,7 @@ module Sub = {
         let dispose =
           ripgrep.Ripgrep.findInFiles(
             ~followSymlinks=params.followSymlinks,
+            ~useIgnoreFiles=params.useIgnoreFiles,
             ~searchExclude=params.exclude,
             ~searchInclude=params.include_,
             ~directory=params.directory,
@@ -67,6 +69,7 @@ module Sub = {
       (
         ~uniqueId: string,
         ~followSymlinks: bool,
+        ~useIgnoreFiles: bool,
         ~exclude: list(string),
         ~include_: list(string),
         ~directory: string,
@@ -78,6 +81,7 @@ module Sub = {
       ) =>
     FindInFilesSub.create({
       followSymlinks,
+      useIgnoreFiles,
       uniqueId,
       exclude,
       include_,

--- a/src/Service/Ripgrep/Service_Ripgrep.rei
+++ b/src/Service/Ripgrep/Service_Ripgrep.rei
@@ -10,6 +10,7 @@ module Sub: {
     (
       ~uniqueId: string,
       ~followSymlinks: bool,
+      ~useIgnoreFiles: bool,
       ~exclude: list(string),
       ~include_: list(string),
       ~directory: string,

--- a/src/Store/QuickmenuStoreConnector.re
+++ b/src/Store/QuickmenuStoreConnector.re
@@ -570,6 +570,11 @@ let subscriptions = (ripgrep, dispatch) => {
         config,
       );
 
+    let useIgnoreFiles =
+      Feature_Configuration.GlobalConfiguration.Search.useIgnoreFiles.get(
+        config,
+      );
+
     switch (Feature_Workspace.openedFolder(workspace)) {
     | None =>
       // It's not really clear what the behavior should be for the ripgrep subscription w/o
@@ -601,6 +606,7 @@ let subscriptions = (ripgrep, dispatch) => {
         RipgrepSubscription.create(
           ~id="workspace-search",
           ~followSymlinks,
+          ~useIgnoreFiles,
           ~filesExclude,
           ~directory,
           ~ripgrep,

--- a/src/Store/RipgrepSubscription.re
+++ b/src/Store/RipgrepSubscription.re
@@ -11,6 +11,7 @@ module Provider = {
   type params = {
     filesExclude: list(string),
     followSymlinks: bool,
+    useIgnoreFiles: bool,
     directory: string,
     ripgrep: Ripgrep.t, // TODO: Necessary dependency?
     onUpdate: list(string) => unit, // TODO: Should return action
@@ -25,6 +26,7 @@ module Provider = {
         ~id,
         ~params as {
           followSymlinks,
+          useIgnoreFiles,
           filesExclude,
           directory,
           ripgrep,
@@ -39,6 +41,7 @@ module Provider = {
     let dispose: unit => unit =
       ripgrep.Ripgrep.search(
         ~followSymlinks,
+        ~useIgnoreFiles,
         ~filesExclude,
         ~directory,
         ~onUpdate,
@@ -71,6 +74,7 @@ let create =
     (
       ~id,
       ~followSymlinks,
+      ~useIgnoreFiles,
       ~filesExclude,
       ~directory,
       ~ripgrep,
@@ -83,6 +87,7 @@ let create =
     (module Provider),
     {
       followSymlinks,
+      useIgnoreFiles,
       filesExclude,
       directory,
       ripgrep,


### PR DESCRIPTION
__Issue:__ There is no way to configure Onivim to ignore the `.gitignore` files when searching (via the Control+P quickopen or find-in-files)

__Fix:__ Add a setting `search.useIgnoreFiles`, which defaults to `true`, and specifices whether Control+P/find-in-files should take the ignore files into consideration.

Fixes #3792 