### PR TITLE
chore: CI - Use common step for installing esy (upgrade esy to 0.6.10)

### DIFF
--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -4,8 +4,7 @@ steps:
   - task: NodeTool@0
     inputs:
       versionSpec: "14.15.4"
-  - script: npm install -g esy@0.6.7
-    displayName: 'npm install -g esy@0.6.7'
+  - template: utils/use-esy.yml
   - script: npm install -g yarn
     displayName: 'npm install -g yarn'
   - script: npm install -g prettier


### PR DESCRIPTION
The hygiene check was using esy@0.6.7, but the rest of the build pipeline uses esy@0.6.10 - bring it back in sync