### PR TITLE
chore(ci): Windows - don't delete Android SDK 

### DIFF
--- a/.ci/clean-windows-deps.yml
+++ b/.ci/clean-windows-deps.yml
@@ -27,8 +27,6 @@ steps:
     displayName: "Remove Internet Explorer"
   - script: rd /s /q "C:\Program Files\Unity Hub"
     displayName: "Remove Unity"
-  - script: rd /s /q "C:\Program Files\Android"
-    displayName: "Remove Android SDK"
   - script: rd /s /q "C:\Program Files\MongoDB"
     displayName: "Remove MongoDB"
   - script: rd /s /q "%JAVA_HOME%"


### PR DESCRIPTION
- Fix CI build on Windows