### PR TITLE
Fix linguist tool configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,9 @@
 # Hide vendored extension code
 extensions/* linguist-generated
 
+# Hide vendored code
+vendor/* linguist-vendored
+
 # Test files
 integration_test/test.crlf text eol=crlf
 integration_test/test.lf text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,9 @@ integration_test/large-c-file.c linguist-generated
 # Hide vendored sqlite
 bench/reason-treesitter/sqlite3.c linguist-vendored
 
+# Hide large bench files
+bench/collateral/* linguist-vendored
+
 # Test files
 integration_test/test.crlf text eol=crlf
 integration_test/test.lf text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,10 +23,10 @@
 *esy.lock/* linguist-generated
 
 # Hide vendored extension code
-extensions/* linguist-generated
+extensions/** linguist-generated
 
 # Hide vendored code
-vendor/* linguist-vendored
+vendor/** linguist-vendored
 
 # Test files
 integration_test/test.crlf text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,12 @@ extensions/** linguist-generated
 # Hide vendored code
 vendor/** linguist-vendored
 
+# Hide large integration test file
+integration_test/large-c-file.c linguist-generated
+
+# Hide vendored sqlite
+bench/reason-treesitter/sqlite3.c linguist-vendored
+
 # Test files
 integration_test/test.crlf text eol=crlf
 integration_test/test.lf text eol=lf


### PR DESCRIPTION
After these changes: 
![image](https://user-images.githubusercontent.com/19646569/135263509-15553b15-08e2-4589-935c-9048962fc293.png)

Up to that moment, C is main, mostly because of [vendored sqlite](https://github.com/onivim/oni2/blob/fda6bf7f3bb8caa6bc66225d36886a07a7a1579a/bench/reason-treesitter/sqlite3.c)

![image](https://user-images.githubusercontent.com/19646569/135263545-3b922e52-699e-4107-bb7f-32d2a4a31a82.png)
