### PR TITLE
Fix Docker build

### DIFF
--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -27,7 +27,7 @@ RUN yum -y install nasm
 RUN yum -y install https://repo.ius.io/ius-release-el7.rpm
 RUN yum -y remove git
 RUN yum -y install epel-release
-RUN yum -y install git222
+RUN yum -y install git236
 
 # 3706 - install gsettings-settings-daemon:
 # This includes the `org.gnome.settings-daemon.plugins.xsettings.gschema.xml` that needs to be overridden


### PR DESCRIPTION
It previously failed for me with this:

```
Step 21/26 : RUN yum -y install git222
 ---> Running in 6eb1f74aa373
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: centos.westmancom.com
 * centos-sclo-rh: centos.les.net
 * centos-sclo-sclo: centos.westmancom.com
 * epel: linux-mirrors.fnal.gov
 * extras: centos.westmancom.com
 * updates: centos.westmancom.com
No package git222 available.
Error: Nothing to do
```

Fixes #3865