### PR TITLE
docs: Convert source code to MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (C) 2021 Outrun Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -62,30 +62,9 @@ Please also see our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## License
 
-Onivim 2 is licensed under the [Outrun Labs EULA 1.1](./Outrun-Labs-EULA-v1.1.md).
+Onivim 2 source code is licensed under the [MIT](LICENSE.md) license.
 
-The TL;DR is:
-- __Free__ for __non-commercial__ and __educational use__.
-- __Commercial use__ requires the purchase of a license.
-- You may not redistribute source code or binaries under a different license.
-
-You can pre-order a commercial license here: https://v2.onivim.io
-
-As we get closer to shipping our MVP, we'll increase the pre-order price, until we settle on our full pricing model.
-
-> __NOTE:__ Anyone who contributed financially to Onivim v1 via our past funding sources (BountySource, Patreon, PayPal, OpenCollective) - gets a lifetime license. If you haven't received your license key, and you contributed previously, please contact me at bryphe@outrunlabs.com (or feel free to reach out at [Twitter](https://twitter.com/oni_vim) or our [Discord](https://discord.gg/7maEAxV)). __Thank you for supporting the project!__
-
-Alternatively, you can contribute to the project through [Patreon](https://www.patreon.com/onivim), which helps us with ongoing costs.
-
-#### 'Time-Delay' Dual License
-
-Because of the support we've received from open source communities, we've decided to __dual-license the code after 18 months__ - every commit, starting with [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), will be dual-licensed via the __MIT License__ 18 months from that commit's date to `master`. For commit [017c513](https://github.com/onivim/oni2/commit/017c5131b4bba3006f726a3ef0f5a33028e059b5), as it was committed to `master` on __4/18/2019__ that means it would be dual-licensed with __MIT License__ on __10/18/2020__. 
-
-For convenience, we will maintain an [oni2-mit](https://github.com/onivim/oni2-mit) repo containing the MIT-licensed code. The first commit to that repo will be on __July 2, 2020__.
-
-Any external contributions to the project from outside Outrun Labs, LLC will not be subject to this 'time-delay' - they'll be dual-licensed immediately under the MIT License.
-
-We hope that this approach will bring us the best of worlds - the ability to have a commercially sustainable product, with high quality - as well as giving back to the open source communities by having our work eventually end up in the open, and ensuring that external contributions are always open source.
+Onivim 2 downloads, available at https://v2.onivim.io/, are licensed under the [Outrun Labs EULA 1.1](./Outrun-Labs-EULA-v1.1.md).
 
 #### Third-Party Code
 

--- a/docs/docs/other/faq.md
+++ b/docs/docs/other/faq.md
@@ -63,18 +63,7 @@ If you did not receive a license key - feel free to send me a mail at [orders@ou
 
 ### Is Onivim 2 open-source?
 
-We're developing Onivim 2 [in the open](https://github.com/onivim/oni2), but it is licensed under a [commercial EULA](https://github.com/onivim/oni2/blob/master/Outrun-Labs-EULA-v1.1.md).
-
-However, we value open source - and to that end, we've implemented a 'time-delay' open source license. __Each commit that makes it to `master` will be dual-licensed under the permissive MIT license after 18 months__.
-We maintain a [separate repo](https://github.com/onivim/oni2-mit) containing the MIT licensed code, which is sync'd daily. 
-
-We hope that this can help us strike a balance: __the sustainability of a commercial offering__ while __giving back to the open source community__.
-
-When we talk about sustainability - we mean not only in the context of Onivim 2, but in the broader context of open-source. 
-
-To that end, we dedicate a portion of the proceeds from sales of Onivim 2 to open-source projects we leverage, like:
-- [Vim](https://www.vim.org/sponsor/hall_of_honour.php)
-- [Neovim](https://salt.bountysource.com/teams/neovim/supporters)
+As of September 2021, the source code for Onivim 2 has been re-licensed under the [MIT](https://github.com/onivim/oni2/blob/master/LICENSE.md)
 
 ### What is the refund policy?
 


### PR DESCRIPTION
This change converts the source code license to MIT, from a proprietary EULA.

Unfortunately, as I haven't been able to contribute much to the project lately - I'm hoping this can help lower the barrier to entry to contributing (it's already really hard as it is, due to the technology used!) This will also make it easier to use Onivim with source-based package managers like AUR.

I'd like to open the downloads as well down the road, but there's still a few things I need to get figured out before I can do that.