### PR TITLE
fix(build/docker): Bump node from 10.x to 12.x

### DIFF
--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y install llvm-toolset-7.0
 RUN scl enable llvm-toolset-7.0 'clang -v'
 
 RUN yum -y install gcc-c++ make sudo
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | sudo -E bash -
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | sudo -E bash -
 RUN yum -y install nodejs npm coreutils grep tar sed gawk diffutils autoconf unzip python3
 
 RUN yum -y install file fuse fuse-devel wget bzip2-devel libXt-devel libSM-devel libICE-devel ncurses-devel libacl-devel libxrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel mesa-libGLU-devel gtk3-devel perl-Digest-SHA bzip2 m4 patch which cmake3 git libxkbfile-devel


### PR DESCRIPTION
Following the documented way to build from source using
docker fails because the version of Node used is deprecated.

Bumping to the currently supported version 12.x solves
the problem and allows building from source.

P.S.: Thank you for this project! :)